### PR TITLE
Allow more operators to access webhook pages

### DIFF
--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -121,10 +121,17 @@ function isStoreAdmin(req, res, next) {
 }
 
 function isMohitOperator(req, res, next) {
+  const allowed = [
+    'mohitOperator',
+    'chandanSir',
+    'sales',
+    'sonuOpe',
+    'mam',
+  ];
   if (
     req.session &&
     req.session.user &&
-    req.session.user.username === 'mohitOperator'
+    allowed.includes(req.session.user.username)
   ) {
     return next();
   }


### PR DESCRIPTION
## Summary
- extend `isMohitOperator` middleware to whitelist several operator accounts

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6870e431fccc832099153aff75a70c50