### PR TITLE
Fix late deduction logic and improve deduction notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ Lunch breaks are deducted from recorded hours only for workers paid on a `dihadi
 
 `dihadi` workers do not receive any special treatment for Sundays. Their pay is purely based on hours worked.
 
-Punching in after **09:15** results in an additional one-hour deduction from the day's counted hours for all employees.
+Punching in after **09:15** results in an additional one-hour deduction from the day's counted hours for **dihadi** (daily wage) employees only.
 
 ### Sunday Attendance Rules
 

--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -19,7 +19,11 @@ function effectiveHours(punchIn, punchOut, salaryType = 'dihadi') {
   mins -= lunchDeduction(punchIn, punchOut, salaryType);
 
   // Deduct an additional hour for late arrivals after 09:15
-  if (start.isAfter(moment('09:15:00', 'HH:mm:ss'))) {
+  // Late deduction only applies to daily wage (dihadi) employees
+  if (
+    salaryType === 'dihadi' &&
+    start.isAfter(moment('09:15:00', 'HH:mm:ss'))
+  ) {
     mins -= 60;
   }
 

--- a/routes/departmentMgmtRoutes.js
+++ b/routes/departmentMgmtRoutes.js
@@ -297,9 +297,9 @@ router.get('/departments/salary/download', isAuthenticated, isOperator, async (r
         }
       });
       const notes = [];
-      if (absent) notes.push(`${absent} Absent`);
-      if (onePunch) notes.push(`${onePunch} One Punch`);
-      if (sundayAbs) notes.push(`${sundayAbs} Sun Absent`);
+      if (absent) notes.push(`${absent} day(s) absent`);
+      if (onePunch) notes.push(`${onePunch} day(s) with missing punch`);
+      if (sundayAbs) notes.push(`${sundayAbs} Sunday absence(s)`);
       r.deduction_reason = notes.join(', ');
       r.overtime_hours = otHours.toFixed(2);
       r.overtime_days = otDays;
@@ -440,10 +440,10 @@ router.get('/departments/salary/download-rule', isAuthenticated, isOperator, asy
         }
       });
       const notes = [];
-      if (absent) notes.push(`${absent} Absent`);
-      if (onePunch) notes.push(`${onePunch} One Punch`);
-      if (sundayAbs) notes.push(`${sundayAbs} Sun Absent`);
-      if (halfDays) notes.push(`${halfDays} Half`);
+      if (absent) notes.push(`${absent} day(s) absent`);
+      if (onePunch) notes.push(`${onePunch} day(s) with missing punch`);
+      if (sundayAbs) notes.push(`${sundayAbs} Sunday absence(s)`);
+      if (halfDays) notes.push(`${halfDays} half-day(s)`);
       r.deduction_reason = notes.join(', ');
       r.overtime_hours = otHours.toFixed(2);
       r.overtime_days = otDays;
@@ -556,9 +556,9 @@ router.get('/departments/dihadi/download-rule', isAuthenticated, isOperator, asy
       const rate = emp.allotted_hours ? parseFloat(emp.salary) / parseFloat(emp.allotted_hours) : 0;
       const amount = parseFloat((totalHours * rate).toFixed(2));
       const notes = [];
-      if (absent) notes.push(`${absent} Absent`);
-      if (onePunch) notes.push(`${onePunch} One Punch`);
-      if (late) notes.push(`${late} Late`);
+      if (absent) notes.push(`${absent} day(s) absent`);
+      if (onePunch) notes.push(`${onePunch} day(s) with missing punch`);
+      if (late) notes.push(`${late} late arrival(s)`);
       rows.push({
         supervisor: emp.supervisor_name,
         department: emp.department_name || '',
@@ -640,9 +640,9 @@ router.get('/departments/dihadi/download', isAuthenticated, isOperator, async (r
       const rate = emp.allotted_hours ? parseFloat(emp.salary) / parseFloat(emp.allotted_hours) : 0;
       const amount = parseFloat((totalHours * rate).toFixed(2));
       const notes = [];
-      if (absent) notes.push(`${absent} Absent`);
-      if (onePunch) notes.push(`${onePunch} One Punch`);
-      if (late) notes.push(`${late} Late`);
+      if (absent) notes.push(`${absent} day(s) absent`);
+      if (onePunch) notes.push(`${onePunch} day(s) with missing punch`);
+      if (late) notes.push(`${late} late arrival(s)`);
       rows.push({
         supervisor: emp.supervisor_name,
         department: emp.department_name || '',

--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -341,16 +341,18 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
         }
 
         if (
+          emp.salary_type === 'dihadi' &&
           a.punch_in &&
           moment(a.punch_in, 'HH:mm:ss').isAfter(moment('09:15:00', 'HH:mm:ss'))
         ) {
-          a.deduction_reason += (a.deduction_reason ? '; ' : '') + 'Late';
+          a.deduction_reason +=
+            (a.deduction_reason ? '; ' : '') + 'Late arrival after 09:15';
         }
       } else {
         if (a.status === 'absent') {
-          a.deduction_reason = 'Absent';
+          a.deduction_reason = 'Absent from work';
         } else if (a.status === 'one punch only') {
-          a.deduction_reason = 'One punch only';
+          a.deduction_reason = 'Missing punch in/out';
         } else {
           a.deduction_reason = '';
         }
@@ -362,14 +364,17 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
           effectiveHours(a.punch_in, a.punch_out, 'monthly') <
             parseFloat(emp.allotted_hours) * 0.55
         ) {
-          a.deduction_reason += (a.deduction_reason ? '; ' : '') + 'Half Day';
+          a.deduction_reason += (a.deduction_reason ? '; ' : '') +
+            'Worked less than half day';
         }
 
         if (
+          emp.salary_type === 'dihadi' &&
           a.punch_in &&
           moment(a.punch_in, 'HH:mm:ss').isAfter(moment('09:15:00', 'HH:mm:ss'))
         ) {
-          a.deduction_reason += (a.deduction_reason ? '; ' : '') + 'Late';
+          a.deduction_reason += (a.deduction_reason ? '; ' : '') +
+            'Late arrival after 09:15';
         }
       }
     });


### PR DESCRIPTION
## Summary
- limit late arrival deduction logic to dihadi (daily wage) employees
- clarify README about late arrival deduction
- use descriptive deduction reasons in salary view
- improve deduction notes in department salary exports

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867814bc574832097005bb951544d99