### PR TITLE
Fix dihadi late/lunch deduction logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,11 +261,11 @@ primarily from `helpers/salaryCalculator.js` and related routes.
   based on their punch‑out time:
   - 0 minutes if the employee leaves before **13:10**.
   - 30 minutes if the employee leaves between **13:10** and **18:10**.
-- 60 minutes for any punch‑out after **18:10**.
-- Dihadi workers arriving after **09:15** lose **one hour** from their total
-  working hours. This deduction is skipped when the punch in time is later
-  than 40% of the allotted shift. Their day is still capped at **11 working
-  hours**.
+- 60 minutes for any punch‑out after **18:10** when the shift begins before the
+  40% mark; otherwise only **30 minutes** is deducted.
+Dihadi workers arriving after **09:15** lose **one hour** from their total
+working hours, unless their punch in time is later than **40%** of the allotted
+shift. Their day is still capped at **11 working hours**.
 
 #### Monthly Worker Attendance
 

--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -555,7 +555,12 @@ router.get('/employees/:id/salary', isAuthenticated, isSupervisor, async (req, r
           emp.salary_type === 'dihadi' ? emp.allotted_hours : undefined
         );
         a.hours = formatHours(hrsDec);
-        a.lunch_deduction = lunchDeduction(a.punch_in, a.punch_out, emp.salary_type);
+        a.lunch_deduction = lunchDeduction(
+          a.punch_in,
+          a.punch_out,
+          emp.salary_type,
+          emp.salary_type === 'dihadi' ? emp.allotted_hours : undefined
+        );
         if (emp.salary_type === 'monthly') {
           const baseHours = isSun ? 9 : parseFloat(emp.allotted_hours || 0);
           let diff = hrsDec - baseHours;
@@ -1055,7 +1060,12 @@ router.get('/supervisor/dihadi/download', isAuthenticated, isSupervisor, async (
               'dihadi',
               emp.allotted_hours
             );
-            const lunch = lunchDeduction(a.punch_in, a.punch_out, 'dihadi');
+            const lunch = lunchDeduction(
+              a.punch_in,
+              a.punch_out,
+              'dihadi',
+              emp.allotted_hours
+            );
             byDate[day] = hrs.toFixed(2);
             totalHrs += hrs;
             totalLunch += lunch;


### PR DESCRIPTION
## Summary
- update lunch deduction to depend on shift threshold
- skip late deduction after 40% of shift
- pass allotted hours when calculating lunch breaks
- document new rules in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688092a3455883208344768b60c0a2dd