### PR TITLE
Improve Twilio configuration handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Kotty Track is a Node.js and Express application used to manage the production w
    SESSION_SECRET=your-session-secret
    PORT=3000
    NODE_ENV=development
+   # Twilio credentials (optional - required for WhatsApp/SMS alerts)
+   TWILIO_ACCOUNT_SID=your-twilio-sid
+   TWILIO_AUTH_TOKEN=your-twilio-token
+   TWILIO_WHATSAPP_FROM=whatsapp:+14155238886
+   TWILIO_SMS_FROM=+19284272221
    ```
    Encrypt the file:
    ```bash

--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -2051,8 +2051,13 @@ const TWILIO_AUTH_TOKEN     = global.env.TWILIO_AUTH_TOKEN;
 const TWILIO_WHATSAPP_FROM  = global.env.TWILIO_WHATSAPP_FROM;
 const TWILIO_SMS_FROM       = global.env.TWILIO_SMS_FROM;
 
-// 2) Create Twilio Client
-const TWILIO_CLIENT = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+// 2) Create Twilio Client only when credentials are provided
+let TWILIO_CLIENT = null;
+if (TWILIO_ACCOUNT_SID && TWILIO_AUTH_TOKEN) {
+  TWILIO_CLIENT = twilio(TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN);
+} else {
+  console.warn("Twilio credentials missing; notifications disabled.");
+}
 
 // Hard-coded user → phone map
 const USER_PHONE_MAP = {
@@ -2080,6 +2085,9 @@ function chunkMessage(text, limit=1600) {
 
 /** Send one chunk via WhatsApp, fallback to SMS if WA fails. */
 async function sendChunk(phone, body) {
+  if (!TWILIO_CLIENT) {
+    return { ok: false, via: null, error: "Twilio client not configured" };
+  }
   try {
     // Attempt WhatsApp
     await TWILIO_CLIENT.messages.create({


### PR DESCRIPTION
## Summary
- document required Twilio environment variables
- create Twilio client only when credentials exist
- skip sending alerts when Twilio is not configured

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686fdcc029288320a1ab8d4d52bbc676