### PR TITLE
Persist push notification subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,3 +383,5 @@ server restarts.
 To receive browser push notifications you must generate VAPID keys and set
 `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` in your `.env` file. Clients visiting
 `/webhook/logs` will register a service worker that subscribes to push updates.
+Subscriptions are persisted in the `push_subscriptions` table so notifications
+continue working after server restarts.


### PR DESCRIPTION
## Summary
- load existing push subscriptions from DB on startup
- store new subscriptions in the `push_subscriptions` table
- document that subscriptions survive restarts

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6870d305fe888320adb1bf01367a58f8