### PR TITLE
Add inventory alerts list page

### DIFF
--- a/routes/skuRoutes.js
+++ b/routes/skuRoutes.js
@@ -1,10 +1,23 @@
 const express = require('express');
 const router = express.Router();
 const { isAuthenticated, isOperator } = require('../middlewares/auth');
+const { pool } = require('../config/db');
 
 router.get('/sku/:sku', isAuthenticated, isOperator, (req, res) => {
   const sku = req.params.sku;
   res.render('skuDetail', { sku });
+});
+
+router.get('/inventory/alerts', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const [alerts] = await pool.query(
+      'SELECT sku, quantity, created_at FROM inventory_alerts ORDER BY created_at DESC LIMIT 50'
+    );
+    res.render('inventoryAlerts', { alerts });
+  } catch (err) {
+    console.error('Failed to load inventory alerts', err);
+    res.render('inventoryAlerts', { alerts: [] });
+  }
 });
 
 module.exports = router;

--- a/views/inventoryAlerts.ejs
+++ b/views/inventoryAlerts.ejs
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="vapid-public" content="<%= vapidPublicKey %>">
+  <title>Inventory Alerts</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { background-color: #f8f9fa; }
+  </style>
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Inventory Alerts</span>
+    <div class="ms-auto">
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+<div class="container py-4">
+  <div class="table-responsive shadow-sm">
+    <table class="table table-bordered table-striped table-sm align-middle">
+      <thead class="table-dark">
+        <tr>
+          <th>Time</th>
+          <th>SKU</th>
+          <th>Inventory</th>
+        </tr>
+      </thead>
+      <tbody id="alert-body">
+        <% alerts.forEach(function(a){ %>
+          <tr>
+            <td><%= a.created_at.toLocaleString('en-CA', { hour12: false }) %></td>
+            <td><%= a.sku %></td>
+            <td><%= a.quantity %></td>
+          </tr>
+        <% }); %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const alertBody = document.getElementById('alert-body');
+  const evt = new EventSource('/webhook/logs/stream');
+  evt.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+    if (data.alert) {
+      addRow(data.alert);
+    }
+  };
+  function addRow(alert){
+    const row = document.createElement('tr');
+    const time = new Date().toLocaleString('en-CA', { hour12: false });
+    row.innerHTML = `<td>${time}</td><td>${alert.sku}</td><td>${alert.quantity}</td>`;
+    alertBody.prepend(row);
+    if(alertBody.rows.length > 50){
+      alertBody.deleteRow(-1);
+    }
+  }
+</script>
+<script src="/public/js/notification.js"></script>
+</body>
+</html>

--- a/views/webhookLogs.ejs
+++ b/views/webhookLogs.ejs
@@ -53,7 +53,7 @@
     } else if (data.log) {
       addRow(data.log);
     } else if (data.alert) {
-      showNotification(data.alert.message, data.alert.sku);
+      showNotification(data.alert.message);
     }
   };
 
@@ -71,13 +71,10 @@
     }
   }
 
-  function showNotification(msg, sku) {
+  function showNotification(msg) {
     if (window.Notification && Notification.permission === 'granted') {
       const n = new Notification('Inventory Alert', { body: msg });
-      if (sku) {
-        // Open the SKU detail page directly
-        n.onclick = () => window.open('/sku/' + encodeURIComponent(sku), '_blank');
-      }
+      n.onclick = () => window.open('/inventory/alerts', '_blank');
     }
   }
 


### PR DESCRIPTION
## Summary
- show real-time inventory alerts page
- broadcast inventory quantity with alerts
- redirect push notifications to the new alerts list
- allow viewing alerts list via `/inventory/alerts`
- update logs page notifications to open alerts list

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_687258c4407c8320a90efcef39bae9ff