### PR TITLE
Fix advance deduction form path

### DIFF
--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -101,7 +101,7 @@
       <button type="button" class="btn btn-outline-secondary btn-sm toggle-salary ms-1"><i class="fas fa-eye"></i></button>
     </h6>
     <% if (outstanding > 0) { %>
-      <form action="/supervisor/employees/<%= employee.id %>/salary/deduct-advance" method="POST" class="row g-2 mb-2">
+      <form action="/employees/<%= employee.id %>/salary/deduct-advance" method="POST" class="row g-2 mb-2">
         <input type="hidden" name="month" value="<%= salary.month %>">
         <div class="col-auto">
           <input type="number" step="0.01" name="amount" class="form-control" max="<%= outstanding %>" placeholder="Deduction amount" required>


### PR DESCRIPTION
## Summary
- correct the path used to deduct salary advances

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686683b48db4832094bcbeb2b4d75476