### PR TITLE
Increase stock market page font sizes

### DIFF
--- a/views/stockMarket.ejs
+++ b/views/stockMarket.ejs
@@ -29,7 +29,8 @@
       background: var(--color-bg-primary);
       color: var(--color-text-primary);
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-      line-height: 1.6;
+      font-size: 18px;
+      line-height: 1.65;
     }
 
     .navbar {
@@ -41,7 +42,7 @@
 
     .navbar-brand {
       font-weight: 700;
-      font-size: 1.15rem;
+      font-size: 1.4rem;
       letter-spacing: -0.01em;
       color: var(--color-text-primary) !important;
     }
@@ -54,7 +55,7 @@
       background: linear-gradient(135deg, rgba(15, 82, 186, 0.08), rgba(15, 82, 186, 0.02));
       border: 1px solid var(--color-border);
       border-radius: 16px;
-      padding: 1.25rem 1.5rem;
+      padding: 1.5rem 1.75rem;
       box-shadow: var(--shadow-soft);
     }
 
@@ -65,7 +66,7 @@
     }
 
     .card-body {
-      padding: 1.5rem;
+      padding: 1.75rem;
     }
 
     .nav-pills {
@@ -80,7 +81,8 @@
     .nav-pills .nav-link {
       color: var(--color-text-secondary);
       border-radius: 10px;
-      padding: 0.65rem 1.25rem;
+      padding: 0.8rem 1.4rem;
+      font-size: 1.05rem;
       font-weight: 600;
       border: 1px solid transparent;
     }
@@ -96,7 +98,7 @@
       padding: 0.45rem 0.8rem;
       border-radius: 999px;
       font-weight: 700;
-      font-size: 0.9rem;
+      font-size: 1.05rem;
       letter-spacing: 0.01em;
       display: inline-flex;
       align-items: center;
@@ -133,14 +135,14 @@
       border-color: rgba(15, 157, 88, 0.28);
     }
 
-    .table { color: var(--color-text-primary); }
+    .table { color: var(--color-text-primary); font-size: 1.05rem; }
 
     .table thead th {
       background: #f0f4f9;
       color: var(--color-text-secondary);
       text-transform: uppercase;
       letter-spacing: 0.05em;
-      font-size: 0.8rem;
+      font-size: 1rem;
       border-bottom: 1px solid var(--color-border);
       position: sticky;
       top: 0;
@@ -156,14 +158,15 @@
     }
 
     .table tbody td {
-      padding: 0.85rem;
+      padding: 1rem 0.85rem;
       vertical-align: middle;
     }
 
     .search-input {
       border: 1px solid var(--color-border);
       border-radius: 10px;
-      padding: 0.7rem 1rem;
+      padding: 0.9rem 1.1rem;
+      font-size: 1.05rem;
     }
 
     .input-group-text {
@@ -173,9 +176,9 @@
       border-radius: 10px 0 0 10px !important;
     }
 
-    h3 { font-weight: 800; letter-spacing: -0.02em; }
+    h3 { font-weight: 800; letter-spacing: -0.02em; font-size: 2rem; }
     .text-faint { color: var(--color-text-muted); }
-    .metric-label { color: var(--color-text-secondary); font-weight: 600; }
+    .metric-label { color: var(--color-text-secondary); font-weight: 700; font-size: 1.05rem; }
 
     .legend-pills { display: flex; align-items: center; gap: 0.75rem; flex-wrap: wrap; }
 
@@ -192,12 +195,12 @@
       border: 1px solid var(--color-border);
       background: var(--color-surface);
       box-shadow: var(--shadow-md);
-      padding: 1rem 1.25rem;
+      padding: 1.25rem 1.5rem;
     }
 
-    .stat-label { color: var(--color-text-muted); font-weight: 600; font-size: 0.95rem; }
-    .stat-value { font-size: 1.65rem; font-weight: 800; letter-spacing: -0.02em; }
-    .stat-subtle { color: var(--color-text-secondary); font-weight: 600; font-size: 0.95rem; }
+    .stat-label { color: var(--color-text-muted); font-weight: 700; font-size: 1.1rem; }
+    .stat-value { font-size: 2.2rem; font-weight: 800; letter-spacing: -0.02em; }
+    .stat-subtle { color: var(--color-text-secondary); font-weight: 700; font-size: 1.05rem; }
 
     .action-card {
       border: 1px dashed var(--color-border);
@@ -205,8 +208,9 @@
       background: var(--color-accent-soft);
       color: var(--color-accent);
       box-shadow: var(--shadow-soft);
-      padding: 1rem 1.25rem;
+      padding: 1.25rem 1.5rem;
       height: 100%;
+      font-size: 1.05rem;
     }
 
     .action-card:hover {
@@ -217,8 +221,9 @@
     }
 
     @media (max-width: 768px) {
-      .card-body { padding: 1.1rem; }
-      h3 { font-size: 1.35rem; }
+      .card-body { padding: 1.25rem; }
+      h3 { font-size: 1.5rem; }
+      body { font-size: 17px; }
     }
 
     @media print {


### PR DESCRIPTION
## Summary
- enlarge typography across the stock market view for better long-distance legibility
- adjust padding and input sizing to match the larger font scale

## Testing
- npm start -- --help (fails: Cannot find module 'secure-env')

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926b33ac1488320a620352f1dc20dc3)