### PR TITLE
Apply late arrival deduction and align dihadis

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,8 @@ Lunch breaks are deducted from recorded hours only for workers paid on a `dihadi
 
 `dihadi` workers do not receive any special treatment for Sundays. Their pay is purely based on hours worked.
 
+Punching in after **09:15** results in an additional one-hour deduction from the day's counted hours for all employees.
+
 ### Sunday Attendance Rules
 
 - **Salary below 13,500** – each Sunday worked grants an extra day's pay unless the employee belongs to a special department.

--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -17,6 +17,12 @@ function effectiveHours(punchIn, punchOut, salaryType = 'dihadi') {
   const end = moment(punchOut, 'HH:mm:ss');
   let mins = end.diff(start, 'minutes');
   mins -= lunchDeduction(punchIn, punchOut, salaryType);
+
+  // Deduct an additional hour for late arrivals after 09:15
+  if (start.isAfter(moment('09:15:00', 'HH:mm:ss'))) {
+    mins -= 60;
+  }
+
   if (mins > 11 * 60) mins = 11 * 60;
   if (mins < 0) mins = 0;
   return mins / 60;

--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -339,6 +339,13 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
         } else {
           a.deduction_reason = '';
         }
+
+        if (
+          a.punch_in &&
+          moment(a.punch_in, 'HH:mm:ss').isAfter(moment('09:15:00', 'HH:mm:ss'))
+        ) {
+          a.deduction_reason += (a.deduction_reason ? '; ' : '') + 'Late';
+        }
       } else {
         if (a.status === 'absent') {
           a.deduction_reason = 'Absent';
@@ -356,6 +363,13 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
             parseFloat(emp.allotted_hours) * 0.55
         ) {
           a.deduction_reason += (a.deduction_reason ? '; ' : '') + 'Half Day';
+        }
+
+        if (
+          a.punch_in &&
+          moment(a.punch_in, 'HH:mm:ss').isAfter(moment('09:15:00', 'HH:mm:ss'))
+        ) {
+          a.deduction_reason += (a.deduction_reason ? '; ' : '') + 'Late';
         }
       }
     });


### PR DESCRIPTION
## Summary
- deduct an hour from effective hours if punch-in is after 09:15
- mark late arrivals in salary views and dihadi exports
- use the same hour calculation for dihadi download and include deduction reasons
- document late-arrival rule in README

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6867702ca6708320a49090b81383942c