### PR TITLE
Fix webhook route and add logs page

### DIFF
--- a/routes/inventoryWebhook.js
+++ b/routes/inventoryWebhook.js
@@ -2,34 +2,53 @@
 const express = require('express');
 const router = express.Router();
 
+// In-memory store for recent webhook requests
+const logs = [];
+
 // Override global JSON parser: use raw buffer to capture true payload
 router.post(
   '/inventory',
   express.raw({ type: 'application/json', limit: '1mb' }),
   (req, res) => {
     // 1) Inspect all incoming headers
-    console.log('— HEADERS —', req.headers);
+    const headers = req.headers;
 
-    // 2) Convert buffer → UTF-8 string and log raw JSON
-    const raw = req.body.toString('utf8');
-    console.log('— RAW BODY —', raw);
+    // 2) Determine if body is Buffer (when express.json did NOT run)
+    let raw;
+    if (Buffer.isBuffer(req.body)) {
+      raw = req.body.toString('utf8');
+    } else {
+      // Already parsed to object; reconstruct JSON string for logging
+      raw = JSON.stringify(req.body);
+    }
 
-    // 3) Parse JSON manually
+    // 3) Parse JSON only when body is still a string
     let data;
     try {
-      data = JSON.parse(raw);
+      data = Buffer.isBuffer(req.body) ? JSON.parse(raw) : req.body;
     } catch (err) {
-      console.error('❌ JSON.parse failed:', err);
       return res.status(400).send('Invalid JSON');
     }
 
-    // 4) Log structured object
-    console.log('📥 Inventory update received:', JSON.stringify(data, null, 2));
-    console.log('🔑 Access-Token header:', req.get('Access-Token'));
+    // Store log entry
+    logs.push({
+      time: new Date().toISOString(),
+      headers,
+      raw,
+      data,
+      accessToken: req.get('Access-Token'),
+    });
+    // keep only last 50
+    if (logs.length > 50) logs.shift();
 
-    // 5) Acknowledge receipt to prevent retries
+    // Acknowledge receipt to prevent retries
     res.status(200).send('OK');
   }
 );
+
+// View webhook logs
+router.get('/logs', (req, res) => {
+  res.render('webhookLogs', { logs });
+});
 
 module.exports = router;

--- a/views/webhookLogs.ejs
+++ b/views/webhookLogs.ejs
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Webhook Logs</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Webhook Logs</span>
+  </div>
+</nav>
+<div class="container mt-4">
+  <h3>Recent Inventory Webhook Calls</h3>
+  <table class="table table-bordered table-sm">
+    <thead class="table-light">
+      <tr>
+        <th>Time</th>
+        <th>Access Token</th>
+        <th>Raw Body</th>
+        <th>Parsed Data</th>
+      </tr>
+    </thead>
+    <tbody>
+    <% logs.slice().reverse().forEach(function(log) { %>
+      <tr>
+        <td><%= log.time %></td>
+        <td><%= log.accessToken %></td>
+        <td><pre class="mb-0"><%= log.raw %></pre></td>
+        <td><pre class="mb-0"><%= JSON.stringify(log.data, null, 2) %></pre></td>
+      </tr>
+    <% }); %>
+    </tbody>
+  </table>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- keep last webhook requests in memory
- expose `/webhook/logs` page
- create `views/webhookLogs.ejs` for viewing webhook data

## Testing
- `npm install`
- `node -e "require('./routes/inventoryWebhook')"`


------
https://chatgpt.com/codex/tasks/task_e_686f9fee48d8832082cd54fda349385c