### PR TITLE
Add hourly salary override support

### DIFF
--- a/utils/specialTeamEmployees.js
+++ b/utils/specialTeamEmployees.js
@@ -1,0 +1,1 @@
+module.exports.SPECIAL_TEAM_EMPLOYEE_IDS = [];


### PR DESCRIPTION
## Summary
- support specifying Sunday hours when uploading hourly salary data
- skip hourly processing for special team employees
- compute pay day-by-day for hourly salary calculations
- expose list of special team employees

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68792066178483209e6b58c8a73c7b93