### PR TITLE
Revamp stock market view and add Mohit-only bulk tools

### DIFF
--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -147,6 +147,15 @@ function isMohitOperator(req, res, next) {
   return res.redirect('/');
 }
 
+function isOnlyMohitOperator(req, res, next) {
+  const username = req.session?.user?.username;
+  if (username && username.toLowerCase() === 'mohitoperator') {
+    return next();
+  }
+  req.flash('error', 'You do not have permission to view this page.');
+  return res.redirect('/');
+}
+
 // ---------------------------------------------------------------------------
 // Helper to restrict routes to specific user ids
 function allowUserIds(ids) {
@@ -200,6 +209,7 @@ module.exports = {
     isIndentFiller,
     isStoreManager,
     isMohitOperator,
+    isOnlyMohitOperator,
     allowUserIds,
     allowRoles
 };

--- a/routes/easyecomRoutes.js
+++ b/routes/easyecomRoutes.js
@@ -1,7 +1,7 @@
 const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/db');
-const { isAuthenticated, isOperator } = require('../middlewares/auth');
+const { isAuthenticated, isOperator, isOnlyMohitOperator } = require('../middlewares/auth');
 const {
   PERIOD_PRESETS,
   resolvePeriod,
@@ -54,7 +54,7 @@ router.get('/ops', isAuthenticated, isOperator, async (req, res) => {
   }
 });
 
-router.get('/stock-market', isAuthenticated, isOperator, async (req, res) => {
+router.get('/stock-market', isAuthenticated, isOnlyMohitOperator, async (req, res) => {
   try {
     const periodKey = normalizePeriod(req.query.period);
     const [inventory, orders] = await Promise.all([
@@ -75,6 +75,78 @@ router.get('/stock-market', isAuthenticated, isOperator, async (req, res) => {
     req.flash('error', 'Could not load stock market view');
     res.redirect('/');
   }
+});
+
+router.get('/stock-market/data', isAuthenticated, isOnlyMohitOperator, async (req, res) => {
+  try {
+    const periodKey = normalizePeriod(req.query.period);
+    const [inventory, orders] = await Promise.all([
+      getInventoryRunway(pool),
+      getMomentumWithGrowth(pool, { periodKey }),
+    ]);
+
+    res.json({
+      inventory,
+      orders,
+      period: resolvePeriod(periodKey),
+    });
+  } catch (err) {
+    console.error('Failed to fetch stock market data:', err);
+    res.status(500).json({ error: 'Unable to refresh data' });
+  }
+});
+
+function parseBulkLines(input = '') {
+  return input
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split(',').map((cell) => cell.trim()));
+}
+
+router.get('/stock-market/making-time', isAuthenticated, isOnlyMohitOperator, (req, res) => {
+  res.render('stockMarketBulkMakingTime', {
+    user: req.session?.user || null,
+    result: null,
+    bulkInput: '',
+  });
+});
+
+router.post('/stock-market/making-time', isAuthenticated, isOnlyMohitOperator, async (req, res) => {
+  const bulkInput = req.body?.bulkInput || '';
+  const lines = parseBulkLines(bulkInput);
+  const errors = [];
+  const success = [];
+
+  for (let idx = 0; idx < lines.length; idx += 1) {
+    const [skuRaw, warehouseRaw, daysRaw] = lines[idx];
+    const sku = skuRaw?.toUpperCase();
+    const warehouse = warehouseRaw || null;
+    const makingTime = Number(daysRaw);
+
+    if (!sku || Number.isNaN(makingTime)) {
+      errors.push(`Row ${idx + 1}: Invalid data`);
+      continue;
+    }
+
+    try {
+      await saveReplenishmentRule(pool, {
+        sku,
+        warehouse_id: warehouse || null,
+        making_time_days: makingTime,
+      });
+      success.push(sku);
+    } catch (err) {
+      console.error('Failed to save making time', err);
+      errors.push(`Row ${idx + 1}: Could not save ${sku}`);
+    }
+  }
+
+  res.render('stockMarketBulkMakingTime', {
+    user: req.session?.user || null,
+    bulkInput,
+    result: { errors, success },
+  });
 });
 
 module.exports = router;

--- a/views/stockMarket.ejs
+++ b/views/stockMarket.ejs
@@ -7,47 +7,42 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
   <style>
-    /* Professional color palette and improved design system */
     :root {
-      --color-bg-primary: #0a0e1a;
-      --color-bg-secondary: #111827;
-      --color-bg-tertiary: #1a2332;
-      --color-bg-elevated: #1f2937;
-      --color-border: #2d3748;
-      --color-border-subtle: #1e293b;
-      --color-text-primary: #f8fafc;
-      --color-text-secondary: #cbd5e1;
-      --color-text-muted: #94a3b8;
-      --color-accent: #3b82f6;
-      --color-accent-hover: #2563eb;
-      --color-success: #10b981;
-      --color-warning: #8b5cf6;
-      --color-danger: #ef4444;
-      --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
-      --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
-      --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.2), 0 4px 6px -4px rgb(0 0 0 / 0.1);
-      --shadow-glow: 0 0 30px rgba(59, 130, 246, 0.12);
+      --color-bg-primary: #f7f9fb;
+      --color-surface: #ffffff;
+      --color-border: #dce4ed;
+      --color-text-primary: #1b2838;
+      --color-text-secondary: #4b5563;
+      --color-text-muted: #6b7280;
+      --color-accent: #0f52ba;
+      --color-accent-soft: #e9f0ff;
+      --color-danger: #d60036;
+      --color-danger-soft: #ffe5ec;
+      --color-warning: #7c3aed;
+      --color-warning-soft: #f1e9ff;
+      --color-success: #0f9d58;
+      --shadow-md: 0 14px 24px rgba(15, 82, 186, 0.06);
+      --shadow-soft: 0 2px 8px rgba(0, 0, 0, 0.05);
     }
 
     body {
       background: var(--color-bg-primary);
       color: var(--color-text-primary);
-      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       line-height: 1.6;
     }
 
-    /* Enhanced navbar with better spacing and professional styling */
     .navbar {
-      background: var(--color-bg-secondary) !important;
-      border-bottom: 1px solid var(--color-border-subtle);
-      box-shadow: var(--shadow-md);
+      background: var(--color-surface) !important;
+      border-bottom: 1px solid var(--color-border);
+      box-shadow: var(--shadow-soft);
       padding: 1rem 0;
     }
 
     .navbar-brand {
       font-weight: 700;
-      font-size: 1.25rem;
-      letter-spacing: -0.02em;
+      font-size: 1.15rem;
+      letter-spacing: -0.01em;
       color: var(--color-text-primary) !important;
     }
 
@@ -55,295 +50,169 @@
       color: var(--color-accent);
     }
 
-    /* Refined card design with better elevation */
-    .card {
-      background: var(--color-bg-secondary);
-      border: 1px solid var(--color-border-subtle);
-      border-radius: 12px;
-      box-shadow: var(--shadow-md);
-      transition: all 0.2s ease;
+    .page-lede {
+      background: linear-gradient(135deg, rgba(15, 82, 186, 0.08), rgba(15, 82, 186, 0.02));
+      border: 1px solid var(--color-border);
+      border-radius: 16px;
+      padding: 1.25rem 1.5rem;
+      box-shadow: var(--shadow-soft);
     }
 
-    .card.glow {
-      box-shadow: var(--shadow-glow), var(--shadow-md);
+    .card {
+      border: 1px solid var(--color-border);
+      border-radius: 16px;
+      box-shadow: var(--shadow-md);
     }
 
     .card-body {
       padding: 1.5rem;
     }
 
-    /* Professional tab navigation */
     .nav-pills {
       gap: 0.5rem;
-      background: var(--color-bg-secondary);
-      padding: 0.5rem;
-      border-radius: 10px;
-      border: 1px solid var(--color-border-subtle);
+      padding: 0.35rem;
+      background: var(--color-surface);
+      border: 1px solid var(--color-border);
+      border-radius: 12px;
+      box-shadow: var(--shadow-soft);
     }
 
     .nav-pills .nav-link {
       color: var(--color-text-secondary);
-      border-radius: 8px;
-      padding: 0.625rem 1.25rem;
+      border-radius: 10px;
+      padding: 0.65rem 1.25rem;
       font-weight: 600;
-      transition: all 0.2s ease;
       border: 1px solid transparent;
     }
 
-    .nav-pills .nav-link:hover {
-      color: var(--color-text-primary);
-      background-color: var(--color-bg-tertiary);
-    }
-
     .nav-pills .nav-link.active {
-      background-color: var(--color-accent);
-      color: white;
-      box-shadow: 0 4px 12px rgba(59, 130, 246, 0.3);
+      background: var(--color-accent);
+      border-color: var(--color-accent);
+      color: #fff;
+      box-shadow: 0 10px 18px rgba(15, 82, 186, 0.25);
     }
 
-    /* Refined status pills with better contrast */
     .status-pill {
-      padding: 0.375rem 0.75rem;
-      border-radius: 6px;
-      font-weight: 600;
-      font-size: 0.8125rem;
-      letter-spacing: 0.02em;
+      padding: 0.45rem 0.8rem;
+      border-radius: 999px;
+      font-weight: 700;
+      font-size: 0.9rem;
+      letter-spacing: 0.01em;
       display: inline-flex;
       align-items: center;
-      gap: 0.375rem;
-      transition: all 0.2s ease;
+      gap: 0.45rem;
+      border: 1px solid transparent;
+      text-transform: uppercase;
     }
 
     .status-pill::before {
       content: '';
-      width: 6px;
-      height: 6px;
+      width: 10px;
+      height: 10px;
       border-radius: 50%;
       background: currentColor;
-      opacity: 0.8;
+      box-shadow: 0 0 0 6px rgba(0, 0, 0, 0.04);
     }
 
     .status-red {
-      background: rgba(239, 68, 68, 0.15);
-      color: #fca5a5;
-      border: 1px solid rgba(239, 68, 68, 0.3);
+      background: var(--color-danger-soft);
+      color: var(--color-danger);
+      border-color: rgba(214, 0, 54, 0.32);
+      box-shadow: 0 0 0 2px rgba(214, 0, 54, 0.14);
     }
 
     .status-purple {
-      background: rgba(139, 92, 246, 0.15);
-      color: #c4b5fd;
-      border: 1px solid rgba(139, 92, 246, 0.3);
+      background: var(--color-warning-soft);
+      color: var(--color-warning);
+      border-color: rgba(124, 58, 237, 0.28);
     }
 
     .status-green {
-      background: rgba(16, 185, 129, 0.15);
-      color: #6ee7b7;
-      border: 1px solid rgba(16, 185, 129, 0.3);
+      background: #e8f5ef;
+      color: var(--color-success);
+      border-color: rgba(15, 157, 88, 0.28);
     }
 
-    /* Professional table styling with better readability */
-    .table-dark {
-      --bs-table-bg: var(--color-bg-secondary);
-      --bs-table-hover-bg: var(--color-bg-tertiary);
-      --bs-table-border-color: var(--color-border-subtle);
-      color: var(--color-text-primary);
-    }
-
-    .table-responsive {
-      border-radius: 12px;
-      overflow: hidden;
-      border: 1px solid var(--color-border-subtle);
-      background: var(--color-bg-secondary);
-    }
+    .table { color: var(--color-text-primary); }
 
     .table thead th {
-      background: var(--color-bg-tertiary);
-      color: var(--color-text-muted);
+      background: #f0f4f9;
+      color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.05em;
-      font-size: 0.75rem;
-      font-weight: 700;
+      font-size: 0.8rem;
       border-bottom: 1px solid var(--color-border);
-      padding: 1rem;
       position: sticky;
       top: 0;
       z-index: 10;
     }
 
-    .table tbody tr {
-      border-bottom: 1px solid var(--color-border-subtle);
-      transition: all 0.15s ease;
+    .table tbody tr.row-critical {
+      background: linear-gradient(90deg, rgba(214, 0, 54, 0.08), rgba(214, 0, 54, 0.02));
     }
 
-    .table tbody tr:hover {
-      background: var(--color-bg-tertiary) !important;
-      transform: scale(1.001);
-    }
-
-    .table tbody tr:last-child {
-      border-bottom: none;
+    .table tbody tr.row-warning {
+      background: linear-gradient(90deg, rgba(124, 58, 237, 0.05), rgba(124, 58, 237, 0.01));
     }
 
     .table tbody td {
-      padding: 1rem;
+      padding: 0.85rem;
       vertical-align: middle;
     }
 
-    .table .fw-semibold {
-      color: var(--color-text-primary);
-      font-weight: 600;
-    }
-
-    /* Improved search input design */
     .search-input {
-      background: var(--color-bg-tertiary);
       border: 1px solid var(--color-border);
-      color: var(--color-text-primary);
-      border-radius: 8px;
-      padding: 0.625rem 1rem;
-      transition: all 0.2s ease;
-    }
-
-    .search-input:focus {
-      background: var(--color-bg-elevated);
-      border-color: var(--color-accent);
-      color: var(--color-text-primary);
-      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-      outline: none;
-    }
-
-    .search-input::placeholder {
-      color: var(--color-text-muted);
+      border-radius: 10px;
+      padding: 0.7rem 1rem;
     }
 
     .input-group-text {
-      background: var(--color-bg-tertiary) !important;
-      border: 1px solid var(--color-border) !important;
-      border-right: none !important;
-      color: var(--color-text-muted) !important;
-      border-radius: 8px 0 0 8px;
-    }
-
-    .input-group .search-input {
-      border-left: none;
-      border-radius: 0 8px 8px 0;
-    }
-
-    /* Better form controls */
-    .form-select {
-      background: var(--color-bg-tertiary);
-      border: 1px solid var(--color-border);
-      color: var(--color-text-primary);
-      border-radius: 8px;
-      padding: 0.5rem 2.5rem 0.5rem 1rem;
-      transition: all 0.2s ease;
-      background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3e%3cpath fill='none' stroke='%23cbd5e1' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='m2 5 6 6 6-6'/%3e%3c/svg%3e");
-    }
-
-    .form-select:focus {
-      border-color: var(--color-accent);
-      box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
-      outline: none;
-    }
-
-    /* Enhanced button styling */
-    .btn-outline-light {
-      color: var(--color-text-secondary);
       border-color: var(--color-border);
-      border-radius: 8px;
-      font-weight: 600;
-      padding: 0.5rem 1.25rem;
-      transition: all 0.2s ease;
+      background: var(--color-accent-soft);
+      color: var(--color-accent);
+      border-radius: 10px 0 0 10px !important;
     }
 
-    .btn-outline-light:hover {
-      background: var(--color-bg-elevated);
-      color: var(--color-text-primary);
-      border-color: var(--color-accent);
-    }
+    h3 { font-weight: 800; letter-spacing: -0.02em; }
+    .text-faint { color: var(--color-text-muted); }
+    .metric-label { color: var(--color-text-secondary); font-weight: 600; }
 
-    /* Typography refinements */
-    h3 {
+    .legend-pills { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
+
+    .alert-note {
+      color: var(--color-danger);
       font-weight: 700;
-      letter-spacing: -0.02em;
-      color: var(--color-text-primary);
-    }
-
-    .text-faint {
-      color: var(--color-text-muted);
-    }
-
-    .metric-label {
-      color: var(--color-text-secondary);
-      font-size: 0.9375rem;
-      font-weight: 500;
-    }
-
-    /* Growth indicator styling */
-    .bi-arrow-up-right {
-      color: var(--color-success) !important;
-    }
-
-    .bi-arrow-down-right {
-      color: var(--color-danger) !important;
-    }
-
-    /* Responsive improvements */
-    @media (max-width: 768px) {
-      .card-body {
-        padding: 1rem;
-      }
-
-      .table thead th,
-      .table tbody td {
-        padding: 0.75rem 0.5rem;
-        font-size: 0.875rem;
-      }
-
-      h3 {
-        font-size: 1.5rem;
-      }
-    }
-
-    /* Legend pills container */
-    .legend-pills {
-      display: flex;
+      display: inline-flex;
       align-items: center;
-      gap: 0.75rem;
-      flex-wrap: wrap;
+      gap: 0.35rem;
     }
 
-    /* Smooth animations */
-    @keyframes fadeIn {
-      from {
-        opacity: 0;
-        transform: translateY(10px);
-      }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
+    @media (max-width: 768px) {
+      .card-body { padding: 1.1rem; }
+      h3 { font-size: 1.35rem; }
     }
 
-    .tab-pane {
-      animation: fadeIn 0.3s ease;
+    @media print {
+      body { background: #fff; }
+      .navbar, .page-lede, .nav, .input-group { display: none !important; }
+      .status-pill { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+      .table tbody tr { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
     }
   </style>
 </head>
 <body>
-<!-- Enhanced navbar structure -->
-<nav class="navbar navbar-expand-lg navbar-dark">
+<nav class="navbar navbar-expand-lg">
   <div class="container-fluid">
     <span class="navbar-brand">
       <i class="bi bi-graph-up-arrow me-2"></i>Stock Market View
     </span>
     <div class="ms-auto d-flex align-items-center gap-3">
       <% if (user) { %>
-        <span class="text-light small">
+        <span class="text-secondary small">
           Hi, <strong><%= user.username || user.name %></strong>
         </span>
       <% } %>
-      <a href="/logout" class="btn btn-outline-light btn-sm">
+      <a href="/logout" class="btn btn-outline-secondary btn-sm">
         <i class="bi bi-box-arrow-right me-1"></i>Logout
       </a>
     </div>
@@ -351,27 +220,31 @@
 </nav>
 
 <div class="container py-4">
-  <!-- Improved header section with better spacing -->
-  <div class="d-flex flex-wrap align-items-center justify-content-between mb-4 gap-3">
-    <div>
-      <h3 class="fw-bold mb-2">Inventory runway & order momentum</h3>
-      <p class="text-faint mb-0">
-        Color-coded heat similar to a trading screen. Red = immediate risk, Purple = watchlist, Green = safe.
-      </p>
+  <div class="page-lede mb-4">
+    <div class="d-flex flex-wrap align-items-center justify-content-between gap-3">
+      <div>
+        <h3 class="fw-bold mb-2">Inventory runway & order momentum</h3>
+        <p class="text-faint mb-0">
+          A calm, light view for fast decisions. Red rows mean critical stockout risk; purple rows mark SKUs on watch.
+        </p>
+        <div class="alert-note mt-2">
+          <i class="bi bi-exclamation-triangle-fill"></i>
+          Critical red items need immediate action.
+        </div>
+      </div>
+      <div class="d-flex align-items-center gap-2">
+        <label class="text-faint fw-semibold" for="period-select">Period</label>
+        <select class="form-select" id="period-select" name="period">
+          <% Object.entries(periodPresets).forEach(([key, preset]) => { %>
+            <option value="<%= key %>" <%= key === periodKey ? 'selected' : '' %>>
+              <%= preset.label %>
+            </option>
+          <% }); %>
+        </select>
+      </div>
     </div>
-    <form class="d-flex align-items-center gap-2" method="get" action="">
-      <label class="text-faint fw-semibold">Period</label>
-      <select class="form-select form-select-sm" name="period" onchange="this.form.submit()">
-        <% Object.entries(periodPresets).forEach(([key, preset]) => { %>
-          <option value="<%= key %>" <%= key === periodKey ? 'selected' : '' %>>
-            <%= preset.label %>
-          </option>
-        <% }); %>
-      </select>
-    </form>
   </div>
 
-  <!-- Refined tab navigation -->
   <ul class="nav nav-pills mb-4" id="pills-tab" role="tablist">
     <li class="nav-item" role="presentation">
       <button class="nav-link active" id="inventory-tab" data-bs-toggle="pill" data-bs-target="#inventory" type="button" role="tab">
@@ -386,30 +259,29 @@
   </ul>
 
   <div class="tab-content" id="pills-tabContent">
-    <!-- Enhanced inventory tab with better card design -->
     <div class="tab-pane fade show active" id="inventory" role="tabpanel">
-      <div class="card glow mb-4">
+      <div class="card mb-4">
         <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-3">
           <div class="legend-pills">
-            <span class="status-pill status-red">Risk</span>
+            <span class="status-pill status-red">Critical</span>
             <span class="status-pill status-purple">Watch</span>
-            <span class="status-pill status-green">Safe</span>
+            <span class="status-pill status-green">Healthy</span>
           </div>
-          <div class="input-group" style="max-width: 340px;">
+          <div class="input-group" style="max-width: 360px;">
             <span class="input-group-text">
               <i class="bi bi-search"></i>
             </span>
-            <input 
-              type="search" 
-              id="inventory-search" 
-              class="form-control search-input" 
+            <input
+              type="search"
+              id="inventory-search"
+              class="form-control search-input"
               placeholder="Search SKU or warehouse..."
             >
           </div>
         </div>
       </div>
       <div class="table-responsive">
-        <table class="table table-hover table-dark align-middle mb-0" id="inventory-table">
+        <table class="table table-hover align-middle mb-0" id="inventory-table">
           <thead>
             <tr>
               <th>SKU</th>
@@ -424,7 +296,7 @@
           <tbody>
             <% inventory.forEach(item => { %>
               <% const infinite = !Number.isFinite(item.days_left); %>
-              <tr data-filter="<%= `${item.sku} ${item.warehouse_id ?? ''}`.toLowerCase() %>">
+              <tr data-filter="<%= `${item.sku} ${item.warehouse_id ?? ''}`.toLowerCase() %>" class="<%= item.status === 'red' ? 'row-critical' : item.status === 'purple' ? 'row-warning' : '' %>">
                 <td class="fw-semibold"><%= item.sku %></td>
                 <td class="text-faint"><%= item.warehouse_id ?? 'N/A' %></td>
                 <td class="text-end"><%= item.inventory.toLocaleString() %></td>
@@ -433,11 +305,11 @@
                 <td class="text-end"><%= infinite ? '∞' : item.days_left.toFixed(1) %></td>
                 <td>
                   <% if (item.status === 'red') { %>
-                    <span class="status-pill status-red">Red</span>
+                    <span class="status-pill status-red">Critical</span>
                   <% } else if (item.status === 'purple') { %>
-                    <span class="status-pill status-purple">Purple</span>
+                    <span class="status-pill status-purple">Watch</span>
                   <% } else { %>
-                    <span class="status-pill status-green">Green</span>
+                    <span class="status-pill status-green">Healthy</span>
                   <% } %>
                 </td>
               </tr>
@@ -447,36 +319,35 @@
       </div>
     </div>
 
-    <!-- Enhanced orders tab with consistent styling -->
     <div class="tab-pane fade" id="orders" role="tabpanel">
-      <div class="card glow mb-4">
+      <div class="card mb-4">
         <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-3">
           <div>
             <div class="metric-label">
-              Orders ranked by volume for <strong><%= period.label %></strong>
+              Orders ranked by volume for <strong id="orders-period-label"><%= period.label %></strong>
             </div>
             <div class="text-faint">Growth compares to the immediately previous window.</div>
           </div>
-          <div class="input-group" style="max-width: 340px;">
+          <div class="input-group" style="max-width: 360px;">
             <span class="input-group-text">
               <i class="bi bi-search"></i>
             </span>
-            <input 
-              type="search" 
-              id="orders-search" 
-              class="form-control search-input" 
+            <input
+              type="search"
+              id="orders-search"
+              class="form-control search-input"
               placeholder="Search SKU or warehouse..."
             >
           </div>
         </div>
       </div>
       <div class="table-responsive">
-        <table class="table table-hover table-dark align-middle mb-0" id="orders-table">
+        <table class="table table-hover align-middle mb-0" id="orders-table">
           <thead>
             <tr>
               <th>SKU</th>
               <th>Warehouse</th>
-              <th class="text-end">Orders (<%= period.label %>)</th>
+              <th class="text-end">Orders (<span class="period-inline"><%= period.label %></span>)</th>
               <th class="text-end">Prev window</th>
               <th class="text-end">Growth</th>
             </tr>
@@ -484,7 +355,7 @@
           <tbody>
             <% orders.forEach(order => { %>
               <% const growth = Number(order.growth || 0); %>
-              <% const arrow = growth > 0 ? 'bi-arrow-up-right' : (growth < 0 ? 'bi-arrow-down-right' : 'bi-dash text-light'); %>
+              <% const arrow = growth > 0 ? 'bi-arrow-up-right text-success' : (growth < 0 ? 'bi-arrow-down-right text-danger' : 'bi-dash text-secondary'); %>
               <tr data-filter="<%= `${order.sku} ${order.warehouse_id ?? ''}`.toLowerCase() %>">
                 <td class="fw-semibold"><%= order.sku %></td>
                 <td class="text-faint"><%= order.warehouse_id ?? 'N/A' %></td>
@@ -505,20 +376,107 @@
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
 <script>
-  function attachSearch(inputId, tableId) {
-    const input = document.getElementById(inputId);
-    const rows = Array.from(document.querySelectorAll(`#${tableId} tbody tr`));
-    input?.addEventListener('input', () => {
-      const value = input.value.toLowerCase();
-      rows.forEach(row => {
-        const haystack = row.dataset.filter || '';
-        row.style.display = haystack.includes(value) ? '' : 'none';
-      });
+  const initialData = {
+    inventory: <%- JSON.stringify(inventory) %>,
+    orders: <%- JSON.stringify(orders) %>,
+    periodKey: '<%= periodKey %>',
+  };
+
+  const periodSelect = document.getElementById('period-select');
+  const inventorySearch = document.getElementById('inventory-search');
+  const ordersSearch = document.getElementById('orders-search');
+
+  function formatNumber(value) {
+    if (value === null || value === undefined) return '0';
+    return Number(value).toLocaleString();
+  }
+
+  function statusLabel(status) {
+    if (status === 'red') return { text: 'Critical', className: 'status-red', row: 'row-critical' };
+    if (status === 'purple') return { text: 'Watch', className: 'status-purple', row: 'row-warning' };
+    return { text: 'Healthy', className: 'status-green', row: '' };
+  }
+
+  function attachSearch(input, tableId) {
+    const table = document.getElementById(tableId);
+    input?.addEventListener('input', () => applyFilter(table, input.value));
+  }
+
+  function applyFilter(table, term) {
+    const value = (term || '').toLowerCase();
+    table?.querySelectorAll('tbody tr').forEach((row) => {
+      const haystack = row.dataset.filter || '';
+      row.style.display = haystack.includes(value) ? '' : 'none';
     });
   }
 
-  attachSearch('inventory-search', 'inventory-table');
-  attachSearch('orders-search', 'orders-table');
+  function renderInventory(rows) {
+    const tbody = document.querySelector('#inventory-table tbody');
+    const searchTerm = inventorySearch?.value || '';
+    tbody.innerHTML = rows.map((item) => {
+      const infinite = !Number.isFinite(item.days_left);
+      const label = statusLabel(item.status);
+      return `
+        <tr data-filter="${(item.sku + ' ' + (item.warehouse_id || '')).toLowerCase()}" class="${label.row}">
+          <td class="fw-semibold">${item.sku}</td>
+          <td class="text-faint">${item.warehouse_id ?? 'N/A'}</td>
+          <td class="text-end">${formatNumber(item.inventory)}</td>
+          <td class="text-end">${item.making_time_days}</td>
+          <td class="text-end">${item.yesterday_orders}</td>
+          <td class="text-end">${infinite ? '∞' : Number(item.days_left).toFixed(1)}</td>
+          <td><span class="status-pill ${label.className}">${label.text}</span></td>
+        </tr>`;
+    }).join('');
+    applyFilter(document.getElementById('inventory-table'), searchTerm);
+  }
+
+  function renderOrders(rows, periodLabel) {
+    const tbody = document.querySelector('#orders-table tbody');
+    const searchTerm = ordersSearch?.value || '';
+    tbody.innerHTML = rows.map((order) => {
+      const growth = Number(order.growth || 0);
+      const arrow = growth > 0
+        ? 'bi-arrow-up-right text-success'
+        : growth < 0
+          ? 'bi-arrow-down-right text-danger'
+          : 'bi-dash text-secondary';
+      return `
+        <tr data-filter="${(order.sku + ' ' + (order.warehouse_id || '')).toLowerCase()}">
+          <td class="fw-semibold">${order.sku}</td>
+          <td class="text-faint">${order.warehouse_id ?? 'N/A'}</td>
+          <td class="text-end">${order.orders}</td>
+          <td class="text-end text-faint">${order.previous_orders}</td>
+          <td class="text-end"><i class="bi ${arrow} me-1"></i>${growth.toFixed(1)}%</td>
+        </tr>`;
+    }).join('');
+    document.getElementById('orders-period-label').textContent = periodLabel;
+    document.querySelector('#orders-table thead .period-inline').textContent = periodLabel;
+    applyFilter(document.getElementById('orders-table'), searchTerm);
+  }
+
+  async function refreshData() {
+    const period = periodSelect?.value || initialData.periodKey;
+    const params = new URLSearchParams({ period });
+    try {
+      const response = await fetch(`${window.location.pathname}/data?${params.toString()}`);
+      if (!response.ok) throw new Error('Failed to fetch latest data');
+      const payload = await response.json();
+      renderInventory(payload.inventory || []);
+      renderOrders(payload.orders || [], payload.period.label);
+    } catch (err) {
+      console.error('Refresh failed:', err);
+    }
+  }
+
+  attachSearch(inventorySearch, 'inventory-table');
+  attachSearch(ordersSearch, 'orders-table');
+  periodSelect?.addEventListener('change', () => refreshData());
+
+  // Hydrate from initial payload so formatting is consistent
+  renderInventory(initialData.inventory || []);
+  renderOrders(initialData.orders || [], document.getElementById('orders-period-label').textContent);
+
+  setInterval(refreshData, 15000);
 </script>
 </body>
 </html>

--- a/views/stockMarketBulkMakingTime.ejs
+++ b/views/stockMarketBulkMakingTime.ejs
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Bulk Making Time</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <style>
+    body { background: #f7f9fb; font-family: 'Inter', sans-serif; }
+    .card { border: 1px solid #dce4ed; border-radius: 14px; box-shadow: 0 8px 24px rgba(15, 82, 186, 0.08); }
+    .badge-soft { background: #e9f0ff; color: #0f52ba; border: 1px solid #d0dcf0; }
+    textarea { font-family: 'JetBrains Mono', 'SFMono-Regular', Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace; }
+  </style>
+</head>
+<body>
+  <div class="container py-4">
+    <div class="d-flex align-items-center justify-content-between mb-3">
+      <h3 class="fw-bold mb-0">Bulk set making time</h3>
+      <a href="/easyecom/stock-market" class="btn btn-outline-secondary">Back to stock market</a>
+    </div>
+
+    <div class="card">
+      <div class="card-body">
+        <p class="text-muted">Paste comma-separated rows to update making time in bulk.</p>
+        <div class="alert alert-info">
+          Format: <span class="badge badge-soft">SKU, Warehouse(optional), Making Time (days)</span>
+          <br>Example: <code>SKU123, WH1, 5</code> or <code>SKU123,,7</code> for default warehouse
+        </div>
+        <% if (result && result.errors.length) { %>
+          <div class="alert alert-danger">
+            <strong>Some rows failed:</strong>
+            <ul class="mb-0">
+              <% result.errors.forEach(err => { %>
+                <li><%= err %></li>
+              <% }); %>
+            </ul>
+          </div>
+        <% } %>
+        <% if (result && result.success.length) { %>
+          <div class="alert alert-success">
+            Updated <strong><%= result.success.length %></strong> row(s).
+          </div>
+        <% } %>
+        <form method="post" action="/easyecom/stock-market/making-time">
+          <div class="mb-3">
+            <label for="bulkInput" class="form-label fw-semibold">Bulk input</label>
+            <textarea class="form-control" id="bulkInput" name="bulkInput" rows="8" placeholder="SKU123, WH1, 5&#10;SKU456,,7" required><%= bulkInput || '' %></textarea>
+          </div>
+          <button type="submit" class="btn btn-primary">Update making time</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- refresh the stock market page with a light theme, scarier critical state styling, and print-friendly status colors
- add a Mohit-only JSON refresh path plus client polling so inventory and orders update in real time without reloading
- introduce a MohitOperator-only bulk making-time entry screen to update SKU rules en masse

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69269b528cc083209ad214edc27cd7c5)