### PR TITLE
Update half-day logic and supervisor export

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -163,9 +163,10 @@ async function calculateSalaryForMonth(conn, employeeId, month) {
         absent++;
       } else if (emp.allotted_hours) {
         const hrsWorked = effectiveHours(a.punch_in, a.punch_out, 'monthly');
-        if (hrsWorked <= 1) {
+        const allotted = parseFloat(emp.allotted_hours);
+        if (hrsWorked < allotted * 0.4) {
           absent++;
-        } else if (hrsWorked < parseFloat(emp.allotted_hours) * 0.55) {
+        } else if (hrsWorked < allotted * 0.85) {
           halfDeduct += 0.5;
         }
       }

--- a/routes/departmentMgmtRoutes.js
+++ b/routes/departmentMgmtRoutes.js
@@ -440,8 +440,9 @@ router.get('/departments/salary/download-rule', isAuthenticated, isOperator, asy
           const diff = hrs - parseFloat(r.allotted_hours || 0);
           if (diff > 0) { otHours += diff; otDays++; }
           else if (diff < 0) { utHours += Math.abs(diff); utDays++; }
-          if (hrs < parseFloat(r.allotted_hours || 0) * 0.55) halfDays++;
-          if (rule === 'monthly_short' && hrs < parseFloat(r.allotted_hours || 0)) shortDays++;
+          const allotted = parseFloat(r.allotted_hours || 0);
+          if (hrs >= allotted * 0.4 && hrs < allotted * 0.85) halfDays++;
+          if (rule === 'monthly_short' && hrs < allotted) shortDays++;
         }
       });
       const notes = [];


### PR DESCRIPTION
## Summary
- tweak half-day calculation to apply between 40–85% of allotted hours
- adjust salary deduction notes for half days
- include monthly advance deduction in supervisor export
- output day-wise attendance summary for supervisor salary download

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6868fc33f8ac8320b237fc4aee78560a