### PR TITLE
Implement undertime deduction in salary downloads

### DIFF
--- a/views/operatorSalaries.ejs
+++ b/views/operatorSalaries.ejs
@@ -19,10 +19,6 @@
 </nav>
 <div class="container my-4">
   <%- include('partials/flashMessages') %>
-  <form action="/operator/departments/salary/download-hours" method="GET" class="d-flex gap-2 mb-3">
-    <input type="month" name="month" class="form-control" required>
-    <button type="submit" class="btn btn-success"><i class="bi bi-file-earmark-arrow-down"></i> Hours Excel</button>
-  </form>
   <table class="table table-bordered">
     <thead>
       <tr>

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -89,12 +89,7 @@
         <button type="submit" class="btn btn-success"><i class="bi bi-file-earmark-arrow-down"></i> Salary Excel</button>
       </form>
     </div>
-    <div class="col-md-6 mt-2 mt-md-0">
-      <form action="/supervisor/salary/download-hours" method="GET" class="d-flex gap-2 align-items-end">
-        <input type="month" name="month" class="form-control" value="<%= selectedMonth %>" required>
-        <button type="submit" class="btn btn-success"><i class="bi bi-file-earmark-arrow-down"></i> Hours Excel</button>
-      </form>
-    </div>
+    <div class="col-md-6"></div>
   </div>
   <h4>Add Employee</h4>
   <form action="/supervisor/employees" method="POST" class="row g-3 mb-4">


### PR DESCRIPTION
## Summary
- remove supervisor and operator routes for hours-based salary download
- drop download-hours forms from salary views
- add undertime deduction logic to salary Excel exports
- include new `UT Deduct` and `UT Detail` columns in salary sheets

## Testing
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_68766a8c0f7083208db381386aee51d0