### PR TITLE
Refine production flow assignments and rejection handling

### DIFF
--- a/routes/productionApiRoutes.js
+++ b/routes/productionApiRoutes.js
@@ -53,8 +53,13 @@ async function fetchBundleByCode(connection, bundleCode) {
             b.bundle_code,
             b.pieces_in_bundle,
             b.lot_id,
+            b.size_id,
+            s.size_label,
+            s.pattern_count,
+            s.bundle_count,
             l.lot_number
        FROM api_lot_bundles b
+       INNER JOIN api_lot_sizes s ON s.id = b.size_id
        INNER JOIN api_lots l ON l.id = b.lot_id
       WHERE b.bundle_code = ?
       LIMIT 1`,
@@ -70,9 +75,12 @@ async function fetchPieceByCode(connection, pieceCode) {
             p.lot_id,
             b.id AS bundle_id,
             b.bundle_code,
+            b.size_id,
+            s.size_label,
             l.lot_number
        FROM api_lot_piece_codes p
        INNER JOIN api_lot_bundles b ON b.id = p.bundle_id
+       INNER JOIN api_lot_sizes s ON s.id = p.size_id
        INNER JOIN api_lots l ON l.id = p.lot_id
       WHERE p.piece_code = ?
       LIMIT 1`,
@@ -92,6 +100,153 @@ async function fetchLotByNumber(connection, lotNumber) {
     [lotNumber],
   );
   return rows[0] || null;
+}
+
+async function fetchLotWithSizes(connection, lotNumber) {
+  const [rows] = await connection.query(
+    `SELECT l.id AS lot_id,
+            l.lot_number,
+            l.total_pieces,
+            s.id AS size_id,
+            s.size_label,
+            s.pattern_count,
+            s.total_pieces AS size_total_pieces,
+            s.bundle_count,
+            b.id AS bundle_id,
+            b.bundle_code,
+            b.pieces_in_bundle,
+            b.bundle_sequence
+       FROM api_lots l
+       INNER JOIN api_lot_sizes s ON s.lot_id = l.id
+       LEFT JOIN api_lot_bundles b ON b.size_id = s.id
+      WHERE l.lot_number = ?
+      ORDER BY s.size_label, b.bundle_sequence`,
+    [lotNumber],
+  );
+
+  if (!rows.length) {
+    return null;
+  }
+
+  const lot = {
+    lot_id: rows[0].lot_id,
+    lot_number: rows[0].lot_number,
+    total_pieces: rows[0].total_pieces,
+    sizes: [],
+  };
+
+  const sizeMap = new Map();
+  const labelMap = new Map();
+
+  for (const row of rows) {
+    let size = sizeMap.get(row.size_id);
+    if (!size) {
+      size = {
+        size_id: row.size_id,
+        size_label: row.size_label,
+        pattern_count: row.pattern_count,
+        total_pieces: row.size_total_pieces,
+        bundle_count: row.bundle_count,
+        bundles: [],
+      };
+      sizeMap.set(row.size_id, size);
+      labelMap.set((row.size_label || '').toUpperCase(), size);
+      lot.sizes.push(size);
+    }
+
+    if (row.bundle_id) {
+      size.bundles.push({
+        bundle_id: row.bundle_id,
+        bundle_code: row.bundle_code,
+        bundle_sequence: row.bundle_sequence,
+        pieces_in_bundle: row.pieces_in_bundle,
+      });
+    }
+  }
+
+  lot.sizeMap = sizeMap;
+  lot.sizeLabelMap = labelMap;
+  return lot;
+}
+
+function parseSizeAssignments(raw) {
+  if (raw === undefined || raw === null || raw === '') {
+    return [];
+  }
+
+  let parsed = raw;
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      parsed = trimmed.split(',').map(token => ({ sizeLabel: token.trim() }));
+    }
+  }
+
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  return parsed
+    .map(entry => {
+      if (!entry) return null;
+      if (typeof entry === 'string') {
+        return { sizeLabel: entry };
+      }
+      if (typeof entry === 'object') {
+        return entry;
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+function parsePieceCodeList(raw) {
+  if (raw === undefined || raw === null || raw === '') {
+    return [];
+  }
+
+  let parsed = raw;
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    try {
+      parsed = JSON.parse(trimmed);
+    } catch (err) {
+      parsed = trimmed.split(',');
+    }
+  }
+
+  if (!Array.isArray(parsed)) {
+    return [];
+  }
+
+  const unique = new Set();
+  for (const item of parsed) {
+    const code = normaliseCode(item);
+    if (code) {
+      unique.add(code);
+    }
+  }
+  return Array.from(unique.values());
+}
+
+async function maybeResolveUserMaster(connection, userId, payload, { allowMissing = false } = {}) {
+  if (!payload || typeof payload !== 'object') {
+    if (allowMissing) return null;
+    return resolveUserMaster(connection, userId, {});
+  }
+
+  try {
+    return await resolveUserMaster(connection, userId, payload);
+  } catch (error) {
+    if (allowMissing && error.status === 400) {
+      return null;
+    }
+    throw error;
+  }
 }
 
 async function ensureNoDuplicate(connection, stage, codeValue) {
@@ -132,6 +287,7 @@ async function closeEvents(
   const [result] = await connection.query(
     `UPDATE production_flow_events
         SET is_closed = 1,
+            event_status = 'closed',
             closed_at = NOW(),
             closed_by_stage = ?,
             closed_by_user_id = ?,
@@ -144,17 +300,135 @@ async function closeEvents(
 }
 
 async function insertEventRows(connection, rows) {
+  if (!rows.length) {
+    return;
+  }
+
   const chunkSize = 200;
   for (let i = 0; i < rows.length; i += chunkSize) {
-    const chunk = rows.slice(i, i + chunkSize);
+    const chunk = rows.slice(i, i + chunkSize).map(row => [
+      row.stage,
+      row.code_type ?? row.codeType,
+      row.code_value ?? row.codeValue,
+      row.lot_id ?? row.lotId,
+      row.bundle_id ?? row.bundleId ?? null,
+      row.size_id ?? row.sizeId ?? null,
+      row.piece_id ?? row.pieceId ?? null,
+      row.lot_number ?? row.lotNumber,
+      row.bundle_code ?? row.bundleCode ?? null,
+      row.size_label ?? row.sizeLabel ?? null,
+      row.piece_code ?? row.pieceCode ?? null,
+      row.pattern_count ?? row.patternCount ?? null,
+      row.bundle_count ?? row.bundleCount ?? null,
+      row.pieces_total ?? row.piecesTotal ?? null,
+      row.user_id ?? row.userId,
+      row.user_username ?? row.userUsername,
+      row.user_role ?? row.userRole,
+      row.master_id ?? row.masterId ?? null,
+      row.master_name ?? row.masterName ?? null,
+      row.remark ?? null,
+      row.event_status ?? row.eventStatus ?? 'open',
+      row.is_closed ? 1 : 0,
+      row.closed_by_stage ?? row.closedByStage ?? null,
+      row.closed_by_user_id ?? row.closedByUserId ?? null,
+      row.closed_by_user_username ?? row.closedByUserUsername ?? null,
+      row.closed_at ?? row.closedAt ?? null,
+    ]);
+
     await connection.query(
       `INSERT INTO production_flow_events
-         (stage, code_type, code_value, lot_id, bundle_id, piece_id, lot_number, bundle_code, piece_code, pieces_total,
-         user_id, user_username, user_role, master_id, master_name, remark)
+         (stage, code_type, code_value, lot_id, bundle_id, size_id, piece_id,
+          lot_number, bundle_code, size_label, piece_code, pattern_count, bundle_count, pieces_total,
+          user_id, user_username, user_role, master_id, master_name, remark, event_status,
+          is_closed, closed_by_stage, closed_by_user_id, closed_by_user_username, closed_at)
        VALUES ?`,
       [chunk],
     );
   }
+}
+
+async function insertRejectionEvents(connection, stage, user, pieceCodes, remark) {
+  if (!pieceCodes.length) {
+    return { inserted: 0, codes: [], pieces: [] };
+  }
+
+  const [pieces] = await connection.query(
+    `SELECT p.id AS piece_id,
+            p.piece_code,
+            p.lot_id,
+            p.size_id,
+            p.bundle_id,
+            b.bundle_code,
+            s.size_label,
+            l.lot_number
+       FROM api_lot_piece_codes p
+       INNER JOIN api_lot_bundles b ON b.id = p.bundle_id
+       INNER JOIN api_lot_sizes s ON s.id = p.size_id
+       INNER JOIN api_lots l ON l.id = p.lot_id
+      WHERE p.piece_code IN (?)`,
+    [pieceCodes],
+  );
+
+  if (!pieces.length) {
+    throw createHttpError(404, 'No matching piece codes were found for rejection.');
+  }
+
+  const foundCodes = new Set(pieces.map(p => p.piece_code));
+  const missing = pieceCodes.filter(code => !foundCodes.has(code));
+  if (missing.length) {
+    throw createHttpError(404, `Piece codes not found: ${missing.join(', ')}`);
+  }
+
+  const pieceIds = pieces.map(p => p.piece_id);
+  const [existing] = await connection.query(
+    `SELECT piece_id
+       FROM production_flow_events
+      WHERE stage = ?
+        AND piece_id IN (?)`,
+    [stage, pieceIds],
+  );
+
+  if (existing.length) {
+    const existingIds = new Set(existing.map(row => row.piece_id));
+    const duplicates = pieces
+      .filter(p => existingIds.has(p.piece_id))
+      .map(p => p.piece_code);
+    throw createHttpError(
+      409,
+      `Piece codes already submitted for ${stage}: ${duplicates.join(', ')}`,
+    );
+  }
+
+  const now = new Date();
+  const rows = pieces.map(piece => ({
+    stage,
+    code_type: 'piece',
+    code_value: piece.piece_code,
+    lot_id: piece.lot_id,
+    bundle_id: piece.bundle_id,
+    size_id: piece.size_id,
+    piece_id: piece.piece_id,
+    lot_number: piece.lot_number,
+    bundle_code: piece.bundle_code,
+    size_label: piece.size_label,
+    piece_code: piece.piece_code,
+    pieces_total: 1,
+    user_id: user.id,
+    user_username: user.username,
+    user_role: user.roleName,
+    master_id: null,
+    master_name: null,
+    remark,
+    event_status: 'rejected',
+    is_closed: true,
+    closed_by_stage: stage,
+    closed_by_user_id: user.id,
+    closed_by_user_username: user.username,
+    closed_at: now,
+  }));
+
+  await insertEventRows(connection, rows);
+  return { inserted: rows.length, codes: pieceCodes, pieces };
 }
 
 function parseMasterId(value) {
@@ -231,9 +505,20 @@ router.post(
     const rawCode = req.body.code;
     const remark = normaliseRemark(req.body.remark);
     const code = normaliseCode(rawCode);
-    const requiresMaster = STAGES_REQUIRING_MASTER.has(stage);
+    const stageRequiresMaster = STAGES_REQUIRING_MASTER.has(stage);
+    const rejectedPiecesInput =
+      stage === 'jeans_assembly' || stage === 'washing_in'
+        ? parsePieceCodeList(
+            req.body.rejectedPieces ??
+              req.body.rejectPieces ??
+              req.body.rejected_piece_codes ??
+              req.body.rejectedPieceCodes ??
+              req.body.reject_piece_codes ??
+              [],
+          )
+        : [];
 
-    if (!code) {
+    if (!code && rejectedPiecesInput.length === 0) {
       return res.status(400).json({ error: 'A valid code is required.' });
     }
 
@@ -241,122 +526,264 @@ router.post(
     try {
       await connection.beginTransaction();
 
-      const masterDetails = requiresMaster
-        ? await resolveUserMaster(connection, user.id, req.body)
-        : { masterId: null, masterName: null };
-
       if (stage === 'back_pocket' || stage === 'stitching_master') {
-        const bundle = await fetchBundleByCode(connection, code);
-        if (!bundle) {
-          throw createHttpError(404, 'Bundle code not found.');
+        const lot = await fetchLotWithSizes(connection, code);
+        if (!lot) {
+          throw createHttpError(404, 'Lot code not found.');
         }
 
-        await ensureNoDuplicate(connection, stage, code);
+        const assignmentsRaw =
+          req.body.assignments ??
+          req.body.sizeAssignments ??
+          req.body.sizes ??
+          req.body.size_ids ??
+          req.body.sizeIds;
 
-        await insertEventRows(connection, [[
-          stage,
-          'bundle',
-          code,
-          bundle.lot_id,
-          bundle.bundle_id,
-          null,
-          bundle.lot_number,
-          bundle.bundle_code,
-          null,
-          bundle.pieces_in_bundle,
-          user.id,
-          user.username,
-          user.roleName,
-          masterDetails.masterId,
-          masterDetails.masterName,
-          remark,
-        ]]);
+        let assignments = parseSizeAssignments(assignmentsRaw);
+        const defaultMaster = stageRequiresMaster
+          ? await maybeResolveUserMaster(connection, user.id, req.body, { allowMissing: true })
+          : { masterId: null, masterName: null };
 
+        if (!assignments.length) {
+          assignments = lot.sizes.map(size => ({ sizeId: size.size_id }));
+        }
+
+        if (!assignments.length) {
+          throw createHttpError(400, 'No sizes found to assign for this lot.');
+        }
+
+        const usedSizeIds = new Set();
+        const eventRows = [];
+        const summary = [];
+        const bundleCodeMap = new Map();
+
+        for (const assignment of assignments) {
+          const sizeIdRaw = assignment.sizeId ?? assignment.size_id ?? assignment.id;
+          const sizeLabelRaw = assignment.sizeLabel ?? assignment.size_label ?? assignment.size;
+
+          let size = null;
+          if (sizeIdRaw !== undefined && sizeIdRaw !== null && sizeIdRaw !== '') {
+            const sizeId = Number.parseInt(sizeIdRaw, 10);
+            if (!Number.isInteger(sizeId)) {
+              throw createHttpError(400, 'Invalid sizeId provided in assignments.');
+            }
+            size = lot.sizeMap.get(sizeId) || null;
+          } else if (sizeLabelRaw) {
+            const normalised = normaliseCode(sizeLabelRaw);
+            if (normalised) {
+              size = lot.sizeLabelMap.get(normalised) || null;
+            }
+          }
+
+          if (!size) {
+            throw createHttpError(404, 'One or more sizes were not found in this lot.');
+          }
+
+          if (usedSizeIds.has(size.size_id)) {
+            throw createHttpError(
+              409,
+              `Size ${size.size_label} has been provided multiple times in the request.`,
+            );
+          }
+
+          let masterDetails = { masterId: null, masterName: null };
+          if (stageRequiresMaster) {
+            masterDetails =
+              (await maybeResolveUserMaster(connection, user.id, assignment, { allowMissing: true })) ||
+              defaultMaster;
+
+            if (!masterDetails || (!masterDetails.masterId && !masterDetails.masterName)) {
+              throw createHttpError(
+                400,
+                `Master selection is required for size ${size.size_label}.`,
+              );
+            }
+          }
+
+          if (!Array.isArray(size.bundles) || !size.bundles.length) {
+            throw createHttpError(
+              409,
+              `No bundles were generated for size ${size.size_label}.`,
+            );
+          }
+
+          usedSizeIds.add(size.size_id);
+          summary.push({
+            sizeId: size.size_id,
+            sizeLabel: size.size_label,
+            bundles: size.bundles.length,
+            masterId: masterDetails.masterId ?? null,
+            masterName: masterDetails.masterName ?? null,
+          });
+
+          for (const bundle of size.bundles) {
+            eventRows.push({
+              stage,
+              code_type: 'bundle',
+              code_value: bundle.bundle_code,
+              lot_id: lot.lot_id,
+              bundle_id: bundle.bundle_id,
+              size_id: size.size_id,
+              lot_number: lot.lot_number,
+              bundle_code: bundle.bundle_code,
+              size_label: size.size_label,
+              pattern_count: size.pattern_count,
+              bundle_count: size.bundle_count,
+              pieces_total: bundle.pieces_in_bundle,
+              user_id: user.id,
+              user_username: user.username,
+              user_role: user.roleName,
+              master_id: masterDetails.masterId ?? null,
+              master_name: masterDetails.masterName ?? null,
+              remark,
+            });
+            bundleCodeMap.set(bundle.bundle_id, bundle.bundle_code);
+          }
+        }
+
+        if (!eventRows.length) {
+          throw createHttpError(400, 'No bundle assignments could be generated for this request.');
+        }
+
+        const bundleIds = Array.from(new Set(eventRows.map(r => r.bundle_id).filter(Boolean)));
+        if (bundleIds.length) {
+          const [existing] = await connection.query(
+            `SELECT bundle_id
+               FROM production_flow_events
+              WHERE stage = ?
+                AND bundle_id IN (?)`,
+            [stage, bundleIds],
+          );
+
+          if (existing.length) {
+            const duplicates = existing
+              .map(row => bundleCodeMap.get(row.bundle_id))
+              .filter(Boolean);
+            throw createHttpError(
+              409,
+              `Bundles already submitted for this stage: ${duplicates.join(', ')}`,
+            );
+          }
+        }
+
+        await insertEventRows(connection, eventRows);
         await connection.commit();
 
         return res.json({
           success: true,
           stage,
           data: {
-            lotNumber: bundle.lot_number,
-            bundleCode: bundle.bundle_code,
-            pieces: bundle.pieces_in_bundle,
-            masterId: masterDetails.masterId,
-            masterName: masterDetails.masterName,
+            lotNumber: lot.lot_number,
+            assignments: summary,
           },
         });
       }
 
+      const masterDetails = stageRequiresMaster
+        ? await resolveUserMaster(connection, user.id, req.body)
+        : { masterId: null, masterName: null };
+
       if (stage === 'jeans_assembly') {
-        const bundle = await fetchBundleByCode(connection, code);
-        if (!bundle) {
-          throw createHttpError(404, 'Bundle code not found.');
+        let bundle = null;
+        let closedBackPocket = 0;
+        let closedStitching = 0;
+
+        if (code) {
+          bundle = await fetchBundleByCode(connection, code);
+          if (!bundle) {
+            throw createHttpError(404, 'Bundle code not found.');
+          }
+
+          await ensureNoDuplicate(connection, stage, code);
+
+          const [prereq] = await connection.query(
+            `SELECT stage, is_closed
+               FROM production_flow_events
+              WHERE bundle_id = ?
+                AND stage IN ('back_pocket','stitching_master')`,
+            [bundle.bundle_id],
+          );
+
+          const hasBackPocket = prereq.some(row => row.stage === 'back_pocket' && row.is_closed === 0);
+          const hasStitching = prereq.some(row => row.stage === 'stitching_master' && row.is_closed === 0);
+
+          if (!hasBackPocket || !hasStitching) {
+            throw createHttpError(409, 'Bundle must be submitted by both back_pocket and stitching_master before jeans assembly.');
+          }
+
+          await insertEventRows(connection, [{
+            stage,
+            code_type: 'bundle',
+            code_value: code,
+            lot_id: bundle.lot_id,
+            bundle_id: bundle.bundle_id,
+            size_id: bundle.size_id,
+            lot_number: bundle.lot_number,
+            bundle_code: bundle.bundle_code,
+            size_label: bundle.size_label,
+            pattern_count: bundle.pattern_count,
+            bundle_count: bundle.bundle_count,
+            pieces_total: bundle.pieces_in_bundle,
+            user_id: user.id,
+            user_username: user.username,
+            user_role: user.roleName,
+            master_id: masterDetails.masterId,
+            master_name: masterDetails.masterName,
+            remark,
+          }]);
+
+          closedBackPocket = await closeEvents(connection, {
+            stage: 'back_pocket',
+            bundleId: bundle.bundle_id,
+            closedByStage: 'jeans_assembly',
+            closedByUserId: user.id,
+            closedByUsername: user.username,
+          });
+
+          closedStitching = await closeEvents(connection, {
+            stage: 'stitching_master',
+            bundleId: bundle.bundle_id,
+            closedByStage: 'jeans_assembly',
+            closedByUserId: user.id,
+            closedByUsername: user.username,
+          });
         }
 
-        await ensureNoDuplicate(connection, stage, code);
-
-        const [prereq] = await connection.query(
-          `SELECT stage, is_closed
-             FROM production_flow_events
-            WHERE bundle_id = ?
-              AND stage IN ('back_pocket','stitching_master')`,
-          [bundle.bundle_id],
-        );
-
-        const hasBackPocket = prereq.some(row => row.stage === 'back_pocket' && row.is_closed === 0);
-        const hasStitching = prereq.some(row => row.stage === 'stitching_master' && row.is_closed === 0);
-
-        if (!hasBackPocket || !hasStitching) {
-          throw createHttpError(409, 'Bundle must be submitted by both back_pocket and stitching_master before jeans assembly.');
+        let rejectionResult = { inserted: 0, codes: [], pieces: [] };
+        if (rejectedPiecesInput.length) {
+          rejectionResult = await insertRejectionEvents(
+            connection,
+            stage,
+            user,
+            rejectedPiecesInput,
+            remark,
+          );
         }
 
-        await insertEventRows(connection, [[
-          stage,
-          'bundle',
-          code,
-          bundle.lot_id,
-          bundle.bundle_id,
-          null,
-          bundle.lot_number,
-          bundle.bundle_code,
-          null,
-          bundle.pieces_in_bundle,
-          user.id,
-          user.username,
-          user.roleName,
-          masterDetails.masterId,
-          masterDetails.masterName,
-          remark,
-        ]]);
-
-        const closed = await closeEvents(connection, {
-          stage: 'back_pocket',
-          bundleId: bundle.bundle_id,
-          closedByStage: 'jeans_assembly',
-          closedByUserId: user.id,
-          closedByUsername: user.username,
-        });
-
-        const closed2 = await closeEvents(connection, {
-          stage: 'stitching_master',
-          bundleId: bundle.bundle_id,
-          closedByStage: 'jeans_assembly',
-          closedByUserId: user.id,
-          closedByUsername: user.username,
-        });
+        if (!bundle && rejectionResult.inserted === 0) {
+          throw createHttpError(400, 'Bundle code or rejected piece codes are required.');
+        }
 
         await connection.commit();
+
+        const responseLotNumber = bundle
+          ? bundle.lot_number
+          : rejectionResult.pieces[0]?.lot_number || null;
+        const responseBundleCode = bundle ? bundle.bundle_code : null;
+        const responsePieces = bundle ? bundle.pieces_in_bundle : null;
 
         return res.json({
           success: true,
           stage,
           data: {
-            lotNumber: bundle.lot_number,
-            bundleCode: bundle.bundle_code,
-            pieces: bundle.pieces_in_bundle,
-            closedPrevious: closed + closed2,
+            lotNumber: responseLotNumber,
+            bundleCode: responseBundleCode,
+            pieces: responsePieces,
             masterId: masterDetails.masterId,
             masterName: masterDetails.masterName,
+            rejectedPieces: rejectionResult.codes,
+            closedBackPocket,
+            closedStitching,
           },
         });
       }
@@ -396,10 +823,14 @@ router.post(
           `SELECT DISTINCT p.id   AS piece_id,
                           p.piece_code,
                           p.bundle_id,
+                          p.size_id,
+                          s.size_label,
                           b.bundle_code
              FROM api_lot_piece_codes p
              INNER JOIN api_lot_bundles b
                      ON b.id = p.bundle_id
+             INNER JOIN api_lot_sizes s
+                     ON s.id = p.size_id
              INNER JOIN production_flow_events je
                      ON je.bundle_id = p.bundle_id
                     AND je.stage = 'jeans_assembly'
@@ -415,24 +846,26 @@ router.post(
           );
         }
 
-        const rowsToInsert = pieces.map(piece => [
-          'washing',
-          'piece',
-          piece.piece_code,
-          lot.lot_id,
-          piece.bundle_id,
-          piece.piece_id,
-          lot.lot_number,
-          piece.bundle_code,
-          piece.piece_code,
-          1,
-          user.id,
-          user.username,
-          user.roleName,
-          null,
-          null,
+        const rowsToInsert = pieces.map(piece => ({
+          stage: 'washing',
+          code_type: 'piece',
+          code_value: piece.piece_code,
+          lot_id: lot.lot_id,
+          bundle_id: piece.bundle_id,
+          size_id: piece.size_id,
+          piece_id: piece.piece_id,
+          lot_number: lot.lot_number,
+          bundle_code: piece.bundle_code,
+          size_label: piece.size_label,
+          piece_code: piece.piece_code,
+          pieces_total: 1,
+          user_id: user.id,
+          user_username: user.username,
+          user_role: user.roleName,
+          master_id: null,
+          master_name: null,
           remark,
-        ]);
+        }));
 
         await insertEventRows(connection, rowsToInsert);
 
@@ -458,66 +891,102 @@ router.post(
       }
 
       if (stage === 'washing_in') {
-        const piece = await fetchPieceByCode(connection, code);
-        if (!piece) {
+        const piece = code ? await fetchPieceByCode(connection, code) : null;
+        if (code && !piece) {
           throw createHttpError(404, 'Piece code not found.');
         }
 
-        await ensureNoDuplicate(connection, stage, code);
+        if (piece) {
+          await ensureNoDuplicate(connection, stage, code);
 
-        const [washingEvents] = await connection.query(
-          `SELECT id, is_closed
-             FROM production_flow_events
-            WHERE stage = 'washing'
-              AND piece_id = ?
-            LIMIT 1`,
-          [piece.piece_id],
-        );
+          const [washingEvents] = await connection.query(
+            `SELECT id, is_closed
+               FROM production_flow_events
+              WHERE stage = 'washing'
+                AND piece_id = ?
+              LIMIT 1`,
+            [piece.piece_id],
+          );
 
-        if (!washingEvents.length) {
-          throw createHttpError(409, 'Washing stage entry missing for this piece.');
+          if (!washingEvents.length) {
+            throw createHttpError(409, 'Washing stage entry missing for this piece.');
+          }
+
+          if (washingEvents[0].is_closed) {
+            throw createHttpError(409, 'This piece is already closed for washing.');
+          }
+
+          await insertEventRows(connection, [{
+            stage,
+            code_type: 'piece',
+            code_value: code,
+            lot_id: piece.lot_id,
+            bundle_id: piece.bundle_id,
+            size_id: piece.size_id,
+            piece_id: piece.piece_id,
+            lot_number: piece.lot_number,
+            bundle_code: piece.bundle_code,
+            size_label: piece.size_label,
+            piece_code: piece.piece_code,
+            pieces_total: 1,
+            user_id: user.id,
+            user_username: user.username,
+            user_role: user.roleName,
+            master_id: null,
+            master_name: null,
+            remark,
+          }]);
+
+          await closeEvents(connection, {
+            stage: 'washing',
+            pieceId: piece.piece_id,
+            closedByStage: 'washing_in',
+            closedByUserId: user.id,
+            closedByUsername: user.username,
+          });
         }
 
-        if (washingEvents[0].is_closed) {
-          throw createHttpError(409, 'This piece is already closed for washing.');
+        let rejectionResult = { inserted: 0, codes: [], pieces: [] };
+        if (rejectedPiecesInput.length) {
+          rejectionResult = await insertRejectionEvents(
+            connection,
+            stage,
+            user,
+            rejectedPiecesInput,
+            remark,
+          );
+
+          for (const rejected of rejectionResult.pieces) {
+            await closeEvents(connection, {
+              stage: 'washing',
+              pieceId: rejected.piece_id,
+              closedByStage: 'washing_in',
+              closedByUserId: user.id,
+              closedByUsername: user.username,
+            });
+          }
         }
 
-        await insertEventRows(connection, [[
-          stage,
-          'piece',
-          code,
-          piece.lot_id,
-          piece.bundle_id,
-          piece.piece_id,
-          piece.lot_number,
-          piece.bundle_code,
-          piece.piece_code,
-          1,
-          user.id,
-          user.username,
-          user.roleName,
-          null,
-          null,
-          remark,
-        ]]);
-
-        await closeEvents(connection, {
-          stage: 'washing',
-          pieceId: piece.piece_id,
-          closedByStage: 'washing_in',
-          closedByUserId: user.id,
-          closedByUsername: user.username,
-        });
+        if (!piece && rejectionResult.inserted === 0) {
+          throw createHttpError(400, 'Piece code or rejected piece codes are required.');
+        }
 
         await connection.commit();
+
+        const responseLotNumber = piece
+          ? piece.lot_number
+          : rejectionResult.pieces[0]?.lot_number || null;
+        const responseBundleCode = piece ? piece.bundle_code : null;
+        const responsePieceCode = piece ? piece.piece_code : null;
 
         return res.json({
           success: true,
           stage,
           data: {
-            lotNumber: piece.lot_number,
-            bundleCode: piece.bundle_code,
-            pieceCode: piece.piece_code,
+            lotNumber: responseLotNumber,
+            bundleCode: responseBundleCode,
+            pieceCode: responsePieceCode,
+            rejectedPieces: rejectionResult.codes,
           },
         });
       }
@@ -541,24 +1010,26 @@ router.post(
           throw createHttpError(409, 'All pieces must be recorded in washing_in before finishing.');
         }
 
-        await insertEventRows(connection, [[
+        await insertEventRows(connection, [{
           stage,
-          'bundle',
-          code,
-          bundle.lot_id,
-          bundle.bundle_id,
-          null,
-          bundle.lot_number,
-          bundle.bundle_code,
-          null,
-          bundle.pieces_in_bundle,
-          user.id,
-          user.username,
-          user.roleName,
-          masterDetails.masterId,
-          masterDetails.masterName,
+          code_type: 'bundle',
+          code_value: code,
+          lot_id: bundle.lot_id,
+          bundle_id: bundle.bundle_id,
+          size_id: bundle.size_id,
+          lot_number: bundle.lot_number,
+          bundle_code: bundle.bundle_code,
+          size_label: bundle.size_label,
+          pattern_count: bundle.pattern_count,
+          bundle_count: bundle.bundle_count,
+          pieces_total: bundle.pieces_in_bundle,
+          user_id: user.id,
+          user_username: user.username,
+          user_role: user.roleName,
+          master_id: masterDetails.masterId,
+          master_name: masterDetails.masterName,
           remark,
-        ]]);
+        }]);
 
         const closed = await closeEvents(connection, {
           stage: 'washing_in',
@@ -656,12 +1127,12 @@ router.get(
         }
         const [rows] = await pool.query(
           `SELECT id, stage, code_type AS codeType, code_value AS codeValue,
-                  lot_id AS lotId, bundle_id AS bundleId, piece_id AS pieceId,
-                  lot_number AS lotNumber, bundle_code AS bundleCode, piece_code AS pieceCode,
-                  pieces_total AS piecesTotal,
+                  lot_id AS lotId, bundle_id AS bundleId, size_id AS sizeId, piece_id AS pieceId,
+                  lot_number AS lotNumber, bundle_code AS bundleCode, size_label AS sizeLabel, piece_code AS pieceCode,
+                  pattern_count AS patternCount, bundle_count AS bundleCount, pieces_total AS piecesTotal,
                   user_id AS userId, user_username AS userUsername, user_role AS userRole,
                   master_id AS masterId, master_name AS masterName,
-                  remark, is_closed AS isClosed,
+                  remark, event_status AS eventStatus, is_closed AS isClosed,
                   closed_by_stage AS closedByStage,
                   closed_by_user_id AS closedByUserId,
                   closed_by_user_username AS closedByUserUsername,
@@ -681,12 +1152,12 @@ router.get(
       for (const stage of STAGES) {
         const [rows] = await pool.query(
           `SELECT id, stage, code_type AS codeType, code_value AS codeValue,
-                  lot_id AS lotId, bundle_id AS bundleId, piece_id AS pieceId,
-                  lot_number AS lotNumber, bundle_code AS bundleCode, piece_code AS pieceCode,
-                  pieces_total AS piecesTotal,
+                  lot_id AS lotId, bundle_id AS bundleId, size_id AS sizeId, piece_id AS pieceId,
+                  lot_number AS lotNumber, bundle_code AS bundleCode, size_label AS sizeLabel, piece_code AS pieceCode,
+                  pattern_count AS patternCount, bundle_count AS bundleCount, pieces_total AS piecesTotal,
                   user_id AS userId, user_username AS userUsername, user_role AS userRole,
                   master_id AS masterId, master_name AS masterName,
-                  remark, is_closed AS isClosed,
+                  remark, event_status AS eventStatus, is_closed AS isClosed,
                   closed_by_stage AS closedByStage,
                   closed_by_user_id AS closedByUserId,
                   closed_by_user_username AS closedByUserUsername,

--- a/sql/production_flow_tables.sql
+++ b/sql/production_flow_tables.sql
@@ -8,10 +8,14 @@ CREATE TABLE IF NOT EXISTS production_flow_events (
   code_value VARCHAR(64) NOT NULL,
   lot_id BIGINT UNSIGNED NOT NULL,
   bundle_id BIGINT UNSIGNED DEFAULT NULL,
+  size_id BIGINT UNSIGNED DEFAULT NULL,
   piece_id BIGINT UNSIGNED DEFAULT NULL,
   lot_number VARCHAR(32) NOT NULL,
   bundle_code VARCHAR(64) DEFAULT NULL,
+  size_label VARCHAR(16) DEFAULT NULL,
   piece_code VARCHAR(64) DEFAULT NULL,
+  pattern_count INT UNSIGNED DEFAULT NULL,
+  bundle_count INT UNSIGNED DEFAULT NULL,
   pieces_total INT UNSIGNED DEFAULT NULL,
   user_id BIGINT UNSIGNED NOT NULL,
   user_username VARCHAR(100) NOT NULL,
@@ -19,6 +23,7 @@ CREATE TABLE IF NOT EXISTS production_flow_events (
   master_id BIGINT UNSIGNED DEFAULT NULL,
   master_name VARCHAR(255) DEFAULT NULL,
   remark VARCHAR(255) DEFAULT NULL,
+  event_status ENUM('open','closed','rejected') NOT NULL DEFAULT 'open',
   is_closed TINYINT(1) NOT NULL DEFAULT 0,
   closed_by_stage ENUM('back_pocket','stitching_master','jeans_assembly','washing','washing_in','finishing') DEFAULT NULL,
   closed_by_user_id BIGINT UNSIGNED DEFAULT NULL,
@@ -29,9 +34,11 @@ CREATE TABLE IF NOT EXISTS production_flow_events (
   UNIQUE KEY uk_production_flow_stage_code (stage, code_value),
   KEY idx_production_flow_lot_stage (lot_id, stage),
   KEY idx_production_flow_bundle_stage (bundle_id, stage),
+  KEY idx_production_flow_size_stage (size_id, stage),
   KEY idx_production_flow_piece_stage (piece_id, stage),
   CONSTRAINT fk_production_flow_lot FOREIGN KEY (lot_id) REFERENCES api_lots(id),
   CONSTRAINT fk_production_flow_bundle FOREIGN KEY (bundle_id) REFERENCES api_lot_bundles(id),
+  CONSTRAINT fk_production_flow_size FOREIGN KEY (size_id) REFERENCES api_lot_sizes(id),
   CONSTRAINT fk_production_flow_piece FOREIGN KEY (piece_id) REFERENCES api_lot_piece_codes(id),
   CONSTRAINT fk_production_flow_user FOREIGN KEY (user_id) REFERENCES users(id),
   CONSTRAINT fk_production_flow_master FOREIGN KEY (master_id) REFERENCES user_masters(id) ON DELETE SET NULL,
@@ -43,4 +50,14 @@ CREATE TABLE IF NOT EXISTS production_flow_events (
 --   ADD COLUMN master_id BIGINT UNSIGNED DEFAULT NULL AFTER user_role,
 --   ADD COLUMN master_name VARCHAR(255) DEFAULT NULL AFTER master_id,
 --   ADD CONSTRAINT fk_production_flow_master FOREIGN KEY (master_id) REFERENCES user_masters(id) ON DELETE SET NULL;
+
+-- Migration snippet to bring existing tables in sync with the new size + rejection tracking:
+-- ALTER TABLE production_flow_events
+--   ADD COLUMN size_id BIGINT UNSIGNED DEFAULT NULL AFTER bundle_id,
+--   ADD COLUMN size_label VARCHAR(16) DEFAULT NULL AFTER lot_number,
+--   ADD COLUMN pattern_count INT UNSIGNED DEFAULT NULL AFTER size_label,
+--   ADD COLUMN bundle_count INT UNSIGNED DEFAULT NULL AFTER pattern_count,
+--   ADD COLUMN event_status ENUM('open','closed','rejected') NOT NULL DEFAULT 'open' AFTER remark,
+--   ADD CONSTRAINT fk_production_flow_size FOREIGN KEY (size_id) REFERENCES api_lot_sizes(id),
+--   ADD KEY idx_production_flow_size_stage (size_id, stage);
 


### PR DESCRIPTION
## Summary
- allow back_pocket and stitching_master stages to accept lot-level submissions, expanding them into per-bundle events with size metadata and optional per-size masters
- add rejection handling for jeans assembly and washing_in stages while capturing size references and event status on production flow events
- extend the production_flow_events schema with size columns, event status, and documented migration guidance

## Testing
- npm run lint *(fails: Missing script "lint")*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914447ec73c8320828498175fcf134b)