### PR TITLE
Add bulk miss punch fix via Excel

### DIFF
--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -386,6 +386,16 @@
             <button type="submit" class="btn btn-primary w-100">Fix Miss Punch</button>
           </div>
         </form>
+        <hr>
+        <form action="/operator/departments/bulk-fix-miss-punch" method="POST" enctype="multipart/form-data" class="row g-3 align-items-end">
+          <div class="col-md-6">
+            <label class="form-label">Excel File (employeeid column)</label>
+            <input type="file" name="excelFile" accept=".xlsx,.xls" class="form-control" required>
+          </div>
+          <div class="col-md-6 text-end">
+            <button type="submit" class="btn btn-primary w-100">Fix in Bulk</button>
+          </div>
+        </form>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- allow uploading Excel sheets of employee IDs to bulk-correct missing punches
- update operator department page with new upload form

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868ee90ff6c83209eb051ceb8728ac5