### PR TITLE
Add manual roll entry form on fabric invoice rolls page

### DIFF
--- a/views/fabricInvoiceRolls.ejs
+++ b/views/fabricInvoiceRolls.ejs
@@ -111,14 +111,63 @@
                 </table>
             </div>
 
-            <!-- Bulk Upload for Rolls -->
-            <div class="mt-4 no-print">
-                <a href="/fabric-manager/bulk-upload/rolls" class="btn btn-outline-primary me-2">
-                    <i class="fas fa-upload"></i> Bulk Upload Fabric Invoice Rolls
-                </a>
-                <a href="/fabric-manager/dashboard" class="btn btn-outline-success">
-                    <i class="fas fa-arrow-left"></i> Back to Dashboard
-                </a>
+            <div class="row g-4 no-print">
+                <div class="col-lg-7">
+                    <div class="card shadow-sm h-100">
+                        <div class="card-header bg-primary text-white">
+                            <i class="fas fa-plus-circle"></i> Add Roll Manually
+                        </div>
+                        <div class="card-body">
+                            <form action="/fabric-manager/insert/roll" method="POST" class="row g-3">
+                                <input type="hidden" name="invoice_id" value="<%= invoice.id %>">
+                                <div class="col-md-6">
+                                    <label for="roll_no" class="form-label">Roll Number</label>
+                                    <input type="number" class="form-control" id="roll_no" name="roll_no" min="1" required>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="per_roll_weight" class="form-label">Per Roll Weight</label>
+                                    <input type="number" step="0.01" class="form-control" id="per_roll_weight" name="per_roll_weight" required>
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="color" class="form-label">Color</label>
+                                    <input type="text" class="form-control" id="color" name="color" placeholder="Optional">
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="gr_no_by_vendor" class="form-label">GR No by Vendor</label>
+                                    <input type="text" class="form-control" id="gr_no_by_vendor" name="gr_no_by_vendor" placeholder="Optional">
+                                </div>
+                                <div class="col-md-6">
+                                    <label for="unit" class="form-label">Unit</label>
+                                    <select id="unit" name="unit" class="form-select" required>
+                                        <option value="" disabled selected>Select Unit</option>
+                                        <option value="METER">METER</option>
+                                        <option value="KG">KG</option>
+                                    </select>
+                                </div>
+                                <div class="col-12 text-end">
+                                    <button type="submit" class="btn btn-primary">
+                                        <i class="fas fa-save"></i> Add Roll
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
+                <div class="col-lg-5">
+                    <div class="card shadow-sm h-100">
+                        <div class="card-header bg-light">
+                            <i class="fas fa-upload"></i> Bulk Actions
+                        </div>
+                        <div class="card-body d-flex flex-column gap-2">
+                            <a href="/fabric-manager/bulk-upload/rolls" class="btn btn-outline-primary">
+                                <i class="fas fa-file-excel"></i> Bulk Upload Fabric Invoice Rolls
+                            </a>
+                            <a href="/fabric-manager/dashboard" class="btn btn-outline-success">
+                                <i class="fas fa-arrow-left"></i> Back to Dashboard
+                            </a>
+                        </div>
+                    </div>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- add a Bootstrap card with a manual roll entry form on the fabric invoice rolls page
- keep existing rolls table and add a bulk actions card for uploads and navigation

## Testing
- npm start *(fails: missing secure-env dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eca1927c0883209a62e675d35d4590