### PR TITLE
Add stitching payment history and summary

### DIFF
--- a/views/stitchingContractHistory.ejs
+++ b/views/stitchingContractHistory.ejs
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Contract Payment History</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Payment History</span>
+    <a href="/stitchingdashboard/payments/contract" class="btn btn-outline-light btn-sm">Back</a>
+  </div>
+</nav>
+  <div class="container mt-4">
+    <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Date</th>
+        <th>Lot</th>
+        <th>SKU</th>
+        <th>Qty</th>
+        <th>Rate</th>
+        <th>Amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% payments.forEach(function(p){ %>
+        <tr>
+          <td><%= new Date(p.paid_on).toLocaleDateString('en-CA') %></td>
+          <td><%= p.lot_no %></td>
+          <td><%= p.sku %></td>
+          <td><%= p.qty %></td>
+          <td><%= p.rate %></td>
+          <td><%= p.amount %></td>
+        </tr>
+      <% }) %>
+    </tbody>
+    </table>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/stitchingContractPayments.ejs
+++ b/views/stitchingContractPayments.ejs
@@ -6,14 +6,17 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
 </head>
 <body>
-<nav class="navbar navbar-dark bg-dark">
-  <div class="container-fluid">
-    <span class="navbar-brand">Contract Payments</span>
-    <a href="/stitchingdashboard" class="btn btn-outline-light btn-sm">Back</a>
-  </div>
-</nav>
-<div class="container mt-4">
-  <form method="POST" action="/stitchingdashboard/payments/contract/pay">
+  <nav class="navbar navbar-dark bg-dark">
+    <div class="container-fluid">
+      <span class="navbar-brand">Contract Payments</span>
+      <div class="d-flex gap-2 ms-auto">
+        <a href="/stitchingdashboard/payments/contract/history" class="btn btn-outline-light btn-sm">History</a>
+        <a href="/stitchingdashboard" class="btn btn-outline-light btn-sm">Back</a>
+      </div>
+    </div>
+  </nav>
+  <div class="container mt-4">
+  <form id="payForm">
     <input type="text" id="searchTable" class="form-control mb-3" placeholder="Search lot or SKU">
     <table class="table table-bordered" id="paymentsTable">
       <thead>
@@ -42,11 +45,30 @@
       </tbody>
     </table>
     <div class="text-end">
-      <button type="submit" class="btn btn-primary">Get Paid</button>
+      <button type="button" id="payBtn" class="btn btn-primary">Get Paid</button>
     </div>
   </form>
-</div>
-<script>
+  <!-- Summary Modal -->
+  <div class="modal fade" id="summaryModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title">Payment Summary</h5>
+          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+        </div>
+        <div class="modal-body">
+          <p id="summaryText"></p>
+        </div>
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+          <button type="button" id="confirmPay" class="btn btn-success">Confirm</button>
+        </div>
+      </div>
+    </div>
+  </div>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
   const searchInput = document.getElementById('searchTable');
   const rows = Array.from(document.querySelectorAll('#paymentsTable tbody tr'));
   searchInput.addEventListener('input', () => {
@@ -56,6 +78,25 @@
       r.style.display = text.includes(term) ? '' : 'none';
     });
   });
-</script>
-</body>
-</html>
+
+  const modalEl = new bootstrap.Modal(document.getElementById('summaryModal'));
+  document.getElementById('payBtn').addEventListener('click', () => {
+    const checks = Array.from(document.querySelectorAll('input[name="lotIds"]:checked'));
+    if (!checks.length) return;
+    let total = 0;
+    checks.forEach(c => {
+      const row = c.closest('tr');
+      total += parseFloat(row.children[6].innerText) || 0;
+    });
+    document.getElementById('summaryText').innerText = `Selected Lots: ${checks.length}\nTotal Amount: ${total.toFixed(2)}`;
+    modalEl.show();
+  });
+
+  document.getElementById('confirmPay').addEventListener('click', () => {
+    const ids = Array.from(document.querySelectorAll('input[name="lotIds"]:checked')).map(c => c.value);
+    if (!ids.length) return;
+    window.location.href = `/stitchingdashboard/payments/contract/summary?ids=${ids.join(',')}`;
+  });
+  </script>
+  </body>
+  </html>

--- a/views/stitchingContractSummary.ejs
+++ b/views/stitchingContractSummary.ejs
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Confirm Contract Payment</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Confirm Payment</span>
+    <a href="/stitchingdashboard/payments/contract" class="btn btn-outline-light btn-sm">Back</a>
+  </div>
+</nav>
+  <div class="container mt-4">
+  <form method="POST" action="/stitchingdashboard/payments/contract/pay">
+    <table class="table table-bordered">
+      <thead>
+        <tr>
+          <th>Lot</th>
+          <th>SKU</th>
+          <th>Qty</th>
+          <th>Rate</th>
+          <th>Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        <% lots.forEach(function(l){ %>
+          <tr>
+            <td><%= l.lot_no %></td>
+            <td><%= l.sku %></td>
+            <td><%= l.total_pieces %></td>
+            <td><%= l.rate %></td>
+            <td><%= l.amount %></td>
+          </tr>
+          <input type="hidden" name="lotIds" value="<%= l.id %>">
+        <% }) %>
+      </tbody>
+    </table>
+    <h5 class="text-end">Total Amount: <%= totalAmount %></h5>
+    <div class="text-end">
+      <button type="submit" class="btn btn-success">Confirm Payment</button>
+    </div>
+  </form>
+  </div>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add history and summary routes for contract payments
- show payment history link and confirmation modal
- redirect to a summary page showing each lot and total before final payment

## Testing
- `npm test` *(fails: Missing script)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_688907c502a883208dca7d2f4b7e8e83