### PR TITLE
Add indent management workflow for indent fillers and store managers

### DIFF
--- a/app.js
+++ b/app.js
@@ -98,6 +98,7 @@ const apiAuthRoutes = require('./routes/apiAuthRoutes');
 const apiRoutes = require('./routes/apiRoutes');
 const productionApiRoutes = require('./routes/productionApiRoutes');
 const featuresRoutes = require('./routes/featuresRoutes');
+const indentRoutes = require('./routes/indentRoutes');
 
 // Use Routes
 app.use('/', authRoutes);
@@ -135,6 +136,7 @@ app.use('/api', apiAuthRoutes);
 app.use('/api', apiRoutes);
 app.use('/api', productionApiRoutes);
 app.use('/', featuresRoutes);
+app.use('/indent', indentRoutes);
 
 // Home Route
 app.get('/', (req, res) => {

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -120,6 +120,14 @@ function isStoreAdmin(req, res, next) {
     return hasRole('store_admin')(req, res, next);
 }
 
+function isIndentFiller(req, res, next) {
+  return hasRole('indent_filler')(req, res, next);
+}
+
+function isStoreManager(req, res, next) {
+  return hasRole('store_manager')(req, res, next);
+}
+
 function isMohitOperator(req, res, next) {
   const allowed = [
     'mohitOperator',
@@ -189,6 +197,8 @@ module.exports = {
     isCatalogUpload,
     isStoreEmployee,
     isStoreAdmin,
+    isIndentFiller,
+    isStoreManager,
     isMohitOperator,
     allowUserIds,
     allowRoles

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -88,6 +88,12 @@ router.post('/login', async (req, res) => {
       case 'store_employee':
         res.redirect('/inventory/dashboard');
         break;
+      case 'indent_filler':
+        res.redirect('/indent');
+        break;
+      case 'store_manager':
+        res.redirect('/indent/manage');
+        break;
       case 'accounts':
         res.redirect('/purchase');
         break;

--- a/routes/indentRoutes.js
+++ b/routes/indentRoutes.js
@@ -1,0 +1,262 @@
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const {
+  isAuthenticated,
+  isIndentFiller,
+  isStoreManager
+} = require('../middlewares/auth');
+
+const ALLOWED_STATUSES = ['open', 'proceeding', 'arrived'];
+
+function sanitizeInteger(value, fallback = 0) {
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0) {
+    return fallback;
+  }
+  return parsed;
+}
+
+function sanitizeDecimal(value) {
+  if (value === undefined || value === null || value === '') {
+    return null;
+  }
+  const parsed = parseFloat(value);
+  return Number.isNaN(parsed) ? null : parsed;
+}
+
+async function logStatusChange(requestId, userId, previousStatus, newStatus, note = null) {
+  if (previousStatus === newStatus) {
+    return;
+  }
+  try {
+    await pool.query(
+      `INSERT INTO indent_request_audit (request_id, changed_by, previous_status, new_status, note)
+       VALUES (?, ?, ?, ?, ?)`,
+      [requestId, userId, previousStatus, newStatus, note]
+    );
+  } catch (error) {
+    console.warn('Could not write indent audit log:', error.message);
+  }
+}
+
+router.get('/', isAuthenticated, isIndentFiller, async (req, res) => {
+  try {
+    const [requests] = await pool.query(
+      `SELECT ir.*
+         FROM indent_requests ir
+        WHERE ir.filler_id = ?
+        ORDER BY ir.created_at DESC
+        LIMIT 200`,
+      [req.session.user.id]
+    );
+
+    res.render('indentFillerDashboard', {
+      user: req.session.user,
+      requests
+    });
+  } catch (error) {
+    console.error('Error loading indent filler dashboard:', error);
+    req.flash('error', 'Unable to load your indent requests right now.');
+    res.redirect('/');
+  }
+});
+
+router.post('/create', isAuthenticated, isIndentFiller, async (req, res) => {
+  const {
+    goodsDescription,
+    quantity,
+    requestDate,
+    usedLastMonth,
+    usedLastSevenDays
+  } = req.body;
+
+  if (!goodsDescription || !quantity || !requestDate) {
+    req.flash('error', 'Goods description, quantity and date are required.');
+    return res.redirect('/indent');
+  }
+
+  const normalizedDescription = goodsDescription.trim();
+  if (normalizedDescription.length > 255) {
+    req.flash('error', 'Goods description should be under 255 characters.');
+    return res.redirect('/indent');
+  }
+
+  const parsedQuantity = parseFloat(quantity);
+  if (Number.isNaN(parsedQuantity) || parsedQuantity <= 0) {
+    req.flash('error', 'Quantity must be a positive number.');
+    return res.redirect('/indent');
+  }
+
+  try {
+    await pool.query(
+      `INSERT INTO indent_requests
+         (filler_id, goods_description, quantity_requested, request_date,
+          used_last_month, used_last_seven_days)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        req.session.user.id,
+        normalizedDescription,
+        parsedQuantity,
+        requestDate,
+        sanitizeInteger(usedLastMonth),
+        sanitizeInteger(usedLastSevenDays)
+      ]
+    );
+
+    req.flash('success', 'Indent request submitted successfully.');
+    res.redirect('/indent');
+  } catch (error) {
+    console.error('Error creating indent request:', error);
+    req.flash('error', 'Unable to submit your request at the moment.');
+    res.redirect('/indent');
+  }
+});
+
+router.get('/manage', isAuthenticated, isStoreManager, async (req, res) => {
+  try {
+    const [requests] = await pool.query(
+      `SELECT ir.*, uf.username AS filler_name,
+              up.username AS proceeded_by_name,
+              ua.username AS arrived_by_name
+         FROM indent_requests ir
+    LEFT JOIN users uf ON ir.filler_id = uf.id
+    LEFT JOIN users up ON ir.proceeded_by = up.id
+    LEFT JOIN users ua ON ir.arrived_by = ua.id
+     ORDER BY ir.created_at DESC
+        LIMIT 400`
+    );
+
+    const [statsRows] = await pool.query(
+      `SELECT status, COUNT(*) AS total
+         FROM indent_requests
+        GROUP BY status`
+    );
+
+    const stats = ALLOWED_STATUSES.reduce((acc, status) => {
+      acc[status] = 0;
+      return acc;
+    }, {});
+    statsRows.forEach(row => {
+      if (ALLOWED_STATUSES.includes(row.status)) {
+        stats[row.status] = row.total;
+      }
+    });
+
+    res.render('storeManagerIndentDashboard', {
+      user: req.session.user,
+      requests,
+      stats
+    });
+  } catch (error) {
+    console.error('Error loading store manager dashboard:', error);
+    req.flash('error', 'Unable to load indent requests right now.');
+    res.redirect('/');
+  }
+});
+
+router.post('/requests/:id/proceed', isAuthenticated, isStoreManager, async (req, res) => {
+  const requestId = Number(req.params.id);
+  if (!Number.isInteger(requestId) || requestId <= 0) {
+    req.flash('error', 'Invalid request selected.');
+    return res.redirect('/indent/manage');
+  }
+
+  try {
+    const [[request]] = await pool.query(
+      'SELECT status FROM indent_requests WHERE id = ?',
+      [requestId]
+    );
+
+    if (!request) {
+      req.flash('error', 'Indent request not found.');
+      return res.redirect('/indent/manage');
+    }
+
+    if (request.status !== 'open') {
+      req.flash('error', 'Only open requests can be moved to proceeding.');
+      return res.redirect('/indent/manage');
+    }
+
+    await pool.query(
+      `UPDATE indent_requests
+          SET status = 'proceeding',
+              proceed_date = NOW(),
+              proceeded_by = ?
+        WHERE id = ?`,
+      [req.session.user.id, requestId]
+    );
+
+    await logStatusChange(requestId, req.session.user.id, request.status, 'proceeding');
+
+    req.flash('success', 'Request marked as proceeding.');
+    res.redirect('/indent/manage');
+  } catch (error) {
+    console.error('Error updating request status to proceeding:', error);
+    req.flash('error', 'Unable to update the request.');
+    res.redirect('/indent/manage');
+  }
+});
+
+router.post('/requests/:id/arrive', isAuthenticated, isStoreManager, async (req, res) => {
+  const requestId = Number(req.params.id);
+  const { arrivalDate, finalQuantity, remark } = req.body;
+  if (!Number.isInteger(requestId) || requestId <= 0) {
+    req.flash('error', 'Invalid request selected.');
+    return res.redirect('/indent/manage');
+  }
+  if (!arrivalDate) {
+    req.flash('error', 'Arrival date is required.');
+    return res.redirect('/indent/manage');
+  }
+  const normalizedArrival = arrivalDate.trim();
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalizedArrival)) {
+    req.flash('error', 'Please provide arrival date in YYYY-MM-DD format.');
+    return res.redirect('/indent/manage');
+  }
+
+  const parsedQuantity = sanitizeDecimal(finalQuantity);
+
+  try {
+    const [[request]] = await pool.query(
+      'SELECT status FROM indent_requests WHERE id = ?',
+      [requestId]
+    );
+
+    if (!request) {
+      req.flash('error', 'Indent request not found.');
+      return res.redirect('/indent/manage');
+    }
+
+    await pool.query(
+      `UPDATE indent_requests
+          SET status = 'arrived',
+              arrival_date = ?,
+              arrived_by = ?,
+              final_quantity = ?,
+              remark = ?,
+              proceed_date = COALESCE(proceed_date, NOW()),
+              proceeded_by = COALESCE(proceeded_by, ?)
+        WHERE id = ?`,
+      [
+        normalizedArrival,
+        req.session.user.id,
+        parsedQuantity,
+        remark ? remark.trim() : null,
+        req.session.user.id,
+        requestId
+      ]
+    );
+
+    await logStatusChange(requestId, req.session.user.id, request.status, 'arrived', remark);
+
+    req.flash('success', 'Request marked as arrived.');
+    res.redirect('/indent/manage');
+  } catch (error) {
+    console.error('Error marking request as arrived:', error);
+    req.flash('error', 'Unable to update the request.');
+    res.redirect('/indent/manage');
+  }
+});
+
+module.exports = router;

--- a/sql/indent_management_tables.sql
+++ b/sql/indent_management_tables.sql
@@ -1,0 +1,39 @@
+-- SQL definition for indent management feature
+
+CREATE TABLE IF NOT EXISTS indent_requests (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    filler_id BIGINT UNSIGNED NOT NULL,
+    goods_description VARCHAR(255) NOT NULL,
+    quantity_requested DECIMAL(12,2) NOT NULL,
+    request_date DATE NOT NULL,
+    used_last_month INT UNSIGNED DEFAULT 0,
+    used_last_seven_days INT UNSIGNED DEFAULT 0,
+    status ENUM('open', 'proceeding', 'arrived') DEFAULT 'open',
+    proceeded_by BIGINT UNSIGNED DEFAULT NULL,
+    proceed_date DATETIME DEFAULT NULL,
+    arrived_by BIGINT UNSIGNED DEFAULT NULL,
+    arrival_date DATETIME DEFAULT NULL,
+    final_quantity DECIMAL(12,2) DEFAULT NULL,
+    remark VARCHAR(500) DEFAULT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_indent_requests_filler FOREIGN KEY (filler_id) REFERENCES users(id),
+    CONSTRAINT fk_indent_requests_proceeded FOREIGN KEY (proceeded_by) REFERENCES users(id),
+    CONSTRAINT fk_indent_requests_arrived FOREIGN KEY (arrived_by) REFERENCES users(id),
+    INDEX idx_indent_requests_status (status),
+    INDEX idx_indent_requests_filler (filler_id),
+    INDEX idx_indent_requests_created_at (created_at)
+);
+
+CREATE TABLE IF NOT EXISTS indent_request_audit (
+    id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    request_id BIGINT UNSIGNED NOT NULL,
+    changed_by BIGINT UNSIGNED NOT NULL,
+    previous_status ENUM('open', 'proceeding', 'arrived') NOT NULL,
+    new_status ENUM('open', 'proceeding', 'arrived') NOT NULL,
+    note VARCHAR(500) DEFAULT NULL,
+    changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT fk_indent_audit_request FOREIGN KEY (request_id) REFERENCES indent_requests(id),
+    CONSTRAINT fk_indent_audit_user FOREIGN KEY (changed_by) REFERENCES users(id),
+    INDEX idx_indent_audit_request (request_id)
+);

--- a/views/indentFillerDashboard.ejs
+++ b/views/indentFillerDashboard.ejs
@@ -1,0 +1,394 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Indent Request Desk</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      integrity="sha512-1ycn6Ica9999htg3bK+0m0RwlcC4GjXnu5N219X2Dz7P+G9hbQUn7qYB6czS4fFqqTZPIYO/V+B2Bl+zYxZ3g=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #f6f8fb;
+        --card: #ffffff;
+        --primary: #2563eb;
+        --text: #0f172a;
+        --muted: #64748b;
+        --border: #e2e8f0;
+        --success: #0f9d58;
+        --warning: #f97316;
+        --info: #0891b2;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        min-height: 100vh;
+      }
+      .page {
+        max-width: 1200px;
+        margin: 0 auto;
+        padding: 32px 16px 64px;
+      }
+      header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 16px;
+        margin-bottom: 24px;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 1.8rem;
+        font-weight: 600;
+      }
+      header .user-meta {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 0.95rem;
+        color: var(--muted);
+      }
+      a.btn-link {
+        color: var(--primary);
+        font-weight: 600;
+        text-decoration: none;
+      }
+      a.btn-link:hover {
+        text-decoration: underline;
+      }
+      .card {
+        background: var(--card);
+        border-radius: 18px;
+        padding: 24px;
+        box-shadow: 0 15px 35px rgba(15, 23, 42, 0.08);
+        border: 1px solid var(--border);
+        margin-bottom: 24px;
+      }
+      form label {
+        display: block;
+        font-weight: 600;
+        margin-bottom: 6px;
+      }
+      form input,
+      form textarea {
+        width: 100%;
+        padding: 12px 14px;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        font-size: 1rem;
+        background: #fdfefe;
+      }
+      form textarea {
+        min-height: 90px;
+        resize: vertical;
+      }
+      .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 18px;
+      }
+      .actions {
+        text-align: right;
+        margin-top: 16px;
+      }
+      button.primary {
+        padding: 12px 28px;
+        border-radius: 999px;
+        border: none;
+        background: linear-gradient(120deg, #2563eb, #1d4ed8);
+        color: #fff;
+        font-weight: 600;
+        font-size: 1rem;
+        cursor: pointer;
+        box-shadow: 0 10px 25px rgba(37, 99, 235, 0.35);
+      }
+      button.primary:disabled {
+        opacity: 0.6;
+        cursor: not-allowed;
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      .table-wrapper {
+        overflow-x: auto;
+      }
+      th,
+      td {
+        padding: 14px 12px;
+        text-align: left;
+        border-bottom: 1px solid var(--border);
+        font-size: 0.95rem;
+      }
+      th {
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--muted);
+      }
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 6px;
+        font-weight: 600;
+        font-size: 0.85rem;
+        padding: 6px 14px;
+        border-radius: 999px;
+        text-transform: capitalize;
+      }
+      .status-open {
+        background: rgba(249, 115, 22, 0.15);
+        color: #c2410c;
+      }
+      .status-proceeding {
+        background: rgba(8, 145, 178, 0.15);
+        color: #0f766e;
+      }
+      .status-arrived {
+        background: rgba(15, 157, 88, 0.18);
+        color: #0f9d58;
+      }
+      .empty-state {
+        text-align: center;
+        padding: 40px 0 10px;
+        color: var(--muted);
+      }
+      .flash {
+        border-radius: 12px;
+        padding: 14px 16px;
+        font-weight: 500;
+        margin-bottom: 18px;
+      }
+      .alert {
+        border-radius: 12px;
+        padding: 12px 16px;
+        font-weight: 500;
+        margin-bottom: 16px;
+        border: 1px solid var(--border);
+      }
+      .alert-danger {
+        background: rgba(239, 68, 68, 0.12);
+        color: #b91c1c;
+        border-color: rgba(239, 68, 68, 0.3);
+      }
+      .alert-success {
+        background: rgba(15, 157, 88, 0.12);
+        color: #0f9d58;
+        border-color: rgba(15, 157, 88, 0.3);
+      }
+      .btn-close {
+        float: right;
+        border: none;
+        background: transparent;
+        font-size: 1rem;
+        cursor: pointer;
+        color: var(--muted);
+      }
+      .alert-dismissible {
+        position: relative;
+        padding-right: 2.5rem;
+      }
+      .alert-dismissible .btn-close {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        float: none;
+      }
+      .alert.fade.show {
+        opacity: 1;
+      }
+      .flash-success {
+        background: rgba(15, 157, 88, 0.1);
+        color: #0f9d58;
+        border: 1px solid rgba(15, 157, 88, 0.2);
+      }
+      .flash-error {
+        background: rgba(239, 68, 68, 0.1);
+        color: #b91c1c;
+        border: 1px solid rgba(239, 68, 68, 0.2);
+      }
+      @media (max-width: 720px) {
+        header {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+        table,
+        thead,
+        tbody,
+        th,
+        td,
+        tr {
+          display: block;
+        }
+        thead {
+          display: none;
+        }
+        tr {
+          border: 1px solid var(--border);
+          margin-bottom: 14px;
+          border-radius: 16px;
+          padding: 10px 12px;
+          background: var(--card);
+        }
+        td {
+          border: none;
+          padding: 6px 0;
+        }
+        td::before {
+          content: attr(data-label);
+          display: block;
+          font-weight: 600;
+          color: var(--muted);
+          margin-bottom: 4px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <header>
+        <h1>Indent Request Desk</h1>
+        <div class="user-meta">
+          <span><strong><%= user.username %></strong> &middot; Indent Filler</span>
+          <a class="btn-link" href="/logout">Logout</a>
+        </div>
+      </header>
+
+      <%- include('partials/flashMessages'); %>
+
+      <section class="card">
+        <h2 style="margin-top: 0">Raise a Requirement</h2>
+        <p style="color: var(--muted); margin-bottom: 24px">
+          Submit a clear description so the store manager can act on it quickly.
+        </p>
+        <form action="/indent/create" method="POST">
+          <div class="grid">
+            <div>
+              <label for="goodsDescription">Goods &amp; Description</label>
+              <textarea
+                id="goodsDescription"
+                name="goodsDescription"
+                placeholder="e.g. Thread cones 40/2 for Line A"
+                required
+              ></textarea>
+            </div>
+            <div>
+              <label for="quantity">Quantity</label>
+              <input
+                type="number"
+                id="quantity"
+                name="quantity"
+                min="0"
+                step="0.01"
+                placeholder="0"
+                required
+              />
+            </div>
+            <div>
+              <label for="requestDate">Date Needed</label>
+              <input type="date" id="requestDate" name="requestDate" required />
+            </div>
+            <div>
+              <label for="usedLastMonth">Used in last 30 days</label>
+              <input
+                type="number"
+                id="usedLastMonth"
+                name="usedLastMonth"
+                min="0"
+                placeholder="0"
+              />
+            </div>
+            <div>
+              <label for="usedLastSevenDays">Used in last 7 days</label>
+              <input
+                type="number"
+                id="usedLastSevenDays"
+                name="usedLastSevenDays"
+                min="0"
+                placeholder="0"
+              />
+            </div>
+          </div>
+          <div class="actions">
+            <button class="primary" type="submit">Submit Request</button>
+          </div>
+        </form>
+      </section>
+
+      <section class="card">
+        <h2 style="margin-top: 0">Recent Activity</h2>
+        <% if (!requests || !requests.length) { %>
+        <div class="empty-state">No requests raised yet.</div>
+        <% } else { %>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Goods &amp; Description</th>
+                <th>Qty</th>
+                <th>Request Date</th>
+                <th>Status</th>
+                <th>Proceed Date</th>
+                <th>Arrival Date</th>
+                <th>Final Qty</th>
+                <th>Remarks</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% requests.forEach(item => { %>
+              <tr>
+                <td data-label="Goods"><strong><%= item.goods_description %></strong></td>
+                <td data-label="Qty"><%= item.quantity_requested %></td>
+                <td data-label="Date"><%= item.request_date ? new Date(item.request_date).toLocaleDateString('en-IN') : '-' %></td>
+                <td data-label="Status">
+                  <span class="status-pill status-<%= item.status %>"><%= item.status %></span>
+                </td>
+                <td data-label="Proceed">
+                  <%= item.proceed_date ? new Date(item.proceed_date).toLocaleDateString('en-IN') : '-' %>
+                </td>
+                <td data-label="Arrival">
+                  <%= item.arrival_date ? new Date(item.arrival_date).toLocaleDateString('en-IN') : '-' %>
+                </td>
+                <td data-label="Final Qty"><%= item.final_quantity || '-' %></td>
+                <td data-label="Remarks"><%= item.remark || '-' %></td>
+              </tr>
+              <% }) %>
+            </tbody>
+          </table>
+        </div>
+        <% } %>
+      </section>
+    </div>
+    <script>
+      const dateInput = document.getElementById('requestDate');
+      if (dateInput && !dateInput.value) {
+        const today = new Date();
+        dateInput.value = today.toISOString().substring(0, 10);
+      }
+      document.querySelectorAll('.btn-close').forEach(btn => {
+        btn.addEventListener('click', () => {
+          if (btn.parentElement) {
+            btn.parentElement.remove();
+          }
+        });
+      });
+    </script>
+  </body>
+</html>

--- a/views/storeManagerIndentDashboard.ejs
+++ b/views/storeManagerIndentDashboard.ejs
@@ -1,0 +1,408 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Store Manager · Indent Control</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+      integrity="sha512-1ycn6Ica9999htg3bK+0m0RwlcC4GjXnu5N219X2Dz7P+G9hbQUn7qYB6czS4fFqqTZPIYO/V+B2Bl+zYxZ3g=="
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        --bg: #eff3fb;
+        --card: #ffffff;
+        --primary: #1d4ed8;
+        --text: #0f172a;
+        --muted: #475569;
+        --border: #e2e8f0;
+      }
+      * {
+        box-sizing: border-box;
+      }
+      body {
+        margin: 0;
+        font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+        background: var(--bg);
+        color: var(--text);
+        min-height: 100vh;
+      }
+      .page {
+        max-width: 1300px;
+        margin: 0 auto;
+        padding: 32px 16px 64px;
+      }
+      header {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: space-between;
+        align-items: center;
+        gap: 12px;
+        margin-bottom: 24px;
+      }
+      h1 {
+        margin: 0;
+        font-weight: 700;
+        font-size: 2rem;
+      }
+      header .user-meta {
+        color: var(--muted);
+        display: flex;
+        gap: 12px;
+        align-items: center;
+      }
+      a.btn-link {
+        color: var(--primary);
+        font-weight: 600;
+        text-decoration: none;
+      }
+      a.btn-link:hover {
+        text-decoration: underline;
+      }
+      .cards {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 18px;
+        margin-bottom: 24px;
+      }
+      .stat-card {
+        background: var(--card);
+        border-radius: 20px;
+        padding: 20px;
+        border: 1px solid var(--border);
+        box-shadow: 0 10px 35px rgba(15, 23, 42, 0.06);
+      }
+      .stat-label {
+        text-transform: uppercase;
+        font-size: 0.8rem;
+        color: var(--muted);
+        letter-spacing: 0.08em;
+        margin-bottom: 10px;
+      }
+      .stat-value {
+        font-size: 2rem;
+        font-weight: 700;
+      }
+      .card {
+        background: var(--card);
+        border-radius: 24px;
+        padding: 24px;
+        border: 1px solid var(--border);
+        box-shadow: 0 15px 40px rgba(15, 23, 42, 0.08);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      .table-wrapper {
+        overflow-x: auto;
+      }
+      th,
+      td {
+        padding: 12px;
+        border-bottom: 1px solid var(--border);
+        font-size: 0.95rem;
+        vertical-align: middle;
+      }
+      th {
+        font-size: 0.85rem;
+        text-transform: uppercase;
+        letter-spacing: 0.07em;
+        color: var(--muted);
+      }
+      .status-pill {
+        display: inline-flex;
+        align-items: center;
+        padding: 6px 14px;
+        border-radius: 999px;
+        font-weight: 600;
+        font-size: 0.85rem;
+        text-transform: capitalize;
+      }
+      .status-open {
+        background: rgba(249, 115, 22, 0.16);
+        color: #9a3412;
+      }
+      .status-proceeding {
+        background: rgba(8, 145, 178, 0.2);
+        color: #155e75;
+      }
+      .status-arrived {
+        background: rgba(15, 157, 88, 0.18);
+        color: #0f9d58;
+      }
+      .action-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+        align-items: center;
+      }
+      .action-bar form {
+        display: inline-flex;
+        gap: 8px;
+        align-items: center;
+      }
+      .btn {
+        border-radius: 999px;
+        border: none;
+        padding: 8px 18px;
+        font-weight: 600;
+        cursor: pointer;
+        font-size: 0.9rem;
+      }
+      .btn-primary {
+        background: linear-gradient(120deg, #2563eb, #1e40af);
+        color: #fff;
+        box-shadow: 0 10px 25px rgba(37, 99, 235, 0.3);
+      }
+      .btn-outline {
+        background: transparent;
+        border: 1px solid var(--border);
+        color: var(--muted);
+      }
+      .arrival-form {
+        display: none;
+        margin-top: 10px;
+        padding-top: 10px;
+        border-top: 1px dashed var(--border);
+      }
+      .arrival-form.active {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+        gap: 12px;
+      }
+      .arrival-form label {
+        display: flex;
+        flex-direction: column;
+        font-weight: 600;
+        font-size: 0.85rem;
+        color: var(--muted);
+        gap: 6px;
+      }
+      .arrival-form input,
+      .arrival-form textarea {
+        width: 100%;
+        padding: 10px 12px;
+        border-radius: 12px;
+        border: 1px solid var(--border);
+        font-family: inherit;
+      }
+      .alert {
+        border-radius: 12px;
+        padding: 12px 16px;
+        font-weight: 500;
+        margin-bottom: 16px;
+        border: 1px solid var(--border);
+      }
+      .alert-danger {
+        background: rgba(239, 68, 68, 0.12);
+        color: #b91c1c;
+        border-color: rgba(239, 68, 68, 0.3);
+      }
+      .alert-success {
+        background: rgba(15, 157, 88, 0.12);
+        color: #0f9d58;
+        border-color: rgba(15, 157, 88, 0.3);
+      }
+      .btn-close {
+        float: right;
+        border: none;
+        background: transparent;
+        font-size: 1rem;
+        cursor: pointer;
+        color: var(--muted);
+      }
+      .alert-dismissible {
+        position: relative;
+        padding-right: 2.5rem;
+      }
+      .alert-dismissible .btn-close {
+        position: absolute;
+        top: 12px;
+        right: 12px;
+        float: none;
+      }
+      .alert.fade.show {
+        opacity: 1;
+      }
+      @media (max-width: 960px) {
+        table,
+        thead,
+        tbody,
+        th,
+        td,
+        tr {
+          display: block;
+        }
+        thead {
+          display: none;
+        }
+        tr {
+          border: 1px solid var(--border);
+          margin-bottom: 12px;
+          border-radius: 18px;
+          padding: 12px;
+          background: var(--card);
+        }
+        td {
+          border: none;
+          padding: 6px 0;
+        }
+        td::before {
+          content: attr(data-label);
+          display: block;
+          font-weight: 600;
+          color: var(--muted);
+          margin-bottom: 4px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <header>
+        <h1>Indent Control Room</h1>
+        <div class="user-meta">
+          <span><strong><%= user.username %></strong> &middot; Store Manager</span>
+          <a class="btn-link" href="/logout">Logout</a>
+        </div>
+      </header>
+
+      <%- include('partials/flashMessages'); %>
+
+      <div class="cards">
+        <div class="stat-card">
+          <div class="stat-label">Open</div>
+          <div class="stat-value"><%= stats.open || 0 %></div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Proceeding</div>
+          <div class="stat-value" style="color: #0f766e"><%= stats.proceeding || 0 %></div>
+        </div>
+        <div class="stat-card">
+          <div class="stat-label">Arrived</div>
+          <div class="stat-value" style="color: #0f9d58"><%= stats.arrived || 0 %></div>
+        </div>
+      </div>
+
+      <section class="card">
+        <h2 style="margin-top: 0">Latest Indent Requests</h2>
+        <p style="color: var(--muted); margin-bottom: 20px">
+          Keep the flow smooth by acknowledging requests promptly.
+        </p>
+        <div class="table-wrapper">
+          <table>
+            <thead>
+              <tr>
+                <th>Goods &amp; Description</th>
+                <th>Quantity</th>
+                <th>Indent Filler</th>
+                <th>Dates</th>
+                <th>Status</th>
+                <th>Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% if (!requests || !requests.length) { %>
+              <tr>
+                <td colspan="6" style="text-align: center; padding: 32px">No requests yet.</td>
+              </tr>
+              <% } else { %>
+              <% requests.forEach(row => { %>
+              <tr>
+                <td data-label="Goods">
+                  <strong><%= row.goods_description %></strong>
+                  <div style="color: var(--muted); font-size: 0.85rem; margin-top: 4px">
+                    Used last month: <%= row.used_last_month || 0 %> · last 7 days:
+                    <%= row.used_last_seven_days || 0 %>
+                  </div>
+                </td>
+                <td data-label="Quantity"><%= row.quantity_requested %></td>
+                <td data-label="Filler">
+                  <strong><%= row.filler_name || '—' %></strong>
+                </td>
+                <td data-label="Dates">
+                  <div><small>Requested:</small> <%= row.request_date ? new Date(row.request_date).toLocaleDateString('en-IN') : '-' %></div>
+                  <div><small>Proceed:</small> <%= row.proceed_date ? new Date(row.proceed_date).toLocaleDateString('en-IN') : '-' %></div>
+                  <div><small>Arrived:</small> <%= row.arrival_date ? new Date(row.arrival_date).toLocaleDateString('en-IN') : '-' %></div>
+                </td>
+                <td data-label="Status">
+                  <span class="status-pill status-<%= row.status %>"><%= row.status %></span>
+                  <% if (row.final_quantity) { %>
+                  <div style="font-size: 0.8rem; color: var(--muted)">Final qty: <%= row.final_quantity %></div>
+                  <% } %>
+                  <% if (row.remark) { %>
+                  <div style="font-size: 0.8rem; color: var(--muted)"><%= row.remark %></div>
+                  <% } %>
+                </td>
+                <td data-label="Actions">
+                  <% if (row.status === 'arrived') { %>
+                  <div style="color: var(--muted); font-size: 0.85rem">Completed</div>
+                  <% } else { %>
+                  <div class="action-bar">
+                    <% if (row.status === 'open') { %>
+                    <form action="/indent/requests/<%= row.id %>/proceed" method="POST">
+                      <button class="btn btn-primary" type="submit">Proceed</button>
+                    </form>
+                    <% } %>
+                    <button class="btn btn-outline arrival-toggle" data-id="<%= row.id %>">
+                      Mark Arrived
+                    </button>
+                  </div>
+                  <form
+                    class="arrival-form"
+                    id="arrival-form-<%= row.id %>"
+                    action="/indent/requests/<%= row.id %>/arrive"
+                    method="POST"
+                  >
+                    <label>
+                      Arrival Date
+                      <input type="date" name="arrivalDate" required />
+                    </label>
+                    <label>
+                      Quantity Received
+                      <input type="number" step="0.01" name="finalQuantity" placeholder="Optional" />
+                    </label>
+                    <label>
+                      Remark
+                      <textarea name="remark" rows="2" placeholder="Optional"></textarea>
+                    </label>
+                    <div>
+                      <button class="btn btn-primary" type="submit">Confirm</button>
+                    </div>
+                  </form>
+                  <% } %>
+                </td>
+              </tr>
+              <% }) %>
+              <% } %>
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+    <script>
+      document.querySelectorAll('.arrival-toggle').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const form = document.getElementById(`arrival-form-${btn.dataset.id}`);
+          if (form) {
+            form.classList.toggle('active');
+          }
+        });
+      });
+      document.querySelectorAll('.btn-close').forEach(btn => {
+        btn.addEventListener('click', () => btn.parentElement && btn.parentElement.remove());
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add dedicated routes, role guards, and login redirects for the new indent filler and store manager roles so they can raise and action indent requests
- introduce modern EJS dashboards for both user types, including creation forms, status tracking, and inline arrival confirmations while keeping the UI lightweight
- provide the required SQL schema (indent requests plus audit trail) to deploy the new workflow safely and document the tables in the repo

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691c0127c68c832082582d933cb05800)