### PR TITLE
Add size wise PIC report

### DIFF
--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -174,6 +174,10 @@
       <i class="bi bi-file-earmark-check fs-3" aria-hidden="true"></i>
       <div>PIC Report</div>
     </a>
+    <a href="/operator/dashboard/pic-size-report" class="nav-card">
+      <i class="bi bi-file-earmark-spreadsheet fs-3" aria-hidden="true"></i>
+      <div>Size PIC Report</div>
+    </a>
       <a href="/operator/departments" class="nav-card">
         <i class="bi bi-wallet2 fs-3" aria-hidden="true"></i>
         <div>Salaries</div>

--- a/views/operatorSizeReport.ejs
+++ b/views/operatorSizeReport.ejs
@@ -1,0 +1,168 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Download Size PIC Report</title>
+
+  <!-- Bootstrap CSS (for basic styling) -->
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"
+    rel="stylesheet"
+  />
+
+  <style>
+    /* Simple overlay for "Processing..." state */
+    #overlaySpinner {
+      position: fixed;
+      top: 0; 
+      left: 0; 
+      width: 100%; 
+      height: 100%;
+      background: rgba(0,0,0,0.4);
+      display: none; /* hidden by default */
+      align-items: center;
+      justify-content: center;
+      z-index: 9999;
+    }
+    #overlaySpinner .spinner {
+      background: #fff;
+      padding: 20px;
+      border-radius: 10px;
+      text-align: center;
+    }
+  </style>
+</head>
+<body class="p-3">
+  <h1>Size Wise PIC Report Download</h1>
+  <hr>
+
+  <div class="mb-4">
+    <p>
+      This page downloads the Excel-based PIC Report broken down by size. Select your filters
+      below and click <strong>Download Report</strong>. A “Processing” overlay 
+      will appear while the system generates the Excel file.
+    </p>
+  </div>
+
+  <!-- Filter Form (no direct submission, we'll handle it via JS) -->
+  <form id="filterForm" class="row g-3">
+    <div class="col-md-2">
+      <label class="form-label">Lot Type</label>
+      <select name="lotType" class="form-select">
+        <option value="all">All</option>
+        <option value="denim">Denim</option>
+        <option value="hosiery">Hosiery</option>
+      </select>
+    </div>
+    <div class="col-md-2">
+      <label class="form-label">Department</label>
+      <select name="department" class="form-select">
+        <option value="all">All</option>
+        <option value="cutting">Cutting</option>
+        <option value="stitching">Stitching</option>
+        <option value="assembly">Assembly</option>
+        <option value="washing">Washing</option>
+        <option value="washing_in">Washing In</option>
+        <option value="finishing">Finishing</option>
+      </select>
+    </div>
+    <div class="col-md-2">
+      <label class="form-label">Status</label>
+      <select name="status" class="form-select">
+        <option value="all">All</option>
+        <option value="pending">Pending</option>
+        <option value="inline">In-Line</option>
+        <option value="completed">Completed</option>
+        <option value="denied">Denied</option>
+        <option value="not_assigned">Not Assigned</option>
+      </select>
+    </div>
+    <div class="col-md-2">
+      <label class="form-label">Date Filter</label>
+      <select name="dateFilter" class="form-select">
+        <option value="createdAt">Created At</option>
+        <option value="assignedOn">Assigned On</option>
+      </select>
+    </div>
+    <div class="col-md-2">
+      <label class="form-label">Start Date</label>
+      <input type="date" name="startDate" class="form-control">
+    </div>
+    <div class="col-md-2">
+      <label class="form-label">End Date</label>
+      <input type="date" name="endDate" class="form-control">
+    </div>
+  </form>
+
+  <div class="mt-3">
+    <button class="btn btn-success" onclick="downloadReport()">Download Report</button>
+  </div>
+
+  <!-- Overlay Spinner -->
+  <div id="overlaySpinner">
+    <div class="spinner">
+      <div class="mb-2">Generating Excel report...</div>
+      <div class="spinner-border text-primary" role="status">
+        <span class="visually-hidden">Loading...</span>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    // Show the overlay spinner
+    function showSpinner() {
+      document.getElementById("overlaySpinner").style.display = "flex";
+    }
+    // Hide the overlay spinner
+    function hideSpinner() {
+      document.getElementById("overlaySpinner").style.display = "none";
+    }
+
+    // Collect form filters, call /dashboard/pic-report with download=1,
+    // fetch as Blob, then force download
+    async function downloadReport() {
+      try {
+        // 1. Collect form data
+        const form = document.getElementById("filterForm");
+        const formData = new FormData(form);
+        const params = new URLSearchParams();
+
+        for (const [key, val] of formData.entries()) {
+          params.append(key, val);
+        }
+        // Make sure we include download=1 to trigger Excel output
+        params.set("download", "1");
+
+        // 2. Show spinner
+        showSpinner();
+
+        // 3. Fetch the route that returns the Excel as a binary
+        const url = "/operator/dashboard/pic-size-report?" + params.toString();
+        const response = await fetch(url, { method: "GET" });
+        if (!response.ok) {
+          throw new Error("Server responded with status " + response.status);
+        }
+
+        // 4. Convert response to Blob
+        const blob = await response.blob();
+
+        // 5. Force download
+        const downloadUrl = window.URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = downloadUrl;
+        // We'll set the file name ourselves
+        a.download = "PICReport-BySize.xlsx";
+        document.body.appendChild(a);
+        a.click();
+        a.remove();
+        window.URL.revokeObjectURL(downloadUrl);
+      } catch (err) {
+        alert("Error downloading report: " + err.message);
+      } finally {
+        // 6. Hide spinner
+        hideSpinner();
+      }
+    }
+  </script>
+</body>
+</html>

--- a/views/partials/operatorNavLinks.ejs
+++ b/views/partials/operatorNavLinks.ejs
@@ -5,6 +5,7 @@
 <a href="#" onclick="window.print()"><i class="bi bi-printer"></i> Print</a>
 <a href="/assign-to-washing"><i class="bi bi-arrow-right-circle"></i> Washing</a>
 <a href="/operator/dashboard/pic-report"><i class="bi bi-file-earmark-check"></i>Per Piece Report</a>
+<a href="/operator/dashboard/pic-size-report"><i class="bi bi-file-earmark-spreadsheet"></i>Size PIC Report</a>
 <a href="/operator/departments"><i class="bi bi-wallet2"></i> Salaries</a>
 <a href="/operator/dashboard/employees/download"><i class="bi bi-file-earmark-spreadsheet"></i> Employee Excel</a>
 <div class="mt-3">


### PR DESCRIPTION
## Summary
- create page to download PIC report per SKU size
- link new report from operator dashboard and sidebar
- implement `/dashboard/pic-size-report` route that aggregates data by lot and size

## Testing
- `node -c routes/operatorRoutes.js`

------
https://chatgpt.com/codex/tasks/task_e_687115532f7483208e231c2c79bde34c