### PR TITLE
Update Sunday pay logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,10 +257,10 @@ Punching in after **09:15** results in an additional one-hour deduction from the
 
 ### Sunday Attendance Rules
 
-- **Salary below 13,500** – each Sunday worked grants an extra day's pay unless the employee belongs to a special department.
-- **Special departments (`catalog`, `account`, `merchant`)** – Sundays do not grant extra pay; worked Sundays become leave credits.
-- **Salary 13,500 or more** – a worked Sunday is credited as leave unless covered by the employee's `paid_sunday_allowance`.
-- **Paid Sunday allowance** – specifies how many Sundays in a month are paid regardless of salary. Extra Sundays become leave credits.
+- **Special departments (`catalog`, `account`, `merchant`)** – Sundays never grant extra pay; any worked Sunday is credited as leave.
+- **All other departments** – a Sunday is paid only when the employee works that day and has unused `paid_sunday_allowance`. Otherwise the day is credited as leave.
+
+Employees receive Sunday pay only when they have valid punch in/out times with positive working hours.
 
 These credited days are automatically inserted into `employee_leaves` during salary calculations.
 If an employee misses Saturday or Monday **and** also skips the Sunday, the weekend becomes a "sandwich" and all three days are deducted from salary. When the employee works on that Sunday, the sandwich rule is ignored and any adjacent absence is paid.

--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -135,16 +135,17 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
     }
 
     if (isSun) {
-      if (status === 'present') {
-        if (specialDept) {
-          creditLeaves.push(dateStr);
-        } else if (parseFloat(emp.salary) < 13500) {
-          extraPay += dailyRate;
-        } else if (paidUsed < (emp.paid_sunday_allowance || 0)) {
-          extraPay += dailyRate;
-          paidUsed++;
-        } else {
-          creditLeaves.push(dateStr);
+      if (status === 'present' && a.punch_in && a.punch_out) {
+        const hrsWorked = effectiveHours(a.punch_in, a.punch_out, 'monthly');
+        if (hrsWorked > 0) {
+          if (specialDept) {
+            creditLeaves.push(dateStr);
+          } else if (paidUsed < (emp.paid_sunday_allowance || 0)) {
+            extraPay += dailyRate;
+            paidUsed++;
+          } else {
+            creditLeaves.push(dateStr);
+          }
         }
       }
     } else {

--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -325,16 +325,19 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
       }
       const isSun = moment(a.date).day() === 0;
       if (isSun && emp.salary_type !== 'dihadi') {
-        if (a.status === 'present') {
-          if (specialDept) {
-            a.deduction_reason = 'Leave credited';
-          } else if (parseFloat(emp.salary) < 13500) {
-            a.deduction_reason = 'Paid Sunday';
-          } else if (paidUsed < (emp.paid_sunday_allowance || 0)) {
-            a.deduction_reason = 'Paid Sunday (override)';
-            paidUsed++;
+        if (a.status === 'present' && a.punch_in && a.punch_out) {
+          const hrsWorked = effectiveHours(a.punch_in, a.punch_out, 'monthly');
+          if (hrsWorked > 0) {
+            if (specialDept) {
+              a.deduction_reason = 'Leave credited';
+            } else if (paidUsed < (emp.paid_sunday_allowance || 0)) {
+              a.deduction_reason = 'Paid Sunday';
+              paidUsed++;
+            } else {
+              a.deduction_reason = 'Leave credited';
+            }
           } else {
-            a.deduction_reason = 'Leave credited';
+            a.deduction_reason = '';
           }
         } else {
           a.deduction_reason = '';


### PR DESCRIPTION
## Summary
- change Sunday logic to rely on `paid_sunday_allowance` only
- only pay for Sundays when punches show positive hours
- document new rules in README

## Testing
- `npm install`
- `npm start` *(fails: Cannot find module 'secure-env')*


------
https://chatgpt.com/codex/tasks/task_e_6868abacf3948320a119a833fbf0e07d