### PR TITLE
Add Sunday tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,35 @@ ALTER TABLE employees
 The index name `punching_id` comes from the original schema. After dropping it
 we create a composite unique index on `(punching_id, created_by)` so each
 supervisor can reuse punching IDs without clashes.
+
+### Sunday tracking and paid leave
+
+To support rules around Sunday work and paid leave balances, add these columns:
+
+```sql
+ALTER TABLE employees
+  ADD COLUMN pays_sunday TINYINT(1) NOT NULL DEFAULT 0,
+  ADD COLUMN paid_leave_balance DECIMAL(5,2) NOT NULL DEFAULT 0;
+
+ALTER TABLE employee_daily_hours
+  ADD COLUMN is_sunday TINYINT(1) NOT NULL DEFAULT 0;
+```
+
+`pays_sunday` indicates whether an employee receives regular salary for Sundays.
+Each record in `employee_daily_hours` now stores whether the date was a Sunday
+via the `is_sunday` column, enabling future salary rules like the sandwich rule
+and Sunday deductions.
+
+### Financial tracking
+
+Employees now track advances, debits, and night shifts. Add these columns:
+
+```sql
+ALTER TABLE employees
+  ADD COLUMN advance_balance DECIMAL(10,2) NOT NULL DEFAULT 0,
+  ADD COLUMN debit_balance DECIMAL(10,2) NOT NULL DEFAULT 0,
+  ADD COLUMN nights_worked INT NOT NULL DEFAULT 0;
+```
+
+`advance_balance` and `debit_balance` store outstanding amounts that will be deducted from salary.
+`nights_worked` counts how many night shifts were performed in the current period and can be edited by supervisors.

--- a/views/attendance.ejs
+++ b/views/attendance.ejs
@@ -23,8 +23,8 @@
     <form action="/attendance/upload" method="POST" enctype="multipart/form-data" class="mb-4">
       <div class="row g-3 align-items-end">
         <div class="col-md-5">
-          <label class="form-label">Attendance File (.xlsx)</label>
-          <input type="file" name="attendanceFile" accept=".xlsx" class="form-control" required>
+          <label class="form-label">Attendance File (.xlsx or .json)</label>
+          <input type="file" name="attendanceFile" accept=".xlsx,.json" class="form-control" required>
         </div>
         <div class="col-md-5">
           <label class="form-label">Salary File (.xlsx)</label>

--- a/views/employeeEdit.ejs
+++ b/views/employeeEdit.ejs
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Edit Employee</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-dark bg-dark mb-3">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">Dashboard</a>
+    <span class="navbar-text text-white">Logged in as <%= user.username %></span>
+    <a href="/logout" class="btn btn-outline-light btn-sm ms-2">Logout</a>
+  </div>
+</nav>
+<div class="container">
+  <%- include('partials/flashMessages') %>
+  <h4>Edit Details - <%= employee.name %></h4>
+  <form action="/supervisor/employees/<%= employee.id %>/edit" method="POST" class="row g-3">
+    <div class="col-md-3">
+      <label class="form-label">Pays Sunday</label>
+      <select name="pays_sunday" class="form-select">
+        <option value="0" <%= employee.pays_sunday ? '' : 'selected' %>>No</option>
+        <option value="1" <%= employee.pays_sunday ? 'selected' : '' %>>Yes</option>
+      </select>
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Advance Balance</label>
+      <input type="number" step="0.01" name="advance_balance" value="<%= employee.advance_balance || 0 %>" class="form-control">
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Debit Balance</label>
+      <input type="number" step="0.01" name="debit_balance" value="<%= employee.debit_balance || 0 %>" class="form-control">
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Nights Worked</label>
+      <input type="number" name="nights_worked" value="<%= employee.nights_worked || 0 %>" class="form-control">
+    </div>
+    <div class="col-md-3">
+      <label class="form-label">Paid Leave Balance</label>
+      <input type="number" step="0.1" name="paid_leave_balance" value="<%= employee.paid_leave_balance || 0 %>" class="form-control">
+    </div>
+    <div class="col-12">
+      <button type="submit" class="btn btn-primary">Save</button>
+      <a href="/supervisor/employees" class="btn btn-secondary ms-2">Cancel</a>
+    </div>
+  </form>
+</div>
+</body>
+</html>

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -190,7 +190,7 @@
     <div class="card-body">
       <form action="/operator/upload-attendance" method="POST" enctype="multipart/form-data" class="row g-2">
         <div class="col-sm-8">
-          <input type="file" name="attendanceFile" accept=".xlsx" class="form-control" required>
+          <input type="file" name="attendanceFile" accept=".xlsx,.json" class="form-control" required>
         </div>
         <div class="col-sm-4">
           <button type="submit" class="btn btn-primary w-100">Upload</button>

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -67,6 +67,10 @@
           <th>Salary Type</th>
           <th>Amount</th>
           <th>Phone</th>
+          <th>Pays Sun</th>
+          <th>Advance</th>
+          <th>Debit</th>
+          <th>Nights</th>
           <th>Status</th>
           <th>Created</th>
           <th>Last Salary</th>
@@ -83,6 +87,10 @@
             <td class="text-capitalize"><%= emp.salary_type %></td>
             <td><%= emp.salary_amount %></td>
             <td><%= emp.phone || '' %></td>
+            <td><%= emp.pays_sunday ? 'Yes' : 'No' %></td>
+            <td><%= emp.advance_balance || 0 %></td>
+            <td><%= emp.debit_balance || 0 %></td>
+            <td><%= emp.nights_worked || 0 %></td>
             <td><%= emp.is_active ? 'Active' : 'Inactive' %></td>
             <td><%= new Date(emp.created_at).toLocaleDateString() %></td>
             <td>₹<%= (emp.lastSalary || 0).toFixed(2) %></td>
@@ -94,8 +102,9 @@
                 </button>
               </form>
               <a href="/supervisor/employees/<%= emp.id %>/salary" class="btn btn-sm btn-secondary me-1">Salary</a>
-              <a href="/supervisor/employees/<%= emp.id %>/history" class="btn btn-sm btn-info">View</a>
-            </td>
+              <a href="/supervisor/employees/<%= emp.id %>/history" class="btn btn-sm btn-info me-1">View</a>
+              <a href="/supervisor/employees/<%= emp.id %>/edit" class="btn btn-sm btn-warning">Edit</a>
+              </td>
           </tr>
         <% }) %>
       </tbody>


### PR DESCRIPTION
## Summary
- capture Sunday info when parsing attendance
- store `is_sunday` flag on attendance records
- document DB columns for Sunday rules
- allow supervisors to edit paid Sunday, advance, debit and night details
- expose those details on the employee list

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d1c1b27688320bb1ba889eebe6229