### PR TITLE
Enhance operator department management

### DIFF
--- a/routes/hrRoutes.js
+++ b/routes/hrRoutes.js
@@ -150,7 +150,16 @@ router.get('/operator/departments', isAuthenticated, isOperator, async (req, res
        ORDER BY d.created_at DESC`
     );
     const [supervisors] = await pool.query(
-      `SELECT id, username FROM users WHERE role_id IN (SELECT id FROM roles WHERE name='supervisor') AND is_active=1`
+      `SELECT u.id,
+              u.username,
+              IFNULL(SUM(e.salary_amount), 0) AS total_salary,
+              COUNT(e.id) AS employee_count
+         FROM users u
+         LEFT JOIN employees e ON e.created_by = u.id AND e.is_active = 1
+        WHERE u.role_id IN (SELECT id FROM roles WHERE name='supervisor')
+          AND u.is_active = 1
+        GROUP BY u.id
+        ORDER BY u.username`
     );
     const [employees] = await pool.query(
       `SELECT e.id, e.punching_id, e.name, u.username AS supervisor_name
@@ -242,6 +251,24 @@ router.post('/operator/supervisor/:id/toggle', isAuthenticated, isOperator, asyn
   } catch (err) {
     console.error('Error toggling supervisor:', err);
     req.flash('error', 'Failed to update supervisor status.');
+  }
+  res.redirect('/operator/departments');
+});
+
+// POST /operator/employees/:id/change-supervisor - reassign employee creator
+router.post('/operator/employees/:id/change-supervisor', isAuthenticated, isOperator, async (req, res) => {
+  const employeeId = req.params.id;
+  const { supervisor_id } = req.body;
+  if (!supervisor_id) {
+    req.flash('error', 'Missing supervisor.');
+    return res.redirect('/operator/departments');
+  }
+  try {
+    await pool.query('UPDATE employees SET created_by=? WHERE id=?', [supervisor_id, employeeId]);
+    req.flash('success', 'Employee supervisor updated.');
+  } catch (err) {
+    console.error('Error updating employee supervisor:', err);
+    req.flash('error', 'Failed to update employee supervisor.');
   }
   res.redirect('/operator/departments');
 });

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -5,6 +5,27 @@
   <title>Departments</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" />
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-0FR2E8AI7rHxT2ut9qO0GZBmLFlUPUvz1ouKQEdDHKZt/ffNpAuBdYwVDcXlJ3BhqxEmFIHR7Fl/uhXwFwMjKQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <style>
+    body {
+      font-family: 'Poppins', sans-serif;
+      background-color: #eef1f4;
+    }
+    .card {
+      box-shadow: 0 2px 6px rgba(0,0,0,0.05);
+      border: none;
+      border-radius: 8px;
+      margin-bottom: 1.5rem;
+    }
+    .card-header {
+      background-color: #343a40;
+      color: #fff;
+      font-weight: 500;
+      border-top-left-radius: 8px;
+      border-top-right-radius: 8px;
+    }
+  </style>
 </head>
 <body class="bg-light">
 <nav class="navbar navbar-dark bg-dark mb-3">
@@ -22,112 +43,147 @@
     <div class="alert alert-success"><%= success %></div>
   <% } %>
 
-  <h3>Create Department</h3>
-  <form action="/operator/departments/create" method="POST" class="row g-2 mb-4">
-    <div class="col-sm-4">
-      <input type="text" name="name" class="form-control" placeholder="Department name" required>
+  <div class="card">
+    <div class="card-header">Create Department</div>
+    <div class="card-body">
+      <form action="/operator/departments/create" method="POST" class="row g-2">
+        <div class="col-sm-4">
+          <input type="text" name="name" class="form-control" placeholder="Department name" required>
+        </div>
+        <div class="col-sm-4">
+          <select name="supervisor_id" class="form-select">
+            <option value="">-- Assign Supervisor --</option>
+            <% supervisors.forEach(function(s){ %>
+              <option value="<%= s.id %>"><%= s.username %></option>
+            <% }) %>
+          </select>
+        </div>
+        <div class="col-sm-2">
+          <button type="submit" class="btn btn-primary w-100" data-bs-toggle="tooltip" title="Create Department">
+            <i class="fa-solid fa-plus"></i>
+          </button>
+        </div>
+      </form>
     </div>
-    <div class="col-sm-4">
-      <select name="supervisor_id" class="form-select">
-        <option value="">-- Assign Supervisor --</option>
-        <% supervisors.forEach(function(s){ %>
-          <option value="<%= s.id %>"><%= s.username %></option>
-        <% }) %>
-      </select>
-    </div>
-    <div class="col-sm-2">
-      <button type="submit" class="btn btn-primary w-100">Create</button>
-    </div>
-  </form>
+  </div>
 
-  <h3>Departments</h3>
-  <div class="table-responsive">
-    <table class="table table-bordered table-striped">
-      <thead class="table-light">
-        <tr>
-          <th>ID</th>
-          <th>Name</th>
-          <th>Supervisor</th>
-          <th>Change Supervisor</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% departments.forEach(function(d){ %>
+  <div class="card">
+    <div class="card-header">Departments</div>
+    <div class="card-body table-responsive">
+      <table class="table table-bordered table-striped mb-0">
+        <thead class="table-light">
           <tr>
-            <td><%= d.id %></td>
-            <td><%= d.name %></td>
-            <td><%= d.supervisor_name || 'Unassigned' %></td>
-            <td>
-              <form action="/operator/departments/change-supervisor" method="POST" class="row g-2">
-                <input type="hidden" name="department_id" value="<%= d.id %>">
-                <div class="col-8">
-                  <select name="supervisor_id" class="form-select form-select-sm" required>
+            <th>ID</th>
+            <th>Name</th>
+            <th>Supervisor</th>
+            <th>Change Supervisor</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% departments.forEach(function(d){ %>
+            <tr>
+              <td><%= d.id %></td>
+              <td><%= d.name %></td>
+              <td><%= d.supervisor_name || 'Unassigned' %></td>
+              <td>
+                <form action="/operator/departments/change-supervisor" method="POST" class="row g-2">
+                  <input type="hidden" name="department_id" value="<%= d.id %>">
+                  <div class="col-8">
+                    <select name="supervisor_id" class="form-select form-select-sm" required>
+                      <% supervisors.forEach(function(s){ %>
+                        <option value="<%= s.id %>" <%= d.supervisor_name===s.username ? 'selected' : '' %>><%= s.username %></option>
+                      <% }) %>
+                    </select>
+                  </div>
+                  <div class="col-4">
+                    <button type="submit" class="btn btn-sm btn-outline-primary w-100" data-bs-toggle="tooltip" title="Update Supervisor">
+                      <i class="fa-solid fa-floppy-disk"></i>
+                    </button>
+                  </div>
+                </form>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card mt-4">
+    <div class="card-header">Supervisors</div>
+    <div class="card-body table-responsive">
+      <table class="table table-bordered mb-0">
+        <thead class="table-light">
+          <tr>
+            <th>ID</th>
+            <th>Username</th>
+            <th>Employees</th>
+            <th>Total Salary</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% supervisors.forEach(function(s){ %>
+            <tr>
+              <td><%= s.id %></td>
+              <td><%= s.username %></td>
+              <td><%= s.employee_count %></td>
+              <td>₹<%= Number(s.total_salary).toLocaleString() %></td>
+              <td>
+                <form action="/operator/supervisor/<%= s.id %>/toggle" method="POST" class="d-inline">
+                  <input type="hidden" name="action" value="deactivate">
+                  <button type="submit" class="btn btn-sm btn-danger" data-bs-toggle="tooltip" title="Deactivate">
+                    <i class="fa-solid fa-user-slash"></i>
+                  </button>
+                </form>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="card mt-4">
+    <div class="card-header">Employees</div>
+    <div class="card-body table-responsive">
+      <table class="table table-bordered table-striped mb-0">
+        <thead class="table-light">
+          <tr>
+            <th>ID</th>
+            <th>Punching ID</th>
+            <th>Name</th>
+            <th>Created By</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% employees.forEach(function(emp){ %>
+            <tr>
+              <td><%= emp.id %></td>
+              <td><%= emp.punching_id %></td>
+              <td><%= emp.name %></td>
+              <td>
+                <form action="/operator/employees/<%= emp.id %>/change-supervisor" method="POST" class="d-flex">
+                  <select name="supervisor_id" class="form-select form-select-sm me-1">
                     <% supervisors.forEach(function(s){ %>
-                      <option value="<%= s.id %>" <%= d.supervisor_name===s.username ? 'selected' : '' %>><%= s.username %></option>
+                      <option value="<%= s.id %>" <%= emp.supervisor_name===s.username ? 'selected' : '' %>><%= s.username %></option>
                     <% }) %>
                   </select>
-                </div>
-                <div class="col-4">
-                  <button type="submit" class="btn btn-sm btn-secondary w-100">Update</button>
-                </div>
-              </form>
-            </td>
-          </tr>
-        <% }) %>
-      </tbody>
-    </table>
-  </div>
-
-  <h3 class="mt-4">Supervisors</h3>
-  <div class="table-responsive">
-    <table class="table table-bordered">
-      <thead class="table-light">
-        <tr>
-          <th>ID</th>
-          <th>Username</th>
-          <th>Action</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% supervisors.forEach(function(s){ %>
-          <tr>
-            <td><%= s.id %></td>
-            <td><%= s.username %></td>
-            <td>
-              <form action="/operator/supervisor/<%= s.id %>/toggle" method="POST" class="d-inline">
-                <input type="hidden" name="action" value="deactivate">
-                <button type="submit" class="btn btn-sm btn-danger">Deactivate</button>
-              </form>
-            </td>
-          </tr>
-        <% }) %>
-      </tbody>
-    </table>
-  </div>
-
-  <h3 class="mt-4">Employees</h3>
-  <div class="table-responsive">
-    <table class="table table-bordered table-striped">
-      <thead class="table-light">
-        <tr>
-          <th>ID</th>
-          <th>Punching ID</th>
-          <th>Name</th>
-          <th>Created By</th>
-        </tr>
-      </thead>
-      <tbody>
-        <% employees.forEach(function(emp){ %>
-          <tr>
-            <td><%= emp.id %></td>
-            <td><%= emp.punching_id %></td>
-            <td><%= emp.name %></td>
-            <td><%= emp.supervisor_name || '' %></td>
-          </tr>
-        <% }) %>
-      </tbody>
-    </table>
+                  <button type="submit" class="btn btn-sm btn-outline-primary" data-bs-toggle="tooltip" title="Save">
+                    <i class="fa-solid fa-floppy-disk"></i>
+                  </button>
+                </form>
+              </td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+    </div>
   </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  document.querySelectorAll('[data-bs-toggle="tooltip"]').forEach(el => new bootstrap.Tooltip(el));
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- compute employee count in supervisor query
- allow reassigning employee supervisors
- add minimalist UI with icons and tooltips
- show employee counts in supervisor list

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_684ac89c25848320b556f02858bfc7ac