### PR TITLE
Revise production flow routing for bundle assignments

### DIFF
--- a/sql/production_flow_tables.sql
+++ b/sql/production_flow_tables.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS production_flow_events (
   piece_id BIGINT UNSIGNED DEFAULT NULL,
   lot_number VARCHAR(32) NOT NULL,
   bundle_code VARCHAR(64) DEFAULT NULL,
+  bundle_sequence INT UNSIGNED DEFAULT NULL,
   size_label VARCHAR(16) DEFAULT NULL,
   piece_code VARCHAR(64) DEFAULT NULL,
   pattern_count INT UNSIGNED DEFAULT NULL,
@@ -34,6 +35,7 @@ CREATE TABLE IF NOT EXISTS production_flow_events (
   UNIQUE KEY uk_production_flow_stage_code (stage, code_value),
   KEY idx_production_flow_lot_stage (lot_id, stage),
   KEY idx_production_flow_bundle_stage (bundle_id, stage),
+  KEY idx_production_flow_bundle_sequence_stage (bundle_sequence, stage),
   KEY idx_production_flow_size_stage (size_id, stage),
   KEY idx_production_flow_piece_stage (piece_id, stage),
   CONSTRAINT fk_production_flow_lot FOREIGN KEY (lot_id) REFERENCES api_lots(id),
@@ -55,9 +57,11 @@ CREATE TABLE IF NOT EXISTS production_flow_events (
 -- ALTER TABLE production_flow_events
 --   ADD COLUMN size_id BIGINT UNSIGNED DEFAULT NULL AFTER bundle_id,
 --   ADD COLUMN size_label VARCHAR(16) DEFAULT NULL AFTER lot_number,
+--   ADD COLUMN bundle_sequence INT UNSIGNED DEFAULT NULL AFTER bundle_code,
 --   ADD COLUMN pattern_count INT UNSIGNED DEFAULT NULL AFTER size_label,
 --   ADD COLUMN bundle_count INT UNSIGNED DEFAULT NULL AFTER pattern_count,
 --   ADD COLUMN event_status ENUM('open','closed','rejected') NOT NULL DEFAULT 'open' AFTER remark,
 --   ADD CONSTRAINT fk_production_flow_size FOREIGN KEY (size_id) REFERENCES api_lot_sizes(id),
---   ADD KEY idx_production_flow_size_stage (size_id, stage);
+--   ADD KEY idx_production_flow_size_stage (size_id, stage),
+--   ADD KEY idx_production_flow_bundle_sequence_stage (bundle_sequence, stage);
 


### PR DESCRIPTION
## Summary
- allow back_pocket and stitching_master users to distribute lot bundles across masters with bundle-level targeting and conflict checks
- remove master requirements from downstream stages while expanding per-piece rejection handling and washing/finishing workflows
- capture bundle sequence metadata in production_flow_events and document the schema changes needed to support the new flow

## Testing
- not run (not available)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691493916600832090c9ff2377b3aeeb)