### PR TITLE
Improve contract payment UX

### DIFF
--- a/views/stitchingContractHistory.ejs
+++ b/views/stitchingContractHistory.ejs
@@ -16,7 +16,7 @@
     <table class="table table-bordered">
     <thead>
       <tr>
-        <th>Date</th>
+        <th>Date/Time</th>
         <th>Lot</th>
         <th>SKU</th>
         <th>Qty</th>
@@ -25,15 +25,18 @@
       </tr>
     </thead>
     <tbody>
+      <% let lastPaid = null; %>
       <% payments.forEach(function(p){ %>
+        <% const paidAt = new Date(p.paid_on).toLocaleString('en-CA', {hour12: false}); %>
         <tr>
-          <td><%= new Date(p.paid_on).toLocaleDateString('en-CA') %></td>
+          <td><%= paidAt === lastPaid ? '' : paidAt %></td>
           <td><%= p.lot_no %></td>
           <td><%= p.sku %></td>
           <td><%= p.qty %></td>
           <td><%= p.rate %></td>
           <td><%= p.amount %></td>
         </tr>
+        <% if(paidAt !== lastPaid) { lastPaid = paidAt; } %>
       <% }) %>
     </tbody>
     </table>

--- a/views/stitchingContractSummary.ejs
+++ b/views/stitchingContractSummary.ejs
@@ -38,7 +38,8 @@
       </tbody>
     </table>
     <h5 class="text-end">Total Amount: <%= totalAmount %></h5>
-    <div class="text-end">
+    <div class="d-flex justify-content-end gap-2">
+      <button type="button" onclick="window.print()" class="btn btn-secondary">Print</button>
       <button type="submit" class="btn btn-success">Confirm Payment</button>
     </div>
   </form>


### PR DESCRIPTION
## Summary
- group payments by timestamp in payment history so multiple lots paid together are shown together
- add a print option before confirming contract payments

## Testing
- `npm start` *(fails: SESSION_SECRET not defined)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68890b1effe88320a59e53c4081dc7d9