### PR TITLE
Fix salary hours and base display

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -31,7 +31,8 @@ function effectiveHours(punchIn, punchOut, salaryType = 'dihadi') {
     mins -= 60;
   }
 
-  if (mins > 11 * 60) mins = 11 * 60;
+  // Cap daily hours at 11 only for dihadi workers
+  if (salaryType === 'dihadi' && mins > 11 * 60) mins = 11 * 60;
   if (mins < 0) mins = 0;
   return mins / 60;
 }

--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -45,6 +45,7 @@
       - <%= half === 1 ? '1-15' : '16-end' %>
     <% } %>
   </h5>
+  <h6>Base Salary: <%= employee.salary %></h6>
   <table class="table table-bordered">
     <thead>
       <tr>
@@ -68,7 +69,7 @@
       <% attendance.forEach(a => { %>
         <tr>
           <td><%= a.date.toLocaleDateString('en-CA') %></td>
-          <td><%= a.status %></td>
+          <td><%= a.status.charAt(0).toUpperCase() + a.status.slice(1) %></td>
           <td><%= a.detailed_status || '' %></td>
           <td><%= a.punch_in || '' %></td>
           <td><%= a.punch_out || '' %></td>


### PR DESCRIPTION
## Summary
- avoid capping daily hours for monthly staff
- show base salary in employee salary details
- capitalize status display

## Testing
- `node --check helpers/salaryCalculator.js`
- `npm install`
- `npm start` *(fails: Cannot find module 'secure-env')*

------
https://chatgpt.com/codex/tasks/task_e_68777dd5af688320b3681d154861709d