### PR TITLE
Add daily earnings and miss punch count to salary sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Kotty Track is a Node.js and Express application used to manage the production w
 - **Supervisor cleanup** â Operators can remove a supervisor's employees and all related records in one action.
 - **Audit logging** â Important actions are written to log files for later review.
 - **Washer monthly summary** – Export monthly washer statistics including assigned, completed, pending pieces and completion percentage.
+- **Salary breakdown** – Monthly salary exports now show daily hours with corresponding earnings and the total count of miss punches.
 
 ## Installation
 


### PR DESCRIPTION
## Summary
- Include daily earnings alongside worked hours in the supervisor salary export
- Track and report miss punch counts for each employee
- Document salary sheet breakdown features in README

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c2d9046c883209c32a6bc21913a45