### PR TITLE
Fix update modal data loading

### DIFF
--- a/routes/washingInRoutes.js
+++ b/routes/washingInRoutes.js
@@ -578,7 +578,7 @@ router.get('/update/:id/json', isAuthenticated, isWashingInMaster, async (req, r
     console.error('[ERROR] GET /washingin/update/:id/json =>', err);
     return res.status(500).json({ error: err.message });
   }
-  console.log('updateSizes received →', req.body.updateSizes);
+  // No further processing needed
 
 });
 

--- a/views/finishingDashboard.ejs
+++ b/views/finishingDashboard.ejs
@@ -567,6 +567,10 @@
         const resp = await fetch(`/finishingdashboard/update/${entryId}/json`);
         if (!resp.ok) throw new Error('Failed to fetch update JSON');
         const data = await resp.json();
+        if (!Array.isArray(data.sizes) || !data.sizes.length) {
+          document.getElementById('updateAlertContainer').innerHTML = '<div class="alert alert-danger">No size data available.</div>';
+          return;
+        }
         data.sizes.forEach(sz => {
           const tr = document.createElement('tr');
           tr.innerHTML = `
@@ -589,7 +593,10 @@
           document.getElementById('updateSubmitBtn').classList.remove('btn-secondary');
           document.getElementById('updateSubmitBtn').classList.add('btn-primary');
         }
-      } catch (err) { console.error(err); }
+      } catch (err) {
+        console.error(err);
+        document.getElementById('updateAlertContainer').innerHTML = '<div class="alert alert-danger">Failed to load data.</div>';
+      }
     });
     updateForm.addEventListener('submit', (evt) => {
       const oldFields = document.querySelectorAll('.updateSizeField');

--- a/views/jeansAssemblyDashboard.ejs
+++ b/views/jeansAssemblyDashboard.ejs
@@ -182,6 +182,7 @@
           <div class="modal-body">
             <p><strong>Updating Entry ID:</strong>
                <span id="updatingEntryId"></span></p>
+            <div id="updateAlert" class="alert alert-danger d-none"></div>
             <table class="table table-bordered" id="updateSizesTable">
               <thead class="table-light">
                 <tr>
@@ -397,11 +398,13 @@
     const updateModal = document.getElementById('updateModal');
     const updateSizesTable = document.getElementById('updateSizesTable');
     const updatingEntryId  = document.getElementById('updatingEntryId');
+    const updateAlert = document.getElementById('updateAlert');
     updateModal.addEventListener('show.bs.modal', async evt=>{
       const entryId = evt.relatedTarget.getAttribute('data-entry-id');
       updatingEntryId.textContent = entryId;
       const tbody = updateSizesTable.querySelector('tbody');
       tbody.innerHTML='';
+      updateAlert.classList.add('d-none');
       document.getElementById('updateForm').action =
         `/jeansassemblydashboard/update/${entryId}`;
 
@@ -409,6 +412,11 @@
         const r = await fetch(`/jeansassemblydashboard/update/${entryId}/json`);
         if(!r.ok) throw new Error(r.status);
         const {sizes=[]}=await r.json();
+        if(!sizes.length){
+          updateAlert.textContent='No size data available.';
+          updateAlert.classList.remove('d-none');
+          return;
+        }
         sizes.forEach(sz=>{
           const tr=document.createElement('tr');
           tr.innerHTML=`
@@ -419,7 +427,11 @@
                        placeholder="0" data-size-label="${sz.size_label}"></td>`;
           tbody.appendChild(tr);
         });
-      }catch(e){ console.error('Fetch update sizes:',e); }
+      }catch(e){
+        console.error('Fetch update sizes:',e);
+        updateAlert.textContent='Failed to load data.';
+        updateAlert.classList.remove('d-none');
+      }
     });
 
     document.getElementById('updateForm').addEventListener('submit', async e=>{

--- a/views/stitchingDashboard.ejs
+++ b/views/stitchingDashboard.ejs
@@ -432,12 +432,13 @@
           </div>
           <div class="modal-body">
             <p>
-              <strong>
-                <span data-lang="en">Updating Entry ID:</span>
-                <span data-lang="hi">अपडेट हो रही एंट्री आईडी:</span>
-              </strong>
-              <span id="updatingEntryId">-</span>
-            </p>
+            <strong>
+              <span data-lang="en">Updating Entry ID:</span>
+              <span data-lang="hi">अपडेट हो रही एंट्री आईडी:</span>
+            </strong>
+            <span id="updatingEntryId">-</span>
+            <div id="updateAlert" class="alert alert-danger d-none mt-2"></div>
+          </p>
             <div class="table-responsive">
               <table class="table table-bordered align-middle" id="updateSizesTable">
                 <thead class="table-light">
@@ -780,6 +781,7 @@
     const updateModal = document.getElementById('updateModal');
     const updateForm = document.getElementById('updateForm');
     const updateSizesTable = document.getElementById('updateSizesTable');
+    const updateAlert = document.getElementById('updateAlert');
     let currentUpdateEntryId = null;
 
     if (updateModal) {
@@ -789,15 +791,17 @@
         updateForm.action = '/stitchingdashboard/update/' + currentUpdateEntryId;
         document.getElementById('updatingEntryId').textContent = currentUpdateEntryId;
         updateSizesTable.querySelector('tbody').innerHTML = '';
+        updateAlert.classList.add('d-none');
 
         try {
           const res = await fetch(`/stitchingdashboard/update/${currentUpdateEntryId}/json`);
-          if (!res.ok) {
-            console.error('Error fetching existing sizes. Status:', res.status);
+          if (!res.ok) throw new Error(res.status);
+          const data = await res.json();
+          if (!Array.isArray(data.sizes) || !data.sizes.length) {
+            updateAlert.textContent = 'No size data available.';
+            updateAlert.classList.remove('d-none');
             return;
           }
-          const data = await res.json();
-          if (!data.sizes) return;
 
           data.sizes.forEach(sz => {
             const tr = document.createElement('tr');
@@ -832,6 +836,8 @@
           });
         } catch (err) {
           console.error(err);
+          updateAlert.textContent = 'Failed to load data.';
+          updateAlert.classList.remove('d-none');
         }
       });
 

--- a/views/washingDashboard.ejs
+++ b/views/washingDashboard.ejs
@@ -291,9 +291,10 @@
         </div>
         <div class="modal-body">
           <p>
-            <strong>Updating Entry ID:</strong>
-            <span id="updatingEntryId">-</span>
-          </p>
+          <strong>Updating Entry ID:</strong>
+          <span id="updatingEntryId">-</span>
+          <div id="updateAlert" class="alert alert-danger d-none mt-2"></div>
+        </p>
           <div class="table-responsive">
             <table class="table table-bordered align-middle" id="updateSizesTable">
               <thead class="table-light">
@@ -597,6 +598,7 @@
     const $updateForm       = $('#updateForm');
     const $updateSizesTable = $('#updateSizesTable tbody');
     const $updatingEntryId  = $('#updatingEntryId');
+    const $updateAlert      = $('#updateAlert');
 
     // When modal opens, fetch current sizes & remain
     $updateModal.on('show.bs.modal', async function(e) {
@@ -604,11 +606,16 @@
       $updatingEntryId.text(entryId);
       $updateForm.attr('action', `/washingdashboard/update/${entryId}`);
       $updateSizesTable.empty();
+      $updateAlert.addClass('d-none').text('');
 
       try {
         const res  = await fetch(`/washingdashboard/update/${entryId}/json`);
+        if (!res.ok) throw new Error('Fetch error');
         const data = await res.json();
-        if (!Array.isArray(data.sizes)) return;
+        if (!Array.isArray(data.sizes) || !data.sizes.length) {
+          $updateAlert.text('No size data available.').removeClass('d-none');
+          return;
+        }
 
         data.sizes.forEach(sz => {
           const tr = $(`
@@ -632,6 +639,7 @@
         });
       } catch (err) {
         console.error('Error loading update data:', err);
+        $updateAlert.text('Failed to load data.').removeClass('d-none');
       }
     });
 

--- a/views/washingInDashboard.ejs
+++ b/views/washingInDashboard.ejs
@@ -241,6 +241,7 @@
               <strong>Updating Entry ID:</strong>
               <span id="updatingEntryId">-</span>
             </p>
+            <div id="updateAlert" class="alert alert-danger d-none"></div>
             <!-- Table for showing existing sizes and allowing increment -->
             <div class="table-responsive">
               <table class="table table-bordered align-middle" id="updateSizesTable">
@@ -521,7 +522,8 @@
     const $updateModal = $('#updateModal'),
           $updateForm  = $('#updateForm'),
           $sizesBody   = $('#updateSizesTable tbody'),
-          $upId        = $('#updatingEntryId');
+          $upId        = $('#updatingEntryId'),
+          $alert       = $('#updateAlert');
 
     // When modal is shown, fetch current sizes for the entry
     $updateModal.on('show.bs.modal', async e => {
@@ -529,24 +531,33 @@
       $updateForm.attr('action', `/washingin/update/${id}`);
       $upId.text(id);
       $sizesBody.empty();
+      $alert.addClass('d-none').text('');
 
-      const res = await fetch(`/washingin/update/${id}/json`);
-      if (!res.ok) return alert('Fetch error');
-
-      // Populate table with existing size usage and remaining
-      (await res.json()).sizes.forEach(s => {
-        $sizesBody.append(`
-          <tr>
-            <td>${s.size_label}</td>
-            <td>${s.pieces}</td>
-            <td>${s.remain}</td>
-            <td>
-              <input type="number" class="form-control" min="0"
-                     data-size-id="${s.id}" autocomplete="off">
-            </td>
-          </tr>
-        `);
-      });
+      try {
+        const res = await fetch(`/washingin/update/${id}/json`);
+        if (!res.ok) throw new Error('Fetch error');
+        const data = await res.json();
+        if (!Array.isArray(data.sizes) || !data.sizes.length) {
+          $alert.text('No size data available.').removeClass('d-none');
+          return;
+        }
+        data.sizes.forEach(s => {
+          $sizesBody.append(`
+            <tr>
+              <td>${s.size_label}</td>
+              <td>${s.pieces}</td>
+              <td>${s.remain}</td>
+              <td>
+                <input type="number" class="form-control" min="0"
+                       data-size-id="${s.id}" autocomplete="off">
+              </td>
+            </tr>
+          `);
+        });
+      } catch (err) {
+        console.error(err);
+        $alert.text('Failed to load data.').removeClass('d-none');
+      }
     });
 
     // After modal closes, refresh the existing entries list


### PR DESCRIPTION
## Summary
- improve error handling when loading size data for update modals
- show alert messages when size data can't be loaded
- clean up unreachable log in `washingInRoutes`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6880a95f19b88320b700d912d0bb2823