### PR TITLE
Add Stitch TAT link on operator dashboard

### DIFF
--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -194,6 +194,10 @@
         <i class="bi bi-exclamation-diamond fs-3" aria-hidden="true"></i>
         <div>Duplicate Lots</div>
       </a>
+      <a href="/operator/stitching-tat" class="nav-card">
+        <i class="bi bi-hourglass-split fs-3" aria-hidden="true"></i>
+        <div>Stitching TAT</div>
+      </a>
       <a href="/webhook/logs" class="nav-card">
         <i class="bi bi-plug fs-3" aria-hidden="true"></i>
         <div>Hooks</div>


### PR DESCRIPTION
## Summary
- add a navigation card for Stitching TAT

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b217c0a408320848cd1151777d30a