### PR TITLE
Add dynamic template for stitching rates

### DIFF
--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -206,6 +206,14 @@
         <i class="bi bi-plug fs-3" aria-hidden="true"></i>
         <div>Hooks</div>
       </a>
+      <a href="/stitchingdashboard/payments/rates" class="nav-card" data-bs-toggle="tooltip" data-bs-placement="top" title="Configure stitching rates">
+        <i class="bi bi-currency-rupee fs-3" aria-hidden="true"></i>
+        <div>Rates</div>
+      </a>
+    </div>
+
+    <div class="alert alert-info" role="alert">
+      Need to update stitching rates? Use the <strong>Rates</strong> card above to download the template and upload your pricing.
     </div>
 
   <!-- Stat Cards -->

--- a/views/stitchingRateConfig.ejs
+++ b/views/stitchingRateConfig.ejs
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <title>Stitching Rates</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css">
 </head>
 <body>
 <nav class="navbar navbar-dark bg-dark">
@@ -21,14 +22,23 @@
   <% } %>
 
   <div class="mb-4">
-    <form method="POST" action="/stitchingdashboard/payments/rates/upload" enctype="multipart/form-data" class="row g-2">
+    <form method="POST" action="/stitchingdashboard/payments/rates/upload" enctype="multipart/form-data" class="row g-2 align-items-center">
       <div class="col-md-5">
-        <input type="file" name="excelFile" accept=".xls,.xlsx" class="form-control" required>
+        <input type="file" name="excelFile" accept=".xls,.xlsx" class="form-control" required
+               data-bs-toggle="tooltip" data-bs-placement="top" title="Select the Excel file containing SKU and Rate columns">
       </div>
       <div class="col-auto">
-        <button type="submit" class="btn btn-primary">Upload Excel</button>
+        <button type="submit" class="btn btn-primary">
+          <i class="bi bi-upload"></i> Upload Excel
+        </button>
+      </div>
+      <div class="col-auto">
+        <a href="/stitchingdashboard/payments/rates/template" class="btn btn-outline-secondary">
+          <i class="bi bi-download"></i> Download Template
+        </a>
       </div>
     </form>
+    <small class="text-muted">Use the template format to prepare rates and upload to update SKU pricing.</small>
   </div>
 
   <h5>Existing SKU Rates</h5>
@@ -65,8 +75,15 @@
         <textarea name="opRates" class="form-control" rows="10"><% opRows.forEach(function(r){ %><%= r.operation %>:<%= r.rate %>\n<% }) %></textarea>
       </div>
     </div>
-    <button type="submit" class="btn btn-success mt-3">Save All</button>
+    <button type="submit" class="btn btn-success mt-3">
+      <i class="bi bi-save"></i> Save All
+    </button>
   </form>
 </div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
+  tooltipTriggerList.forEach(t => new bootstrap.Tooltip(t));
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- generate Excel template for rate uploads via new route
- link operator dashboard and config page to new template
- drop the static sample file

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6888be047bbc8320b5eb175c272dca5d