### PR TITLE
Improve washing payment flow and dashboard loading

### DIFF
--- a/views/washingPaymentDashboard.ejs
+++ b/views/washingPaymentDashboard.ejs
@@ -27,13 +27,13 @@
 
   <div class="row" id="washerList">
     <% washers.forEach(function(w){ %>
-      <div class="col-md-4 mb-3 washer-card" data-washer-name="<%= w.name.toLowerCase() %>">
+      <div class="col-md-4 mb-3 washer-card" data-washer-name="<%= w.username.toLowerCase() %>" data-washer-id="<%= w.id %>">
         <div class="card h-100 shadow-sm">
           <div class="card-header d-flex align-items-center justify-content-between">
             <div>
               <i class="fa fa-user me-2 text-primary" data-bs-toggle="tooltip" title="Washer"></i>
-              <span class="washer-name"><%= w.name %></span>
-              <span class="badge bg-secondary"><%= w.lots.length %> lots</span>
+              <span class="washer-name"><%= w.username %></span>
+              <span class="badge bg-secondary" id="count-<%= w.id %>"><%= w.lot_count %> lots</span>
             </div>
             <button
               class="btn btn-sm btn-outline-primary collapse-btn"
@@ -45,33 +45,9 @@
               <i class="fa fa-eye"></i>
             </button>
           </div>
-          <div id="lots-<%= w.id %>" class="collapse">
+          <div id="lots-<%= w.id %>" class="collapse" data-loaded="false">
             <div class="card-body">
-              <form class="lotForm">
-                <table class="table table-sm table-bordered">
-                  <thead>
-                    <tr>
-                      <th>Lot</th>
-                      <th>Qty</th>
-                      <th>Select</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    <% w.lots.forEach(function(l){ %>
-                      <tr>
-                        <td><%= l.lot_no %></td>
-                        <td><%= l.total_pieces %></td>
-                        <td><input type="checkbox" name="lotIds" value="<%= l.id %>"></td>
-                      </tr>
-                    <% }); %>
-                  </tbody>
-                </table>
-                <div class="text-end">
-                  <button type="button" class="btn btn-success proceedBtn" data-bs-toggle="tooltip" title="Proceed to payment for selected lots">
-                    <i class="fa fa-arrow-right"></i> Proceed to Payment
-                  </button>
-                </div>
-              </form>
+              <div class="text-center text-muted">Select to view lots</div>
             </div>
           </div>
         </div>
@@ -97,18 +73,46 @@
     }
   });
 
-  document.querySelectorAll('.proceedBtn').forEach(btn => {
-    btn.addEventListener('click', function(){
-      const form = this.closest('.lotForm');
-      const ids = Array.from(form.querySelectorAll('input[name="lotIds"]:checked')).map(c=>c.value);
-      if(!ids.length) return;
-      window.location.href = '/washingdashboard/payments/summary?ids=' + ids.join(',');
-    });
-  });
-
   // enable tooltips
   const tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"], .collapse-btn'));
   tooltipTriggerList.map(el => new bootstrap.Tooltip(el));
+
+  // load lots on first expansion
+  document.querySelectorAll('.collapse').forEach(col => {
+    col.addEventListener('show.bs.collapse', async function () {
+      if (this.dataset.loaded === 'true') return;
+      const washerId = this.id.split('-')[1];
+      const body = this.querySelector('.card-body');
+      body.innerHTML = '<div class="text-center text-muted">Loading...</div>';
+      try {
+        const res = await fetch(`/washingdashboard/payments/washer/${washerId}/lots`);
+        const data = await res.json();
+        if (!data.lots.length) {
+          body.innerHTML = '<p class="text-muted">No pending lots.</p>';
+          this.dataset.loaded = 'true';
+          return;
+        }
+        const form = document.createElement('form');
+        form.className = 'lotForm';
+        let tableHtml = '<table class="table table-sm table-bordered"><thead><tr><th>Lot</th><th>Qty</th><th>Select</th></tr></thead><tbody>';
+        data.lots.forEach(l => {
+          tableHtml += `<tr><td>${l.lot_no}</td><td>${l.total_pieces}</td><td><input type="checkbox" name="lotIds" value="${l.id}"></td></tr>`;
+        });
+        tableHtml += '</tbody></table><div class="text-end"><button type="button" class="btn btn-success proceedBtn"><i class="fa fa-arrow-right"></i> Proceed to Payment</button></div>';
+        form.innerHTML = tableHtml;
+        body.innerHTML = '';
+        body.appendChild(form);
+        form.querySelector('.proceedBtn').addEventListener('click', function(){
+          const ids = Array.from(form.querySelectorAll('input[name="lotIds"]:checked')).map(c=>c.value);
+          if(!ids.length) return;
+          window.location.href = '/washingdashboard/payments/summary?ids=' + ids.join(',');
+        });
+        this.dataset.loaded = 'true';
+      } catch (err) {
+        body.innerHTML = '<p class="text-danger">Failed to load lots</p>';
+      }
+    });
+  });
 </script>
 </body>
 </html>

--- a/views/washingPaymentSummary.ejs
+++ b/views/washingPaymentSummary.ejs
@@ -23,13 +23,23 @@
         Lot <%= l.lot_no %> (Qty: <%= l.total_pieces %>)
       </div>
       <div class="card-body">
-        <% rates.forEach(function(r){ %>
-          <div class="form-check">
-            <input class="form-check-input rate-check" data-rate="<%= r.rate %>" type="checkbox" name="desc_<%= l.id %>" value="<%= r.description %>">
-            <label class="form-check-label"><%= r.description %> (₹<%= r.rate %>)</label>
+        <div id="desc-container-<%= l.id %>" class="desc-container" data-lot="<%= l.id %>" data-qty="<%= l.total_pieces %>">
+          <div class="row g-2 desc-row">
+            <div class="col">
+              <select class="form-select desc-select" name="desc_<%= l.id %>[]">
+                <option value="">Select description</option>
+                <% rates.forEach(function(r){ %>
+                  <option value="<%= r.description %>" data-rate="<%= r.rate %>"><%= r.description %> (₹<%= r.rate %>)</option>
+                <% }); %>
+              </select>
+            </div>
+            <div class="col-auto">
+              <button type="button" class="btn btn-outline-danger remove-desc d-none">&times;</button>
+            </div>
           </div>
-        <% }); %>
-        <p class="mt-2">Total Rate: ₹<span id="rate-<%= l.id %>">0</span></p>
+        </div>
+        <button type="button" class="btn btn-sm btn-outline-primary add-desc" data-lot="<%= l.id %>">Add Description</button>
+        <p class="mt-2 mb-0">Total Rate: ₹<span id="rate-<%= l.id %>">0</span></p>
         <p>Amount: ₹<span id="amount-<%= l.id %>">0</span></p>
       </div>
     </div>
@@ -40,17 +50,38 @@
 </form>
 </div>
 <script>
-  const rateMap = { <% rates.forEach(function(r, idx){ %>'<%= r.description %>':<%= r.rate %><% if (idx < rates.length-1) { %>,<% } %><% }); %> };
-  <% lots.forEach(function(l){ %>
-    document.querySelectorAll('input[name="desc_<%= l.id %>"]').forEach(cb => {
-      cb.addEventListener('change', function(){
-        const sel = Array.from(document.querySelectorAll('input[name="desc_<%= l.id %>"]:checked'));
-        let rate = 0; sel.forEach(c => { rate += rateMap[c.value] || 0; });
-        document.getElementById('rate-<%= l.id %>').innerText = rate.toFixed(2);
-        document.getElementById('amount-<%= l.id %>').innerText = (rate * <%= l.total_pieces %>).toFixed(2);
-      });
+  const rateOptions = `<option value="">Select description</option><% rates.forEach(function(r){ %><option value="<%= r.description %>" data-rate="<%= r.rate %>"><%= r.description %> (₹<%= r.rate %>)</option><% }); %>`;
+
+  function updateTotals(lotId){
+    const container = document.getElementById('desc-container-' + lotId);
+    const qty = parseFloat(container.dataset.qty);
+    let totalRate = 0;
+    container.querySelectorAll('.desc-select').forEach(sel => {
+      const rate = parseFloat(sel.selectedOptions[0]?.dataset.rate || 0);
+      totalRate += rate;
     });
-  <% }); %>
+    document.getElementById('rate-' + lotId).innerText = totalRate.toFixed(2);
+    document.getElementById('amount-' + lotId).innerText = (totalRate * qty).toFixed(2);
+  }
+
+  document.querySelectorAll('.add-desc').forEach(btn => {
+    btn.addEventListener('click', function(){
+      const lotId = this.dataset.lot;
+      const container = document.getElementById('desc-container-' + lotId);
+      const row = document.createElement('div');
+      row.className = 'row g-2 desc-row mt-1';
+      row.innerHTML = `<div class="col"><select class="form-select desc-select" name="desc_${lotId}[]">${rateOptions}</select></div><div class="col-auto"><button type="button" class="btn btn-outline-danger remove-desc">&times;</button></div>`;
+      container.appendChild(row);
+      row.querySelector('.desc-select').addEventListener('change', () => updateTotals(lotId));
+      row.querySelector('.remove-desc').addEventListener('click', () => { row.remove(); updateTotals(lotId); });
+    });
+  });
+
+  document.querySelectorAll('.desc-container').forEach(container => {
+    const lotId = container.dataset.lot;
+    const select = container.querySelector('.desc-select');
+    select.addEventListener('change', () => updateTotals(lotId));
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Lazy load washer lot lists via new `/washer/:id/lots` endpoint to avoid heavy initial queries
- Redesign washing payment summary to add multiple descriptions per lot with rate calculation
- Refactor dashboard UI for cleaner, professional layout

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bab865922083209eec253b038780bd