### PR TITLE
Add templates and employee ID support for advance uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,8 @@ CREATE TABLE employee_nights (
 ```
 Uploading a sheet increases the employee's salary by `nights * (salary / days_in_month)` for the specified month. Duplicate uploads for the same employee and month are ignored. Operators can download an Excel template via the `/salary/night-template` route. The file includes the columns `supervisorname`, `supervisordepartment`, `punchingid`, `name`, `nights`, `month`.
 
+Advance and deduction uploads also provide templates. Use `/salary/advance-template` to download a spreadsheet with columns `employeeid`, `punchingid`, `name`, `amount` and `reason`. For recording salary deductions of an advance, download `/salary/advance-deduction-template` which lists `employeeid`, `punchingid`, `name`, `month` and `amount`.
+
 ### Sandwich Dates
 
 Create a table so operators can mark certain dates as "sandwich" days:

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -114,6 +114,12 @@
             <div class="mb-3 text-center">
               <a href="/salary/night-template" class="btn btn-success w-100">Download Night Template</a>
             </div>
+            <div class="mb-3 text-center">
+              <a href="/salary/advance-template" class="btn btn-success w-100">Download Advance Template</a>
+            </div>
+            <div class="mb-3 text-center">
+              <a href="/salary/advance-deduction-template" class="btn btn-success w-100">Download Deduction Template</a>
+            </div>
           <div class="download-buttons">
             <form action="/operator/departments/salary/download" method="GET">
               <input type="month" name="month" class="form-control" value="<%= currentMonth %>" required>


### PR DESCRIPTION
## Summary
- support employeeid in advance and deduction uploads
- skip lookup by punching ID when employeeid is supplied
- add routes to download advance and deduction Excel templates
- link new templates in the operator department view
- document new template routes in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868d944c9608320a6751474364a5830