### PR TITLE
Limit purchase dashboard to accounts users

### DIFF
--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -171,9 +171,6 @@ function allowRoles(roles) {
   };
 }
 
-// Allow purchaseGRN and accounts roles to access purchase dashboard
-const isPurchaseOrAccounts = allowRoles(['purchaseGRN', 'accounts']);
-
 module.exports = {
     isAuthenticated,
     isAdmin,
@@ -194,6 +191,5 @@ module.exports = {
     isStoreAdmin,
     isMohitOperator,
     allowUserIds,
-    allowRoles,
-    isPurchaseOrAccounts
+    allowRoles
 };

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -88,6 +88,9 @@ router.post('/login', async (req, res) => {
       case 'store_employee':
         res.redirect('/inventory/dashboard');
         break;
+      case 'accounts':
+        res.redirect('/purchase');
+        break;
       case 'checking':
       case 'quality_assurance':
         res.redirect('/department/dashboard');


### PR DESCRIPTION
## Summary
- Redirect accounts role to the purchase dashboard after login
- Restrict purchase dashboard access to accounts and load data concurrently
- Remove unused purchase role middleware

## Testing
- `npm test` *(fails: Missing script: "test")*
- `node -c routes/authRoutes.js`
- `node -c routes/purchaseRoutes.js`
- `node -c middlewares/auth.js`

------
https://chatgpt.com/codex/tasks/task_e_68a461f33e948320acd9cdb4726529b3