### PR TITLE
Raise attendance edit limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ If an employee misses Saturday or Monday **and** also skips the Sunday, the week
 
 ### Attendance Edit Logs
 
-Operators can adjust an employee's punch in/out times. A log table tracks these updates and limits each employee to three edits total:
+Operators can adjust an employee's punch in/out times. A log table tracks these updates and limits each employee to thirty-five edits total:
 ```sql
 CREATE TABLE attendance_edit_logs (
   id INT AUTO_INCREMENT PRIMARY KEY,
@@ -284,7 +284,7 @@ CREATE TABLE attendance_edit_logs (
   FOREIGN KEY (operator_id) REFERENCES users(id)
 );
 ```
-Operators can modify punch times from the dashboard, but once three rows exist in `attendance_edit_logs` for an employee no further edits are allowed. Every update recalculates the employee's salary for that month.
+Operators can modify punch times from the dashboard, but once thirty-five rows exist in `attendance_edit_logs` for an employee no further edits are allowed. Every update recalculates the employee's salary for that month.
 
 ### Night Shift Uploads
 

--- a/routes/operatorEmployeeRoutes.js
+++ b/routes/operatorEmployeeRoutes.js
@@ -86,7 +86,7 @@ router.post('/employees/:id/edit', isAuthenticated, isOperator, async (req, res)
     const supervisorId = emp.supervisor_id;
 
     const [logRows] = await conn.query('SELECT COUNT(*) AS cnt FROM attendance_edit_logs WHERE employee_id = ?', [empId]);
-    if (logRows[0].cnt >= 3) {
+    if (logRows[0].cnt >= 35) {
       await conn.rollback();
       req.flash('error', 'Edit limit reached for this employee');
       conn.release();

--- a/views/operatorEditAttendance.ejs
+++ b/views/operatorEditAttendance.ejs
@@ -31,8 +31,8 @@
       <label class="form-label">Punch Out</label>
       <input type="time" name="punch_out" class="form-control" value="<%= attendance ? attendance.punch_out : '' %>">
     </div>
-    <button type="submit" class="btn btn-primary" <% if(editCount >= 3){ %> disabled <% } %> >Update</button>
-    <span class="ms-2">Remaining edits: <%= 3 - editCount %></span>
+    <button type="submit" class="btn btn-primary" <% if(editCount >= 35){ %> disabled <% } %> >Update</button>
+    <span class="ms-2">Remaining edits: <%= 35 - editCount %></span>
   </form>
 </div>
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
## Summary
- allow up to 35 attendance edits before locking updates
- show remaining edits accordingly
- update documentation

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b5c032b248320ba41e97f0408e716