### PR TITLE
Fix dihadi salary view

### DIFF
--- a/helpers/detailedStatus.js
+++ b/helpers/detailedStatus.js
@@ -4,6 +4,20 @@ const { SPECIAL_SUNDAY_SUPERVISORS } = require('../utils/supervisors');
 const { effectiveHours } = require('./salaryCalculator');
 
 function applyDetailedStatus(attendance, emp, sandwichDates) {
+  if (emp.salary_type === 'dihadi') {
+    attendance.forEach(a => {
+      if (a.status === 'present' && a.punch_in && a.punch_out && effectiveHours(a.punch_in, a.punch_out, 'dihadi') > 0) {
+        a.detailed_status = 'Present';
+      } else if (a.status === 'one punch only') {
+        a.detailed_status = 'Missing punch';
+      } else if (a.status === 'absent') {
+        a.detailed_status = 'Absent';
+      } else {
+        a.detailed_status = a.status.charAt(0).toUpperCase() + a.status.slice(1);
+      }
+    });
+    return;
+  }
   const attMap = {};
   attendance.forEach(a => {
     attMap[moment(a.date).format('YYYY-MM-DD')] = a.status;

--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -521,7 +521,12 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
     );
     applyDetailedStatus(attendance, emp, sandwichDates);
     const daysInMonth = moment(month + '-01').daysInMonth();
-    const dailyRate = parseFloat(emp.salary) / daysInMonth;
+    let dailyRate;
+    if (emp.salary_type === 'dihadi') {
+      dailyRate = parseFloat(emp.salary);
+    } else {
+      dailyRate = parseFloat(emp.salary) / daysInMonth;
+    }
     let totalHours = 0;
     let sundayHours = 0;
     let hourlyRate = 0;
@@ -530,10 +535,11 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
     let partialPay = 0;
     let overtimeTotal = 0;
     let undertimeTotal = 0;
-    if (
-      emp.salary_type === 'dihadi' ||
-      (emp.salary_type === 'monthly' && hourlyView)
-    ) {
+    if (emp.salary_type === 'dihadi') {
+      hourlyRate = emp.allotted_hours
+        ? parseFloat(emp.salary) / parseFloat(emp.allotted_hours)
+        : 0;
+    } else if (emp.salary_type === 'monthly' && hourlyView) {
       hourlyRate = emp.allotted_hours
         ? dailyRate / parseFloat(emp.allotted_hours)
         : 0;


### PR DESCRIPTION
## Summary
- correct daily rate and hourly rate for dihadi in salary view
- avoid Sunday/leave statuses for daily-wage workers

## Testing
- `npm install`
- `node -e "require('./helpers/detailedStatus.js');"`
- `node -e "require('./routes/salaryRoutes.js');"` *(fails: cannot read DB_HOST env)*

------
https://chatgpt.com/codex/tasks/task_e_687dca6c994c8320bb7ef28153e203cf