### PR TITLE
Add store admin inventory management

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,6 +75,7 @@ const editCuttingLotRoutes = require("./routes/editcuttinglots.js");
 const washingIN = require('./routes/washingInRoutes');
 const catalogR = require('./routes/catalogupload');
 const inventoryRoutes = require('./routes/inventoryRoutes');
+const storeAdminRoutes = require('./routes/storeAdminRoutes');
 
 // Use Routes
 app.use('/', authRoutes);
@@ -95,6 +96,7 @@ app.use('/', bulkUploadRoutes);
 app.use('/washingin', washingIN);
 app.use('/catalogupload', catalogR);
 app.use('/inventory', inventoryRoutes);
+app.use('/store-admin', storeAdminRoutes);
 
 // Home Route
 app.get('/', (req, res) => {

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -109,6 +109,10 @@ function isDepartmentUser(req, res, next) {
     res.redirect('/');
 }
 
+function isStoreAdmin(req, res, next) {
+    return hasRole('store_admin')(req, res, next);
+}
+
 function isStoreEmployee(req, res, next) {
     return hasRole('store_employee')(req, res, next);
 }
@@ -128,5 +132,6 @@ module.exports = {
     isPaymentAuthoriser,
     isWashingInMaster,
     isCatalogUpload,
+    isStoreAdmin,
     isStoreEmployee
 };

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -79,9 +79,12 @@ router.post('/login', async (req, res) => {
       case 'jeans_assembly':
           res.redirect('/jeansassemblydashboard');
           break;
-        case 'washing_in':            // New case for washing in
-          res.redirect('/washingin');
-          break;
+      case 'washing_in':            // New case for washing in
+        res.redirect('/washingin');
+        break;
+      case 'store_admin':
+        res.redirect('/store-admin/dashboard');
+        break;
       case 'store_employee':
         res.redirect('/inventory/dashboard');
         break;

--- a/routes/storeAdminRoutes.js
+++ b/routes/storeAdminRoutes.js
@@ -1,0 +1,101 @@
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isStoreAdmin } = require('../middlewares/auth');
+
+// Dashboard for store admin
+router.get('/dashboard', isAuthenticated, isStoreAdmin, async (req, res) => {
+  try {
+    const [goods] = await pool.query('SELECT * FROM goods_inventory ORDER BY description_of_goods, size');
+    const [dispatched] = await pool.query(`SELECT d.*, g.description_of_goods, g.size, g.unit
+                                            FROM dispatched_data d
+                                            JOIN goods_inventory g ON d.goods_id = g.id
+                                            ORDER BY d.dispatched_at DESC LIMIT 200`);
+    res.render('storeAdminDashboard', { user: req.session.user, goods, dispatched });
+  } catch (err) {
+    console.error('Error loading store admin dashboard:', err);
+    req.flash('error', 'Could not load dashboard');
+    res.redirect('/');
+  }
+});
+
+// Create new goods item
+router.post('/create-item', isAuthenticated, isStoreAdmin, async (req, res) => {
+  const { description, size, unit } = req.body;
+  if (!description || !size || !unit) {
+    req.flash('error', 'All fields are required');
+    return res.redirect('/store-admin/dashboard');
+  }
+  try {
+    await pool.query('INSERT INTO goods_inventory (description_of_goods, size, unit, qty) VALUES (?, ?, ?, 0)', [description, size, unit]);
+    req.flash('success', 'Item created');
+    res.redirect('/store-admin/dashboard');
+  } catch (err) {
+    console.error('Error creating item:', err);
+    req.flash('error', 'Could not create item');
+    res.redirect('/store-admin/dashboard');
+  }
+});
+
+// Add quantity
+router.post('/add', isAuthenticated, isStoreAdmin, async (req, res) => {
+  const goodsId = req.body.goods_id;
+  const qty = parseInt(req.body.quantity, 10);
+  if (!goodsId || isNaN(qty) || qty <= 0) {
+    req.flash('error', 'Invalid quantity');
+    return res.redirect('/store-admin/dashboard');
+  }
+  let conn;
+  try {
+    conn = await pool.getConnection();
+    await conn.beginTransaction();
+    await conn.query('INSERT INTO incoming_data (goods_id, quantity, added_by, added_at) VALUES (?, ?, ?, NOW())',
+      [goodsId, qty, req.session.user.id]);
+    await conn.query('UPDATE goods_inventory SET qty = qty + ? WHERE id = ?', [qty, goodsId]);
+    await conn.commit();
+    req.flash('success', 'Quantity added');
+  } catch (err) {
+    if (conn) await conn.rollback();
+    console.error('Error adding quantity:', err);
+    req.flash('error', 'Could not add quantity');
+  } finally {
+    if (conn) conn.release();
+  }
+  res.redirect('/store-admin/dashboard');
+});
+
+// Dispatch goods
+router.post('/dispatch', isAuthenticated, isStoreAdmin, async (req, res) => {
+  const goodsId = req.body.goods_id;
+  const qty = parseInt(req.body.quantity, 10);
+  const remark = req.body.remark || null;
+  if (!goodsId || isNaN(qty) || qty <= 0) {
+    req.flash('error', 'Invalid quantity');
+    return res.redirect('/store-admin/dashboard');
+  }
+  let conn;
+  try {
+    conn = await pool.getConnection();
+    await conn.beginTransaction();
+    const [[row]] = await conn.query('SELECT qty FROM goods_inventory WHERE id = ?', [goodsId]);
+    if (!row || row.qty < qty) {
+      req.flash('error', 'Quantity exceeds available');
+      await conn.rollback();
+      return res.redirect('/store-admin/dashboard');
+    }
+    await conn.query('INSERT INTO dispatched_data (goods_id, quantity, remark, dispatched_by, dispatched_at) VALUES (?, ?, ?, ?, NOW())',
+      [goodsId, qty, remark, req.session.user.id]);
+    await conn.query('UPDATE goods_inventory SET qty = qty - ? WHERE id = ?', [qty, goodsId]);
+    await conn.commit();
+    req.flash('success', 'Goods dispatched');
+  } catch (err) {
+    if (conn) await conn.rollback();
+    console.error('Error dispatching goods:', err);
+    req.flash('error', 'Could not dispatch goods');
+  } finally {
+    if (conn) conn.release();
+  }
+  res.redirect('/store-admin/dashboard');
+});
+
+module.exports = router;

--- a/views/storeAdminDashboard.ejs
+++ b/views/storeAdminDashboard.ejs
@@ -1,0 +1,160 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Store Admin Inventory</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" rel="stylesheet">
+  <style>
+    .low-stock { background-color: #f8d7da; }
+  </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="#">Store Admin</a>
+    <div class="ms-auto">
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container my-4">
+  <%- include('partials/flashMessages') %>
+  <form action="/store-admin/create-item" method="POST" class="row g-3 mb-4">
+    <div class="col-md-4">
+      <label class="form-label">Description</label>
+      <input type="text" name="description" class="form-control" required>
+    </div>
+    <div class="col-md-2">
+      <label class="form-label">Size</label>
+      <input type="text" name="size" class="form-control" required>
+    </div>
+    <div class="col-md-2">
+      <label class="form-label">Unit</label>
+      <input type="text" name="unit" class="form-control" required>
+    </div>
+    <div class="col-md-2 align-self-end">
+      <button type="submit" class="btn btn-success">Create Item</button>
+    </div>
+  </form>
+  <ul class="nav nav-tabs" id="invTabs" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="add-tab" data-bs-toggle="tab" data-bs-target="#addTab" type="button" role="tab">Add Quantity</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="dispatch-tab" data-bs-toggle="tab" data-bs-target="#dispatchTab" type="button" role="tab">Dispatch Goods</button>
+    </li>
+  </ul>
+  <div class="tab-content mt-3">
+    <div class="tab-pane fade show active" id="addTab" role="tabpanel">
+      <form action="/store-admin/add" method="POST" class="row g-3">
+        <div class="col-md-6">
+          <label class="form-label">Item</label>
+          <input list="goodsList" id="addItem" class="form-control" required>
+          <input type="hidden" name="goods_id" id="addGoodsId">
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Quantity</label>
+          <input type="number" name="quantity" class="form-control" required min="1">
+        </div>
+        <div class="col-md-3 align-self-end">
+          <button type="submit" class="btn btn-primary">Add</button>
+        </div>
+      </form>
+    </div>
+    <div class="tab-pane fade" id="dispatchTab" role="tabpanel">
+      <form action="/store-admin/dispatch" method="POST" class="row g-3">
+        <div class="col-md-6">
+          <label class="form-label">Item</label>
+          <input list="goodsList" id="dispatchItem" class="form-control" required>
+          <input type="hidden" name="goods_id" id="dispatchGoodsId">
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Quantity</label>
+          <input type="number" name="quantity" class="form-control" required min="1">
+        </div>
+        <div class="col-md-3">
+          <label class="form-label">Remark</label>
+          <input type="text" name="remark" class="form-control">
+        </div>
+        <div class="col-12">
+          <button type="submit" class="btn btn-warning">Dispatch</button>
+        </div>
+      </form>
+    </div>
+  </div>
+  <datalist id="goodsList">
+    <% goods.forEach(g => { %>
+      <option data-id="<%= g.id %>" value="<%= g.description_of_goods %> - <%= g.size %> - <%= g.unit %>"></option>
+    <% }) %>
+  </datalist>
+
+  <h4 class="mt-4">Current Inventory</h4>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Description</th>
+          <th>Size</th>
+          <th>Unit</th>
+          <th>Qty</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% goods.forEach(g => { %>
+          <tr class="<%= g.qty == 100 ? 'low-stock' : '' %>">
+            <td><%= g.description_of_goods %></td>
+            <td><%= g.size %></td>
+            <td><%= g.unit %></td>
+            <td><%= g.qty %></td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="d-flex justify-content-between mt-3">
+    <a href="/inventory/download/incoming" class="btn btn-success btn-sm">Download Incoming Excel</a>
+    <a href="/inventory/download/dispatched" class="btn btn-success btn-sm">Download Dispatched Excel</a>
+  </div>
+
+  <h4 class="mt-4">Recent Dispatches</h4>
+  <div class="table-responsive">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Item</th>
+          <th>Qty</th>
+          <th>Remark</th>
+          <th>Date</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% dispatched.forEach(d => { %>
+          <tr>
+            <td><%= d.description_of_goods %> - <%= d.size %> <%= d.unit %></td>
+            <td><%= d.quantity %></td>
+            <td><%= d.remark || '' %></td>
+            <td><%= d.dispatched_at.toISOString().slice(0,16).replace('T',' ') %></td>
+          </tr>
+        <% }) %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  function bindDatalist(inputId, hiddenId) {
+    const input = document.getElementById(inputId);
+    const hidden = document.getElementById(hiddenId);
+    input.addEventListener('input', function() {
+      const option = document.querySelector(`#goodsList option[value="${this.value}"]`);
+      hidden.value = option ? option.dataset.id : '';
+    });
+  }
+  bindDatalist('addItem', 'addGoodsId');
+  bindDatalist('dispatchItem', 'dispatchGoodsId');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow store_admin role for auth
- redirect store_admin to new dashboard on login
- implement inventory management routes for store_admin
- expose new /store-admin route in app
- create storeAdminDashboard view with datalist search

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_6853e58b87488320b7e31e1e4e2a70e8