### PR TITLE
Improve washing payment UI and handle long washer names

### DIFF
--- a/views/washingPaymentDashboard.ejs
+++ b/views/washingPaymentDashboard.ejs
@@ -67,9 +67,9 @@
       <div class="col-lg-3 col-md-4 col-sm-6 mb-4 washer-card" data-washer-name="<%= w.username.toLowerCase() %>" data-washer-id="<%= w.id %>">
         <div class="card h-100 shadow-sm">
           <div class="card-header bg-white border-0 d-flex align-items-center justify-content-between">
-            <div class="d-flex align-items-center">
+            <div class="d-flex align-items-center flex-grow-1 overflow-hidden">
               <i class="fa fa-user fa-lg me-2 text-primary" data-bs-toggle="tooltip" title="Washer"></i>
-              <span class="washer-name"><%= w.username %></span>
+              <span class="washer-name text-truncate" data-bs-toggle="tooltip" title="<%= w.username %>"><%= w.username %></span>
             </div>
             <span class="badge bg-light text-dark" id="count-<%= w.id %>"><%= w.lot_count %> lots</span>
           </div>

--- a/views/washingPaymentSummary.ejs
+++ b/views/washingPaymentSummary.ejs
@@ -4,9 +4,36 @@
   <meta charset="UTF-8" />
   <title>Washing Payment Summary</title>
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <style>
+    body {
+      background-color: #f8f9fa;
+      font-family: "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    }
+
+    .navbar {
+      background: linear-gradient(135deg, #0d6efd 0%, #6610f2 100%);
+    }
+
+    .card {
+      border: none;
+      border-radius: 0.75rem;
+      box-shadow: 0 0.5rem 1rem rgba(0, 0, 0, 0.15);
+    }
+
+    .card-header {
+      background-color: #fff;
+      font-weight: 600;
+      border-bottom: none;
+    }
+
+    .add-desc,
+    .remove-desc {
+      border-radius: 0.5rem;
+    }
+  </style>
 </head>
 <body>
-<nav class="navbar navbar-dark bg-dark">
+<nav class="navbar navbar-dark">
   <div class="container-fluid">
     <span class="navbar-brand">Washing Payment</span>
     <div class="d-flex gap-2 ms-auto">
@@ -18,7 +45,7 @@
 <form method="POST" action="/washingdashboard/payments/create">
   <% lots.forEach(function(l){ %>
     <input type="hidden" name="lotIds" value="<%= l.id %>">
-    <div class="card mb-3">
+    <div class="card mb-4">
       <div class="card-header">
         Lot <%= l.lot_no %> (Qty: <%= l.total_pieces %>)
       </div>


### PR DESCRIPTION
## Summary
- Refined washer payment dashboard to gracefully handle excessively long washer names with truncation and tooltips.
- Restyled washing payment summary page with gradient navbar, softer cards, and consistent typography for a cleaner look.

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bac31fbc9c832099cab20db560f93e