### PR TITLE
Persist SKU thresholds

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,11 +132,18 @@ CREATE TABLE push_subscriptions (
   p256dh TEXT NOT NULL,
   auth TEXT NOT NULL
 );
+
+CREATE TABLE sku_thresholds (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  sku VARCHAR(255) NOT NULL UNIQUE,
+  threshold INT NOT NULL
+);
 ```
 
 `inventory_alerts` stores each threshold breach so operators can review past
 events. `push_subscriptions` holds browser push registration data for users
-who have allowed notifications.
+who have allowed notifications. `sku_thresholds` keeps the threshold for each
+SKU so webhook alerts survive server restarts.
 
 Create a `store_admin` role in the `roles` table to allow managing the list of goods. Users with this role can add new items (description, size and unit) from the Store Admin dashboard. Newly created items automatically appear in the store inventory pages.
 
@@ -370,6 +377,8 @@ The `/webhook/inventory` endpoint records incoming webhook data and broadcasts a
 Requests do not require a session but must include the `Access-Token` header provided by EasyEcom.
 Use `/webhook/config` to map each SKU to its own threshold.
 Enter one mapping per line in the form `SKU:THRESHOLD`.
+Values are stored in `sku_thresholds` so the configuration persists across
+server restarts.
 
 To receive browser push notifications you must generate VAPID keys and set
 `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` in your `.env` file. Clients visiting


### PR DESCRIPTION
## Summary
- keep inventory webhook thresholds after restart by storing them in `sku_thresholds`
- load thresholds on startup and allow updating them via `/webhook/config`
- document the new table and behaviour in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870bfebb4688320a2577fc0a46b0fd9