### PR TITLE
Add active employee dashboard card

### DIFF
--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -240,11 +240,13 @@ router.get("/dashboard", isAuthenticated, isOperator, async (req, res) => {
         (SELECT COALESCE(SUM(total_pieces),0) FROM stitching_data)           AS totalStitched,
         (SELECT COALESCE(SUM(total_pieces),0) FROM washing_data)             AS totalWashed,
         (SELECT COALESCE(SUM(total_pieces),0) FROM finishing_data)           AS totalFinished,
-        (SELECT COUNT(*) FROM users)                                        AS userCount
+        (SELECT COUNT(*) FROM users)                                        AS userCount,
+        (SELECT COUNT(*) FROM employees WHERE is_active = 1)                AS activeEmployeeCount
     `);
 
     const lotCount = totals.lotCount;
     const totalPiecesCut = parseFloat(totals.totalPieces) || 0;
+    const activeEmployeeCount = totals.activeEmployeeCount;
 
     // 6) advanced analytics
     const advancedAnalytics = await computeAdvancedAnalytics(startDate, endDate);
@@ -258,6 +260,7 @@ router.get("/dashboard", isAuthenticated, isOperator, async (req, res) => {
       totalWashed: totals.totalWashed,
       totalFinished: totals.totalFinished,
       userCount: totals.userCount,
+      activeEmployeeCount,
       advancedAnalytics,
       operatorPerformance,
       query: { search, startDate, endDate, sortField, sortOrder, category },

--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -181,11 +181,12 @@
   </div>
 
   <!-- Stat Cards -->
-    <div class="row row-cols-2 row-cols-md-3 row-cols-lg-4 g-3 mb-4">
+    <div class="row row-cols-2 row-cols-md-3 row-cols-lg-5 g-3 mb-4">
       <div class="col"><div class="stat-box"><div class="stat-title">Total Kits</div><div class="stat-value"><%= lotCount %></div></div></div>
       <div class="col"><div class="stat-box"><div class="stat-title">Cut Pieces</div><div class="stat-value"><%= totalPiecesCut %></div></div></div>
       <div class="col"><div class="stat-box"><div class="stat-title">Finished</div><div class="stat-value"><%= totalFinished %></div></div></div>
       <div class="col"><div class="stat-box"><div class="stat-title">Users</div><div class="stat-value"><%= userCount %></div></div></div>
+      <div class="col"><div class="stat-box"><div class="stat-title">Active Employees</div><div class="stat-value"><%= activeEmployeeCount %></div></div></div>
     </div>
 
     <!-- SKU Insights Panel -->


### PR DESCRIPTION
## Summary
- show a stat for active employees on the operator dashboard
- compute active employee count in dashboard route

## Testing
- `node -e "require('./routes/operatorRoutes.js');"`

------
https://chatgpt.com/codex/tasks/task_e_6865121a036c8320a4c9d3f465e02541