### PR TITLE
Fix Sunday credit logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,13 +292,13 @@ Punching in after **09:15** results in an additional one-hour deduction from the
 
 ### Sunday Attendance Rules
 
-- **Special departments (`catalog`, `account`, `merchant`)** – Sundays never grant extra pay; any worked Sunday is credited as leave.
+- **Special departments (`catalog`, `accounts`, `merchant`)** – Sundays never grant extra pay. A worked Sunday is credited as leave only when both the preceding Saturday and following Monday are present; if either is absent, that Sunday is unpaid.
 - **All other departments** – a Sunday is paid only when the employee works that day and has unused `paid_sunday_allowance`. Otherwise the day is credited as leave.
 
 Employees receive Sunday pay only when they have valid punch in/out times with positive working hours.
 
 These credited days are automatically inserted into `employee_leaves` during salary calculations.
-For most teams, a Sunday becomes unpaid whenever the employee is absent on the adjacent Saturday or Monday. If both days are missed, all three (Saturday–Sunday–Monday) are deducted from salary. Teams supervised by **Rohit Shukla** follow the old rule where Sunday counts only when Saturday *and* Monday are absent. When the employee works on that Sunday, any adjacent absence is paid as usual.
+For most teams, a Sunday becomes unpaid whenever the employee is absent on the adjacent Saturday or Monday. If both days are missed, all three (Saturday–Sunday–Monday) are deducted from salary. Teams supervised by **Rohit Shukla** follow the old rule where Sunday counts only when Saturday *and* Monday are absent. When the employee works on that Sunday, any adjacent absence is paid as usual. Special departments only receive the Sunday credit when both adjacent days are present.
 
 ### Attendance Edit Logs
 

--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -501,7 +501,17 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
           const hrsWorked = effectiveHours(a.punch_in, a.punch_out, 'monthly');
           if (hrsWorked > 0) {
             if (specialDept) {
-              a.deduction_reason = 'Leave credited';
+              const satKey = moment(a.date).subtract(1, 'day').format('YYYY-MM-DD');
+              const monKey = moment(a.date).add(1, 'day').format('YYYY-MM-DD');
+              const satStatus = attMap[satKey] !== undefined ? attMap[satKey] : 'present';
+              const monStatus = attMap[monKey] !== undefined ? attMap[monKey] : 'present';
+              const missedSat = satStatus === 'absent' || satStatus === 'one punch only';
+              const missedMon = monStatus === 'absent' || monStatus === 'one punch only';
+              if (!missedSat && !missedMon) {
+                a.deduction_reason = 'Leave credited';
+              } else {
+                a.deduction_reason = 'Unpaid due to adjacent absence';
+              }
             } else if (paidUsed < (emp.paid_sunday_allowance || 0)) {
               a.deduction_reason = 'Paid Sunday';
               paidUsed++;


### PR DESCRIPTION
## Summary
- update Sunday credit rules for `catalog`, `accounts`, and `merchant` departments
- adjust absence logic in salary calculator for special departments
- clarify deduction reason for Sundays in salary routes
- document updated Sunday policy in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6874ea08c79c832092491eefe5471fe8