### PR TITLE
Fix employee supervisor fetch parsing

### DIFF
--- a/routes/operatorEmployeeRoutes.js
+++ b/routes/operatorEmployeeRoutes.js
@@ -65,7 +65,7 @@ router.get(
   async (req, res) => {
     const supId = req.params.id;
     try {
-      const [[supervisor]] = await fetchCached(`op-sup-${supId}`, () =>
+      const [supervisor] = await fetchCached(`op-sup-${supId}`, () =>
         pool
           .query(
             'SELECT id, username FROM users WHERE id = ? AND role_id IN (SELECT id FROM roles WHERE name = "supervisor")',
@@ -256,7 +256,7 @@ router.get(
     const supId = req.params.id;
     const date = req.query.date || moment().format("YYYY-MM-DD");
     try {
-      const [[supervisor]] = await fetchCached(`op-sup-${supId}`, () =>
+      const [supervisor] = await fetchCached(`op-sup-${supId}`, () =>
         pool
           .query(
             'SELECT id, username FROM users WHERE id = ? AND role_id IN (SELECT id FROM roles WHERE name = "supervisor")',


### PR DESCRIPTION
## Summary
- fix fetchCached result destructuring for supervisor routes

## Testing
- `node --check routes/operatorEmployeeRoutes.js`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687dd2934f1c8320835400e3d6bf4511