### PR TITLE
Fix pay_sunday salary calc and timestamped downloads

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -122,7 +122,8 @@ exports.calculateSalaryForMonth = calculateSalaryForMonth;
 // Monthly salaried workers are paid based on the hours they work in the
 // month. The hourly rate is derived from their monthly salary by
 // dividing by the number of days in the month and then by the allotted
-// hours per day. Sundays optionally pay double when `pay_sunday` is set.
+// hours per day. Sundays are paid only when `pay_sunday` is enabled and
+// those days earn double the normal hourly rate.
 async function calculateMonthly(conn, employeeId, month, emp) {
   const monthStart = moment(month + '-01');
   const join = emp.date_of_joining ? moment(emp.date_of_joining) : null;
@@ -163,9 +164,8 @@ async function calculateMonthly(conn, employeeId, month, emp) {
       const mon = day.clone().add(1, 'day');
       const satWorked = sat.isBefore(startDate) || worked.has(sat.format('YYYY-MM-DD'));
       const monWorked = mon.isAfter(monthEnd) || worked.has(mon.format('YYYY-MM-DD'));
-      if (!satWorked || !monWorked) continue;
-      const multiplier = paySunday ? 2 : 1;
-      gross += hours * hourlyRate * multiplier;
+      if (!satWorked || !monWorked || !paySunday) continue;
+      gross += hours * hourlyRate * 2;
     } else {
       gross += hours * hourlyRate;
     }

--- a/routes/departmentMgmtRoutes.js
+++ b/routes/departmentMgmtRoutes.js
@@ -283,10 +283,9 @@ router.get('/departments/salary/download', isAuthenticated, isOperator, async (r
         advance_left: advLeft
       });
     });
-    res.setHeader(
-      'Content-Disposition',
-      `attachment; filename="operator_salary_${month}.xlsx"`
-    );
+    const timestamp = moment().format('YYYY-MM-DD_HH-mm-ss');
+    const filename = `${req.session.user.username}_${timestamp}.xlsx`;
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.setHeader(
       'Content-Type',
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'

--- a/routes/dihadiRoutes.js
+++ b/routes/dihadiRoutes.js
@@ -108,7 +108,9 @@ router.get('/supervisor/dihadi/download', isAuthenticated, isSupervisor, async (
     columns.push({ header: 'Net Payment', key: 'net_payment', width: 12 });
     sheet.columns = columns;
     rows.forEach(r => sheet.addRow(r));
-    res.setHeader('Content-Disposition', 'attachment; filename="DihadiHours.xlsx"');
+    const timestamp = moment().format('YYYY-MM-DD_HH-mm-ss');
+    const filename = `${req.session.user.username}_${timestamp}.xlsx`;
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     await workbook.xlsx.write(res);
     res.end();

--- a/routes/employeeRoutes.js
+++ b/routes/employeeRoutes.js
@@ -374,7 +374,9 @@ router.get('/salary/download', isAuthenticated, isSupervisor, async (req, res) =
       }
       sheet.addRow(row);
     });
-    res.setHeader('Content-Disposition', `attachment; filename="salary_${month}.xlsx"`);
+    const timestamp = moment().format('YYYY-MM-DD_HH-mm-ss');
+    const filename = `${req.session.user.username}_${timestamp}.xlsx`;
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     res.setHeader(
       'Content-Type',
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
@@ -443,10 +445,9 @@ router.get('/employees/:id/salary/download', isAuthenticated, isSupervisor, asyn
     }
     const doc = new PDFDocument();
     res.setHeader('Content-Type', 'application/pdf');
-    res.setHeader(
-      'Content-Disposition',
-      `attachment; filename="salary_${emp.name}_${month}.pdf"`
-    );
+    const timestamp = moment().format('YYYY-MM-DD_HH-mm-ss');
+    const filename = `${req.session.user.username}_${timestamp}.pdf`;
+    res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
     doc.pipe(res);
     doc.fontSize(16).text('Salary Slip', { align: 'center' });
     doc.moveDown();


### PR DESCRIPTION
## Summary
- Only pay Sundays for monthly employees when allowed and double the rate when `pay_sunday` is true
- Name operator and supervisor downloads using `username_date_time`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ad6ed6cac8320a8dd5e60573780c1