### PR TITLE
Add purchase dashboard with parties and factories management

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,3 +365,32 @@ CREATE TABLE stitching_operation_payments (
 
 The operator dashboard exposes a page to maintain `stitching_rates` so contract
 amounts can be calculated automatically.
+
+### Purchase Dashboard
+
+The Purchase dashboard stores party and factory details along with simple
+payment terms.
+
+```sql
+CREATE TABLE parties (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  gst_number VARCHAR(50),
+  state VARCHAR(100),
+  pincode VARCHAR(20),
+  due_payment_days INT DEFAULT 0
+);
+
+CREATE TABLE factories (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(255) NOT NULL,
+  gst_number VARCHAR(50),
+  state VARCHAR(100)
+);
+
+-- allow purchaseGRN users to sign in
+INSERT INTO roles (name) VALUES ('purchaseGRN');
+```
+
+`due_payment_days` records how many days after billing a payment becomes due.
+Accounts users can edit this number but only the day count is stored.

--- a/app.js
+++ b/app.js
@@ -91,6 +91,7 @@ const flipkartReturnRoutes = require('./routes/flipkartReturnRoutes');
 const flipkartIssueStatusRoutes = require('./routes/flipkartIssueStatusRoutes');
 const inventoryWebhook = require('./routes/inventoryWebhook');
 const skuRoutes = require('./routes/skuRoutes');
+const purchaseRoutes = require('./routes/purchaseRoutes');
 
 // Use Routes
 app.use('/', authRoutes);
@@ -121,6 +122,7 @@ app.use('/', dihariRoutes);
 app.use('/flipkart', flipkartReturnRoutes);
 app.use('/flipkart', flipkartIssueStatusRoutes);
 app.use('/webhook', inventoryWebhook);
+app.use('/purchase', purchaseRoutes);
 app.use('/', skuRoutes);
 
 // Home Route

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -155,6 +155,25 @@ function allowUserIds(ids) {
   };
 }
 
+// ---------------------------------------------------------------------------
+// Helper to restrict routes to specific roles
+function allowRoles(roles) {
+  return function (req, res, next) {
+    if (req.session && req.session.user && roles.includes(req.session.user.roleName)) {
+      return next();
+    }
+
+    if (req.headers.accept && req.headers.accept.indexOf('application/json') !== -1) {
+      return res.status(403).json({ error: 'You do not have permission to view this resource.' });
+    }
+    req.flash('error', 'You do not have permission to view this page.');
+    return res.redirect('/');
+  };
+}
+
+// Allow purchaseGRN and accounts roles to access purchase dashboard
+const isPurchaseOrAccounts = allowRoles(['purchaseGRN', 'accounts']);
+
 module.exports = {
     isAuthenticated,
     isAdmin,
@@ -174,5 +193,7 @@ module.exports = {
     isStoreEmployee,
     isStoreAdmin,
     isMohitOperator,
-    allowUserIds
+    allowUserIds,
+    allowRoles,
+    isPurchaseOrAccounts
 };

--- a/routes/purchaseRoutes.js
+++ b/routes/purchaseRoutes.js
@@ -1,0 +1,108 @@
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isAccountsAdmin, isPurchaseOrAccounts } = require('../middlewares/auth');
+
+// GET /purchase - render dashboard for purchaseGRN and accounts roles
+router.get('/', isAuthenticated, isPurchaseOrAccounts, async (req, res) => {
+  try {
+    const [parties] = await pool.query(
+      'SELECT id, name, gst_number, state, pincode, due_payment_days FROM parties ORDER BY name'
+    );
+    const [factories] = await pool.query(
+      'SELECT id, name, gst_number, state FROM factories ORDER BY name'
+    );
+    res.render('purchaseDashboard', {
+      user: req.session.user,
+      parties,
+      factories
+    });
+  } catch (err) {
+    console.error('Error loading purchase dashboard:', err);
+    req.flash('error', 'Failed to load purchase dashboard');
+    res.redirect('/');
+  }
+});
+
+// POST /purchase/parties - create a new party
+router.post('/parties', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  const { name, gst_number, state, pincode, due_payment_days } = req.body;
+  if (!name) {
+    req.flash('error', 'Party name is required');
+    return res.redirect('/purchase');
+  }
+  try {
+    await pool.query(
+      `INSERT INTO parties (name, gst_number, state, pincode, due_payment_days)
+       VALUES (?, ?, ?, ?, ?)`,
+      [name, gst_number, state, pincode, due_payment_days || 0]
+    );
+    req.flash('success', 'Party created');
+    res.redirect('/purchase');
+  } catch (err) {
+    console.error('Error creating party:', err);
+    req.flash('error', 'Failed to create party');
+    res.redirect('/purchase');
+  }
+});
+
+// POST /purchase/parties/:id - update an existing party
+router.post('/parties/:id', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  const id = req.params.id;
+  const { name, gst_number, state, pincode, due_payment_days } = req.body;
+  try {
+    await pool.query(
+      `UPDATE parties
+       SET name = ?, gst_number = ?, state = ?, pincode = ?, due_payment_days = ?
+       WHERE id = ?`,
+      [name, gst_number, state, pincode, due_payment_days || 0, id]
+    );
+    req.flash('success', 'Party updated');
+    res.redirect('/purchase');
+  } catch (err) {
+    console.error('Error updating party:', err);
+    req.flash('error', 'Failed to update party');
+    res.redirect('/purchase');
+  }
+});
+
+// POST /purchase/factories - create a new factory
+router.post('/factories', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  const { name, gst_number, state } = req.body;
+  if (!name) {
+    req.flash('error', 'Factory name is required');
+    return res.redirect('/purchase');
+  }
+  try {
+    await pool.query(
+      `INSERT INTO factories (name, gst_number, state) VALUES (?, ?, ?)`,
+      [name, gst_number, state]
+    );
+    req.flash('success', 'Factory created');
+    res.redirect('/purchase');
+  } catch (err) {
+    console.error('Error creating factory:', err);
+    req.flash('error', 'Failed to create factory');
+    res.redirect('/purchase');
+  }
+});
+
+// POST /purchase/factories/:id - update factory
+router.post('/factories/:id', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  const id = req.params.id;
+  const { name, gst_number, state } = req.body;
+  try {
+    await pool.query(
+      `UPDATE factories SET name = ?, gst_number = ?, state = ? WHERE id = ?`,
+      [name, gst_number, state, id]
+    );
+    req.flash('success', 'Factory updated');
+    res.redirect('/purchase');
+  } catch (err) {
+    console.error('Error updating factory:', err);
+    req.flash('error', 'Failed to update factory');
+    res.redirect('/purchase');
+  }
+});
+
+module.exports = router;

--- a/views/purchaseDashboard.ejs
+++ b/views/purchaseDashboard.ejs
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>Purchase Dashboard</title>
+  <link rel="stylesheet" href="/public/style.css">
+</head>
+<body>
+  <%- include('partials/flashMessages') %>
+  <h1>Purchase Dashboard</h1>
+
+  <h2>Parties</h2>
+  <% if (user.roleName === 'accounts') { %>
+  <form method="post" action="/purchase/parties">
+    <input type="text" name="name" placeholder="Party Name" required>
+    <input type="text" name="gst_number" placeholder="GST Number">
+    <input type="text" name="state" placeholder="State">
+    <input type="text" name="pincode" placeholder="Pincode">
+    <input type="number" name="due_payment_days" placeholder="Due Days">
+    <button type="submit">Add Party</button>
+  </form>
+  <% } %>
+
+  <table border="1" cellspacing="0" cellpadding="4">
+    <tr>
+      <th>Name</th>
+      <th>GST Number</th>
+      <th>State</th>
+      <th>Pincode</th>
+      <th>Due Days</th>
+      <% if (user.roleName === 'accounts') { %><th>Action</th><% } %>
+    </tr>
+    <% parties.forEach(p => { %>
+    <tr>
+      <form method="post" action="/purchase/parties/<%= p.id %>">
+        <td><input type="text" name="name" value="<%= p.name %>"></td>
+        <td><input type="text" name="gst_number" value="<%= p.gst_number %>"></td>
+        <td><input type="text" name="state" value="<%= p.state %>"></td>
+        <td><input type="text" name="pincode" value="<%= p.pincode %>"></td>
+        <td><input type="number" name="due_payment_days" value="<%= p.due_payment_days %>"></td>
+        <% if (user.roleName === 'accounts') { %>
+        <td><button type="submit">Update</button></td>
+        <% } %>
+      </form>
+    </tr>
+    <% }) %>
+  </table>
+
+  <h2>Factories</h2>
+  <% if (user.roleName === 'accounts') { %>
+  <form method="post" action="/purchase/factories">
+    <input type="text" name="name" placeholder="Factory Name" required>
+    <input type="text" name="gst_number" placeholder="GST Number">
+    <input type="text" name="state" placeholder="State">
+    <button type="submit">Add Factory</button>
+  </form>
+  <% } %>
+
+  <table border="1" cellspacing="0" cellpadding="4">
+    <tr>
+      <th>Name</th>
+      <th>GST Number</th>
+      <th>State</th>
+      <% if (user.roleName === 'accounts') { %><th>Action</th><% } %>
+    </tr>
+    <% factories.forEach(f => { %>
+    <tr>
+      <form method="post" action="/purchase/factories/<%= f.id %>">
+        <td><input type="text" name="name" value="<%= f.name %>"></td>
+        <td><input type="text" name="gst_number" value="<%= f.gst_number %>"></td>
+        <td><input type="text" name="state" value="<%= f.state %>"></td>
+        <% if (user.roleName === 'accounts') { %>
+        <td><button type="submit">Update</button></td>
+        <% } %>
+      </form>
+    </tr>
+    <% }) %>
+  </table>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Introduce purchase dashboard supporting parties and factories management
- Allow accounts users to create/edit parties and factories and set due payment days
- Document SQL schema and new purchase role in README

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689de8f81d548320836c3dd35da4a7c6