### PR TITLE
Fix monthly grace period logic

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -29,6 +29,14 @@ function effectiveHours(punchIn, punchOut, salaryType = 'dihadi') {
   const start = moment(punchIn, 'HH:mm:ss');
   const end = moment(punchOut, 'HH:mm:ss');
   let mins = end.diff(start, 'minutes');
+  // Apply 15 minute grace period for monthly employees
+  if (salaryType !== 'dihadi') {
+    const shiftStart = moment('09:00:00', 'HH:mm:ss');
+    if (start.isAfter(shiftStart)) {
+      const grace = Math.min(15, start.diff(shiftStart, 'minutes'));
+      mins += grace;
+    }
+  }
   mins -= lunchDeduction(punchIn, punchOut, salaryType);
 
   // Deduct minutes for late arrivals after the 15 minute grace period


### PR DESCRIPTION
## Summary
- apply 15‑minute grace for monthly workers in `effectiveHours`

## Testing
- `npm install`
- `node -e "require('./helpers/salaryCalculator'); console.log('module loaded')"`

------
https://chatgpt.com/codex/tasks/task_e_687a0a6d9a848320975ba7c81cc9982f