### PR TITLE
Allow repeat washing entries for lot

### DIFF
--- a/routes/productionApiRoutes.js
+++ b/routes/productionApiRoutes.js
@@ -380,18 +380,6 @@ router.post(
           throw createHttpError(409, 'No open jeans assembly bundles remain for this lot.');
         }
 
-        const [existing] = await connection.query(
-          `SELECT COUNT(*) AS already
-             FROM production_flow_events
-            WHERE stage = 'washing'
-              AND lot_id = ?`,
-          [lot.lot_id],
-        );
-
-        if (existing[0].already) {
-          throw createHttpError(409, 'This lot has already been processed for washing.');
-        }
-
         const [pieces] = await connection.query(
           `SELECT DISTINCT p.id   AS piece_id,
                           p.piece_code,


### PR DESCRIPTION
## Summary
- allow washing stage to be submitted for the same lot multiple times so new jeans assembly bundles can be closed

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69138772832c8320b513a80d4111e00c)