### PR TITLE
Add monthly salary deductions

### DIFF
--- a/views/employeeHistory.ejs
+++ b/views/employeeHistory.ejs
@@ -15,12 +15,16 @@
 </nav>
 <div class="container">
   <h4><%= employee.name %> | Punching ID: <%= employee.punching_id %></h4>
+  <p>Status: <%= employee.is_active ? 'Active' : 'Inactive' %></p>
   <% if (periods.length === 0) { %>
     <p>No attendance data available.</p>
   <% } %>
   <% periods.forEach(function(p){ %>
     <div class="mb-4">
-      <h5><%= p.startDate %> to <%= p.endDate %> - Salary: ₹<%= p.salary.toFixed(2) %></h5>
+      <h5><%= p.startDate %> to <%= p.endDate %> - Gross Salary: ₹<%= p.salary.toFixed(2) %></h5>
+      <p>Night Allowance: ₹<%= p.nightAllowance.toFixed(2) %></p>
+      <p>Advance Deduction: ₹<%= employee.advance_balance.toFixed(2) %> | Debit Deduction: ₹<%= employee.debit_balance.toFixed(2) %></p>
+      <p>Net Salary: ₹<%= p.netSalary.toFixed(2) %></p>
       <p>Total Worked: <%= p.totalHours.toFixed(2) %> hrs (<%= p.diff >= 0 ? 'Overtime' : 'Undertime' %> by <%= Math.abs(p.diff).toFixed(2) %> hrs)</p>
       <table class="table table-bordered">
         <thead class="table-light">

--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -23,7 +23,11 @@
       <p class="mb-1">Expected Hours: <%= expected.toFixed(2) %></p>
       <p class="mb-1">Difference: <%= diff.toFixed(2) %> hrs</p>
       <p class="mb-1">Hourly Rate: ₹<%= hourlyRate.toFixed(2) %></p>
-      <h5 class="mt-3">Payable Salary: ₹<%= salary.toFixed(2) %></h5>
+      <p class="mb-1">Advance Deduction: ₹<%= employee.advance_balance.toFixed(2) %></p>
+      <p class="mb-1">Debit Deduction: ₹<%= employee.debit_balance.toFixed(2) %></p>
+      <p class="mb-1">Night Allowance (<%= employee.nights_worked %> nights): ₹<%= nightAllowance.toFixed(2) %></p>
+      <h5 class="mt-3">Gross Salary: ₹<%= salary.toFixed(2) %></h5>
+      <h5 class="mt-2">Net Payable Salary: ₹<%= netSalary.toFixed(2) %></h5>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- show employee status in history view
- include nights, advances and debits when calculating salary
- display deduction details in salary pages
- prorate monthly salary by the number of attendance days

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d329e0b748320a28dfe32644ca53f