### PR TITLE
Add employee search and salary overview

### DIFF
--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -101,6 +101,18 @@
       </div>
     </form>
 
+    <% if (overview) { %>
+    <div class="card mb-3">
+      <div class="card-body">
+        <h5 class="card-title">Salary Overview</h5>
+        <p class="mb-1">Total Salary of Active Employees: <strong><%= overview.totalSalaryAll %></strong></p>
+        <p class="mb-1">Total Supervisors: <strong><%= overview.totalSupervisors %></strong></p>
+        <p class="mb-1">Supervisor with Most Employees: <strong><%= overview.topEmployeeSupervisor %></strong> (<%= overview.topEmployeeCount %>)</p>
+        <p class="mb-0">Supervisor with Highest Salary: <strong><%= overview.topSalarySupervisor %></strong> (<%= overview.topSalaryAmount %>)</p>
+      </div>
+    </div>
+    <% } %>
+
 
     <div class="table-responsive">
       <table class="table table-bordered">

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -68,6 +68,9 @@
     </div>
   </form>
   <h4>My Employees</h4>
+  <div class="mb-3 col-md-4 px-0">
+    <input type="text" id="employeeSearch" class="form-control" placeholder="Search employees">
+  </div>
   <div class="table-responsive">
     <table class="table table-bordered">
       <thead>
@@ -117,6 +120,15 @@
 <script>
   const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
   tooltipTriggerList.forEach(t => new bootstrap.Tooltip(t));
+
+  const searchInput = document.getElementById('employeeSearch');
+  const rows = Array.from(document.querySelectorAll('table tbody tr'));
+  searchInput.addEventListener('input', () => {
+    const q = searchInput.value.toLowerCase();
+    rows.forEach(r => {
+      r.style.display = r.textContent.toLowerCase().includes(q) ? '' : 'none';
+    });
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add live client-side search on supervisor employee list
- provide salary overview for operator departments
- show overall salary info in table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863a01ad1808320a745bc40ffa0adfc