### PR TITLE
Add edit feature for store admin goods

### DIFF
--- a/routes/storeAdminRoutes.js
+++ b/routes/storeAdminRoutes.js
@@ -98,4 +98,24 @@ router.post('/dispatch', isAuthenticated, isStoreAdmin, async (req, res) => {
   res.redirect('/store-admin/dashboard');
 });
 
+// Update existing goods item
+router.post('/update-item', isAuthenticated, isStoreAdmin, async (req, res) => {
+  const { goods_id, description, size, unit } = req.body;
+  if (!goods_id || !description || !size || !unit) {
+    req.flash('error', 'All fields are required');
+    return res.redirect('/store-admin/dashboard');
+  }
+  try {
+    await pool.query(
+      'UPDATE goods_inventory SET description_of_goods = ?, size = ?, unit = ? WHERE id = ?',
+      [description, size, unit, goods_id]
+    );
+    req.flash('success', 'Item updated');
+  } catch (err) {
+    console.error('Error updating item:', err);
+    req.flash('error', 'Could not update item');
+  }
+  res.redirect('/store-admin/dashboard');
+});
+
 module.exports = router;

--- a/views/storeAdminDashboard.ejs
+++ b/views/storeAdminDashboard.ejs
@@ -103,6 +103,7 @@
           <th>Size</th>
           <th>Unit</th>
           <th>Qty</th>
+          <th>Actions</th>
         </tr>
       </thead>
       <tbody>
@@ -112,6 +113,12 @@
             <td><%= g.size %></td>
             <td><%= g.unit %></td>
             <td><%= g.qty %></td>
+            <td>
+              <button type="button" class="btn btn-sm btn-warning" data-bs-toggle="modal" data-bs-target="#editItemModal"
+                      data-id="<%= g.id %>" data-description="<%= g.description_of_goods %>" data-size="<%= g.size %>" data-unit="<%= g.unit %>">
+                <i class="bi bi-pencil-square"></i> Edit
+              </button>
+            </td>
           </tr>
         <% }) %>
       </tbody>
@@ -146,6 +153,39 @@
       </tbody>
     </table>
   </div>
+
+  <!-- Edit Item Modal -->
+  <div class="modal fade" id="editItemModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <form id="editItemForm" action="/store-admin/update-item" method="POST">
+          <input type="hidden" name="goods_id" id="editGoodsId">
+          <div class="modal-header">
+            <h5 class="modal-title">Edit Item</h5>
+            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+          </div>
+          <div class="modal-body">
+            <div class="mb-3">
+              <label class="form-label">Description</label>
+              <input type="text" class="form-control" name="description" id="editDescription" required>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Size</label>
+              <input type="text" class="form-control" name="size" id="editSize" required>
+            </div>
+            <div class="mb-3">
+              <label class="form-label">Unit</label>
+              <input type="text" class="form-control" name="unit" id="editUnit" required>
+            </div>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button type="submit" class="btn btn-primary">Save</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
@@ -159,6 +199,17 @@
   }
   bindDatalist('addItem', 'addGoodsId');
   bindDatalist('dispatchItem', 'dispatchGoodsId');
+
+  const editItemModal = document.getElementById('editItemModal');
+  if (editItemModal) {
+    editItemModal.addEventListener('show.bs.modal', event => {
+      const button = event.relatedTarget;
+      document.getElementById('editGoodsId').value = button.getAttribute('data-id');
+      document.getElementById('editDescription').value = button.getAttribute('data-description');
+      document.getElementById('editSize').value = button.getAttribute('data-size');
+      document.getElementById('editUnit').value = button.getAttribute('data-unit');
+    });
+  }
 
   const inventorySearch = document.getElementById('inventorySearch');
   const inventoryTable = document.getElementById('inventoryTable');


### PR DESCRIPTION
## Summary
- allow store admins to modify existing goods information
- add Edit button and modal on store admin dashboard
- support saving updated description, size and unit

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6853fa32866083209a6b6422c4141dc5