### PR TITLE
Add overtime tracking and rule placeholder

### DIFF
--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -53,6 +53,10 @@
         <th>Punch In</th>
         <th>Punch Out</th>
         <th>Hours</th>
+        <% if (employee.salary_type === 'monthly') { %>
+          <th>OT Hours</th>
+          <th>UT Hours</th>
+        <% } %>
         <% if (employee.salary_type === 'dihadi') { %>
           <th>Lunch Deduction (mins)</th>
         <% } %>
@@ -67,6 +71,10 @@
           <td><%= a.punch_in || '' %></td>
           <td><%= a.punch_out || '' %></td>
           <td><%= a.hours %></td>
+          <% if (employee.salary_type === 'monthly') { %>
+            <td><%= a.overtime %></td>
+            <td><%= a.undertime %></td>
+          <% } %>
           <% if (employee.salary_type === 'dihadi') { %>
             <td><%= a.lunch_deduction %></td>
           <% } %>
@@ -75,6 +83,9 @@
       <% }) %>
     </tbody>
   </table>
+  <% if (employee.salary_type === 'monthly') { %>
+    <h6>OT: <%= overtimeFormatted || '00:00' %> | UT: <%= undertimeFormatted || '00:00' %></h6>
+  <% } %>
   <% if (employee.salary_type === 'dihadi') { %>
     <h6>Total Hours: <%= totalHours || '00:00' %> | Hourly Pay: <%= hourlyRate.toFixed(2) %></h6>
   <% } %>

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -45,6 +45,14 @@
       overflow-y: auto;
       overflow-x: auto;
     }
+    #employeesTable th, #employeesTable td {
+      min-width: 120px;
+      white-space: nowrap;
+    }
+    #employeesTable th {
+      resize: horizontal;
+      overflow: auto;
+    }
   </style>
 </head>
 <body>
@@ -234,6 +242,15 @@
               </div>
             </div>
           </div>
+          <div class="col">
+            <div class="card summary-card">
+              <div class="card-body">
+                <div class="icon"><i class="bi bi-person-check-fill"></i></div>
+                <div class="fw-semibold">Active Employees</div>
+                <div><%= overview.totalActiveEmployees %></div>
+              </div>
+            </div>
+          </div>
         </div>
         <% } %>
 
@@ -288,6 +305,35 @@
           </div>
         </div>
         <div id="employeesTableContainer" class="table-responsive mt-3"></div>
+      </div>
+    </div>
+  </div>
+  <div class="mt-4">
+    <div class="card shadow-sm">
+      <div class="card-header">Salary Rules</div>
+      <div class="card-body">
+        <div class="alert alert-info">Use SQL like conditions on attendance fields. Example: punch_in > '09:15:00'.</div>
+        <form action="/operator/departments/salary/download-rule" method="GET" class="row g-2">
+          <div class="col-md-3">
+            <label class="form-label">Month</label>
+            <input type="month" name="month" class="form-control" value="<%= currentMonth %>">
+          </div>
+          <div class="col-md-4">
+            <label class="form-label">Preset Rule</label>
+            <select name="rule" class="form-select" id="ruleSelect">
+              <option value="">Custom</option>
+              <option value="dihadi_late">Dihadi: punch after 9:15 deduct 1hr</option>
+              <option value="monthly_short">Monthly: 3 short days deduct 1 day</option>
+            </select>
+          </div>
+          <div class="col-md-5">
+            <label class="form-label">Custom Query</label>
+            <input type="text" name="query" class="form-control" placeholder="e.g. punch_in > '09:15:00'">
+          </div>
+          <div class="col-12 text-end">
+            <button type="submit" class="btn btn-primary">Download With Rule</button>
+          </div>
+        </form>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- show total active employees in departments dashboard
- track overtime and undertime when downloading monthly salary sheets
- display OT/UT hours on supervisor salary view
- widen employee edit table columns
- add placeholder rule creator section with download link

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866215ec7048320a0c643334d58f8c8