### PR TITLE
Fix API lot access for cutting managers

### DIFF
--- a/routes/apiRoutes.js
+++ b/routes/apiRoutes.js
@@ -47,10 +47,11 @@ async function fetchLotIfAuthorized(req, res, lotId) {
     }
 
     const isOperator = user.roleName === 'operator';
+    const isCuttingManager = user.roleName === 'cutting_manager';
     const isOwnCuttingMaster =
-      user.roleName === 'cutting_manager' && Number(user.id) === Number(lot.cuttingMasterId);
+      user.roleName === 'cutting_master' && Number(user.id) === Number(lot.cuttingMasterId);
 
-    if (!isOperator && !isOwnCuttingMaster) {
+    if (!isOperator && !isCuttingManager && !isOwnCuttingMaster) {
       res.status(403).json({ error: 'You do not have permission to view this lot.' });
       return null;
     }


### PR DESCRIPTION
## Summary
- allow cutting managers to access any API lot details
- ensure only cutting masters tied to a lot can view it while preserving operator access

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68f07c4deac08320b8bab4031a27f24e