### PR TITLE
Add salary download and views for monthly employees

### DIFF
--- a/views/employeeSalary.ejs
+++ b/views/employeeSalary.ejs
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Salary Details</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark mb-4">
+  <div class="container-fluid">
+    <span class="navbar-brand">Salary - <%= employee.name %></span>
+    <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+  </div>
+</nav>
+<div class="container">
+  <%- include('partials/flashMessages') %>
+  <h4>Salary Records</h4>
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Month</th>
+        <th>Gross</th>
+        <th>Deduction</th>
+        <th>Net</th>
+        <th>Download</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% salaries.forEach(s => { %>
+        <tr>
+          <td><%= s.month %></td>
+          <td><%= s.gross %></td>
+          <td><%= s.deduction %></td>
+          <td><%= s.net %></td>
+          <td>
+            <a href="/supervisor/employees/<%= employee.id %>/salary/download?month=<%= s.month %>" class="btn btn-sm btn-success">PDF</a>
+          </td>
+        </tr>
+      <% }) %>
+    </tbody>
+  </table>
+  <a href="/supervisor/employees" class="btn btn-secondary">Back</a>
+</div>
+</body>
+</html>

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -212,7 +212,7 @@
                 </button>
               </form>
               <a href="/supervisor/employees/<%= emp.id %>/details" class="btn btn-sm btn-primary">Details</a>
-              <a href="/employees/<%= emp.id %>/salary" class="btn btn-sm btn-secondary">Salary</a>
+              <a href="/supervisor/employees/<%= emp.id %>/salary" class="btn btn-sm btn-secondary">Salary</a>
             </td>
           </tr>
         <% }) %>


### PR DESCRIPTION
## Summary
- add supervisor route to export monthly salary sheet for salaried employees
- provide per-employee salary detail page with PDF download
- fix dashboard link and add salary view template

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6899db485e288320be2635878f294004