### PR TITLE
Update salary view

### DIFF
--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -62,7 +62,7 @@
         <% if (employee.salary_type === 'dihadi') { %>
           <th>Lunch Deduction (mins)</th>
         <% } %>
-        <th>Deduction Reason</th>
+        <th>Amount</th>
       </tr>
     </thead>
     <tbody>
@@ -81,16 +81,17 @@
           <% if (employee.salary_type === 'dihadi') { %>
             <td><%= a.lunch_deduction %></td>
           <% } %>
-          <td><%= a.deduction_reason %></td>
+          <td><%= typeof a.amount === 'number' ? a.amount.toFixed(2) : '' %></td>
         </tr>
       <% }) %>
     </tbody>
   </table>
   <% if (employee.salary_type === 'monthly') { %>
     <h6>OT: <%= overtimeFormatted || '00:00' %> | UT: <%= undertimeFormatted || '00:00' %></h6>
+    <h6>Total Hours: <%= totalHours || '00:00' %> (Sundays: <%= sundayHours || '00:00' %>)</h6>
   <% } %>
   <% if (employee.salary_type === 'dihadi') { %>
-    <h6>Total Hours: <%= totalHours || '00:00' %> | Hourly Pay: <%= hourlyRate.toFixed(2) %> | Amount: <%= partialAmount ? partialAmount.toFixed(2) : '0.00' %></h6>
+    <h6>Total Hours: <%= totalHours || '00:00' %> (Sundays: <%= sundayHours || '00:00' %>) | Hourly Pay: <%= hourlyRate.toFixed(2) %> | Amount: <%= partialAmount ? partialAmount.toFixed(2) : '0.00' %></h6>
   <% } %>
   <% if (salary) { %>
     <h6 class="salary-container">


### PR DESCRIPTION
## Summary
- compute daily amount and hours
- show daily amounts in salary table
- export hours instead of P when downloading
- display totals with Sunday hours

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68793dbfebf4832097685553d83dc9ce