### PR TITLE
Restrict supervisor visibility of employees

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ CREATE TABLE IF NOT EXISTS employee_daily_hours (
 ```
 
 `employee_daily_hours` records how many hours an employee worked on a given day. Later you can calculate under time or overtime by comparing `hours_worked` with the employee's `working_hours`.
+
+To track which supervisor created each employee, add a `created_by` column:
+
+```sql
+ALTER TABLE employees
+  ADD COLUMN created_by INT NOT NULL,
+  ADD CONSTRAINT fk_employee_creator FOREIGN KEY (created_by) REFERENCES users(id);
+```
+
+This column stores the user ID of the supervisor who created the employee.

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -104,6 +104,30 @@
       </tbody>
     </table>
   </div>
+
+  <h3 class="mt-4">Employees</h3>
+  <div class="table-responsive">
+    <table class="table table-bordered table-striped">
+      <thead class="table-light">
+        <tr>
+          <th>ID</th>
+          <th>Punching ID</th>
+          <th>Name</th>
+          <th>Created By</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% employees.forEach(function(emp){ %>
+          <tr>
+            <td><%= emp.id %></td>
+            <td><%= emp.punching_id %></td>
+            <td><%= emp.name %></td>
+            <td><%= emp.supervisor_name || '' %></td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+  </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add database notes for new `created_by` column on employees
- limit `/supervisor/employees` to show only records created by the logged in supervisor
- store `created_by` on employee creation
- restrict employee-hours view in the same way
- expose employees and their creators on the operator departments page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ab8a222508320a523c19f0c5d6389