### PR TITLE
Fix salary calcs for leave credit, sandwich and join dates

### DIFF
--- a/routes/departmentMgmtRoutes.js
+++ b/routes/departmentMgmtRoutes.js
@@ -299,8 +299,6 @@ router.get('/departments/salary/download', isAuthenticated, isOperator, async (r
       adjacent.forEach(a => {
         attMap[moment(a.date).format('YYYY-MM-DD')] = a.status;
       });
-      if (!attMap[prevDay]) attMap[prevDay] = 'absent';
-      if (!attMap[nextDay]) attMap[nextDay] = 'absent';
       let absent = 0, onePunch = 0, sundayAbs = 0;
       let otHours = 0, utHours = 0, otDays = 0, utDays = 0;
       attRows.forEach(a => {


### PR DESCRIPTION
## Summary
- handle employee join date when fetching attendance
- adjust sandwich logic so cross-month days aren't auto-absent
- compute hourly pay correctly for leave credit and sandwich absence
- filter attendance by join date in all salary calculators

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6879ed21080c832089e2e5b9f45cf172