### PR TITLE
Add salary hours download

### DIFF
--- a/views/operatorSalaries.ejs
+++ b/views/operatorSalaries.ejs
@@ -19,6 +19,10 @@
 </nav>
 <div class="container my-4">
   <%- include('partials/flashMessages') %>
+  <form action="/operator/departments/salary/download-hours" method="GET" class="d-flex gap-2 mb-3">
+    <input type="month" name="month" class="form-control" required>
+    <button type="submit" class="btn btn-success"><i class="bi bi-file-earmark-arrow-down"></i> Hours Excel</button>
+  </form>
   <table class="table table-bordered">
     <thead>
       <tr>

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -89,6 +89,12 @@
         <button type="submit" class="btn btn-success"><i class="bi bi-file-earmark-arrow-down"></i> Salary Excel</button>
       </form>
     </div>
+    <div class="col-md-6 mt-2 mt-md-0">
+      <form action="/supervisor/salary/download-hours" method="GET" class="d-flex gap-2 align-items-end">
+        <input type="month" name="month" class="form-control" value="<%= selectedMonth %>" required>
+        <button type="submit" class="btn btn-success"><i class="bi bi-file-earmark-arrow-down"></i> Hours Excel</button>
+      </form>
+    </div>
   </div>
   <h4>Add Employee</h4>
   <form action="/supervisor/employees" method="POST" class="row g-3 mb-4">


### PR DESCRIPTION
## Summary
- add new hour check salary download for supervisors and operators
- enable hour-based Excel downloads in supervisor and operator pages

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687656b58b2c8320a83ab39a4e414e57