### PR TITLE
Secure webhook endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,6 +348,7 @@ Salaries are released 15 days after the end of the month so that any deductions 
 ### Inventory Webhook Alerts
 
 The `/webhook/inventory` endpoint can send WhatsApp alerts when stock levels are low.
+Operator authentication is required for all `/webhook` routes.
 Use `/webhook/config` to map each SKU to its own threshold.
 Enter one mapping per line in the form `SKU:THRESHOLD`.
 Alerts are sent to the hard-coded phone numbers whenever a received payload includes an SKU with quantity below its configured threshold.

--- a/routes/inventoryWebhook.js
+++ b/routes/inventoryWebhook.js
@@ -2,6 +2,7 @@
 const express = require('express');
 const router = express.Router();
 const twilio = require('twilio');
+const { isAuthenticated, isOperator } = require('../middlewares/auth');
 
 // Twilio credentials (same as used elsewhere)
 // Load Twilio credentials from encrypted environment variables
@@ -30,6 +31,8 @@ let alertConfig = {
 // Override global JSON parser: use raw buffer to capture true payload
 router.post(
   '/inventory',
+  isAuthenticated,
+  isOperator,
   express.raw({ type: 'application/json', limit: '1mb' }),
   async (req, res) => {
     // 1) Inspect all incoming headers
@@ -104,7 +107,7 @@ router.post(
 );
 
 // Render a simple page to update alert configuration
-router.get('/config', (req, res) => {
+router.get('/config', isAuthenticated, isOperator, (req, res) => {
   const configText = Object.entries(alertConfig.skuThresholds)
     .map(([sku, th]) => `${sku}:${th}`)
     .join('\n');
@@ -116,7 +119,7 @@ router.get('/config', (req, res) => {
 });
 
 // Update alert configuration
-router.post('/config', (req, res) => {
+router.post('/config', isAuthenticated, isOperator, (req, res) => {
   if (typeof req.body.rules === 'string') {
     const map = {};
     req.body.rules
@@ -139,7 +142,7 @@ router.post('/config', (req, res) => {
 });
 
 // View webhook logs
-router.get('/logs', (req, res) => {
+router.get('/logs', isAuthenticated, isOperator, (req, res) => {
   res.render('webhookLogs', { logs });
 });
 


### PR DESCRIPTION
## Summary
- require operator auth on all webhook routes
- document the new requirement in README

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_686fe8e4b30c8320b97b458887612702