### PR TITLE
Add washing monthly download card

### DIFF
--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -194,6 +194,10 @@
         <i class="bi bi-exclamation-diamond fs-3" aria-hidden="true"></i>
         <div>Lot Dept Counts</div>
       </a>
+      <a href="/operator/dashboard/washing-summary/download" class="nav-card">
+        <i class="bi bi-calendar-range fs-3" aria-hidden="true"></i>
+        <div>Wash Monthly</div>
+      </a>
       <a href="/operator/stitching-tat" class="nav-card">
         <i class="bi bi-hourglass-split fs-3" aria-hidden="true"></i>
         <div>Stitching TAT</div>


### PR DESCRIPTION
## Summary
- add a navigation card on operator dashboard to download washing summary by month

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68872346f0548320b59b22e9b5bd786a