### PR TITLE
Fix monthly employee Sunday pay calculation

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -145,6 +145,8 @@ async function calculateMonthly(conn, employeeId, month, emp) {
   const hourlyRate = emp.allotted_hours
     ? dayRate / parseFloat(emp.allotted_hours)
     : 0;
+  // Sundays always use a fixed 9-hour divisor regardless of allotted hours
+  const sundayHourlyRate = dayRate / 9;
   const [attendance] = await conn.query(
     'SELECT date, punch_in, punch_out FROM employee_attendance WHERE employee_id = ? AND date >= ? AND DATE_FORMAT(date, "%Y-%m") = ?',
     [employeeId, start, month]
@@ -186,7 +188,7 @@ async function calculateMonthly(conn, employeeId, month, emp) {
   }
   let gross =
     weekdayHours * hourlyRate +
-    sundayHours * hourlyRate * 2 +
+    sundayHours * sundayHourlyRate * 2 +
     sundayPaidDays * dayRate;
   gross = parseFloat(gross.toFixed(2));
     const [[advRow]] = await conn.query(

--- a/routes/employeeRoutes.js
+++ b/routes/employeeRoutes.js
@@ -339,6 +339,8 @@ router.get('/salary/download', isAuthenticated, isSupervisor, async (req, res) =
       const hourlyRate = emp.allotted_hours
         ? dayRate / parseFloat(emp.allotted_hours)
         : 0;
+      // Sundays always use 9 hours as the base for hourly calculation
+      const sundayHourlyRate = dayRate / 9;
       const att = attendanceMap.get(emp.id) || [];
       const byDate = {};
       const workedDates = new Set();
@@ -358,7 +360,7 @@ router.get('/salary/download', isAuthenticated, isSupervisor, async (req, res) =
           );
           const pay =
             dateMoment.day() === 0
-              ? hrs * hourlyRate * 2
+              ? hrs * sundayHourlyRate * 2
               : hrs * hourlyRate;
           byDate[day] = `${hrs.toFixed(2)}|${pay.toFixed(2)}`;
           if (dateMoment.day() === 0) {
@@ -397,7 +399,7 @@ router.get('/salary/download', isAuthenticated, isSupervisor, async (req, res) =
 
       const calcGross =
         weekdayHours * hourlyRate +
-        sundayHours * hourlyRate * 2 +
+        sundayHours * sundayHourlyRate * 2 +
         sundayPaidDays * dayRate;
 
       const status = '';


### PR DESCRIPTION
## Summary
- compute Sunday hourly rate for monthly employees using a fixed 9-hour divisor
- apply Sunday rate in gross salary and per-day payouts

## Testing
- `node --check helpers/salaryCalculator.js`
- `node --check routes/employeeRoutes.js`
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689c312c17d483208402cf16065adf75