### PR TITLE
fix: correct hourly salary by excluding unpaid Sundays

### DIFF
--- a/helpers/salaryCalculator.js
+++ b/helpers/salaryCalculator.js
@@ -141,7 +141,16 @@ async function calculateMonthly(conn, employeeId, month, emp) {
       ? join.format('YYYY-MM-DD')
       : monthStart.format('YYYY-MM-DD');
   const daysInMonth = monthStart.daysInMonth();
-  const dayRate = parseFloat(emp.salary) / daysInMonth;
+  const sundaysInMonth = Array.from({ length: daysInMonth }, (_, i) =>
+    monthStart
+      .clone()
+      .date(i + 1)
+      .day()
+  ).filter(d => d === 0).length;
+  const paidDays = emp.pay_sunday
+    ? daysInMonth
+    : daysInMonth - sundaysInMonth;
+  const dayRate = parseFloat(emp.salary) / paidDays;
   const hourlyRate = emp.allotted_hours
     ? dayRate / parseFloat(emp.allotted_hours)
     : 0;


### PR DESCRIPTION
## Summary
- adjust supervisor salary export to average salary over paid days excluding unpaid Sundays
- ensure monthly salary calculations use same paid-days logic

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_689dd2dfe7608320864c921a71b55019