### PR TITLE
Add supervisor data reset option

### DIFF
--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -311,6 +311,27 @@
   </div>
   <div class="mt-4">
     <div class="card shadow-sm">
+      <div class="card-header">Reset Supervisor Data</div>
+      <div class="card-body">
+        <form action="/operator/departments/reset-supervisor" method="POST" class="row g-3 align-items-end" onsubmit="return confirm('Delete all attendance and salary data for this supervisor?');">
+          <div class="col-md-6">
+            <label class="form-label">Supervisor</label>
+            <select name="supervisor_id" class="form-select" required>
+              <option value="">Choose...</option>
+              <% supervisors.forEach(function(s){ %>
+                <option value="<%= s.id %>"><%= s.username %></option>
+              <% }) %>
+            </select>
+          </div>
+          <div class="col-md-6 text-end">
+            <button type="submit" class="btn btn-danger w-100">Clear Data</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </div>
+  <div class="mt-4">
+    <div class="card shadow-sm">
       <div class="card-header">Salary Rules</div>
       <div class="card-body">
         <div class="alert alert-info">Use SQL like conditions on attendance fields. Example: punch_in &gt; '09:15:00'.</div>


### PR DESCRIPTION
## Summary
- allow operators to wipe all attendance and salary data for a supervisor
- add Reset Supervisor Data form on the operator department screen

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686786940c548320ba18adf48a31ad3e