### PR TITLE
Restrict salary editing for non privileged operators

### DIFF
--- a/routes/departmentMgmtRoutes.js
+++ b/routes/departmentMgmtRoutes.js
@@ -992,6 +992,11 @@ router.post('/departments/employees/:id/update', isAuthenticated, isOperator, as
   const paySunday = pay_sunday === '1' || pay_sunday === 1 || pay_sunday === true;
   const isActive = is_active === '1' || is_active === 1 || is_active === true;
   try {
+    let salaryVal = salary;
+    if (req.session.user.id !== PRIVILEGED_OPERATOR_ID) {
+      const [[row]] = await pool.query('SELECT salary FROM employees WHERE id=?', [empId]);
+      salaryVal = row ? row.salary : salary;
+    }
     await pool.query(
       `UPDATE employees SET punching_id=?, name=?, designation=?, phone_number=?, salary=?, salary_type=?, allotted_hours=?, paid_sunday_allowance=?, pay_sunday=?, leave_start_months=?, date_of_joining=?, is_active=? WHERE id=?`,
       [
@@ -999,7 +1004,7 @@ router.post('/departments/employees/:id/update', isAuthenticated, isOperator, as
         name,
         designation,
         phone_number,
-        salary,
+        salaryVal,
         salary_type,
         allotted_hours,
         paid_sunday_allowance || 0,

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -532,17 +532,18 @@
           data.forEach(emp => {
             const joinDate = new Date(emp.date_of_joining).toISOString().split('T')[0];
             const row = document.createElement('tr');
+            const salaryCell = canToggle
+              ? `<div class="input-group input-group-sm">
+                   <input type="password" step="0.01" class="form-control salary-input" name="salary" value="${emp.salary}" required>
+                   <button type="button" class="btn btn-outline-secondary toggle-salary"><i class="fas fa-eye"></i></button>
+                 </div>`
+              : '<span class="salary-hidden">****</span>';
             row.innerHTML = `
               <td><input type="text" class="form-control form-control-sm" name="punching_id" value="${emp.punching_id}"></td>
               <td><input type="text" class="form-control form-control-sm" name="name" value="${emp.name}" required></td>
               <td><input type="text" class="form-control form-control-sm" name="designation" value="${emp.designation || ''}"></td>
               <td><input type="text" class="form-control form-control-sm" name="phone_number" value="${emp.phone_number || ''}" pattern="\\d*"></td>
-              <td class="salary-container">
-                <div class="input-group input-group-sm">
-                  <input type="password" step="0.01" class="form-control salary-input" name="salary" value="${emp.salary}" required>
-                  ${canToggle ? '<button type="button" class="btn btn-outline-secondary toggle-salary"><i class="fas fa-eye"></i></button>' : ''}
-                </div>
-              </td>
+              <td class="salary-container">${salaryCell}</td>
               <td><select class="form-select form-select-sm" name="salary_type">
                     <option value="dihadi" ${emp.salary_type==='dihadi'?'selected':''}>Dihadi</option>
                     <option value="monthly" ${emp.salary_type==='monthly'?'selected':''}>Monthly</option>


### PR DESCRIPTION
## Summary
- hide salary inputs and toggles when operator is not privileged
- keep original salary when non privileged operators update employees
- omit salary column in employee export for non privileged operators

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688458453a408320aead15bdb758e2c4