### PR TITLE
Fix template download for roll bulk upload

### DIFF
--- a/views/bulkUploadRolls.ejs
+++ b/views/bulkUploadRolls.ejs
@@ -75,7 +75,7 @@
                 <!-- Excel Template Information -->
                 <h5>Excel Template</h5>
                 <p>Please download the Excel template to ensure correct formatting:</p>
-                <a href="/path-to-template/fabric_invoice_rolls_template.xlsx" download class="btn btn-outline-success">
+                <a href="/fabric-manager/bulk-upload/rolls/template" class="btn btn-outline-success">
                     <i class="fas fa-download"></i> Download Template
                 </a>
             </div>


### PR DESCRIPTION
## Summary
- add Excel template generator route for fabric invoice rolls
- link new route from bulk upload rolls page

## Testing
- `npm run test` *(fails: Missing script)*
- `node -e "require('./routes/fabricManagerRoutes.js')"` *(fails: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_6864c276c72c8320a22a4d48e9966f4b