### PR TITLE
Allow partial washing processing before lot completion

### DIFF
--- a/routes/productionApiRoutes.js
+++ b/routes/productionApiRoutes.js
@@ -388,7 +388,7 @@ router.post(
           [lot.lot_id],
         );
 
-        if (existing[0].already) {
+        if (existing[0].already >= lot.total_pieces) {
           throw createHttpError(409, 'This lot has already been processed for washing.');
         }
 


### PR DESCRIPTION
## Summary
- update washing stage processing to only block lots that have fully completed washing submissions
- allow subsequent washing entries for the same lot until all pieces have been processed

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913895adabc8320bdf883ffb7afc4b2)