### PR TITLE
Fix dihadi salary logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,6 +250,8 @@ ALTER TABLE employees ADD COLUMN allotted_hours DECIMAL(4,2) NOT NULL DEFAULT 0;
 
 Lunch breaks are deducted from recorded hours only for workers paid on a `dihadi` (daily wage) basis. Monthly salary employees keep their full punch duration.
 
+`dihadi` workers do not receive any special treatment for Sundays. Their pay is purely based on hours worked.
+
 ### Sunday Attendance Rules
 
 - **Salary below 13,500** – each Sunday worked grants an extra day's pay unless the employee belongs to a special department.

--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -158,12 +158,12 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
   );
 }
 
+// Dihadi workers are paid purely on hours worked. Grab all attendance
+// for the month and multiply the total hours by the hourly rate.
 async function calculateDihadiMonthly(conn, employeeId, month, emp) {
-  const startDate = moment(month + '-01').format('YYYY-MM-DD');
-  const endDate = moment(month + '-15').format('YYYY-MM-DD');
   const [attendance] = await conn.query(
-    "SELECT date, punch_in, punch_out FROM employee_attendance WHERE employee_id = ? AND date BETWEEN ? AND ?",
-    [employeeId, startDate, endDate]
+    'SELECT punch_in, punch_out FROM employee_attendance WHERE employee_id = ? AND DATE_FORMAT(date, "%Y-%m") = ?',
+    [employeeId, month]
   );
   const hourlyRate = emp.allotted_hours ? parseFloat(emp.salary) / parseFloat(emp.allotted_hours) : 0;
   let totalHours = 0;

--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -324,7 +324,7 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
         }
       }
       const isSun = moment(a.date).day() === 0;
-      if (isSun) {
+      if (isSun && emp.salary_type !== 'dihadi') {
         if (a.status === 'present') {
           if (specialDept) {
             a.deduction_reason = 'Leave credited';


### PR DESCRIPTION
## Summary
- remove Sunday logic for dihadi workers
- calculate dihadi salary using all days in a month
- document that Sunday rules don't apply to dihadi employees

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68667cb1193c8320b60fa3515a6815f5