### PR TITLE
Fix supervisor dropdown icons and remove employee supervisor editing

### DIFF
--- a/routes/hrRoutes.js
+++ b/routes/hrRoutes.js
@@ -259,22 +259,5 @@ router.post('/operator/supervisor/:id/toggle', isAuthenticated, isOperator, asyn
   res.redirect('/operator/departments');
 });
 
-// POST /operator/employees/:id/change-supervisor - reassign employee creator
-router.post('/operator/employees/:id/change-supervisor', isAuthenticated, isOperator, async (req, res) => {
-  const employeeId = req.params.id;
-  const { supervisor_id } = req.body;
-  if (!supervisor_id) {
-    req.flash('error', 'Missing supervisor.');
-    return res.redirect('/operator/departments');
-  }
-  try {
-    await pool.query('UPDATE employees SET created_by=? WHERE id=?', [supervisor_id, employeeId]);
-    req.flash('success', 'Employee supervisor updated.');
-  } catch (err) {
-    console.error('Error updating employee supervisor:', err);
-    req.flash('error', 'Failed to update employee supervisor.');
-  }
-  res.redirect('/operator/departments');
-});
 
 module.exports = router;

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -6,7 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap" />
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-0FR2E8AI7rHxT2ut9qO0GZBmLFlUPUvz1ouKQEdDHKZt/ffNpAuBdYwVDcXlJ3BhqxEmFIHR7Fl/uhXwFwMjKQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  <!-- Removed integrity attribute which prevented icons from loading -->
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
   <style>
     body {
       font-family: 'Poppins', sans-serif;
@@ -172,18 +173,7 @@
               <td><%= emp.id %></td>
               <td><%= emp.punching_id %></td>
               <td><%= emp.name %></td>
-              <td>
-                <form action="/operator/employees/<%= emp.id %>/change-supervisor" method="POST" class="d-flex">
-                  <select name="supervisor_id" class="form-select form-select-sm me-1">
-                    <% supervisors.forEach(function(s){ %>
-                      <option value="<%= s.id %>" <%= emp.supervisor_name===s.username ? 'selected' : '' %>><%= s.username %></option>
-                    <% }) %>
-                  </select>
-                  <button type="submit" class="btn btn-sm btn-outline-primary" data-bs-toggle="tooltip" title="Save">
-                    <i class="fa-solid fa-floppy-disk"></i>
-                  </button>
-                </form>
-              </td>
+              <td><%= emp.supervisor_name || 'Unassigned' %></td>
             </tr>
           <% }) %>
         </tbody>


### PR DESCRIPTION
## Summary
- remove SRI check for Font Awesome so icons load properly
- display employee supervisor but don't allow editing
- remove route that allowed changing employee supervisor

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684ad07a2c2483209522989dbed850df