### PR TITLE
Improve attendance and salary interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,13 @@ CREATE TABLE IF NOT EXISTS employee_daily_hours (
   employee_id INT NOT NULL,
   work_date DATE NOT NULL,
   hours_worked DECIMAL(5,2) NOT NULL,
+  punch_in TIME NULL,
+  punch_out TIME NULL,
   UNIQUE KEY uniq_emp_day (employee_id, work_date)
 );
 ```
 
-`employee_daily_hours` records how many hours an employee worked on a given day. Later you can calculate under time or overtime by comparing `hours_worked` with the employee's `working_hours`.
+`employee_daily_hours` records how many hours an employee worked on a given day along with the first punch in time and last punch out time. Later you can calculate under time or overtime by comparing `hours_worked` with the employee's `working_hours`.
 
 To track which supervisor created each employee, add a `created_by` column:
 

--- a/helpers/attendanceParser.js
+++ b/helpers/attendanceParser.js
@@ -108,12 +108,14 @@ function parseAttendance(filePath) {
         const dayNum = parseInt(dayCell);
         const dateStr = dayNum ? formatDate(year, month, dayNum) : null;
         let logCell = logRow && typeof logRow[k] === 'string' ? logRow[k] : '';
+        let checkIn = null;
+        let checkOut = null;
         let netMinutes = 0;
         if (logCell && logCell.includes(':')) {
           const times = logCell.split(/\r?\n/).map(t => t.trim()).filter(t => t);
           if (times.length >= 2) {
-            const checkIn = times[0];
-            const checkOut = times[times.length - 1];
+            checkIn = times[0];
+            checkOut = times[times.length - 1];
             const inMins = timeToMinutes(checkIn);
             const outMins = timeToMinutes(checkOut);
             let effectiveIn = inMins;
@@ -129,7 +131,12 @@ function parseAttendance(filePath) {
             netMinutes = rawMinutes - lunchDeduction - latenessDeduction;
           }
         }
-        days.push({ date: dateStr, netHours: parseFloat((netMinutes / 60).toFixed(2)) });
+        days.push({
+          date: dateStr,
+          checkIn,
+          checkOut,
+          netHours: parseFloat((netMinutes / 60).toFixed(2))
+        });
       }
       employees.push({ punchingId: empNo, name: empName, days });
     }
@@ -155,12 +162,14 @@ function parseAttendance(filePath) {
           const dayNum = parseInt(day);
           const dateStr = dayNum ? formatDate(year, month, dayNum) : null;
           const logCell = logRow[k];
+          let checkIn = null;
+          let checkOut = null;
           let netMinutes = 0;
           if (logCell && typeof logCell === 'string') {
             const times = logCell.split(/\r?\n/).map(t => t.trim()).filter(t => t);
             if (times.length >= 2) {
-              const checkIn = times[0];
-              const checkOut = times[times.length - 1];
+              checkIn = times[0];
+              checkOut = times[times.length - 1];
               const inMins = timeToMinutes(checkIn);
               const outMins = timeToMinutes(checkOut);
               let effectiveIn = inMins;
@@ -176,7 +185,12 @@ function parseAttendance(filePath) {
               netMinutes = rawMinutes - lunchDeduction - latenessDeduction;
             }
           }
-          days.push({ date: dateStr, netHours: parseFloat((netMinutes / 60).toFixed(2)) });
+          days.push({
+            date: dateStr,
+            checkIn,
+            checkOut,
+            netHours: parseFloat((netMinutes / 60).toFixed(2))
+          });
         }
         employees.push({ punchingId: empNo, name: empName, days });
         i++; // skip logRow next iteration

--- a/views/employeeAttendance.ejs
+++ b/views/employeeAttendance.ejs
@@ -27,7 +27,10 @@
     <thead class="table-light">
       <tr>
         <th>Date</th>
+        <th>Punch In</th>
+        <th>Punch Out</th>
         <th>Hours Worked</th>
+        <th>Diff (hrs)</th>
         <% if (canEdit) { %><th>Edit</th><% } %>
       </tr>
     </thead>
@@ -35,12 +38,20 @@
       <% attendance.forEach(function(a){ %>
         <tr>
           <td><%= a.work_date.toISOString().split('T')[0] %></td>
+          <td><%= a.punch_in || '-' %></td>
+          <td><%= a.punch_out || '-' %></td>
           <td><%= a.hours_worked %></td>
+          <td>
+            <% const diff = a.hours_worked - employee.working_hours; %>
+            <%= diff.toFixed(2) %>
+          </td>
           <% if (canEdit) { %>
             <td>
               <form action="/operator/employees/<%= employee.id %>/attendance" method="POST" class="d-flex">
                 <input type="hidden" name="date" value="<%= a.work_date.toISOString().split('T')[0] %>">
-                <input type="number" step="0.01" name="hours" value="<%= a.hours_worked %>" class="form-control form-control-sm me-2">
+                <input type="time" name="punch_in" value="<%= a.punch_in %>" class="form-control form-control-sm me-2">
+                <input type="time" name="punch_out" value="<%= a.punch_out %>" class="form-control form-control-sm me-2">
+                <input type="number" step="0.01" name="hours" value="<%= a.hours_worked %>" class="form-control form-control-sm me-2" style="width:90px">
                 <button type="submit" class="btn btn-sm btn-primary">Update</button>
               </form>
             </td>
@@ -52,14 +63,20 @@
   <% if (canEdit) { %>
     <h5>Add / Update Date</h5>
     <form action="/operator/employees/<%= employee.id %>/attendance" method="POST" class="row g-2">
-      <div class="col-sm-4">
+      <div class="col-sm-3">
         <input type="date" name="date" class="form-control" required>
       </div>
-      <div class="col-sm-3">
+      <div class="col-sm-2">
+        <input type="time" name="punch_in" class="form-control" placeholder="In">
+      </div>
+      <div class="col-sm-2">
+        <input type="time" name="punch_out" class="form-control" placeholder="Out">
+      </div>
+      <div class="col-sm-2">
         <input type="number" step="0.01" name="hours" class="form-control" placeholder="Hours" required>
       </div>
-      <div class="col-sm-3">
-        <button type="submit" class="btn btn-success">Save</button>
+      <div class="col-sm-2">
+        <button type="submit" class="btn btn-success w-100">Save</button>
       </div>
     </form>
   <% } %>

--- a/views/employeeHistory.ejs
+++ b/views/employeeHistory.ejs
@@ -26,14 +26,20 @@
         <thead class="table-light">
           <tr>
             <th>Date</th>
+            <th>Punch In</th>
+            <th>Punch Out</th>
             <th>Hours Worked</th>
+            <th>Diff (hrs)</th>
           </tr>
         </thead>
         <tbody>
           <% p.attendance.forEach(function(a){ %>
             <tr>
               <td><%= a.work_date.toISOString().split('T')[0] %></td>
+              <td><%= a.punch_in || '-' %></td>
+              <td><%= a.punch_out || '-' %></td>
               <td><%= a.hours_worked %></td>
+              <td><%= (a.hours_worked - employee.working_hours).toFixed(2) %></td>
             </tr>
           <% }) %>
         </tbody>

--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -14,11 +14,18 @@
   </div>
 </nav>
 <div class="container">
-  <h4><%= employee.name %> | Punching ID: <%= employee.punching_id %></h4>
-  <p>Period: <%= startDate %> to <%= endDate %></p>
-  <p>Total Hours Worked: <%= totalHours.toFixed(2) %></p>
-  <p>Hourly Rate: ₹<%= hourlyRate.toFixed(2) %></p>
-  <h5>Salary According to Attendance: ₹<%= salary.toFixed(2) %></h5>
+  <div class="card">
+    <div class="card-header">Salary Summary</div>
+    <div class="card-body">
+      <h5 class="card-title"><%= employee.name %> | Punching ID: <%= employee.punching_id %></h5>
+      <p class="mb-1">Period: <%= startDate %> to <%= endDate %></p>
+      <p class="mb-1">Total Hours Worked: <%= totalHours.toFixed(2) %></p>
+      <p class="mb-1">Expected Hours: <%= expected.toFixed(2) %></p>
+      <p class="mb-1">Difference: <%= diff.toFixed(2) %> hrs</p>
+      <p class="mb-1">Hourly Rate: ₹<%= hourlyRate.toFixed(2) %></p>
+      <h5 class="mt-3">Payable Salary: ₹<%= salary.toFixed(2) %></h5>
+    </div>
+  </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- track punch in/out times in attendance parser and DB inserts
- show punch in/out and daily diff in attendance history
- redesign salary summary card and include expected hours difference
- document new `punch_in` and `punch_out` columns

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684c0e77920883208b87da534153d08f