### PR TITLE
Add ability to remove SKU thresholds

### DIFF
--- a/routes/inventoryWebhook.js
+++ b/routes/inventoryWebhook.js
@@ -224,6 +224,7 @@ router.get('/config', isAuthenticated, isOperator, isMohitOperator, async (req, 
     .join('\n');
   res.render('inventoryAlertConfig', {
     configText,
+    thresholds: alertConfig.skuThresholds,
     error: req.flash('error'),
     success: req.flash('success'),
   });
@@ -266,6 +267,22 @@ router.post('/config', isAuthenticated, isOperator, isMohitOperator, async (req,
   }
 
   req.flash('success', 'Alert configuration updated');
+  res.redirect('/webhook/config');
+});
+
+// Remove a single SKU threshold
+router.post('/config/remove', isAuthenticated, isOperator, isMohitOperator, async (req, res) => {
+  const sku = (req.body.sku || '').trim().toUpperCase();
+  if (sku) {
+    try {
+      await pool.query('DELETE FROM sku_thresholds WHERE sku = ?', [sku]);
+      await loadSkuThresholds();
+      req.flash('success', `Removed ${sku}`);
+    } catch (err) {
+      console.error('Failed to remove SKU threshold', err);
+      req.flash('error', 'Failed to remove SKU threshold');
+    }
+  }
   res.redirect('/webhook/config');
 });
 

--- a/views/inventoryAlertConfig.ejs
+++ b/views/inventoryAlertConfig.ejs
@@ -27,6 +27,33 @@
     </div>
     <button type="submit" class="btn btn-primary">Save</button>
   </form>
+
+  <div class="mt-4">
+    <h5>Existing Thresholds</h5>
+    <table class="table table-bordered table-sm">
+      <thead class="table-light">
+        <tr>
+          <th>SKU</th>
+          <th>Threshold</th>
+          <th>Action</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% for (const [sku, th] of Object.entries(thresholds || {})) { %>
+          <tr>
+            <td><%= sku %></td>
+            <td><%= th %></td>
+            <td>
+              <form method="POST" action="/webhook/config/remove" onsubmit="return confirm('Remove ' + '<%= sku %>' + '?');">
+                <input type="hidden" name="sku" value="<%= sku %>">
+                <button type="submit" class="btn btn-sm btn-danger">Remove</button>
+              </form>
+            </td>
+          </tr>
+        <% } %>
+      </tbody>
+    </table>
+  </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- list SKU thresholds on `/webhook/config`
- provide a remove button beside each SKU
- implement `/webhook/config/remove` endpoint to delete the threshold

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688746e07cc4832080fa50e68f0c26bd