### PR TITLE
Add washing summary Excel export

### DIFF
--- a/views/washingDashboard.ejs
+++ b/views/washingDashboard.ejs
@@ -246,6 +246,9 @@
           <a href="/washingdashboard/download-all" class="btn btn-success">
             <i class="fas fa-file-excel"></i> Download Excel
           </a>
+          <a href="/washingdashboard/download-summary" class="btn btn-success ms-2">
+            <i class="fas fa-file-excel"></i> Summary Excel
+          </a>
         </div>
 
         <!-- Search Input -->


### PR DESCRIPTION
## Summary
- allow washers to export summary of assignments vs completion
- expose `GET /washingdashboard/download-summary` and show a link in dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688702fe822483208b2ad07e461ff210