### PR TITLE
Add completion rate columns to washer report

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Kotty Track is a Node.js and Express application used to manage the production w
 - **Bulk upload & search** â Operators can upload attendance files and perform bulk updates; Excel exports are available throughout the system.
 - **Supervisor cleanup** â Operators can remove a supervisor's employees and all related records in one action.
 - **Audit logging** â Important actions are written to log files for later review.
+- **Washer monthly summary** – Export monthly washer statistics including assigned, completed, pending pieces and completion percentage.
 
 ## Installation
 

--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -588,7 +588,11 @@ async function buildWasherMonthlySummary(prefix) {
     month: r.month,
     assigned: r.assigned,
     completed: r.completed,
-    cutting: r.cutting
+    cutting: r.cutting,
+    pending: r.assigned - r.completed,
+    completionRate: r.assigned > 0
+      ? parseFloat(((r.completed / r.assigned) * 100).toFixed(2))
+      : 0
   }));
 }
 
@@ -602,6 +606,8 @@ router.get("/dashboard/washing-summary/download", isAuthenticated, isOperator, a
       { header: "Month", key: "month", width: 10 },
       { header: "Assigned", key: "assigned", width: 12 },
       { header: "Completed", key: "completed", width: 12 },
+      { header: "Pending", key: "pending", width: 12 },
+      { header: "Completion %", key: "completionRate", width: 15 },
       { header: "Cutting", key: "cutting", width: 12 }
     ];
     sheetAk.columns = columns;


### PR DESCRIPTION
## Summary
- include pending and completion rate fields in washer monthly summary export
- document washer monthly summary feature

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688728a8e7cc8320a1eafc67288bf3ef