### PR TITLE
Enhance stitching payments

### DIFF
--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -139,6 +139,22 @@ function isMohitOperator(req, res, next) {
   return res.redirect('/');
 }
 
+// ---------------------------------------------------------------------------
+// Helper to restrict routes to specific user ids
+function allowUserIds(ids) {
+  return function (req, res, next) {
+    if (req.session && req.session.user && ids.includes(req.session.user.id)) {
+      return next();
+    }
+
+    if (req.headers.accept && req.headers.accept.indexOf('application/json') !== -1) {
+      return res.status(403).json({ error: 'You do not have permission to view this resource.' });
+    }
+    req.flash('error', 'You do not have permission to view this page.');
+    return res.redirect('/');
+  };
+}
+
 module.exports = {
     isAuthenticated,
     isAdmin,
@@ -157,5 +173,6 @@ module.exports = {
     isCatalogUpload,
     isStoreEmployee,
     isStoreAdmin,
-    isMohitOperator
+    isMohitOperator,
+    allowUserIds
 };

--- a/routes/stitchingPaymentRoutes.js
+++ b/routes/stitchingPaymentRoutes.js
@@ -1,7 +1,12 @@
 const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/db');
-const { isAuthenticated, isStitchingMaster, isOperator } = require('../middlewares/auth');
+const { isAuthenticated, isStitchingMaster, isOperator, allowUserIds } = require('../middlewares/auth');
+
+// ---------------------
+// Allowed user ids for payment pages
+const CONTRACT_USERS = [6, 35];
+const OPERATION_USERS = [8];
 
 // ---------------------
 // Helper to fetch rates
@@ -12,7 +17,7 @@ async function getSkuRate(sku) {
 
 // ---------------------
 // Contract wise payments
-router.get('/contract', isAuthenticated, isStitchingMaster, async (req, res) => {
+router.get('/contract', isAuthenticated, isStitchingMaster, allowUserIds(CONTRACT_USERS), async (req, res) => {
   try {
     const userId = req.session.user.id;
     const [rows] = await pool.query(`
@@ -41,7 +46,7 @@ router.get('/contract', isAuthenticated, isStitchingMaster, async (req, res) => 
   }
 });
 
-router.post('/contract/pay', isAuthenticated, isStitchingMaster, async (req, res) => {
+router.post('/contract/pay', isAuthenticated, isStitchingMaster, allowUserIds(CONTRACT_USERS), async (req, res) => {
   try {
     const userId = req.session.user.id;
     const { lotIds = [] } = req.body;
@@ -81,7 +86,7 @@ async function getOperationRate(op) {
   return row ? parseFloat(row.rate) : 0;
 }
 
-router.get('/operation', isAuthenticated, isStitchingMaster, async (req, res) => {
+router.get('/operation', isAuthenticated, isStitchingMaster, allowUserIds(OPERATION_USERS), async (req, res) => {
   try {
     const userId = req.session.user.id;
     const [lots] = await pool.query(`
@@ -102,7 +107,7 @@ router.get('/operation', isAuthenticated, isStitchingMaster, async (req, res) =>
   }
 });
 
-router.post('/operation/pay', isAuthenticated, isStitchingMaster, async (req, res) => {
+router.post('/operation/pay', isAuthenticated, isStitchingMaster, allowUserIds(OPERATION_USERS), async (req, res) => {
   try {
     const userId = req.session.user.id;
     const { lot_no, payments } = req.body; // payments should be JSON string [{operation, name, qty}]

--- a/views/stitchingContractPayments.ejs
+++ b/views/stitchingContractPayments.ejs
@@ -14,7 +14,8 @@
 </nav>
 <div class="container mt-4">
   <form method="POST" action="/stitchingdashboard/payments/contract/pay">
-    <table class="table table-bordered">
+    <input type="text" id="searchTable" class="form-control mb-3" placeholder="Search lot or SKU">
+    <table class="table table-bordered" id="paymentsTable">
       <thead>
         <tr>
           <th>Select</th>
@@ -40,8 +41,21 @@
         <% }) %>
       </tbody>
     </table>
-    <button type="submit" class="btn btn-primary">Get Paid</button>
+    <div class="text-end">
+      <button type="submit" class="btn btn-primary">Get Paid</button>
+    </div>
   </form>
 </div>
+<script>
+  const searchInput = document.getElementById('searchTable');
+  const rows = Array.from(document.querySelectorAll('#paymentsTable tbody tr'));
+  searchInput.addEventListener('input', () => {
+    const term = searchInput.value.toLowerCase();
+    rows.forEach(r => {
+      const text = r.innerText.toLowerCase();
+      r.style.display = text.includes(term) ? '' : 'none';
+    });
+  });
+</script>
 </body>
 </html>

--- a/views/stitchingDashboard.ejs
+++ b/views/stitchingDashboard.ejs
@@ -177,6 +177,22 @@
               <span data-lang="en">Approve</span>
             </a>
           </li>
+          <% if (user.id && (user.id === 6 || user.id === 35)) { %>
+            <li class="nav-item me-2">
+              <a href="/stitchingdashboard/payments/contract" class="btn btn-outline-light btn-sm">
+                <i class="fas fa-rupee-sign"></i>
+                Contract Pay
+              </a>
+            </li>
+          <% } %>
+          <% if (user.id && user.id === 8) { %>
+            <li class="nav-item me-2">
+              <a href="/stitchingdashboard/payments/operation" class="btn btn-outline-light btn-sm">
+                <i class="fas fa-tasks"></i>
+                Operation Pay
+              </a>
+            </li>
+          <% } %>
           <!-- Logout -->
           <li class="nav-item">
             <a href="/logout" class="btn btn-sm btn-danger">

--- a/views/stitchingOperationPayments.ejs
+++ b/views/stitchingOperationPayments.ejs
@@ -44,9 +44,11 @@
         </tr>
       </tbody>
     </table>
-    <button type="button" class="btn btn-secondary mb-3" id="addRow">Add Row</button>
+    <div class="d-flex justify-content-between align-items-center mb-3">
+      <button type="button" class="btn btn-secondary" id="addRow">Add Row</button>
+      <button type="submit" class="btn btn-primary">Get Paid</button>
+    </div>
     <input type="hidden" name="payments" id="payments">
-    <button type="submit" class="btn btn-primary">Get Paid</button>
   </form>
 </div>
 <script>


### PR DESCRIPTION
## Summary
- add `allowUserIds` middleware for limiting access by user id
- restrict payment routes using allowed user ids
- improve contract payment table with search and better button positioning
- adjust operation payment page layout
- show payment links on stitching dashboard only for authorised users

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888aa64f06c8320a87c3ee413636883