### PR TITLE
Add option to reset all supervisors

### DIFF
--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -335,11 +335,12 @@
     <div class="card shadow-sm">
       <div class="card-header">Reset Supervisor Data</div>
       <div class="card-body">
-        <form action="/operator/departments/reset-supervisor" method="POST" class="row g-3 align-items-end" onsubmit="return confirm('Delete all attendance and salary data for this supervisor?');">
+        <form action="/operator/departments/reset-supervisor" method="POST" class="row g-3 align-items-end" onsubmit="return confirm('Delete all attendance and salary data for the selected supervisor(s)?');">
           <div class="col-md-6">
             <label class="form-label">Supervisor</label>
             <select name="supervisor_id" class="form-select" required>
               <option value="">Choose...</option>
+              <option value="all">All Supervisors</option>
               <% supervisors.forEach(function(s){ %>
                 <option value="<%= s.id %>"><%= s.username %></option>
               <% }) %>


### PR DESCRIPTION
## Summary
- allow resetting salary data for all supervisors
- show new `All Supervisors` option in the operator dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686c0f0cc6348320b457daec5a586abe