### PR TITLE
Add optional Aadhar field

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ CREATE TABLE employees (
  
 );
 ```
+The employees table now includes an optional `aadhar_card_number VARCHAR(20)` column for storing Aadhar information.
+
 Each supervisor must assign unique punching IDs to their employees. This ensures no duplicate entries. Employees earn leave and salary details stored in `employee_salaries`. These actions are available from the operator dashboard, which also lists each supervisor with their active employee count and total monthly salary.
 
 ### Employee Leaves

--- a/routes/departmentMgmtRoutes.js
+++ b/routes/departmentMgmtRoutes.js
@@ -265,7 +265,7 @@ router.get('/departments/salary/download', isAuthenticated, isOperator, async (r
 
     const [rows] = await pool.query(`
       SELECT es.employee_id, es.gross, es.deduction, es.net, es.month,
-             e.punching_id, e.name AS employee_name, e.salary AS base_salary, e.salary_type,
+             e.punching_id, e.name AS employee_name, e.aadhar_card_number, e.salary AS base_salary, e.salary_type,
              e.paid_sunday_allowance, e.pay_sunday, e.allotted_hours,
              (SELECT COALESCE(SUM(amount),0) FROM employee_advances ea WHERE ea.employee_id = es.employee_id) AS advance_taken,
              (SELECT COALESCE(SUM(amount),0) FROM advance_deductions ad WHERE ad.employee_id = es.employee_id) AS advance_deducted,
@@ -403,6 +403,7 @@ router.get('/departments/salary/download', isAuthenticated, isOperator, async (r
       { header: 'Supervisor', key: 'supervisor', width: 20 },
       { header: 'Department', key: 'department', width: 15 },
       { header: 'Punching ID', key: 'punching_id', width: 15 },
+      { header: 'Aadhar', key: 'aadhar', width: 18 },
       { header: 'Employee', key: 'employee', width: 20 },
       { header: 'Salary Type', key: 'salary_type', width: 12 },
       { header: 'Month', key: 'month', width: 10 },
@@ -429,6 +430,7 @@ router.get('/departments/salary/download', isAuthenticated, isOperator, async (r
         supervisor: r.supervisor_name,
         department: r.department_name || '',
         punching_id: r.punching_id,
+        aadhar: r.aadhar_card_number || '',
         employee: r.employee_name,
         salary_type: r.salary_type,
         month: r.month,
@@ -476,7 +478,7 @@ router.get('/departments/salary/download-rule', isAuthenticated, isOperator, asy
 
     const [rows] = await pool.query(`
       SELECT es.employee_id, es.gross, es.deduction, es.net, es.month,
-             e.punching_id, e.name AS employee_name, e.salary AS base_salary, e.salary_type,
+             e.punching_id, e.name AS employee_name, e.aadhar_card_number, e.salary AS base_salary, e.salary_type,
              e.paid_sunday_allowance, e.pay_sunday, e.allotted_hours,
              (SELECT COALESCE(SUM(amount),0) FROM employee_advances ea WHERE ea.employee_id = es.employee_id) AS advance_taken,
              (SELECT COALESCE(SUM(amount),0) FROM advance_deductions ad WHERE ad.employee_id = es.employee_id) AS advance_deducted,
@@ -610,6 +612,7 @@ router.get('/departments/salary/download-rule', isAuthenticated, isOperator, asy
       { header: 'Supervisor', key: 'supervisor', width: 20 },
       { header: 'Department', key: 'department', width: 15 },
       { header: 'Punching ID', key: 'punching_id', width: 15 },
+      { header: 'Aadhar', key: 'aadhar', width: 18 },
       { header: 'Employee', key: 'employee', width: 20 },
       { header: 'Salary Type', key: 'salary_type', width: 12 },
       { header: 'Month', key: 'month', width: 10 },
@@ -636,6 +639,7 @@ router.get('/departments/salary/download-rule', isAuthenticated, isOperator, asy
         supervisor: r.supervisor_name,
         department: r.department_name || '',
         punching_id: r.punching_id,
+        aadhar: r.aadhar_card_number || '',
         employee: r.employee_name,
         salary_type: r.salary_type,
         month: r.month,
@@ -680,7 +684,7 @@ router.get('/departments/dihadi/download-rule', isAuthenticated, isOperator, asy
   if (half === 2) start = moment(month + '-16');
   try {
     const [employees] = await pool.query(`
-      SELECT e.id, e.punching_id, e.name, e.salary, e.allotted_hours,
+      SELECT e.id, e.punching_id, e.name, e.aadhar_card_number, e.salary, e.allotted_hours,
              u.username AS supervisor_name, d.name AS department_name,
              (SELECT COALESCE(SUM(amount),0) FROM employee_advances ea WHERE ea.employee_id = e.id) AS advance_taken,
              (SELECT COALESCE(SUM(amount),0) FROM advance_deductions ad WHERE ad.employee_id = e.id) AS advance_deducted
@@ -740,6 +744,7 @@ router.get('/departments/dihadi/download-rule', isAuthenticated, isOperator, asy
           supervisor: emp.supervisor_name,
           department: emp.department_name || '',
           punching_id: emp.punching_id,
+          aadhar: emp.aadhar_card_number || '',
           employee: emp.name,
           salary_type: 'dihadi',
           period: half === 1 ? '1-15' : '16-end',
@@ -758,6 +763,7 @@ router.get('/departments/dihadi/download-rule', isAuthenticated, isOperator, asy
       { header: 'Supervisor', key: 'supervisor', width: 20 },
       { header: 'Department', key: 'department', width: 15 },
       { header: 'Punching ID', key: 'punching_id', width: 15 },
+      { header: 'Aadhar', key: 'aadhar', width: 18 },
       { header: 'Employee', key: 'employee', width: 20 },
       { header: 'Salary Type', key: 'salary_type', width: 12 },
       { header: 'Period', key: 'period', width: 12 },
@@ -801,7 +807,7 @@ router.get('/departments/dihadi/download', isAuthenticated, isOperator, async (r
   if (half === 2) start = moment(month + '-16');
   try {
     const [employees] = await pool.query(`
-      SELECT e.id, e.punching_id, e.name, e.salary, e.allotted_hours,
+      SELECT e.id, e.punching_id, e.name, e.aadhar_card_number, e.salary, e.allotted_hours,
              u.username AS supervisor_name, d.name AS department_name,
              (SELECT COALESCE(SUM(amount),0) FROM employee_advances ea WHERE ea.employee_id = e.id) AS advance_taken,
              (SELECT COALESCE(SUM(amount),0) FROM advance_deductions ad WHERE ad.employee_id = e.id) AS advance_deducted
@@ -860,6 +866,7 @@ router.get('/departments/dihadi/download', isAuthenticated, isOperator, async (r
           supervisor: emp.supervisor_name,
           department: emp.department_name || '',
           punching_id: emp.punching_id,
+          aadhar: emp.aadhar_card_number || '',
           employee: emp.name,
           salary_type: 'dihadi',
           period: half === 1 ? '1-15' : '16-end',
@@ -878,6 +885,7 @@ router.get('/departments/dihadi/download', isAuthenticated, isOperator, async (r
       { header: 'Supervisor', key: 'supervisor', width: 20 },
       { header: 'Department', key: 'department', width: 15 },
       { header: 'Punching ID', key: 'punching_id', width: 15 },
+      { header: 'Aadhar', key: 'aadhar', width: 18 },
       { header: 'Employee', key: 'employee', width: 20 },
       { header: 'Salary Type', key: 'salary_type', width: 12 },
       { header: 'Period', key: 'period', width: 12 },
@@ -907,7 +915,7 @@ router.get('/departments/advances/download', isAuthenticated, isOperator, async 
   const period = half === 2 ? '16-end' : half === 1 ? '1-15' : 'full';
   try {
     const [rows] = await pool.query(`
-      SELECT e.id, e.punching_id, e.name, e.salary_type,
+      SELECT e.id, e.punching_id, e.name, e.aadhar_card_number, e.salary_type,
              u.username AS supervisor_name, d.name AS department_name,
              (SELECT COALESCE(SUM(amount),0) FROM employee_advances ea WHERE ea.employee_id = e.id) AS total_adv,
              (SELECT COALESCE(SUM(amount),0) FROM advance_deductions ad WHERE ad.employee_id = e.id) AS total_ded,
@@ -931,6 +939,7 @@ router.get('/departments/advances/download', isAuthenticated, isOperator, async 
       { header: 'Supervisor', key: 'supervisor', width: 20 },
       { header: 'Department', key: 'department', width: 15 },
       { header: 'Punching ID', key: 'punching_id', width: 15 },
+      { header: 'Aadhar', key: 'aadhar', width: 18 },
       { header: 'Employee', key: 'employee', width: 20 },
       { header: 'Salary Type', key: 'salary_type', width: 12 },
       { header: 'Period', key: 'period', width: 12 },
@@ -944,6 +953,7 @@ router.get('/departments/advances/download', isAuthenticated, isOperator, async 
         supervisor: r.supervisor_name,
         department: r.department_name || '',
         punching_id: r.punching_id,
+        aadhar: r.aadhar_card_number || '',
         employee: r.name,
         salary_type: r.salary_type,
         period,
@@ -985,7 +995,7 @@ router.get('/departments/:supId/employees-json', isAuthenticated, isOperator, as
 // Update an employee record
 router.post('/departments/employees/:id/update', isAuthenticated, isOperator, async (req, res) => {
   const empId = req.params.id;
-  const { punching_id, name, designation, phone_number, salary, salary_type, allotted_hours, paid_sunday_allowance, pay_sunday, leave_start_months, date_of_joining, is_active } = req.body;
+  const { punching_id, name, designation, phone_number, aadhar_card_number, salary, salary_type, allotted_hours, paid_sunday_allowance, pay_sunday, leave_start_months, date_of_joining, is_active } = req.body;
 
   // Convert boolean like fields to proper numbers. Strings like "0" should be
   // treated as false which JavaScript truthiness would not do by default.
@@ -998,12 +1008,13 @@ router.post('/departments/employees/:id/update', isAuthenticated, isOperator, as
       salaryVal = row ? row.salary : salary;
     }
     await pool.query(
-      `UPDATE employees SET punching_id=?, name=?, designation=?, phone_number=?, salary=?, salary_type=?, allotted_hours=?, paid_sunday_allowance=?, pay_sunday=?, leave_start_months=?, date_of_joining=?, is_active=? WHERE id=?`,
+      `UPDATE employees SET punching_id=?, name=?, designation=?, phone_number=?, aadhar_card_number=?, salary=?, salary_type=?, allotted_hours=?, paid_sunday_allowance=?, pay_sunday=?, leave_start_months=?, date_of_joining=?, is_active=? WHERE id=?`,
       [
         punching_id,
         name,
         designation,
         phone_number,
+        aadhar_card_number,
         salaryVal,
         salary_type,
         allotted_hours,

--- a/routes/employeeRoutes.js
+++ b/routes/employeeRoutes.js
@@ -152,13 +152,13 @@ router.get('/employees', isAuthenticated, isSupervisor, async (req, res) => {
 
 // Create a new employee for the logged in supervisor
 router.post('/employees', isAuthenticated, isSupervisor, async (req, res) => {
-  const { punching_id, name, designation, phone_number, salary, salary_type, allotted_hours, paid_sunday_allowance, pay_sunday, leave_start_months, date_of_joining } = req.body;
+  const { punching_id, name, designation, phone_number, aadhar_card_number, salary, salary_type, allotted_hours, paid_sunday_allowance, pay_sunday, leave_start_months, date_of_joining } = req.body;
   try {
     await pool.query(
       `INSERT INTO employees
-        (supervisor_id, punching_id, name, designation, phone_number, salary, salary_type, allotted_hours, paid_sunday_allowance, pay_sunday, leave_start_months, date_of_joining, is_active)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
-      [req.session.user.id, punching_id, name, designation, phone_number, salary, salary_type, allotted_hours, paid_sunday_allowance || 0, pay_sunday ? 1 : 0, leave_start_months || 3, date_of_joining]
+        (supervisor_id, punching_id, name, designation, phone_number, aadhar_card_number, salary, salary_type, allotted_hours, paid_sunday_allowance, pay_sunday, leave_start_months, date_of_joining, is_active)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 1)`,
+      [req.session.user.id, punching_id, name, designation, phone_number, aadhar_card_number, salary, salary_type, allotted_hours, paid_sunday_allowance || 0, pay_sunday ? 1 : 0, leave_start_months || 3, date_of_joining]
     );
     req.flash('success', 'Employee created');
     res.redirect('/supervisor/employees');

--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -401,7 +401,7 @@ router.get("/dashboard/api/lot", isAuthenticated, isOperator, async (req, res) =
 router.get("/dashboard/employees/download", isAuthenticated, isOperator, async (req, res) => {
   try {
     const [rows] = await pool.query(`
-      SELECT e.id AS employee_id, e.punching_id, e.name AS employee_name,
+      SELECT e.id AS employee_id, e.punching_id, e.name AS employee_name, e.aadhar_card_number,
              e.salary, e.salary_type, u.username AS supervisor_name, d.name AS department_name,
              (SELECT COALESCE(SUM(amount),0) FROM employee_advances ea WHERE ea.employee_id = e.id) AS total_adv,
              (SELECT COALESCE(SUM(amount),0) FROM advance_deductions ad WHERE ad.employee_id = e.id) AS total_ded
@@ -426,6 +426,7 @@ router.get("/dashboard/employees/download", isAuthenticated, isOperator, async (
       { header: "Supervisor", key: "supervisor", width: 20 },
       { header: "Employee", key: "employee", width: 20 },
       { header: "Punching ID", key: "punching_id", width: 15 },
+      { header: "Aadhar", key: "aadhar", width: 18 },
       { header: "Employee ID", key: "employee_id", width: 12 },
       { header: "Salary Type", key: "salary_type", width: 12 },
       { header: "Salary", key: "salary", width: 12 },
@@ -443,6 +444,7 @@ router.get("/dashboard/employees/download", isAuthenticated, isOperator, async (
         supervisor: r.supervisor_name,
         employee: r.employee_name,
         punching_id: r.punching_id,
+        aadhar: r.aadhar_card_number || "",
         employee_id: r.employee_id,
         salary_type: r.salary_type,
         advance_left: advLeft

--- a/routes/salaryRoutes.js
+++ b/routes/salaryRoutes.js
@@ -741,7 +741,7 @@ router.get('/supervisor/salary/download', isAuthenticated, isSupervisor, async (
 
     const [rows] = await pool.query(`
       SELECT es.employee_id, es.gross, es.deduction, es.net, es.month,
-             e.punching_id, e.name AS employee_name, e.salary AS base_salary, e.salary_type,
+             e.punching_id, e.name AS employee_name, e.aadhar_card_number, e.salary AS base_salary, e.salary_type,
              e.paid_sunday_allowance, e.pay_sunday, e.allotted_hours,
              (SELECT COALESCE(SUM(amount),0) FROM employee_advances ea WHERE ea.employee_id = es.employee_id) AS advance_taken,
              (SELECT COALESCE(SUM(amount),0) FROM advance_deductions ad WHERE ad.employee_id = es.employee_id) AS advance_deducted,
@@ -913,6 +913,7 @@ router.get('/supervisor/salary/download', isAuthenticated, isSupervisor, async (
     const sheet = workbook.addWorksheet('Salary');
     const columns = [
       { header: 'Punching ID', key: 'punching_id', width: 12 },
+      { header: 'Aadhar', key: 'aadhar', width: 18 },
       { header: 'Employee', key: 'employee', width: 20 },
       { header: 'Salary Type', key: 'salary_type', width: 12 },
       { header: 'Base Salary', key: 'base_salary', width: 12 }
@@ -966,6 +967,7 @@ router.get('/supervisor/salary/download', isAuthenticated, isSupervisor, async (
         ) && !FULL_SALARY_EMPLOYEE_IDS.includes(r.employee_id);
       const rowData = {
         punching_id: r.punching_id,
+        aadhar: r.aadhar_card_number || '',
         employee: r.employee_name,
         salary_type: r.salary_type,
         base_salary: r.base_salary
@@ -1031,7 +1033,7 @@ router.get('/supervisor/dihadi/download', isAuthenticated, isSupervisor, async (
   if (half === 2) start = moment(month + '-16');
   try {
     const [employees] = await pool.query(
-      `SELECT e.id, e.punching_id, e.name, e.salary, e.allotted_hours,
+      `SELECT e.id, e.punching_id, e.name, e.aadhar_card_number, e.salary, e.allotted_hours,
               es.gross, es.deduction, es.net
          FROM employees e
     LEFT JOIN employee_salaries es ON es.employee_id = e.id AND es.month = ?
@@ -1082,6 +1084,7 @@ router.get('/supervisor/dihadi/download', isAuthenticated, isSupervisor, async (
         const row = {
           employee: emp.name,
           punching_id: emp.punching_id,
+          aadhar: emp.aadhar_card_number || '',
           base_amount: emp.salary
         };
         for (let d = start.date(); d <= end.date(); d++) {
@@ -1101,6 +1104,7 @@ router.get('/supervisor/dihadi/download', isAuthenticated, isSupervisor, async (
     const columns = [
       { header: 'Employee', key: 'employee', width: 20 },
       { header: 'Punching ID', key: 'punching_id', width: 12 },
+      { header: 'Aadhar', key: 'aadhar', width: 18 },
       { header: 'Dihadi Base', key: 'base_amount', width: 12 }
     ];
     for (let d = start.date(); d <= end.date(); d++) {

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -525,7 +525,7 @@
           table.id = 'employeesTable';
           table.className = 'table table-bordered table-sm nowrap w-100';
           table.innerHTML = `<thead><tr>
-            <th>Punch ID</th><th>Name</th><th>Designation</th><th>Phone</th>
+            <th>Punch ID</th><th>Name</th><th>Designation</th><th>Phone</th><th>Aadhar</th>
             <th>Salary</th><th>Type</th><th>Hours</th><th>Mandatory Sun</th><th>Pay Sun?</th><th>Leave Start</th>
             <th>Join Date</th><th>Active</th><th>Save</th></tr></thead>`;
           const tbody = document.createElement('tbody');
@@ -543,6 +543,7 @@
               <td><input type="text" class="form-control form-control-sm" name="name" value="${emp.name}" required></td>
               <td><input type="text" class="form-control form-control-sm" name="designation" value="${emp.designation || ''}"></td>
               <td><input type="text" class="form-control form-control-sm" name="phone_number" value="${emp.phone_number || ''}" pattern="\\d*"></td>
+              <td><input type="text" class="form-control form-control-sm" name="aadhar_card_number" value="${emp.aadhar_card_number || ''}"></td>
               <td class="salary-container">${salaryCell}</td>
               <td><select class="form-select form-select-sm" name="salary_type">
                     <option value="dihadi" ${emp.salary_type==='dihadi'?'selected':''}>Dihadi</option>

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -119,6 +119,10 @@
       <input type="text" name="phone_number" class="form-control" placeholder="Phone number">
     </div>
     <div class="col-md-3">
+      <label class="form-label">Aadhar</label>
+      <input type="text" name="aadhar_card_number" class="form-control" placeholder="Aadhar number">
+    </div>
+    <div class="col-md-3">
       <label class="form-label">Date of Joining</label>
       <input type="date" name="date_of_joining" class="form-control" required>
     </div>


### PR DESCRIPTION
## Summary
- add optional `aadhar_card_number` to README docs
- capture Aadhar when supervisors add or edit employees
- expose Aadhar in operator edit employee page
- include Aadhar in employee and salary exports for operators and supervisors

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_68845ac9e6208320ad016367cf5befae