### PR TITLE
Add caching for inventory alerts

### DIFF
--- a/routes/skuRoutes.js
+++ b/routes/skuRoutes.js
@@ -3,6 +3,22 @@ const router = express.Router();
 const { isAuthenticated, isOperator } = require('../middlewares/auth');
 const { pool } = require('../config/db');
 
+// Simple in-memory cache for inventory alerts
+const ALERT_CACHE_TTL_MS = 60 * 1000; // 1 minute
+let alertCache = { data: null, expiry: 0 };
+
+async function getInventoryAlerts() {
+  const now = Date.now();
+  if (alertCache.data && alertCache.expiry > now) {
+    return alertCache.data;
+  }
+  const [rows] = await pool.query(
+    'SELECT sku, quantity, created_at FROM inventory_alerts ORDER BY created_at DESC LIMIT 50'
+  );
+  alertCache = { data: rows, expiry: now + ALERT_CACHE_TTL_MS };
+  return rows;
+}
+
 router.get('/sku/:sku', isAuthenticated, isOperator, (req, res) => {
   const sku = req.params.sku;
   res.render('skuDetail', { sku });
@@ -10,9 +26,7 @@ router.get('/sku/:sku', isAuthenticated, isOperator, (req, res) => {
 
 router.get('/inventory/alerts', isAuthenticated, isOperator, async (req, res) => {
   try {
-    const [alerts] = await pool.query(
-      'SELECT sku, quantity, created_at FROM inventory_alerts ORDER BY created_at DESC LIMIT 50'
-    );
+    const alerts = await getInventoryAlerts();
     res.render('inventoryAlerts', { alerts });
   } catch (err) {
     console.error('Failed to load inventory alerts', err);


### PR DESCRIPTION
## Summary
- improve `skuRoutes.js` by caching inventory alert queries to reduce DB load

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687be379d38c8320b734cf78dd8848be