### PR TITLE
Add realtime webhook log stream

### DIFF
--- a/views/webhookLogs.ejs
+++ b/views/webhookLogs.ejs
@@ -6,34 +6,64 @@
   <title>Webhook Logs</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
 </head>
-<body>
+<body class="bg-light">
 <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
   <div class="container-fluid">
     <span class="navbar-brand">Webhook Logs</span>
   </div>
 </nav>
-<div class="container mt-4">
-  <h3>Recent Inventory Webhook Calls</h3>
-  <table class="table table-bordered table-sm">
-    <thead class="table-light">
-      <tr>
-        <th>Time</th>
-        <th>Access Token</th>
-        <th>Raw Body</th>
-        <th>Parsed Data</th>
-      </tr>
-    </thead>
-    <tbody>
-    <% logs.slice().reverse().forEach(function(log) { %>
-      <tr>
-        <td><%= log.time %></td>
-        <td><%= log.accessToken %></td>
-        <td><pre class="mb-0"><%= log.raw %></pre></td>
-        <td><pre class="mb-0"><%= JSON.stringify(log.data, null, 2) %></pre></td>
-      </tr>
-    <% }); %>
-    </tbody>
-  </table>
+<div class="container py-4">
+  <h3 class="mb-4">Inventory Webhook Calls</h3>
+  <div class="table-responsive shadow-sm">
+    <table id="log-table" class="table table-bordered table-striped table-sm align-middle">
+      <thead class="table-dark">
+        <tr>
+          <th>Time</th>
+          <th>Access Token</th>
+          <th>Raw Body</th>
+          <th>Parsed Data</th>
+        </tr>
+      </thead>
+      <tbody id="log-body">
+      <% logs.slice().reverse().forEach(function(log) { %>
+        <tr>
+          <td><%= log.time %></td>
+          <td><%= log.accessToken %></td>
+          <td><pre class="mb-0"><%= log.raw %></pre></td>
+          <td><pre class="mb-0"><%= JSON.stringify(log.data, null, 2) %></pre></td>
+        </tr>
+      <% }); %>
+      </tbody>
+    </table>
+  </div>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const logBody = document.getElementById('log-body');
+  const evtSource = new EventSource('/webhook/logs/stream');
+
+  evtSource.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+    if (data.logs) {
+      data.logs.slice().reverse().forEach(addRow);
+    } else if (data.log) {
+      addRow(data.log);
+    }
+  };
+
+  function addRow(log) {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${log.time}</td>
+      <td>${log.accessToken || ''}</td>
+      <td><pre class="mb-0">${log.raw}</pre></td>
+      <td><pre class="mb-0">${JSON.stringify(log.data, null, 2)}</pre></td>
+    `;
+    logBody.prepend(row);
+    if (logBody.rows.length > 50) {
+      logBody.deleteRow(-1);
+    }
+  }
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- broadcast webhook logs over Server-Sent Events
- show live updates in `webhookLogs` page and restyle table

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686febae15088320b54a7f7b5473c66b