### PR TITLE
Add month filter for OT stats

### DIFF
--- a/routes/employeeRoutes.js
+++ b/routes/employeeRoutes.js
@@ -3,7 +3,7 @@ const router = express.Router();
 const { pool } = require('../config/db');
 const { isAuthenticated, isSupervisor } = require('../middlewares/auth');
 const moment = require('moment');
-const { calculateSalaryForMonth } = require('../helpers/salaryCalculator');
+const { calculateSalaryForMonth, effectiveHours } = require('../helpers/salaryCalculator');
 
 // Show employee dashboard for a supervisor
 router.get('/employees', isAuthenticated, isSupervisor, async (req, res) => {
@@ -22,10 +22,68 @@ router.get('/employees', isAuthenticated, isSupervisor, async (req, res) => {
       [userId]
     );
 
+    const totalEmployees = employees.length;
+    const avgSalary = totalEmployees
+      ? (
+          employees.reduce((s, e) => s + parseFloat(e.salary || 0), 0) /
+          totalEmployees
+        ).toFixed(2)
+      : 0;
+
+    const selectedMonth = req.query.month || moment().format('YYYY-MM');
+    const monthStart = moment(selectedMonth + '-01');
+    const months = [];
+    for (let i = 0; i < 6; i++) {
+      const m = moment().subtract(i, 'months');
+      months.push({ value: m.format('YYYY-MM'), label: m.format('MMM YYYY') });
+    }
+
+    let topEmployees = [];
+    if (totalEmployees && monthStart.isValid()) {
+      const startDate = monthStart.format('YYYY-MM-DD');
+      const endDate = monthStart.endOf('month').format('YYYY-MM-DD');
+      const ids = employees.map(e => e.id);
+      const [att] = await pool.query(
+        `SELECT employee_id, punch_in, punch_out
+           FROM employee_attendance
+          WHERE employee_id IN (?) AND date BETWEEN ? AND ?`,
+        [ids, startDate, endDate]
+      );
+      const map = new Map();
+      employees.forEach(e => {
+        map.set(e.id, { name: e.name, diff: 0, emp: e });
+      });
+      att.forEach(a => {
+        const item = map.get(a.employee_id);
+        if (!item) return;
+        const emp = item.emp;
+        if (
+          emp.salary_type !== 'monthly' ||
+          !a.punch_in ||
+          !a.punch_out ||
+          !emp.allotted_hours
+        )
+          return;
+        const hrs = effectiveHours(a.punch_in, a.punch_out, 'monthly');
+        const diff = hrs - parseFloat(emp.allotted_hours || 0);
+        item.diff += diff;
+      });
+      topEmployees = Array.from(map.values())
+        .filter(i => i.diff > 0)
+        .sort((a, b) => b.diff - a.diff)
+        .slice(0, 3)
+        .map(i => i.name);
+    }
+
     res.render('supervisorEmployees', {
       user: req.session.user,
       department,
-      employees
+      employees,
+      totalEmployees,
+      avgSalary,
+      topEmployees,
+      months,
+      selectedMonth
     });
   } catch (err) {
     console.error('Error loading employees:', err);

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -10,6 +10,8 @@
   <style>
     body { font-family: 'Roboto', sans-serif; font-size: 0.95rem; }
     .toggle-salary { cursor: pointer; }
+    .summary-card { text-align: center; border: none; box-shadow: 0 2px 6px rgba(0,0,0,0.05); }
+    .summary-card .icon { font-size: 1.75rem; color: #0d6efd; }
   </style>
 </head>
 <body>
@@ -23,6 +25,44 @@
 </nav>
 <div class="container-fluid my-4">
   <%- include('partials/flashMessages') %>
+  <div class="row row-cols-1 row-cols-md-3 g-3 mb-4">
+    <div class="col">
+      <div class="card summary-card">
+        <div class="card-body">
+          <div class="icon"><i class="fas fa-users"></i></div>
+          <div class="fw-semibold">Total Employees</div>
+          <div><%= totalEmployees %></div>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card summary-card">
+        <div class="card-body">
+          <div class="icon"><i class="fas fa-dollar-sign"></i></div>
+          <div class="fw-semibold">Average Salary</div>
+          <div><%= avgSalary %></div>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card summary-card">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-start mb-1">
+            <div>
+              <div class="icon"><i class="fas fa-clock"></i></div>
+              <div class="fw-semibold">Top OT Employees</div>
+            </div>
+            <select id="otMonth" class="form-select form-select-sm" style="width:auto;">
+              <% months.forEach(m => { %>
+                <option value="<%= m.value %>" <%= m.value === selectedMonth ? 'selected' : '' %>><%= m.label %></option>
+              <% }) %>
+            </select>
+          </div>
+          <div class="small" id="otList"><%= topEmployees.join(', ') %></div>
+        </div>
+      </div>
+    </div>
+  </div>
   <h4>Add Employee</h4>
   <form action="/supervisor/employees" method="POST" class="row g-3 mb-4">
     <div class="col-md-3">
@@ -141,6 +181,15 @@
   };
   searchInput.addEventListener('input', filterEmployees);
   searchBtn.addEventListener('click', filterEmployees);
+
+  const monthSelect = document.getElementById('otMonth');
+  if (monthSelect) {
+    monthSelect.addEventListener('change', () => {
+      const url = new URL(window.location.href);
+      url.searchParams.set('month', monthSelect.value);
+      window.location.href = url.toString();
+    });
+  }
 </script>
 <script src="/public/js/salaryToggle.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- compute top overtime employees based on selected month
- show dropdown to pick month on supervisor employee page

## Testing
- `node --check routes/employeeRoutes.js`
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_686755230f888320994ca6ef372ae0b1