### PR TITLE
Add remove-all SKU threshold option

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ Use `/webhook/config` to map each SKU to its own threshold.
 Enter one mapping per line in the form `SKU:THRESHOLD`.
 Values are stored in `sku_thresholds` so the configuration persists across
 server restarts.
+The configuration page also provides a **Remove All** button to clear all saved thresholds in one step.
 
 To receive browser push notifications you must generate VAPID keys and set
 `VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` in your `.env` file. Clients visiting

--- a/routes/inventoryWebhook.js
+++ b/routes/inventoryWebhook.js
@@ -286,6 +286,19 @@ router.post('/config/remove', isAuthenticated, isOperator, isMohitOperator, asyn
   res.redirect('/webhook/config');
 });
 
+// Remove all SKU thresholds
+router.post('/config/remove-all', isAuthenticated, isOperator, isMohitOperator, async (req, res) => {
+  try {
+    await pool.query('DELETE FROM sku_thresholds');
+    await loadSkuThresholds();
+    req.flash('success', 'Removed all thresholds');
+  } catch (err) {
+    console.error('Failed to remove all SKU thresholds', err);
+    req.flash('error', 'Failed to remove all SKU thresholds');
+  }
+  res.redirect('/webhook/config');
+});
+
 // Store push subscription from client
 router.post('/subscribe', isAuthenticated, isOperator, async (req, res) => {
   if (req.body && req.body.endpoint) {

--- a/views/inventoryAlertConfig.ejs
+++ b/views/inventoryAlertConfig.ejs
@@ -28,6 +28,10 @@
     <button type="submit" class="btn btn-primary">Save</button>
   </form>
 
+  <form method="POST" action="/webhook/config/remove-all" class="mt-2" onsubmit="return confirm('Remove all thresholds?');">
+    <button type="submit" class="btn btn-warning">Remove All</button>
+  </form>
+
   <div class="mt-4">
     <h5>Existing Thresholds</h5>
     <table class="table table-bordered table-sm">


### PR DESCRIPTION
## Summary
- support clearing every SKU threshold in one step
- expose **Remove All** action in inventory alert config
- document the new option in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`


------
https://chatgpt.com/codex/tasks/task_e_6887489777a883209d4cb52b2a1e4965