### PR TITLE
Fix party route matching and increase request size limit

### DIFF
--- a/app.js
+++ b/app.js
@@ -27,8 +27,9 @@ app.set('trust proxy', true);
 });
 */
 // Middleware
-app.use(express.urlencoded({ extended: true }));
-app.use(express.json());
+// Increase body size limits to handle large JSON and form payloads
+app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+app.use(express.json({ limit: '10mb' }));
 
 // Session Configuration
 app.use(session({

--- a/routes/purchaseRoutes.js
+++ b/routes/purchaseRoutes.js
@@ -67,9 +67,16 @@ router.post('/parties', isAuthenticated, isAccountsAdmin, async (req, res) => {
 });
 
 // POST /purchase/parties/:id - update an existing party
-router.post('/parties/:id', isAuthenticated, isAccountsAdmin, async (req, res) => {
-  const id = req.params.id;
+// Restrict :id to digits only so that routes like /parties/bulk don't match
+router.post('/parties/:id(\\d+)', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  const id = parseInt(req.params.id, 10);
   const { name, gst_number, state, pincode, due_payment_days } = req.body;
+
+  if (Number.isNaN(id)) {
+    req.flash('error', 'Invalid party ID');
+    return res.redirect('/purchase');
+  }
+
   try {
     await pool.query(
       `UPDATE parties


### PR DESCRIPTION
## Summary
- prevent `/purchase/parties/bulk` from hitting the single-party update route by restricting `:id` to digits and validating the value
- bump Express JSON/urlencoded body size limit to 10mb to avoid `PayloadTooLargeError`

## Testing
- `node --check app.js`
- `node --check routes/purchaseRoutes.js`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68aec7afacbc8320896502d054d4b0c0