### PR TITLE
Fix salary attendance rules and add supervisor export

### DIFF
--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -64,6 +64,14 @@
       </div>
     </div>
   </div>
+  <div class="row mb-3">
+    <div class="col-md-6">
+      <form action="/supervisor/salary/download" method="GET" class="d-flex gap-2 align-items-end">
+        <input type="month" name="month" class="form-control" value="<%= selectedMonth %>" required>
+        <button type="submit" class="btn btn-success"><i class="bi bi-file-earmark-arrow-down"></i> Salary Excel</button>
+      </form>
+    </div>
+  </div>
   <h4>Add Employee</h4>
   <form action="/supervisor/employees" method="POST" class="row g-3 mb-4">
     <div class="col-md-3">


### PR DESCRIPTION
## Summary
- treat missing attendance as absence
- count hours <= 1 as absent
- allow supervisors to export salary Excel
- add salary download form to supervisor employees page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868afd1ba8883209de29c120f3932bd