### PR TITLE
Fix undertime deduction after lunch

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -16,6 +16,14 @@ function lunchDeduction(punchIn, punchOut, salaryType = 'dihadi') {
 }
 exports.lunchDeduction = lunchDeduction;
 
+function crossedLunch(punchIn, punchOut) {
+  const start = moment(punchIn, 'HH:mm:ss');
+  const end = moment(punchOut, 'HH:mm:ss');
+  const lunch = moment('13:10:00', 'HH:mm:ss');
+  return start.isSameOrBefore(lunch) && end.isAfter(lunch);
+}
+exports.crossedLunch = crossedLunch;
+
 function effectiveHours(punchIn, punchOut, salaryType = 'dihadi') {
   const start = moment(punchIn, 'HH:mm:ss');
   const end = moment(punchOut, 'HH:mm:ss');

--- a/routes/departmentMgmtRoutes.js
+++ b/routes/departmentMgmtRoutes.js
@@ -10,6 +10,7 @@ const XLSX = require('xlsx');
 const {
   calculateSalaryForMonth,
   effectiveHours,
+  crossedLunch,
 } = require('../helpers/salaryCalculator');
 const { validateAttendanceFilename } = require('../helpers/attendanceFilenameValidator');
 
@@ -311,7 +312,9 @@ router.get('/departments/salary/download', isAuthenticated, isOperator, async (r
           const hrs = effectiveHours(a.punch_in, a.punch_out, 'monthly');
           const diff = hrs - parseFloat(r.allotted_hours || 0);
           if (diff > 0) { otHours += diff; otDays++; }
-          else if (diff < 0) { utHours += Math.abs(diff); utDays++; }
+          else if (diff < 0 && crossedLunch(a.punch_in, a.punch_out)) {
+            utHours += Math.abs(diff); utDays++;
+          }
         }
       });
       const notes = [];
@@ -479,7 +482,8 @@ router.get('/departments/salary/download-rule', isAuthenticated, isOperator, asy
           const hrs = effectiveHours(a.punch_in, a.punch_out, 'monthly');
           const diff = hrs - parseFloat(r.allotted_hours || 0);
           if (diff > 0) { otHours += diff; otDays++; }
-          else if (diff < 0) { utHours += Math.abs(diff); utDays++; }
+          else if (diff < 0 && crossedLunch(a.punch_in, a.punch_out)) {
+            utHours += Math.abs(diff); utDays++; }
           const allotted = parseFloat(r.allotted_hours || 0);
           if (hrs >= allotted * 0.4 && hrs < allotted * 0.85) halfDays++;
           if (rule === 'monthly_short' && hrs < allotted) shortDays++;


### PR DESCRIPTION
## Summary
- add `crossedLunch` helper
- apply lunch-based undertime logic in department and salary routes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68778ab65cb88320934f5a437ce099b0