### PR TITLE
Improve department download button layout

### DIFF
--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -28,6 +28,15 @@
       font-size: 1.8rem;
       color: #0d6efd;
     }
+    .download-buttons form {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: end;
+      gap: 0.5rem;
+    }
+    .download-buttons .btn {
+      white-space: nowrap;
+    }
   </style>
 </head>
 <body>
@@ -125,28 +134,20 @@
         <div class="mb-3">
           <a href="/salary/night-template" class="btn btn-success">Download Night Template</a>
         </div>
-        <form action="/operator/departments/salary/download" method="GET" class="row g-3 mb-3">
-          <div class="col-auto">
+        <div class="download-buttons mb-3">
+          <form action="/operator/departments/salary/download" method="GET">
             <input type="month" name="month" class="form-control" value="<%= currentMonth %>" required>
-          </div>
-          <div class="col-auto">
-            <button type="submit" class="btn btn-success">Download Salary Excel</button>
-          </div>
-        </form>
-        <form action="/operator/departments/dihadi/download" method="GET" class="row g-3 mb-3">
-          <div class="col-auto">
+            <button type="submit" class="btn btn-success"><i class="bi bi-file-earmark-arrow-down"></i> Salary Excel</button>
+          </form>
+          <form action="/operator/departments/dihadi/download" method="GET">
             <input type="month" name="month" class="form-control" value="<%= currentMonth %>" required>
-          </div>
-          <div class="col-auto">
             <select name="half" class="form-select" required>
               <option value="1">1-15</option>
               <option value="2">16-end</option>
             </select>
-          </div>
-          <div class="col-auto">
-            <button type="submit" class="btn btn-success">Download Dihadi Excel</button>
-          </div>
-        </form>
+            <button type="submit" class="btn btn-success"><i class="bi bi-file-earmark-arrow-down"></i> Dihadi Excel</button>
+          </form>
+        </div>
 
         <% if (overview) { %>
         <div class="row row-cols-2 row-cols-md-4 g-3 mb-3">


### PR DESCRIPTION
## Summary
- style download section on operator departments page
- add icons and keep forms inline

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6863a6a9a0008320881f7cbc5f187db3