### PR TITLE
Allow washing-in rewash for newly updated quantities

### DIFF
--- a/views/washingInAssignRewash.ejs
+++ b/views/washingInAssignRewash.ejs
@@ -95,7 +95,7 @@
               <option value="">-- Choose a lot --</option>
               <% lots.forEach(l => { %>
               <option value="<%= l.washing_data_id %>">
-                <%= l.lot_no %> | SKU: <%= l.sku %> | Bal: <%= l.total_pieces %>
+                <%= l.lot_no %> | SKU: <%= l.sku %> | Total: <%= l.total_pieces %> | Rewash Bal: <%= l.available_for_rewash %>
               </option>
               <% }) %>
             </select>
@@ -168,6 +168,14 @@
         try {
           const res = await fetch(`/washingin/assign-rewash/data/${selectedVal}`);
           const sizes = await res.json();
+
+          if (!sizes.length) {
+            sizeBody.innerHTML = `<tr><td colspan="3" class="text-center text-muted">No balance available for rewash.</td></tr>`;
+            totalRequested.textContent = '0';
+            submitBtn.disabled = true;
+            sizeSection.style.display = '';
+            return;
+          }
 
           sizeBody.innerHTML = sizes.map(s => `
             <tr>


### PR DESCRIPTION
## Summary
- expose lots for rewash when washer updates leave a remaining balance not yet taken by washing-in
- validate rewash creation against the remaining balance per size so only new quantities can be sent back
- enhance the rewash page to show the rewash balance and gracefully handle lots with no remaining pieces

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68e0b3039d6c83209672f8e5fceab7ea