### PR TITLE
Add card for paid employees

### DIFF
--- a/routes/employeeRoutes.js
+++ b/routes/employeeRoutes.js
@@ -39,8 +39,9 @@ router.get('/employees', isAuthenticated, isSupervisor, async (req, res) => {
       months.push({ value: m.format('YYYY-MM'), label: m.format('MMM YYYY') });
     }
 
-    let topEmployees = [];
-    let presentCount = 0;
+  let topEmployees = [];
+  let presentCount = 0;
+  let paidCount = 0;
     if (totalEmployees && monthStart.isValid()) {
       const startDate = monthStart.format('YYYY-MM-DD');
       const endDate = monthStart.endOf('month').format('YYYY-MM-DD');
@@ -89,6 +90,12 @@ router.get('/employees', isAuthenticated, isSupervisor, async (req, res) => {
         [ids, startDate, endDate]
       );
       presentCount = presentRows[0]?.cnt || 0;
+
+      const [salaryRows] = await pool.query(
+        'SELECT COUNT(*) AS cnt FROM employee_salaries WHERE employee_id IN (?) AND month = ? AND net > 0',
+        [ids, selectedMonth]
+      );
+      paidCount = salaryRows[0]?.cnt || 0;
     }
 
     res.render('supervisorEmployees', {
@@ -99,6 +106,7 @@ router.get('/employees', isAuthenticated, isSupervisor, async (req, res) => {
       avgSalary,
       topEmployees,
       presentCount,
+      paidCount,
       months,
       selectedMonth
     });

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -25,7 +25,7 @@
 </nav>
 <div class="container-fluid my-4">
   <%- include('partials/flashMessages') %>
-  <div class="row row-cols-1 row-cols-md-4 g-3 mb-4">
+  <div class="row row-cols-1 row-cols-md-5 g-3 mb-4">
     <div class="col">
       <div class="card summary-card">
         <div class="card-body">
@@ -50,6 +50,15 @@
           <div class="icon"><i class="fas fa-user-check"></i></div>
           <div class="fw-semibold">Present Employees</div>
           <div><%= presentCount %></div>
+        </div>
+      </div>
+    </div>
+    <div class="col">
+      <div class="card summary-card">
+        <div class="card-body">
+          <div class="icon"><i class="fas fa-money-bill-wave"></i></div>
+          <div class="fw-semibold">Paid Employees</div>
+          <div><%= paidCount %></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- count employees with salary >0 for selected month
- display Paid Employees card on supervisor dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686ba0598f9083209224c0c2086aa768