### PR TITLE
Add order webhook endpoints

### DIFF
--- a/views/orderWebhookLogs.ejs
+++ b/views/orderWebhookLogs.ejs
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="vapid-public" content="<%= vapidPublicKey %>">
+  <title>Webhook Logs</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    pre { white-space: pre-wrap; word-break: break-word; }
+  </style>
+</head>
+<body class="bg-light">
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Webhook Logs</span>
+  </div>
+</nav>
+<div class="container py-4">
+  <h3 class="mb-4">Order Webhook Calls</h3>
+  <div class="table-responsive shadow-sm">
+    <table id="log-table" class="table table-bordered table-striped table-hover table-sm align-middle">
+      <thead class="table-dark">
+        <tr>
+          <th>Time</th>
+          <th>Access Token</th>
+          <th>Raw Body</th>
+          <th>Parsed Data</th>
+        </tr>
+      </thead>
+      <tbody id="log-body">
+      <% logs.slice().reverse().forEach(function(log) { %>
+        <tr>
+          <td><%= log.time %></td>
+          <td><%= log.accessToken %></td>
+          <td><pre class="mb-0"><%= log.raw %></pre></td>
+          <td><pre class="mb-0"><%= JSON.stringify(log.data, null, 2) %></pre></td>
+        </tr>
+      <% }); %>
+      </tbody>
+    </table>
+  </div>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  const logBody = document.getElementById('log-body');
+  const evtSource = new EventSource('/webhook/order/logs/stream');
+
+  evtSource.onmessage = (event) => {
+    const data = JSON.parse(event.data);
+    if (data.logs) {
+      data.logs.slice().reverse().forEach(addRow);
+    } else if (data.log) {
+      addRow(data.log);
+    } else if (data.alert) {
+      showNotification(data.alert.message);
+    }
+  };
+
+  function addRow(log) {
+    const row = document.createElement('tr');
+    row.innerHTML = `
+      <td>${log.time}</td>
+      <td>${log.accessToken || ''}</td>
+      <td><pre class="mb-0">${log.raw}</pre></td>
+      <td><pre class="mb-0">${JSON.stringify(log.data, null, 2)}</pre></td>
+    `;
+    logBody.prepend(row);
+    if (logBody.rows.length > 50) {
+      logBody.deleteRow(-1);
+    }
+  }
+
+  function showNotification(msg) {
+    if (window.Notification && Notification.permission === 'granted') {
+      const n = new Notification('Order Notification', { body: msg });
+      n.onclick = () => window.open('/#', '_blank');
+    }
+  }
+
+  if (window.Notification && Notification.permission !== 'granted') {
+    Notification.requestPermission();
+  }
+</script>
+<script src="/public/js/notification.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- capture order webhooks similar to inventory updates
- allow streaming of order webhook logs via SSE
- add view to show incoming order webhook data

## Testing
- `node -e "const fs=require('fs');const acorn=require('acorn');try{acorn.parse(fs.readFileSync('routes/inventoryWebhook.js','utf8'),{ecmaVersion:2020});console.log('JS OK');}catch(e){console.error(e.message);process.exit(1);}"`
- `node -e "const fs=require('fs');const acorn=require('acorn');function check(p){try{acorn.parse(fs.readFileSync(p,'utf8'),{ecmaVersion:2020});}catch(e){console.error('Syntax error in '+p);process.exit(1);} };const files=require('child_process').execSync('git ls-files \"*.js\"').toString().trim().split(/\n/);files.forEach(check);console.log('All JS syntax OK');"`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688a037630088320bb7bcce48b4586c1