### PR TITLE
Add Hooks card to operator dashboard

### DIFF
--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -186,6 +186,10 @@
         <i class="bi bi-file-earmark-spreadsheet fs-3" aria-hidden="true"></i>
         <div>Employee Excel</div>
       </a>
+      <a href="/webhook/logs" class="nav-card">
+        <i class="bi bi-plug fs-3" aria-hidden="true"></i>
+        <div>Hooks</div>
+      </a>
     </div>
 
   <!-- Stat Cards -->


### PR DESCRIPTION
## Summary
- add navigation card linking to `/webhook/logs` on operator dashboard

## Testing
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_6870b3ef5ee08320ad4255dffb072256