### PR TITLE
Improve operator pages UI

### DIFF
--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -253,15 +253,65 @@
     <!-- Advanced Analytics Panel -->
     <div class="data-panel mb-4">
       <div class="panel-header"><i class="bi bi-graph-up-arrow"></i> Advanced Stats</div>
-      <div class="panel-body row text-center">
-        <div class="col-md-3"><strong>Stitch Conversion:</strong><br><%= advancedAnalytics.stitchConversion %>%</div>
-        <div class="col-md-3"><strong>Wash Conversion:</strong><br><%= advancedAnalytics.washConversion %>%</div>
-        <div class="col-md-3"><strong>Finish Conversion:</strong><br><%= advancedAnalytics.finishConversion %>%</div>
-        <div class="col-md-3"><strong>Avg Turnaround:</strong><br><%= advancedAnalytics.avgTurnaroundTime %> days</div>
-        <div class="col-md-3 mt-3"><strong>Pending Kits:</strong><br><%= advancedAnalytics.pendingLots %></div>
-        <div class="col-md-3 mt-3"><strong>Total Kits:</strong><br><%= advancedAnalytics.totalLots %></div>
-        <div class="col-md-3 mt-3"><strong>Stitch Approval:</strong><br><%= advancedAnalytics.stitchApprovalRate %>%</div>
-        <div class="col-md-3 mt-3"><strong>Wash Approval:</strong><br><%= advancedAnalytics.washApprovalRate %>%</div>
+      <div class="panel-body">
+        <div class="row row-cols-2 row-cols-md-4 g-3 text-center">
+          <div class="col">
+            <div class="stat-box py-3 h-100">
+              <i class="bi bi-speedometer text-primary fs-3"></i>
+              <div class="stat-title">Stitch Conversion</div>
+              <div class="stat-value"><%= advancedAnalytics.stitchConversion %>%</div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="stat-box py-3 h-100">
+              <i class="bi bi-droplet-half text-primary fs-3"></i>
+              <div class="stat-title">Wash Conversion</div>
+              <div class="stat-value"><%= advancedAnalytics.washConversion %>%</div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="stat-box py-3 h-100">
+              <i class="bi bi-check2-square text-primary fs-3"></i>
+              <div class="stat-title">Finish Conversion</div>
+              <div class="stat-value"><%= advancedAnalytics.finishConversion %>%</div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="stat-box py-3 h-100">
+              <i class="bi bi-clock-history text-primary fs-3"></i>
+              <div class="stat-title">Avg Turnaround</div>
+              <div class="stat-value"><%= advancedAnalytics.avgTurnaroundTime %> days</div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="stat-box py-3 h-100">
+              <i class="bi bi-hourglass-split text-primary fs-3"></i>
+              <div class="stat-title">Pending Kits</div>
+              <div class="stat-value"><%= advancedAnalytics.pendingLots %></div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="stat-box py-3 h-100">
+              <i class="bi bi-collection text-primary fs-3"></i>
+              <div class="stat-title">Total Kits</div>
+              <div class="stat-value"><%= advancedAnalytics.totalLots %></div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="stat-box py-3 h-100">
+              <i class="bi bi-file-check text-primary fs-3"></i>
+              <div class="stat-title">Stitch Approval</div>
+              <div class="stat-value"><%= advancedAnalytics.stitchApprovalRate %>%</div>
+            </div>
+          </div>
+          <div class="col">
+            <div class="stat-box py-3 h-100">
+              <i class="bi bi-file-check-fill text-primary fs-3"></i>
+              <div class="stat-title">Wash Approval</div>
+              <div class="stat-value"><%= advancedAnalytics.washApprovalRate %>%</div>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
 

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -102,13 +102,42 @@
     </form>
 
     <% if (overview) { %>
-    <div class="card mb-3">
-      <div class="card-body">
-        <h5 class="card-title">Salary Overview</h5>
-        <p class="mb-1">Total Salary of Active Employees: <strong><%= overview.totalSalaryAll %></strong></p>
-        <p class="mb-1">Total Supervisors: <strong><%= overview.totalSupervisors %></strong></p>
-        <p class="mb-1">Supervisor with Most Employees: <strong><%= overview.topEmployeeSupervisor %></strong> (<%= overview.topEmployeeCount %>)</p>
-        <p class="mb-0">Supervisor with Highest Salary: <strong><%= overview.topSalarySupervisor %></strong> (<%= overview.topSalaryAmount %>)</p>
+    <div class="row row-cols-1 row-cols-md-2 row-cols-lg-4 g-3 mb-4">
+      <div class="col">
+        <div class="card h-100 text-center border-0 shadow-sm">
+          <div class="card-body">
+            <i class="bi bi-cash-stack fs-2 text-primary"></i>
+            <h6 class="mt-2 text-muted">Total Salary</h6>
+            <div class="fs-5 fw-semibold"><%= overview.totalSalaryAll %></div>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="card h-100 text-center border-0 shadow-sm">
+          <div class="card-body">
+            <i class="bi bi-people-fill fs-2 text-primary"></i>
+            <h6 class="mt-2 text-muted">Total Supervisors</h6>
+            <div class="fs-5 fw-semibold"><%= overview.totalSupervisors %></div>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="card h-100 text-center border-0 shadow-sm">
+          <div class="card-body">
+            <i class="bi bi-person-workspace fs-2 text-primary"></i>
+            <h6 class="mt-2 text-muted">Most Employees</h6>
+            <div class="fs-6 fw-semibold"><%= overview.topEmployeeSupervisor %> (<%= overview.topEmployeeCount %>)</div>
+          </div>
+        </div>
+      </div>
+      <div class="col">
+        <div class="card h-100 text-center border-0 shadow-sm">
+          <div class="card-body">
+            <i class="bi bi-graph-up-arrow fs-2 text-primary"></i>
+            <h6 class="mt-2 text-muted">Highest Salary</h6>
+            <div class="fs-6 fw-semibold"><%= overview.topSalarySupervisor %> (<%= overview.topSalaryAmount %>)</div>
+          </div>
+        </div>
       </div>
     </div>
     <% } %>

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -68,8 +68,11 @@
     </div>
   </form>
   <h4>My Employees</h4>
-  <div class="mb-3 col-md-4 px-0">
-    <input type="text" id="employeeSearch" class="form-control" placeholder="Search employees">
+  <div class="mb-3 col-md-5 col-lg-4 px-0">
+    <div class="input-group">
+      <input type="text" id="employeeSearch" class="form-control" placeholder="Search employees">
+      <button id="searchBtn" class="btn btn-outline-secondary" type="button"><i class="fas fa-search"></i></button>
+    </div>
   </div>
   <div class="table-responsive">
     <table class="table table-bordered">
@@ -122,13 +125,16 @@
   tooltipTriggerList.forEach(t => new bootstrap.Tooltip(t));
 
   const searchInput = document.getElementById('employeeSearch');
+  const searchBtn = document.getElementById('searchBtn');
   const rows = Array.from(document.querySelectorAll('table tbody tr'));
-  searchInput.addEventListener('input', () => {
+  const filterEmployees = () => {
     const q = searchInput.value.toLowerCase();
     rows.forEach(r => {
       r.style.display = r.textContent.toLowerCase().includes(q) ? '' : 'none';
     });
-  });
+  };
+  searchInput.addEventListener('input', filterEmployees);
+  searchBtn.addEventListener('click', filterEmployees);
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- split salary overview into four metric cards
- add search button and JS handler on supervisor employee page
- redesign advanced stats section of operator dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6863a2b809e48320a91621c2dfbfc10c