### PR TITLE
Implement monthly attendance editor

### DIFF
--- a/routes/operatorEmployeeRoutes.js
+++ b/routes/operatorEmployeeRoutes.js
@@ -210,4 +210,86 @@ router.post('/supervisors/:id/bulk-attendance', isAuthenticated, isOperator, asy
   }
 });
 
+// Bulk edit attendance for a single employee over a month
+router.get('/employees/:id/bulk-attendance', isAuthenticated, isOperator, async (req, res) => {
+  const empId = req.params.id;
+  const month = req.query.month || moment().format('YYYY-MM');
+  try {
+    const [[employee]] = await pool.query('SELECT id, name, supervisor_id FROM employees WHERE id = ?', [empId]);
+    if (!employee) {
+      req.flash('error', 'Employee not found');
+      return res.redirect('/operator/supervisors');
+    }
+    const [rows] = await pool.query(
+      'SELECT date, punch_in, punch_out FROM employee_attendance WHERE employee_id = ? AND DATE_FORMAT(date, "%Y-%m") = ? ORDER BY date',
+      [empId, month]
+    );
+    const daysInMonth = moment(month, 'YYYY-MM').daysInMonth();
+    const days = [];
+    for (let d = 1; d <= daysInMonth; d++) {
+      const dateStr = moment(`${month}-${d}`, 'YYYY-MM-D').format('YYYY-MM-DD');
+      const att = rows.find(a => moment(a.date).format('YYYY-MM-DD') === dateStr);
+      days.push({ date: dateStr, punch_in: att ? att.punch_in : '', punch_out: att ? att.punch_out : '' });
+    }
+    res.render('operatorEmployeeBulkAttendance', { user: req.session.user, employee, month, days });
+  } catch (err) {
+    console.error('Error loading attendance:', err);
+    req.flash('error', 'Failed to load attendance');
+    res.redirect('back');
+  }
+});
+
+router.post('/employees/:id/bulk-attendance', isAuthenticated, isOperator, async (req, res) => {
+  const empId = req.params.id;
+  const month = req.body.month;
+  let dates = req.body.date || [];
+  let punchIns = req.body.punch_in || [];
+  let punchOuts = req.body.punch_out || [];
+  if (!Array.isArray(dates)) dates = [dates];
+  if (!Array.isArray(punchIns)) punchIns = [punchIns];
+  if (!Array.isArray(punchOuts)) punchOuts = [punchOuts];
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+    const [[emp]] = await conn.query('SELECT supervisor_id FROM employees WHERE id = ?', [empId]);
+    if (!emp) {
+      await conn.rollback();
+      req.flash('error', 'Employee not found');
+      conn.release();
+      return res.redirect('/operator/supervisors');
+    }
+    for (let i = 0; i < dates.length; i++) {
+      const date = dates[i];
+      const punch_in = punchIns[i] || null;
+      const punch_out = punchOuts[i] || null;
+      const [[att]] = await conn.query('SELECT id, punch_in, punch_out FROM employee_attendance WHERE employee_id = ? AND date = ?', [empId, date]);
+      const newStatus = punch_in && punch_out ? 'present' : punch_in || punch_out ? 'one punch only' : 'absent';
+      if (att) {
+        await conn.query('UPDATE employee_attendance SET punch_in = ?, punch_out = ?, status = ? WHERE id = ?', [punch_in, punch_out, newStatus, att.id]);
+        await conn.query(
+          'INSERT INTO attendance_edit_logs (employee_id, attendance_date, old_punch_in, old_punch_out, new_punch_in, new_punch_out, operator_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
+          [empId, date, att.punch_in, att.punch_out, punch_in, punch_out, req.session.user.id]
+        );
+      } else {
+        await conn.query('INSERT INTO employee_attendance (employee_id, date, punch_in, punch_out, status) VALUES (?, ?, ?, ?, ?)', [empId, date, punch_in, punch_out, newStatus]);
+        await conn.query(
+          'INSERT INTO attendance_edit_logs (employee_id, attendance_date, old_punch_in, old_punch_out, new_punch_in, new_punch_out, operator_id) VALUES (?, ?, ?, ?, ?, ?, ?)',
+          [empId, date, null, null, punch_in, punch_out, req.session.user.id]
+        );
+      }
+    }
+    await calculateSalaryForMonth(conn, empId, month);
+    await conn.commit();
+    conn.release();
+    req.flash('success', 'Attendance updated');
+    res.redirect(`/operator/employees/${empId}/bulk-attendance?month=${month}`);
+  } catch (err) {
+    await conn.rollback();
+    conn.release();
+    console.error('Error updating attendance:', err);
+    req.flash('error', 'Failed to update attendance');
+    res.redirect('back');
+  }
+});
+
 module.exports = router;

--- a/views/operatorEmployeeBulkAttendance.ejs
+++ b/views/operatorEmployeeBulkAttendance.ejs
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Employee Attendance - <%= employee.name %></title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Attendance - <%= employee.name %></span>
+    <div class="ms-auto">
+      <a href="/operator/supervisors/<%= employee.supervisor_id %>/employees" class="btn btn-outline-light btn-sm me-2">Back</a>
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container my-4">
+  <%- include('partials/flashMessages') %>
+  <form method="GET" class="row g-2 align-items-end mb-3">
+    <div class="col-auto">
+      <label class="form-label">Month</label>
+      <input type="month" name="month" class="form-control" value="<%= month %>" required>
+    </div>
+    <div class="col-auto">
+      <button class="btn btn-secondary">Load</button>
+    </div>
+  </form>
+  <form method="POST">
+    <input type="hidden" name="month" value="<%= month %>">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Date</th>
+          <th>Punch In</th>
+          <th>Punch Out</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% days.forEach(function(d){ %>
+        <tr>
+          <td><%= d.date %></td>
+          <td>
+            <input type="time" name="punch_in[]" class="form-control form-control-sm" value="<%= d.punch_in || '' %>">
+          </td>
+          <td>
+            <input type="time" name="punch_out[]" class="form-control form-control-sm" value="<%= d.punch_out || '' %>">
+          </td>
+          <input type="hidden" name="date[]" value="<%= d.date %>">
+        </tr>
+        <% }) %>
+      </tbody>
+    </table>
+    <button type="submit" class="btn btn-primary">Update Attendance</button>
+  </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/operatorSupervisorEmployees.ejs
+++ b/views/operatorSupervisorEmployees.ejs
@@ -40,6 +40,7 @@
             <input type="date" name="date" class="form-control form-control-sm me-2" required>
             <button class="btn btn-sm btn-secondary">Edit Punch</button>
           </form>
+          <a href="/operator/employees/<%= emp.id %>/bulk-attendance" class="btn btn-sm btn-primary mt-1">Bulk Edit</a>
         </td>
       </tr>
       <% }) %>


### PR DESCRIPTION
## Summary
- allow operators to update an employee's punch times for a whole month
- add `/operator/employees/:id/bulk-attendance` routes
- link to the new editor from the employee list
- create `operatorEmployeeBulkAttendance.ejs` view

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b5de9b29483208fcdff50711a99aa