### PR TITLE
Add present employees card

### DIFF
--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -25,7 +25,7 @@
 </nav>
 <div class="container-fluid my-4">
   <%- include('partials/flashMessages') %>
-  <div class="row row-cols-1 row-cols-md-3 g-3 mb-4">
+  <div class="row row-cols-1 row-cols-md-4 g-3 mb-4">
     <div class="col">
       <div class="card summary-card">
         <div class="card-body">
@@ -35,12 +35,21 @@
         </div>
       </div>
     </div>
-    <div class="col">
+  <div class="col">
       <div class="card summary-card">
         <div class="card-body">
           <div class="icon"><i class="fas fa-dollar-sign"></i></div>
           <div class="fw-semibold">Average Salary</div>
           <div><%= avgSalary %></div>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card summary-card">
+        <div class="card-body">
+          <div class="icon"><i class="fas fa-user-check"></i></div>
+          <div class="fw-semibold">Present Employees</div>
+          <div><%= presentCount %></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- track how many employees are present for a month
- show this number on supervisor dashboard

## Testing
- `npm test` *(fails: Missing script)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68690bd106d48320b0f764cc2f877b59