### PR TITLE
Add washing item rate management

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,20 @@ CREATE TABLE stitching_operation_payments (
 The operator dashboard exposes a page to maintain `stitching_rates` so contract
 amounts can be calculated automatically.
 
+### Washing Payments
+
+Store per-item washing rates in the `washing_item_rates` table:
+
+```sql
+CREATE TABLE washing_item_rates (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  description VARCHAR(100) NOT NULL UNIQUE,
+  rate DECIMAL(10,2) NOT NULL DEFAULT 0
+);
+```
+
+Operators can add items such as "ice wash" or "acid wash" and set the amount to be paid for each from the washing payment dashboard.
+
 ### Purchase Dashboard
 
 The Purchase dashboard stores party and factory details along with simple

--- a/app.js
+++ b/app.js
@@ -82,6 +82,7 @@ const washingIN = require('./routes/washingInRoutes');
 const catalogR = require('./routes/catalogupload');
 const storeAdminRoutes = require('./routes/storeAdminRoutes');
 const stitchingPaymentRoutes = require('./routes/stitchingPaymentRoutes');
+const washingPaymentRoutes = require('./routes/washingPaymentRoutes');
 
 const inventoryRoutes = require('./routes/inventoryRoutes');
 const departmentMgmtRoutes = require('./routes/departmentMgmtRoutes');
@@ -109,6 +110,7 @@ app.use('/', searchRoutes);
 app.use('/assign-to-washing', assigntowashingRoutes);
 app.use('/jeansassemblydashboard', jeansAssemblyRoutes);
 app.use('/stitchingdashboard/payments', stitchingPaymentRoutes);
+app.use('/washingdashboard/payments', washingPaymentRoutes);
 app.use("/operator", editCuttingLotRoutes);
 app.use('/operator', editWashingAssignmentsRoutes);
 app.use('/operator', departmentMgmtRoutes);

--- a/routes/washingPaymentRoutes.js
+++ b/routes/washingPaymentRoutes.js
@@ -1,0 +1,43 @@
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isOperator } = require('../middlewares/auth');
+
+// Show washing item rates configuration
+router.get('/rates', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const [rows] = await pool.query(
+      'SELECT description, rate FROM washing_item_rates ORDER BY description'
+    );
+    res.render('washingRateConfig', {
+      items: rows,
+      error: req.flash('error'),
+      success: req.flash('success')
+    });
+  } catch (err) {
+    console.error('fetch washing rates', err);
+    req.flash('error', 'Failed to load rates');
+    res.redirect('/operator');
+  }
+});
+
+// Create or update an item rate
+router.post('/rates/update', isAuthenticated, isOperator, async (req, res) => {
+  const { description = '', rate = 0 } = req.body;
+  if (!description.trim()) {
+    return res.redirect('/washingdashboard/payments/rates');
+  }
+  try {
+    await pool.query(
+      'INSERT INTO washing_item_rates (description, rate) VALUES (?, ?) ON DUPLICATE KEY UPDATE rate = VALUES(rate)',
+      [description.trim(), parseFloat(rate) || 0]
+    );
+    req.flash('success', 'Rate saved');
+  } catch (err) {
+    console.error('save washing rate', err);
+    req.flash('error', 'Failed to save rate');
+  }
+  res.redirect('/washingdashboard/payments/rates');
+});
+
+module.exports = router;

--- a/views/washingRateConfig.ejs
+++ b/views/washingRateConfig.ejs
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Washing Item Rates</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+</head>
+<body>
+<nav class="navbar navbar-dark bg-dark">
+  <div class="container-fluid">
+    <span class="navbar-brand">Washing Item Rates</span>
+    <a href="/operator" class="btn btn-outline-light btn-sm">Dashboard</a>
+  </div>
+</nav>
+<div class="container mt-4">
+  <% if (error && error.length) { %>
+    <div class="alert alert-danger"><%= error %></div>
+  <% } %>
+  <% if (success && success.length) { %>
+    <div class="alert alert-success"><%= success %></div>
+  <% } %>
+
+  <h5>Existing Item Rates</h5>
+  <table class="table table-bordered">
+    <thead>
+      <tr>
+        <th>Description</th>
+        <th style="width:200px">Rate</th>
+        <th style="width:100px"></th>
+      </tr>
+    </thead>
+    <tbody>
+      <% items.forEach(function(r){ %>
+        <tr>
+          <form method="POST" action="/washingdashboard/payments/rates/update" class="row g-2">
+            <td><%= r.description %><input type="hidden" name="description" value="<%= r.description %>"></td>
+            <td><input type="number" step="0.01" name="rate" value="<%= r.rate %>" class="form-control"></td>
+            <td><button type="submit" class="btn btn-sm btn-primary">Save</button></td>
+          </form>
+        </tr>
+      <% }) %>
+    </tbody>
+  </table>
+
+  <hr>
+  <h5>Add New Item</h5>
+  <form method="POST" action="/washingdashboard/payments/rates/update" class="row g-2">
+    <div class="col-md-6">
+      <input type="text" name="description" placeholder="Item description" class="form-control" required>
+    </div>
+    <div class="col-md-4">
+      <input type="number" step="0.01" name="rate" placeholder="Rate" class="form-control" required>
+    </div>
+    <div class="col-md-2">
+      <button type="submit" class="btn btn-success">Add</button>
+    </div>
+  </form>
+</div>
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- allow operators to manage washing item descriptions and rates
- expose washing payment rate configuration dashboard
- document washing_item_rates SQL schema

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b198de3de08320ad64b862879a4eb0