### PR TITLE
Improve stock market access and dashboards

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -64,6 +64,9 @@ router.post('/login', async (req, res) => {
       case 'operator':
         res.redirect('/operator/dashboard');
         break;
+      case 'inventory_operator':
+        res.redirect('/easyecom/stock-market');
+        break;
       case 'supervisor':
         res.redirect('/supervisor/employees');
         break;

--- a/routes/authRoutesOptimized.js
+++ b/routes/authRoutesOptimized.js
@@ -71,6 +71,7 @@ router.post('/login', async (req, res) => {
       fabric_manager: '/fabric-manager/dashboard',
       stitching_master: '/stitchingdashboard',
       operator: '/operator/dashboard',
+      inventory_operator: '/easyecom/stock-market',
       supervisor: '/supervisor/employees',
       finishing: '/finishingDashboard',
       washing: '/washingdashboard',

--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -166,6 +166,10 @@
       <i class="bi bi-search fs-3" aria-hidden="true"></i>
       <div>Search</div>
     </a>
+    <a href="/easyecom/stock-market" class="nav-card">
+      <i class="bi bi-graph-up-arrow fs-3" aria-hidden="true"></i>
+      <div>Stock Market</div>
+    </a>
     <a href="/assign-to-washing" class="nav-card">
       <i class="bi bi-arrow-right-circle fs-3" aria-hidden="true"></i>
       <div>Washing</div>

--- a/views/stockMarket.ejs
+++ b/views/stockMarket.ejs
@@ -187,6 +187,35 @@
       gap: 0.35rem;
     }
 
+    .stat-card {
+      border-radius: 14px;
+      border: 1px solid var(--color-border);
+      background: var(--color-surface);
+      box-shadow: var(--shadow-md);
+      padding: 1rem 1.25rem;
+    }
+
+    .stat-label { color: var(--color-text-muted); font-weight: 600; font-size: 0.95rem; }
+    .stat-value { font-size: 1.65rem; font-weight: 800; letter-spacing: -0.02em; }
+    .stat-subtle { color: var(--color-text-secondary); font-weight: 600; font-size: 0.95rem; }
+
+    .action-card {
+      border: 1px dashed var(--color-border);
+      border-radius: 14px;
+      background: var(--color-accent-soft);
+      color: var(--color-accent);
+      box-shadow: var(--shadow-soft);
+      padding: 1rem 1.25rem;
+      height: 100%;
+    }
+
+    .action-card:hover {
+      border-color: var(--color-accent);
+      color: var(--color-accent);
+      text-decoration: none;
+      box-shadow: 0 10px 18px rgba(15, 82, 186, 0.14);
+    }
+
     @media (max-width: 768px) {
       .card-body { padding: 1.1rem; }
       h3 { font-size: 1.35rem; }
@@ -201,6 +230,7 @@
   </style>
 </head>
 <body>
+<% const isMohitOperator = (user?.username || '').toLowerCase() === 'mohitoperator'; %>
 <nav class="navbar navbar-expand-lg">
   <div class="container-fluid">
     <span class="navbar-brand">
@@ -232,7 +262,12 @@
           Critical red items need immediate action.
         </div>
       </div>
-      <div class="d-flex align-items-center gap-2">
+      <div class="d-flex align-items-center gap-3 flex-wrap justify-content-end">
+        <% if (isMohitOperator) { %>
+          <a class="btn btn-outline-primary d-flex align-items-center gap-2" href="/easyecom/stock-market/making-time">
+            <i class="bi bi-upload"></i><span>Bulk making time</span>
+          </a>
+        <% } %>
         <label class="text-faint fw-semibold" for="period-select">Period</label>
         <select class="form-select" id="period-select" name="period">
           <% Object.entries(periodPresets).forEach(([key, preset]) => { %>
@@ -257,6 +292,50 @@
       </button>
     </li>
   </ul>
+
+  <div class="row g-3 mb-4">
+    <div class="col-md-4">
+      <div class="stat-card">
+        <div class="stat-label">Critical SKUs</div>
+        <div class="stat-value" id="metric-critical">0</div>
+        <div class="stat-subtle">Need replenishment now</div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="stat-card">
+        <div class="stat-label">On watch</div>
+        <div class="stat-value" id="metric-watch">0</div>
+        <div class="stat-subtle">Monitor before they slip</div>
+      </div>
+    </div>
+    <div class="col-md-4">
+      <div class="stat-card">
+        <div class="stat-label">Avg. runway</div>
+        <div class="stat-value" id="metric-runway">0d</div>
+        <div class="stat-subtle">Median days left across SKUs</div>
+      </div>
+    </div>
+  </div>
+
+  <% if (isMohitOperator) { %>
+    <div class="row g-3 mb-4">
+      <div class="col-md-6">
+        <a class="action-card d-flex align-items-center justify-content-between" href="/easyecom/stock-market/making-time">
+          <div>
+            <div class="fw-semibold">Bulk making time</div>
+            <div class="small text-faint">Upload rows to refresh replenishment rules quickly.</div>
+          </div>
+          <i class="bi bi-arrow-up-right fs-4"></i>
+        </a>
+      </div>
+      <div class="col-md-6">
+        <div class="action-card">
+          <div class="fw-semibold mb-1">Operator tips</div>
+          <div class="small">Sort by warehouse or search SKUs to zero in on risk. Use the Orders tab to confirm demand before you raise POs.</div>
+        </div>
+      </div>
+    </div>
+  <% } %>
 
   <div class="tab-content" id="pills-tabContent">
     <div class="tab-pane fade show active" id="inventory" role="tabpanel">
@@ -410,6 +489,25 @@
     });
   }
 
+  function updateMetrics(rows = []) {
+    const critical = rows.filter((item) => item.status === 'red').length;
+    const watch = rows.filter((item) => item.status === 'purple').length;
+    const runwayValues = rows
+      .map((item) => Number(item.days_left))
+      .filter((value) => Number.isFinite(value))
+      .sort((a, b) => a - b);
+
+    const midpoint = runwayValues.length ? runwayValues[Math.floor(runwayValues.length / 2)] : 0;
+
+    const criticalEl = document.getElementById('metric-critical');
+    const watchEl = document.getElementById('metric-watch');
+    const runwayEl = document.getElementById('metric-runway');
+
+    if (criticalEl) criticalEl.textContent = critical.toLocaleString();
+    if (watchEl) watchEl.textContent = watch.toLocaleString();
+    if (runwayEl) runwayEl.textContent = `${Number(midpoint || 0).toFixed(1)}d`;
+  }
+
   function renderInventory(rows) {
     const tbody = document.querySelector('#inventory-table tbody');
     const searchTerm = inventorySearch?.value || '';
@@ -428,6 +526,7 @@
         </tr>`;
     }).join('');
     applyFilter(document.getElementById('inventory-table'), searchTerm);
+    updateMetrics(rows);
   }
 
   function renderOrders(rows, periodLabel) {


### PR DESCRIPTION
## Summary
- allow inventory operators (and Mohit) to access the stock market view while keeping bulk making time restricted
- redirect inventory operators to the stock market view after login and surface the tool on the operator dashboard
- refresh the stock market UI with quick metrics and Mohit-only bulk upload entry point

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926a08ea1588320b9ad3cd9b31b784b)