### PR TITLE
Optimize washing assignment route

### DIFF
--- a/routes/assigntowashingRoutes.js
+++ b/routes/assigntowashingRoutes.js
@@ -4,6 +4,13 @@ const router = express.Router();
 const { pool } = require('../config/db');
 const { isAuthenticated, isOperator } = require('../middlewares/auth');
 
+// Simple in-memory cache with TTL for dropdown data
+const cache = {
+  assemblyUsers: { data: null, expiry: 0 },
+  washers: { data: null, expiry: 0 }
+};
+const CACHE_TTL_MS = 60 * 1000; // 1 minute
+
 /**
  * GET /assign-to-washing
  * Render the assignment dashboard with a dropdown of jeans assembly operators (excluding those with "hoisery")
@@ -11,28 +18,46 @@ const { isAuthenticated, isOperator } = require('../middlewares/auth');
  */
 router.get('/', isAuthenticated, isOperator, async (req, res) => {
   try {
-    // Fetch jeans assembly users (exclude usernames that contain "hoisery")
-    const [assemblyUsers] = await pool.query(`
-      SELECT u.id, u.username 
-      FROM users u 
-      JOIN roles r ON u.role_id = r.id 
-      WHERE r.name = 'jeans_assembly' 
-        AND u.username NOT LIKE '%hoisery%'
-      ORDER BY u.username ASC
-    `);
+    const now = Date.now();
+    const fetchAssemblyUsers = async () => {
+      if (cache.assemblyUsers.data && cache.assemblyUsers.expiry > now) {
+        return cache.assemblyUsers.data;
+      }
+      const [rows] = await pool.query(`
+        SELECT u.id, u.username
+        FROM users u
+        JOIN roles r ON u.role_id = r.id
+        WHERE r.name = 'jeans_assembly'
+          AND u.username NOT LIKE '%hoisery%'
+        ORDER BY u.username ASC
+      `);
+      cache.assemblyUsers = { data: rows, expiry: now + CACHE_TTL_MS };
+      return rows;
+    };
 
-    // Fetch washers (active users with role "washing")
-    const [washers] = await pool.query(`
-      SELECT u.id, u.username 
-      FROM users u 
-      JOIN roles r ON u.role_id = r.id 
-      WHERE r.name = 'washing' 
-        AND u.is_active = 1 
-      ORDER BY u.username ASC
-    `);
+    const fetchWashers = async () => {
+      if (cache.washers.data && cache.washers.expiry > now) {
+        return cache.washers.data;
+      }
+      const [rows] = await pool.query(`
+        SELECT u.id, u.username
+        FROM users u
+        JOIN roles r ON u.role_id = r.id
+        WHERE r.name = 'washing'
+          AND u.is_active = 1
+        ORDER BY u.username ASC
+      `);
+      cache.washers = { data: rows, expiry: now + CACHE_TTL_MS };
+      return rows;
+    };
+
+    const [assemblyUsers, washers] = await Promise.all([
+      fetchAssemblyUsers(),
+      fetchWashers()
+    ]);
 
     res.render('assignToWashingDashboard', {
-      assemblyUsers,  // updated variable name for jeans assembly users
+      assemblyUsers,
       washers,
       error: req.flash('error'),
       success: req.flash('success')
@@ -53,47 +78,34 @@ router.get('/data/:userId', isAuthenticated, isOperator, async (req, res) => {
   try {
     const userId = req.params.userId;
     const [rows] = await pool.query(`
-      SELECT jad.id, jad.lot_no, jad.sku, jad.total_pieces,
-             DATE(jad.created_at) AS created_date,
-             jads.size_label, jads.pieces
+      SELECT
+        DATE(jad.created_at) AS created_date,
+        JSON_ARRAYAGG(
+          JSON_OBJECT(
+            'id', jad.id,
+            'lot_no', jad.lot_no,
+            'sku', jad.sku,
+            'total_pieces', jad.total_pieces,
+            'sizes', (
+              SELECT JSON_ARRAYAGG(JSON_OBJECT('size_label', jas.size_label, 'pieces', jas.pieces))
+              FROM jeans_assembly_data_sizes jas
+              WHERE jas.jeans_assembly_data_id = jad.id
+            )
+          ) ORDER BY jad.id ASC
+        ) AS entries
       FROM jeans_assembly_data jad
-      LEFT JOIN jeans_assembly_data_sizes jads ON jad.id = jads.jeans_assembly_data_id
+      LEFT JOIN washing_assignments wa ON wa.jeans_assembly_assignment_id = jad.id
       WHERE jad.user_id = ?
-        AND jad.id NOT IN (SELECT jeans_assembly_assignment_id FROM washing_assignments)
-      ORDER BY jad.created_at DESC, jad.id ASC
+        AND wa.id IS NULL
+      GROUP BY DATE(jad.created_at)
+      ORDER BY created_date DESC
     `, [userId]);
 
-    // Group the results by created_date and by record id
-    const grouped = {};
-    rows.forEach(row => {
-      const date = row.created_date;
-      if (!grouped[date]) grouped[date] = {};
-      if (!grouped[date][row.id]) {
-        grouped[date][row.id] = {
-          id: row.id,
-          lot_no: row.lot_no,
-          sku: row.sku,
-          total_pieces: row.total_pieces,
-          sizes: []
-        };
-      }
-      if (row.size_label) {
-        grouped[date][row.id].sizes.push({
-          size_label: row.size_label,
-          pieces: row.pieces
-        });
-      }
-    });
+    const result = rows.map(row => ({
+      created_date: row.created_date,
+      entries: JSON.parse(row.entries || '[]')
+    }));
 
-    const result = [];
-    for (const date in grouped) {
-      result.push({
-        created_date: date,
-        entries: Object.values(grouped[date])
-      });
-    }
-    // Sort groups by date descending
-    result.sort((a, b) => new Date(b.created_date) - new Date(a.created_date));
     res.json(result);
   } catch (err) {
     console.error('Error fetching jeans assembly data:', err);
@@ -110,32 +122,24 @@ router.get('/data/:userId', isAuthenticated, isOperator, async (req, res) => {
  */
 router.post('/assign', isAuthenticated, isOperator, async (req, res) => {
   try {
-    // Notice the parameter name has changed from stitching_data_id to jeans_assembly_data_id
     const { jeans_assembly_data_id, washer_id } = req.body;
     if (!jeans_assembly_data_id || !washer_id) {
       req.flash('error', 'Invalid parameters.');
       return res.redirect('/assign-to-washing');
     }
 
-    // Get the jeans assembly data record using the provided id
-    const [[assemblyRecord]] = await pool.query(
-      `SELECT * FROM jeans_assembly_data WHERE id = ?`,
-      [jeans_assembly_data_id]
-    );
+    const [ [assemblyRecord], [sizes] ] = await Promise.all([
+      pool.query(`SELECT user_id FROM jeans_assembly_data WHERE id = ?`, [jeans_assembly_data_id]).then(r => r[0]),
+      pool.query(`SELECT size_label, pieces FROM jeans_assembly_data_sizes WHERE jeans_assembly_data_id = ?`, [jeans_assembly_data_id]).then(r => r[0])
+    ]);
+
     if (!assemblyRecord) {
       req.flash('error', 'Jeans Assembly record not found.');
       return res.redirect('/assign-to-washing');
     }
 
-    // Get the sizes from jeans_assembly_data_sizes for this record.
-    const [sizes] = await pool.query(
-      `SELECT size_label, pieces FROM jeans_assembly_data_sizes WHERE jeans_assembly_data_id = ?`,
-      [jeans_assembly_data_id]
-    );
     const sizes_json = JSON.stringify(sizes);
 
-    // Insert a new washing assignment.
-    // Note: We now record the jeans assembly assignment details
     await pool.query(`
       INSERT INTO washing_assignments
         (jeans_assembly_master_id, user_id, jeans_assembly_assignment_id, target_day, assigned_on, sizes_json, is_approved)


### PR DESCRIPTION
## Summary
- cache dropdown data with a short TTL
- aggregate washing data in SQL to reduce JS work
- parallelize select queries when creating assignments

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687a3eb045b48320b192a0e5ad5bb8f6