### PR TITLE
Add search dropdown and live inventory filter

### DIFF
--- a/views/inventoryDashboard.ejs
+++ b/views/inventoryDashboard.ejs
@@ -34,11 +34,8 @@
       <form action="/inventory/add" method="POST" class="row g-3">
         <div class="col-md-6">
           <label class="form-label">Item</label>
-          <select name="goods_id" class="form-select" required>
-            <% goods.forEach(g => { %>
-              <option value="<%= g.id %>"><%= g.description_of_goods %> - <%= g.size %> - <%= g.unit %></option>
-            <% }) %>
-          </select>
+          <input list="goodsList" id="addItem" class="form-control" required>
+          <input type="hidden" name="goods_id" id="addGoodsId">
         </div>
         <div class="col-md-3">
           <label class="form-label">Quantity</label>
@@ -53,11 +50,8 @@
       <form action="/inventory/dispatch" method="POST" class="row g-3">
         <div class="col-md-6">
           <label class="form-label">Item</label>
-          <select name="goods_id" class="form-select" required>
-            <% goods.forEach(g => { %>
-              <option value="<%= g.id %>"><%= g.description_of_goods %> - <%= g.size %> - <%= g.unit %></option>
-            <% }) %>
-          </select>
+          <input list="goodsList" id="dispatchItem" class="form-control" required>
+          <input type="hidden" name="goods_id" id="dispatchGoodsId">
         </div>
         <div class="col-md-3">
           <label class="form-label">Quantity</label>
@@ -73,10 +67,19 @@
       </form>
     </div>
   </div>
+  <datalist id="goodsList">
+    <% goods.forEach(g => { %>
+      <option data-id="<%= g.id %>" value="<%= g.description_of_goods %> - <%= g.size %> - <%= g.unit %>"></option>
+    <% }) %>
+  </datalist>
 
   <h4 class="mt-4">Current Inventory</h4>
+  <div class="input-group mb-3">
+    <span class="input-group-text"><i class="fas fa-search"></i></span>
+    <input type="text" id="inventorySearch" class="form-control" placeholder="Search inventory..." />
+  </div>
   <div class="table-responsive">
-    <table class="table table-bordered">
+    <table class="table table-bordered" id="inventoryTable">
       <thead>
         <tr>
           <th>Description</th>
@@ -128,5 +131,27 @@
   </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  function bindDatalist(inputId, hiddenId) {
+    const input = document.getElementById(inputId);
+    const hidden = document.getElementById(hiddenId);
+    input.addEventListener('input', function () {
+      const option = document.querySelector(`#goodsList option[value="${this.value}"]`);
+      hidden.value = option ? option.dataset.id : '';
+    });
+  }
+  bindDatalist('addItem', 'addGoodsId');
+  bindDatalist('dispatchItem', 'dispatchGoodsId');
+
+  const inventorySearch = document.getElementById('inventorySearch');
+  const inventoryTable = document.getElementById('inventoryTable');
+  inventorySearch.addEventListener('input', () => {
+    const filter = inventorySearch.value.toLowerCase();
+    inventoryTable.querySelectorAll('tbody tr').forEach(tr => {
+      const text = tr.textContent.toLowerCase();
+      tr.style.display = text.includes(filter) ? '' : 'none';
+    });
+  });
+</script>
 </body>
 </html>

--- a/views/storeAdminDashboard.ejs
+++ b/views/storeAdminDashboard.ejs
@@ -91,8 +91,12 @@
   </datalist>
 
   <h4 class="mt-4">Current Inventory</h4>
+  <div class="input-group mb-3">
+    <span class="input-group-text"><i class="fas fa-search"></i></span>
+    <input type="text" id="inventorySearch" class="form-control" placeholder="Search inventory..." />
+  </div>
   <div class="table-responsive">
-    <table class="table table-bordered">
+    <table class="table table-bordered" id="inventoryTable">
       <thead>
         <tr>
           <th>Description</th>
@@ -155,6 +159,16 @@
   }
   bindDatalist('addItem', 'addGoodsId');
   bindDatalist('dispatchItem', 'dispatchGoodsId');
+
+  const inventorySearch = document.getElementById('inventorySearch');
+  const inventoryTable = document.getElementById('inventoryTable');
+  inventorySearch.addEventListener('input', () => {
+    const filter = inventorySearch.value.toLowerCase();
+    inventoryTable.querySelectorAll('tbody tr').forEach(tr => {
+      const text = tr.textContent.toLowerCase();
+      tr.style.display = text.includes(filter) ? '' : 'none';
+    });
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replicate datalist item selection in the inventory dashboard
- provide inventory search bars on both dashboards
- implement client-side filtering for inventory tables

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853e943ad808320979623881457273c