### PR TITLE
Always pay double for worked Sundays

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,9 @@ Monthly employees paid hourly receive their full allotted hours when both punche
 ### Sunday Attendance Rules
 
 - Sundays are paid at the normal day rate even when the employee is absent, unless the sandwich rule applies.
-- **Special departments (`catalog`, `account`, `merchant`, `tech`)** â worked Sundays never grant extra pay and are credited as leave.
-- **Other departments** â the `pay_sunday` flag controls Sundays. When set to `TRUE` a worked Sunday earns double pay; when `FALSE` the day is credited as leave.
+- Worked Sundays always earn double pay.
 - **Mandatory Sundays** â if `paid_sunday_allowance` is greater than zero the employee must work that many Sundays in the month. Missing one counts as an absence and these required days never earn extra pay.
 
-These credited days are automatically inserted into `employee_leaves` during salary calculations.
 For most teams, a Sunday becomes unpaid whenever the employee is absent on the adjacent Saturday or Monday. If both days are missed, all three (SaturdayâSundayâMonday) are deducted from salary. Teams supervised by **Rohit Shukla** follow the old rule where Sunday counts only when Saturday *and* Monday are absent. When the employee works on that Sunday, any adjacent absence is paid as usual.
 
 ### Attendance Edit Logs
@@ -285,10 +283,7 @@ shift. Their day is still capped at **11 working hours**.
   Saturday–Sunday–Monday period is deducted.
 - `paid_sunday_allowance` specifies how many Sundays per month are mandatory.
   Missing one counts as an absence. After the allowance is met, Sundays worked
-  are either paid (`pay_sunday` enabled) or credited as leave when neither
-  Saturday nor Monday is absent.
-- Departments listed in `utils/departments.js` receive leave credit for working
-  Sundays when there are no adjacent absences.
+  are paid double when neither Saturday nor Monday is absent.
 - Supervisors listed in `utils/supervisors.js` follow an older rule where Sunday
   counts as an absence only when **both** Saturday *and* Monday are missed. A
   worked Sunday under these supervisors is always paid.

--- a/routes/employeeRoutes.js
+++ b/routes/employeeRoutes.js
@@ -356,34 +356,14 @@ router.get('/salary/download', isAuthenticated, isSupervisor, async (req, res) =
         }
       }
 
-      // Determine Sunday credits (worked Sundays without pay)
-      let sundayCredits = 0;
+      // Fill in absences for days without attendance
       for (let d = 1; d <= daysInMonth; d++) {
-        const date = monthStart.clone().date(d);
-        if (date.day() === 0 && byDate[d] && parseInt(emp.pay_sunday) !== 1) {
-          sundayCredits++;
-        }
-      }
-
-      // Fill in absences and track how many were covered by Sunday credits
-      let adjustments = 0;
-      for (let d = 1; d <= daysInMonth; d++) {
-        const date = monthStart.clone().date(d);
         if (byDate[d] === undefined) {
           byDate[d] = 'A';
-          if (date.day() !== 0 && sundayCredits > 0) {
-            sundayCredits--;
-            adjustments++;
-          }
         }
       }
 
-      const status =
-        adjustments > 0
-          ? `Adjusted ${adjustments} day(s)`
-          : sundayCredits > 0
-          ? `Credit ${sundayCredits} Sunday(s)`
-          : '';
+      const status = '';
 
       const gross = parseFloat(emp.gross || 0);
       const advDeduct = parseFloat(emp.deduction || 0);


### PR DESCRIPTION
## Summary
- Always apply double day rate for worked Sundays regardless of the `pay_sunday` flag
- Simplify salary sheet generation by removing Sunday credit logic
- Update documentation to reflect new Sunday pay rules

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689ae886018483208b8989d287a2385f