### PR TITLE
Hide salary until toggle

### DIFF
--- a/public/js/salaryToggle.js
+++ b/public/js/salaryToggle.js
@@ -1,0 +1,17 @@
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.toggle-salary').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const container = btn.closest('.salary-container') || btn.parentElement;
+      container.querySelectorAll('.salary-hidden').forEach(span => {
+        const visible = span.dataset.visible === 'true';
+        span.textContent = visible ? '****' : span.dataset.salary;
+        span.dataset.visible = (!visible).toString();
+      });
+      const icon = btn.querySelector('i');
+      if (icon) {
+        icon.classList.toggle('fa-eye');
+        icon.classList.toggle('fa-eye-slash');
+      }
+    });
+  });
+});

--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -8,6 +8,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Roboto', sans-serif; font-size: 0.95rem; }
+    .toggle-salary { cursor: pointer; }
   </style>
 </head>
 <body>
@@ -78,8 +79,16 @@
     <h6>Total Hours: <%= totalHours || '00:00' %> | Hourly Pay: <%= hourlyRate.toFixed(2) %></h6>
   <% } %>
   <% if (salary) { %>
-    <h6>Gross: <%= salary.gross %> | Deduction: <%= salary.deduction %> | Net: <%= salary.net %></h6>
-    <h6>Outstanding Advance: <%= outstanding.toFixed(2) %></h6>
+    <h6 class="salary-container">
+      Gross: <span class="salary-hidden" data-salary="<%= salary.gross %>">****</span> |
+      Deduction: <span class="salary-hidden" data-salary="<%= salary.deduction %>">****</span> |
+      Net: <span class="salary-hidden" data-salary="<%= salary.net %>">****</span>
+      <button type="button" class="btn btn-outline-secondary btn-sm toggle-salary ms-1"><i class="fas fa-eye"></i></button>
+    </h6>
+    <h6 class="salary-container">
+      Outstanding Advance: <span class="salary-hidden" data-salary="<%= outstanding.toFixed(2) %>">****</span>
+      <button type="button" class="btn btn-outline-secondary btn-sm toggle-salary ms-1"><i class="fas fa-eye"></i></button>
+    </h6>
     <% if (outstanding > 0) { %>
       <form action="/supervisor/employees/<%= employee.id %>/salary/deduct-advance" method="POST" class="row g-2 mb-2">
         <input type="hidden" name="month" value="<%= salary.month %>">
@@ -100,5 +109,6 @@
   const tooltipTriggerList = Array.from(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
   tooltipTriggerList.forEach(t => new bootstrap.Tooltip(t));
 </script>
+<script src="/public/js/salaryToggle.js"></script>
 </body>
 </html>

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -38,6 +38,7 @@
     .download-buttons .btn {
       white-space: nowrap;
     }
+    .toggle-salary { cursor: pointer; }
   </style>
 </head>
 <body>
@@ -210,7 +211,12 @@
               <tr>
                 <td><%= s.supervisor_name %></td>
                 <td><%= s.employee_count %></td>
-                <td><%= s.total_salary %></td>
+                <td class="salary-container">
+                  <span class="salary-hidden" data-salary="<%= s.total_salary %>">****</span>
+                  <button type="button" class="btn btn-outline-secondary btn-sm toggle-salary ms-1">
+                    <i class="fas fa-eye"></i>
+                  </button>
+                </td>
               </tr>
               <% }) %>
             </tbody>
@@ -268,7 +274,12 @@
               <td><input type="text" class="form-control form-control-sm" name="name" value="${emp.name}" required></td>
               <td><input type="text" class="form-control form-control-sm" name="designation" value="${emp.designation || ''}"></td>
               <td><input type="text" class="form-control form-control-sm" name="phone_number" value="${emp.phone_number || ''}" pattern="\\d*"></td>
-              <td><input type="number" step="0.01" class="form-control form-control-sm" name="salary" value="${emp.salary}" required></td>
+              <td class="salary-container">
+                <div class="input-group input-group-sm">
+                  <input type="password" step="0.01" class="form-control salary-input" name="salary" value="${emp.salary}" required>
+                  <button type="button" class="btn btn-outline-secondary toggle-salary"><i class="fas fa-eye"></i></button>
+                </div>
+              </td>
               <td><select class="form-select form-select-sm" name="salary_type">
                     <option value="dihadi" ${emp.salary_type==='dihadi'?'selected':''}>Dihadi</option>
                     <option value="monthly" ${emp.salary_type==='monthly'?'selected':''}>Monthly</option>
@@ -281,8 +292,17 @@
                     <option value="0" ${!emp.is_active? 'selected':''}>Inactive</option>
                   </select></td>
               <td><button type="button" class="btn btn-sm btn-primary">Save</button></td>`;
-            const btn = row.querySelector('button');
-            btn.addEventListener('click', () => {
+            const saveBtn = row.querySelector('button.btn-primary');
+            const toggleBtn = row.querySelector('.toggle-salary');
+            const salaryInput = row.querySelector('.salary-input');
+
+            toggleBtn.addEventListener('click', () => {
+              const hidden = salaryInput.getAttribute('type') === 'password';
+              salaryInput.setAttribute('type', hidden ? 'number' : 'password');
+              toggleBtn.innerHTML = hidden ? '<i class="fas fa-eye-slash"></i>' : '<i class="fas fa-eye"></i>';
+            });
+
+            saveBtn.addEventListener('click', () => {
               const inputs = row.querySelectorAll('input,select');
               const payload = {};
               inputs.forEach(i => payload[i.name] = i.type==='checkbox'? i.checked : i.value);
@@ -305,5 +325,6 @@
     });
   }
 </script>
+<script src="/public/js/salaryToggle.js"></script>
 </body>
 </html>

--- a/views/operatorSalaries.ejs
+++ b/views/operatorSalaries.ejs
@@ -4,6 +4,9 @@
   <meta charset="UTF-8">
   <title>Salary Summary</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    .toggle-salary { cursor: pointer; }
+  </style>
 </head>
 <body>
 <nav class="navbar navbar-dark bg-dark">
@@ -29,12 +32,18 @@
         <tr>
           <td><%= s.supervisor_name %></td>
           <td><%= s.employee_count %></td>
-          <td><%= s.total_salary %></td>
+          <td class="salary-container">
+            <span class="salary-hidden" data-salary="<%= s.total_salary %>">****</span>
+            <button type="button" class="btn btn-outline-secondary btn-sm toggle-salary ms-1">
+              <i class="fas fa-eye"></i>
+            </button>
+          </td>
         </tr>
       <% }) %>
     </tbody>
   </table>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script src="/public/js/salaryToggle.js"></script>
 </body>
 </html>

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -9,6 +9,7 @@
   <link href="https://fonts.googleapis.com/css2?family=Roboto&display=swap" rel="stylesheet">
   <style>
     body { font-family: 'Roboto', sans-serif; font-size: 0.95rem; }
+    .toggle-salary { cursor: pointer; }
   </style>
 </head>
 <body>
@@ -98,7 +99,12 @@
             <td><%= emp.name %></td>
             <td><%= emp.designation || '' %></td>
             <td><%= emp.phone_number || '' %></td>
-            <td><%= emp.salary %></td>
+            <td class="salary-container">
+              <span class="salary-hidden" data-salary="<%= emp.salary %>">****</span>
+              <button type="button" class="btn btn-sm btn-outline-secondary toggle-salary ms-1">
+                <i class="fas fa-eye"></i>
+              </button>
+            </td>
             <td><%= emp.salary_type %></td>
             <td><%= emp.allotted_hours %></td>
             <td><%= emp.paid_sunday_allowance %></td>
@@ -136,5 +142,6 @@
   searchInput.addEventListener('input', filterEmployees);
   searchBtn.addEventListener('click', filterEmployees);
 </script>
+<script src="/public/js/salaryToggle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a common salary toggle script
- hide salary data on supervisor employees page
- mask salary totals on operator pages
- protect salary values on employee salary page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864c8952fa883208da14d968220948e