### PR TITLE
Allow per-SKU inventory alert thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,3 +339,10 @@ CREATE TABLE sandwich_dates (
 A sandwich day is normally a paid leave. However, if an employee is absent either the day before or the day after, the sandwich day becomes unpaid and is deducted from salary.
 
 Salaries are released 15 days after the end of the month so that any deductions for damage or misconduct can be applied before payout.
+
+### Inventory Webhook Alerts
+
+The `/webhook/inventory` endpoint can send WhatsApp alerts when stock levels are low.
+Use `/webhook/config` to map each SKU to its own threshold.
+Enter one mapping per line in the form `SKU:THRESHOLD`.
+Alerts are sent to the hard-coded phone numbers whenever a received payload includes an SKU with quantity below its configured threshold.

--- a/views/inventoryAlertConfig.ejs
+++ b/views/inventoryAlertConfig.ejs
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Inventory Alert Configuration</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Inventory Alert Config</span>
+  </div>
+</nav>
+<div class="container mt-4">
+  <% if (error && error.length > 0) { %>
+    <div class="alert alert-danger"><%= error[0] %></div>
+  <% } %>
+  <% if (success && success.length > 0) { %>
+    <div class="alert alert-success"><%= success[0] %></div>
+  <% } %>
+  <form method="POST" action="/webhook/config">
+    <div class="mb-3">
+      <label for="rules" class="form-label">SKU Thresholds (one per line as <code>SKU:THRESHOLD</code>)</label>
+      <textarea class="form-control" id="rules" name="rules" rows="5"><%= configText %></textarea>
+      <div class="form-text">Example: <code>ABC123:10</code></div>
+    </div>
+    <button type="submit" class="btn btn-primary">Save</button>
+  </form>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- support mapping each SKU to its own alert threshold
- update `/webhook/inventory` logic to check per-SKU thresholds
- replace configuration UI with textarea for `SKU:THRESHOLD` mappings
- document new configuration format in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686fb684dd4c8320bbab5be960465e32