### PR TITLE
Fix user lookup in night data upload

### DIFF
--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -145,7 +145,7 @@ router.post('/salary/upload-nights', isAuthenticated, isOperator, upload.single(
       let supervisorCondition = '';
       const params = [punchingId, name];
       if (supName) {
-        const [[sup]] = await conn.query('SELECT id FROM users WHERE name = ? LIMIT 1', [supName]);
+        const [[sup]] = await conn.query('SELECT id FROM users WHERE username = ? LIMIT 1', [supName]);
         if (sup) {
           supervisorCondition = ' AND supervisor_id = ?';
           params.push(sup.id);


### PR DESCRIPTION
## Summary
- fix supervisor lookup on night data upload by using `username`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686b9dc04c508320a292cf3d3293633f