### PR TITLE
Add stock market inventory and order dashboard

### DIFF
--- a/views/stockMarket.ejs
+++ b/views/stockMarket.ejs
@@ -1,0 +1,182 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Inventory Stock Market</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
+  <style>
+    body { background: #0b1324; color: #e9eef7; }
+    .card { background: #111b2f; border: 1px solid #1d2942; }
+    .nav-pills .nav-link.active { background-color: #1f6feb; }
+    .table-dark { --bs-table-bg: #0f172a; }
+    .status-pill { padding: 0.35rem 0.65rem; border-radius: 999px; font-weight: 600; letter-spacing: 0.02em; }
+    .status-red { background: #dc3545; color: #fff; }
+    .status-purple { background: #6f42c1; color: #fff; }
+    .status-green { background: #198754; color: #fff; }
+    .glow { box-shadow: 0 0 25px rgba(31,111,235,0.15); }
+    .table thead th { color: #9fb4d8; text-transform: uppercase; letter-spacing: 0.03em; font-size: 0.8rem; }
+    .metric-label { color: #8ea2c4; font-size: 0.95rem; }
+    .text-faint { color: #7f93b8; }
+    .search-input { background: #0f172a; border: 1px solid #243552; color: #e9eef7; }
+    .search-input:focus { background: #0f172a; color: #fff; }
+  </style>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-dark bg-dark shadow-sm">
+  <div class="container-fluid">
+    <span class="navbar-brand"><i class="bi bi-graph-up-arrow me-2"></i>Stock Market View</span>
+    <div class="ms-auto d-flex align-items-center gap-3">
+      <% if (user) { %>
+        <span class="text-light small">Hi, <strong><%= user.username || user.name %></strong></span>
+      <% } %>
+      <a href="/logout" class="btn btn-outline-light btn-sm">Logout</a>
+    </div>
+  </div>
+</nav>
+
+<div class="container py-4">
+  <div class="d-flex flex-wrap align-items-center justify-content-between mb-3 gap-2">
+    <div>
+      <h3 class="fw-bold mb-1">Inventory runway & order momentum</h3>
+      <p class="text-faint mb-0">Color-coded heat similar to a trading screen. Red = immediate risk, Purple = watchlist, Green = safe.</p>
+    </div>
+    <form class="d-flex align-items-center gap-2" method="get" action="">
+      <label class="text-faint">Period</label>
+      <select class="form-select form-select-sm" name="period" onchange="this.form.submit()">
+        <% Object.entries(periodPresets).forEach(([key, preset]) => { %>
+          <option value="<%= key %>" <%= key === periodKey ? 'selected' : '' %>><%= preset.label %></option>
+        <% }); %>
+      </select>
+    </form>
+  </div>
+
+  <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
+    <li class="nav-item" role="presentation">
+      <button class="nav-link active" id="inventory-tab" data-bs-toggle="pill" data-bs-target="#inventory" type="button" role="tab">Inventory</button>
+    </li>
+    <li class="nav-item" role="presentation">
+      <button class="nav-link" id="orders-tab" data-bs-toggle="pill" data-bs-target="#orders" type="button" role="tab">Orders</button>
+    </li>
+  </ul>
+
+  <div class="tab-content" id="pills-tabContent">
+    <div class="tab-pane fade show active" id="inventory" role="tabpanel">
+      <div class="card glow mb-3">
+        <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-3">
+          <div class="d-flex align-items-center gap-3">
+            <span class="status-pill status-red">Risk</span>
+            <span class="status-pill status-purple">Watch</span>
+            <span class="status-pill status-green">Safe</span>
+          </div>
+          <div class="input-group" style="max-width: 320px;">
+            <span class="input-group-text bg-dark text-light border-0"><i class="bi bi-search"></i></span>
+            <input type="search" id="inventory-search" class="form-control search-input" placeholder="Search SKU or warehouse...">
+          </div>
+        </div>
+      </div>
+      <div class="table-responsive">
+        <table class="table table-hover table-dark align-middle" id="inventory-table">
+          <thead>
+            <tr>
+              <th>SKU</th>
+              <th>Warehouse</th>
+              <th class="text-end">Inventory</th>
+              <th class="text-end">Making time (days)</th>
+              <th class="text-end">Yesterday orders</th>
+              <th class="text-end">Days left</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% inventory.forEach(item => { %>
+              <% const infinite = !Number.isFinite(item.days_left); %>
+              <tr data-filter="<%= `${item.sku} ${item.warehouse_id ?? ''}`.toLowerCase() %>">
+                <td class="fw-semibold"><%= item.sku %></td>
+                <td class="text-faint"><%= item.warehouse_id ?? 'N/A' %></td>
+                <td class="text-end"><%= item.inventory.toLocaleString() %></td>
+                <td class="text-end"><%= item.making_time_days %></td>
+                <td class="text-end"><%= item.yesterday_orders %></td>
+                <td class="text-end"><%= infinite ? '∞' : item.days_left.toFixed(1) %></td>
+                <td>
+                  <% if (item.status === 'red') { %>
+                    <span class="status-pill status-red">Red</span>
+                  <% } else if (item.status === 'purple') { %>
+                    <span class="status-pill status-purple">Purple</span>
+                  <% } else { %>
+                    <span class="status-pill status-green">Green</span>
+                  <% } %>
+                </td>
+              </tr>
+            <% }); %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="tab-pane fade" id="orders" role="tabpanel">
+      <div class="card glow mb-3">
+        <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-3">
+          <div>
+            <div class="metric-label">Orders ranked by volume for <strong><%= period.label %></strong></div>
+            <div class="text-faint">Growth compares to the immediately previous window.</div>
+          </div>
+          <div class="input-group" style="max-width: 320px;">
+            <span class="input-group-text bg-dark text-light border-0"><i class="bi bi-search"></i></span>
+            <input type="search" id="orders-search" class="form-control search-input" placeholder="Search SKU or warehouse...">
+          </div>
+        </div>
+      </div>
+      <div class="table-responsive">
+        <table class="table table-hover table-dark align-middle" id="orders-table">
+          <thead>
+            <tr>
+              <th>SKU</th>
+              <th>Warehouse</th>
+              <th class="text-end">Orders (<%= period.label %>)</th>
+              <th class="text-end">Prev window</th>
+              <th class="text-end">Growth</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% orders.forEach(order => { %>
+              <% const growth = Number(order.growth || 0); %>
+              <% const arrow = growth > 0 ? 'bi-arrow-up-right text-success' : (growth < 0 ? 'bi-arrow-down-right text-danger' : 'bi-dash text-light'); %>
+              <tr data-filter="<%= `${order.sku} ${order.warehouse_id ?? ''}`.toLowerCase() %>">
+                <td class="fw-semibold"><%= order.sku %></td>
+                <td class="text-faint"><%= order.warehouse_id ?? 'N/A' %></td>
+                <td class="text-end"><%= order.orders %></td>
+                <td class="text-end text-faint"><%= order.previous_orders %></td>
+                <td class="text-end">
+                  <i class="bi <%= arrow %> me-1"></i>
+                  <%= growth.toFixed(1) %>%
+                </td>
+              </tr>
+            <% }); %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+<script>
+  function attachSearch(inputId, tableId) {
+    const input = document.getElementById(inputId);
+    const rows = Array.from(document.querySelectorAll(`#${tableId} tbody tr`));
+    input?.addEventListener('input', () => {
+      const value = input.value.toLowerCase();
+      rows.forEach(row => {
+        const haystack = row.dataset.filter || '';
+        row.style.display = haystack.includes(value) ? '' : 'none';
+      });
+    });
+  }
+
+  attachSearch('inventory-search', 'inventory-table');
+  attachSearch('orders-search', 'orders-table');
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add analytics helpers to calculate inventory runway, daily demand, and order momentum growth
- introduce a /easyecom/stock-market route to serve the new stock market style dashboard
- build a tabbed UI that color-codes inventory risk and ranks orders with growth indicators and search filters

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692693508df08320be39adbef5d5ef53)