### PR TITLE
Add per-roll layer tracking to API lots

### DIFF
--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -311,7 +311,16 @@ function normaliseRollEntry(entry) {
     );
   }
 
-  return { rollNo, weightUsed };
+  const layersSource =
+    entry.layers ?? entry.layerCount ?? entry.totalLayers ?? entry.layer_count;
+  const layers = Number(layersSource);
+  if (!Number.isInteger(layers) || layers <= 0) {
+    throw createClientError(
+      `Layers must be provided for roll ${rollNo} and must be a positive whole number.`,
+    );
+  }
+
+  return { rollNo, weightUsed, layers };
 }
 
 router.post(
@@ -441,8 +450,8 @@ router.post(
         );
 
         await conn.query(
-          `INSERT INTO api_lot_rolls (lot_id, fabric_roll_id, roll_no, weight_used) VALUES (?, ?, ?, ?)`,
-          [lotId, rollRecord.id, roll.rollNo, roll.weightUsed],
+          `INSERT INTO api_lot_rolls (lot_id, fabric_roll_id, roll_no, weight_used, layers) VALUES (?, ?, ?, ?, ?)`,
+          [lotId, rollRecord.id, roll.rollNo, roll.weightUsed, roll.layers],
         );
       }
 

--- a/sql/api_lot_tables.sql
+++ b/sql/api_lot_tables.sql
@@ -23,6 +23,7 @@ CREATE TABLE IF NOT EXISTS api_lot_rolls (
   fabric_roll_id BIGINT UNSIGNED NOT NULL,
   roll_no VARCHAR(100) NOT NULL,
   weight_used DECIMAL(12,3) NOT NULL,
+  layers INT UNSIGNED NOT NULL,
   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
   CONSTRAINT fk_api_lot_rolls_lot FOREIGN KEY (lot_id) REFERENCES api_lots(id) ON DELETE CASCADE,
   CONSTRAINT fk_api_lot_rolls_fabric_roll FOREIGN KEY (fabric_roll_id) REFERENCES fabric_invoice_rolls(id)


### PR DESCRIPTION
## Summary
- add a layers column to api_lot_rolls so each roll can track its own layer count
- require layers in the API payload and persist the value when creating lots

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ecca7fb1748320a71adb94415d49da