### PR TITLE
Add printable receipts for contract payments

### DIFF
--- a/views/stitchingContractHistory.ejs
+++ b/views/stitchingContractHistory.ejs
@@ -13,33 +13,35 @@
   </div>
 </nav>
   <div class="container mt-4">
-    <table class="table table-bordered">
-    <thead>
-      <tr>
-        <th>Date/Time</th>
-        <th>Lot</th>
-        <th>SKU</th>
-        <th>Qty</th>
-        <th>Rate</th>
-        <th>Amount</th>
-      </tr>
-    </thead>
-    <tbody>
-      <% let lastPaid = null; %>
-      <% payments.forEach(function(p){ %>
-        <% const paidAt = new Date(p.paid_on).toLocaleString('en-CA', {hour12: false}); %>
-        <tr>
-          <td><%= paidAt === lastPaid ? '' : paidAt %></td>
-          <td><%= p.lot_no %></td>
-          <td><%= p.sku %></td>
-          <td><%= p.qty %></td>
-          <td><%= p.rate %></td>
-          <td><%= p.amount %></td>
-        </tr>
-        <% if(paidAt !== lastPaid) { lastPaid = paidAt; } %>
-      <% }) %>
-    </tbody>
-    </table>
+    <% sessions.forEach(function(s){ %>
+      <h6 class="d-flex justify-content-between align-items-center mt-4">
+        <span><%= new Date(s.time).toLocaleString('en-CA', {hour12: false}) %></span>
+        <a href="/stitchingdashboard/payments/contract/receipt/<%= new Date(s.time).getTime() %>" class="btn btn-sm btn-outline-secondary">Print</a>
+      </h6>
+      <table class="table table-bordered">
+        <thead>
+          <tr>
+            <th>Lot</th>
+            <th>SKU</th>
+            <th>Qty</th>
+            <th>Rate</th>
+            <th>Amount</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% s.payments.forEach(function(p){ %>
+            <tr>
+              <td><%= p.lot_no %></td>
+              <td><%= p.sku %></td>
+              <td><%= p.qty %></td>
+              <td><%= p.rate %></td>
+              <td><%= p.amount %></td>
+            </tr>
+          <% }) %>
+        </tbody>
+      </table>
+      <h6 class="text-end">Session Total: <%= s.total.toFixed(2) %></h6>
+    <% }) %>
   </div>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
 </body>

--- a/views/stitchingContractReceipt.ejs
+++ b/views/stitchingContractReceipt.ejs
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Payment Receipt</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Payment Receipt</span>
+    <a href="/stitchingdashboard/payments/contract/history" class="btn btn-outline-light btn-sm">Back</a>
+  </div>
+</nav>
+<div class="container mt-4">
+  <h5>Paid On: <%= paidAt %></h5>
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Lot</th>
+        <th>SKU</th>
+        <th>Qty</th>
+        <th>Rate</th>
+        <th>Amount</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% payments.forEach(function(p){ %>
+        <tr>
+          <td><%= p.lot_no %></td>
+          <td><%= p.sku %></td>
+          <td><%= p.qty %></td>
+          <td><%= p.rate %></td>
+          <td><%= p.amount %></td>
+        </tr>
+      <% }) %>
+    </tbody>
+  </table>
+  <h5 class="text-end">Total Amount: <%= totalAmount %></h5>
+  <div class="text-end">
+    <button type="button" onclick="window.print()" class="btn btn-secondary">Print</button>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- group contract payment history by session
- add route and view to print past contract payment sessions

## Testing
- `node -c routes/stitchingPaymentRoutes.js`

------
https://chatgpt.com/codex/tasks/task_e_688997ae62148320ae9fef3686168548