### PR TITLE
Implement refined weekend rules

### DIFF
--- a/utils/supervisors.js
+++ b/utils/supervisors.js
@@ -1,0 +1,4 @@
+module.exports.SPECIAL_SUNDAY_SUPERVISORS = ['rohitShukla'];
+// Employees in this list always receive their full salary regardless of
+// attendance or special Sunday rules.
+module.exports.FULL_SALARY_EMPLOYEE_IDS = [697];


### PR DESCRIPTION
## Summary
- define full salary employee list
- return full salary for exempt employees
- adjust Sunday deduction logic
- handle special weekend cases when downloading salaries

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68690727fddc83209a49cd8e226b411f