### PR TITLE
Add hourly salary logic for monthly employees

### DIFF
--- a/routes/departmentMgmtRoutes.js
+++ b/routes/departmentMgmtRoutes.js
@@ -208,9 +208,7 @@ router.post('/departments/salary/upload', isAuthenticated, isOperator, upload.si
         );
       }
       const month = moment(data[0].attendance[0].date).format('YYYY-MM');
-      if (employee.salary_type === 'dihadi') {
-        await calculateSalaryForMonth(conn, employee.id, month);
-      }
+      await calculateSalaryForMonth(conn, employee.id, month);
       uploadedCount++;
     }
     await conn.commit();

--- a/routes/operatorEmployeeRoutes.js
+++ b/routes/operatorEmployeeRoutes.js
@@ -271,9 +271,7 @@ router.post(
         );
       }
       const month = moment(date).format("YYYY-MM");
-      if (emp.salary_type === "dihadi") {
-        await calculateSalaryForMonth(conn, empId, month);
-      }
+      await calculateSalaryForMonth(conn, empId, month);
       await conn.commit();
       req.flash("success", "Attendance updated");
       conn.release();
@@ -407,9 +405,7 @@ router.post(
           );
         }
 
-        if (emp.salary_type === "dihadi") {
-          await calculateSalaryForMonth(conn, empId, month);
-        }
+        await calculateSalaryForMonth(conn, empId, month);
       }
       await conn.commit();
       conn.release();
@@ -550,9 +546,7 @@ router.post(
           );
         }
       }
-      if (emp.salary_type === "dihadi") {
-        await calculateSalaryForMonth(conn, empId, month);
-      }
+      await calculateSalaryForMonth(conn, empId, month);
       await conn.commit();
       conn.release();
       req.flash("success", "Attendance updated");


### PR DESCRIPTION
## Summary
- compute hourly pay for monthly employees and apply 15-minute start grace
- double pay for attended Sundays via `pay_sunday` flag
- recalc salary for all employees after attendance edits and uploads

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899d883858083209a9ad3169d7527e1