### PR TITLE
Add Accounts DC Challan UI, GST master and partial-lot support

### DIFF
--- a/app.js
+++ b/app.js
@@ -134,6 +134,8 @@ app.use('/flipkart', flipkartReturnRoutes);
 app.use('/flipkart', flipkartIssueStatusRoutes);
 app.use('/webhook', inventoryWebhook);
 app.use('/purchase', purchaseRoutes);
+const accountsChallanRoutes = require('./routes/accountsChallanRoutes');
+app.use('/accounts-challan', accountsChallanRoutes);
 app.use('/', skuRoutes);
 app.use('/api', apiAuthRoutes);
 app.use('/api', apiRoutes);

--- a/routes/accountsChallanRoutes.js
+++ b/routes/accountsChallanRoutes.js
@@ -1,0 +1,560 @@
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isAccountsAdmin } = require('../middlewares/auth');
+
+const FISCAL_YEAR = '25-26';
+const RATE = 200;
+
+async function getNextChallanCounter(consigneeId) {
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+
+    const [rows] = await conn.query(
+      `SELECT id, current_counter
+         FROM dc_challan_counters
+        WHERE consignee_id = ? AND year_range = ? FOR UPDATE`,
+      [consigneeId, FISCAL_YEAR]
+    );
+
+    let counter = 1;
+    if (rows.length === 0) {
+      await conn.query(
+        `INSERT INTO dc_challan_counters
+            (consignee_id, year_range, current_counter)
+         VALUES (?, ?, 1)`,
+        [consigneeId, FISCAL_YEAR]
+      );
+    } else {
+      counter = rows[0].current_counter + 1;
+      await conn.query(
+        `UPDATE dc_challan_counters
+            SET current_counter = ?
+          WHERE id = ?`,
+        [counter, rows[0].id]
+      );
+    }
+
+    await conn.commit();
+    conn.release();
+    return counter;
+  } catch (err) {
+    await conn.rollback();
+    conn.release();
+    throw err;
+  }
+}
+
+function buildAssignmentsQuery({ search, limit, offset }) {
+  const params = [];
+  let whereClause = 'WHERE wa.is_approved = 1';
+
+  if (search) {
+    if (search.includes(',')) {
+      const terms = search
+        .split(',')
+        .map((term) => term.trim())
+        .filter(Boolean);
+      if (terms.length) {
+        const conds = [];
+        for (const term of terms) {
+          const like = `%${term}%`;
+          conds.push('(jd.sku LIKE ? OR jd.lot_no LIKE ? OR c.remark LIKE ?)');
+          params.push(like, like, like);
+        }
+        whereClause += ` AND (${conds.join(' OR ')})`;
+      }
+    } else {
+      const like = `%${search}%`;
+      whereClause += ' AND (jd.sku LIKE ? OR jd.lot_no LIKE ? OR c.remark LIKE ?)';
+      params.push(like, like, like);
+    }
+  }
+
+  const sql = `
+    SELECT
+      wa.id AS washing_id,
+      jd.lot_no,
+      jd.sku,
+      jd.total_pieces,
+      jd.remark AS assembly_remark,
+      c.remark AS cutting_remark,
+      wa.target_day,
+      wa.assigned_on,
+      wa.is_approved,
+      wa.assignment_remark,
+      u.username AS washer_username,
+      m.username AS master_username,
+      IFNULL(SUM(dci.issued_pieces), 0) AS issued_pieces,
+      (jd.total_pieces - IFNULL(SUM(dci.issued_pieces), 0)) AS remaining_pieces
+    FROM washing_assignments wa
+    JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
+    JOIN cutting_lots c ON jd.lot_no = c.lot_no
+    JOIN users u ON wa.user_id = u.id
+    JOIN users m ON wa.jeans_assembly_master_id = m.id
+    LEFT JOIN dc_challan_items dci ON dci.washing_id = wa.id
+    ${whereClause}
+    GROUP BY wa.id
+    HAVING remaining_pieces > 0
+    ORDER BY wa.assigned_on DESC
+    LIMIT ? OFFSET ?`;
+
+  params.push(limit, offset);
+  return { sql, params };
+}
+
+router.get('/', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  try {
+    const search = (req.query.search || '').trim();
+    const offset = parseInt(req.query.offset, 10) || 0;
+    const limit = 50;
+
+    const { sql, params } = buildAssignmentsQuery({ search, limit, offset });
+    const [assignments] = await pool.query(sql, params);
+
+    res.render('accountsChallanDashboard', {
+      assignments,
+      search,
+      user: req.session.user,
+      error: req.flash('error'),
+      success: req.flash('success')
+    });
+  } catch (err) {
+    console.error('[ERROR] GET /accounts-challan:', err);
+    req.flash('error', 'Could not load accounts challan dashboard');
+    res.redirect('/');
+  }
+});
+
+router.get('/search', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  try {
+    const search = (req.query.search || '').trim();
+    const offset = parseInt(req.query.offset, 10) || 0;
+    const limit = 50;
+
+    const { sql, params } = buildAssignmentsQuery({ search, limit, offset });
+    const [assignments] = await pool.query(sql, params);
+
+    res.json({ assignments });
+  } catch (err) {
+    console.error('[ERROR] GET /accounts-challan/search:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+router.post('/generate', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  try {
+    const selectedRows = JSON.parse(req.body.selectedRows || '[]');
+    if (!selectedRows.length) {
+      req.flash('error', 'No items selected for challan generation');
+      return res.redirect('/accounts-challan');
+    }
+
+    const [senders] = await pool.query(
+      `SELECT id, name, gstin, state, pan, address, place_of_supply, short_code
+         FROM dc_gst_parties
+        WHERE party_type = 'sender' AND is_active = 1
+        ORDER BY name`
+    );
+    const [consignees] = await pool.query(
+      `SELECT id, name, gstin, state, pan, address, place_of_supply, short_code
+         FROM dc_gst_parties
+        WHERE party_type = 'consignee' AND is_active = 1
+        ORDER BY name`
+    );
+
+    if (!senders.length || !consignees.length) {
+      req.flash('error', 'Please configure sender and consignee GST details first.');
+      return res.redirect('/accounts-challan/gst');
+    }
+
+    res.render('accountsChallanGeneration', {
+      selectedRows,
+      senders,
+      consignees,
+      error: req.flash('error'),
+      success: req.flash('success')
+    });
+  } catch (err) {
+    console.error('[ERROR] POST /accounts-challan/generate:', err);
+    req.flash('error', 'Error generating challan form');
+    res.redirect('/accounts-challan');
+  }
+});
+
+router.post('/create', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  const conn = await pool.getConnection();
+  try {
+    const {
+      challanDate,
+      senderId,
+      consigneeId,
+      selectedRows,
+      vehicleNumber = '',
+      purpose = '',
+      purposePrice = ''
+    } = req.body;
+
+    const itemsInput = JSON.parse(selectedRows || '[]');
+    if (!itemsInput.length) {
+      req.flash('error', 'No items selected for challan');
+      conn.release();
+      return res.redirect('/accounts-challan');
+    }
+
+    const senderIDNum = parseInt(senderId, 10);
+    const consigneeIDNum = parseInt(consigneeId, 10);
+
+    const [[sender]] = await conn.query(
+      `SELECT id, name, gstin, state, pan, address, place_of_supply, short_code
+         FROM dc_gst_parties
+        WHERE id = ? AND party_type = 'sender' AND is_active = 1`,
+      [senderIDNum]
+    );
+    const [[consignee]] = await conn.query(
+      `SELECT id, name, gstin, state, pan, address, place_of_supply, short_code
+         FROM dc_gst_parties
+        WHERE id = ? AND party_type = 'consignee' AND is_active = 1`,
+      [consigneeIDNum]
+    );
+
+    if (!sender || !consignee) {
+      req.flash('error', 'Invalid sender or consignee selected');
+      conn.release();
+      return res.redirect('/accounts-challan');
+    }
+
+    const washingIds = itemsInput.map((item) => parseInt(item.washing_id, 10));
+    if (!washingIds.length) {
+      req.flash('error', 'No valid washing items found');
+      conn.release();
+      return res.redirect('/accounts-challan');
+    }
+
+    const [assignmentRows] = await conn.query(
+      `SELECT
+         wa.id AS washing_id,
+         jd.lot_no,
+         jd.sku,
+         jd.total_pieces,
+         IFNULL(SUM(dci.issued_pieces), 0) AS issued_pieces
+       FROM washing_assignments wa
+       JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
+       LEFT JOIN dc_challan_items dci ON dci.washing_id = wa.id
+       WHERE wa.id IN (?) AND wa.is_approved = 1
+       GROUP BY wa.id`,
+      [washingIds]
+    );
+
+    if (assignmentRows.length !== washingIds.length) {
+      req.flash('error', 'Some selected lots are not approved or missing');
+      conn.release();
+      return res.redirect('/accounts-challan');
+    }
+
+    const assignmentById = new Map(
+      assignmentRows.map((row) => [row.washing_id, row])
+    );
+
+    const items = [];
+    let totalTaxableValue = 0;
+
+    for (const input of itemsInput) {
+      const washingId = parseInt(input.washing_id, 10);
+      const requestedPieces = parseInt(input.challan_pieces, 10);
+      const assignment = assignmentById.get(washingId);
+
+      if (!assignment) {
+        req.flash('error', 'Invalid lot selection');
+        conn.release();
+        return res.redirect('/accounts-challan');
+      }
+
+      const remaining = assignment.total_pieces - assignment.issued_pieces;
+      if (!requestedPieces || requestedPieces <= 0 || requestedPieces > remaining) {
+        req.flash('error', `Invalid challan quantity for lot ${assignment.lot_no}`);
+        conn.release();
+        return res.redirect('/accounts-challan');
+      }
+
+      const taxableValue = requestedPieces * RATE;
+      totalTaxableValue += taxableValue;
+
+      items.push({
+        washing_id: washingId,
+        lot_no: assignment.lot_no,
+        sku: assignment.sku,
+        total_pieces: requestedPieces,
+        lot_total_pieces: assignment.total_pieces,
+        hsnSac: '62034200',
+        rate: RATE,
+        discount: 0,
+        taxableValue,
+        quantityFormatted: `${requestedPieces} PCS`
+      });
+    }
+
+    const totalAmount = totalTaxableValue;
+    const next = await getNextChallanCounter(consignee.id);
+    const code = consignee.short_code || 'XX';
+    const challanNo = `DC/${code}/${FISCAL_YEAR}/${next}`;
+
+    await conn.beginTransaction();
+
+    const insertSql = `
+      INSERT INTO challan (
+        challan_date, challan_no, reference_no, challan_type,
+        sender_name, sender_address, sender_gstin, sender_state, sender_pan,
+        consignee_id, consignee_name, consignee_gstin, consignee_address, place_of_supply,
+        vehicle_number, purpose, purpose_price,
+        items, total_taxable_value, total_amount, total_amount_in_words
+      ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+    `;
+
+    const [resInsert] = await conn.query(insertSql, [
+      challanDate,
+      challanNo,
+      '',
+      'JOB WORK',
+      sender.name,
+      sender.address,
+      sender.gstin,
+      sender.state,
+      sender.pan,
+      consignee.id,
+      consignee.name,
+      consignee.gstin,
+      consignee.address,
+      consignee.place_of_supply,
+      vehicleNumber.trim(),
+      purpose.trim(),
+      purposePrice || 0,
+      JSON.stringify(items),
+      totalTaxableValue,
+      totalAmount,
+      `${totalAmount.toLocaleString('en-IN')} Rupees Only`
+    ]);
+
+    const challanId = resInsert.insertId;
+    const insertItemValues = items.map((item) => [
+      challanId,
+      item.washing_id,
+      item.lot_no,
+      item.sku,
+      item.lot_total_pieces,
+      item.total_pieces
+    ]);
+
+    await conn.query(
+      `INSERT INTO dc_challan_items
+        (challan_id, washing_id, lot_no, sku, total_pieces, issued_pieces)
+       VALUES ?`,
+      [insertItemValues]
+    );
+
+    await conn.commit();
+    conn.release();
+    res.redirect(`/accounts-challan/view/${challanId}`);
+  } catch (err) {
+    await conn.rollback();
+    conn.release();
+    console.error('[ERROR] POST /accounts-challan/create:', err);
+    req.flash('error', 'Error creating challan');
+    res.redirect('/accounts-challan');
+  }
+});
+
+router.get('/view/:challanId', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  try {
+    const challanId = parseInt(req.params.challanId, 10);
+
+    const [rows] = await pool.query('SELECT * FROM challan WHERE id = ?', [challanId]);
+    if (!rows.length) {
+      req.flash('error', 'Challan not found');
+      return res.redirect('/accounts-challan');
+    }
+
+    const ch = rows[0];
+    let items = [];
+    try {
+      items = typeof ch.items === 'string' ? JSON.parse(ch.items) : ch.items;
+    } catch (err) {
+      console.error('Invalid JSON in challan items:', ch.items);
+      req.flash('error', 'Invalid challan data');
+      return res.redirect('/accounts-challan');
+    }
+
+    const challan = {
+      sender: {
+        name: ch.sender_name,
+        address: ch.sender_address,
+        gstin: ch.sender_gstin,
+        state: ch.sender_state,
+        pan: ch.sender_pan
+      },
+      challanDate: ch.challan_date,
+      challanNo: ch.challan_no,
+      referenceNo: ch.reference_no || '',
+      challanType: ch.challan_type,
+      consignee: {
+        name: ch.consignee_name,
+        gstin: ch.consignee_gstin,
+        address: ch.consignee_address,
+        placeOfSupply: ch.place_of_supply
+      },
+      vehicleNumber: ch.vehicle_number,
+      purpose: ch.purpose,
+      purposePrice: ch.purpose_price,
+      items,
+      totalTaxableValue: ch.total_taxable_value,
+      totalAmount: ch.total_amount,
+      totalAmountInWords: ch.total_amount_in_words
+    };
+
+    res.render('challanCreation', { challan });
+  } catch (err) {
+    console.error('[ERROR] GET /accounts-challan/view:', err);
+    req.flash('error', 'Error loading challan');
+    res.redirect('/accounts-challan');
+  }
+});
+
+router.get('/list', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  try {
+    const search = (req.query.search || '').trim();
+    let sql = 'SELECT * FROM challan WHERE 1 ';
+    const params = [];
+
+    if (search) {
+      sql += `
+        AND (
+          challan_no LIKE ?
+          OR JSON_SEARCH(items,'one',?,NULL,'$[*].lot_no') IS NOT NULL
+        )`;
+      params.push(`%${search}%`, search);
+    }
+
+    sql += ' ORDER BY created_at DESC LIMIT 200';
+    const [rows] = await pool.query(sql, params);
+
+    res.render('accountsChallanList', {
+      challans: rows,
+      search,
+      error: req.flash('error'),
+      success: req.flash('success')
+    });
+  } catch (err) {
+    console.error('[ERROR] GET /accounts-challan/list:', err);
+    req.flash('error', 'Could not load challan list');
+    res.redirect('/accounts-challan');
+  }
+});
+
+router.get('/gst', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  try {
+    const [parties] = await pool.query(
+      `SELECT * FROM dc_gst_parties ORDER BY party_type, name`
+    );
+
+    res.render('accountsChallanGst', {
+      parties,
+      error: req.flash('error'),
+      success: req.flash('success')
+    });
+  } catch (err) {
+    console.error('[ERROR] GET /accounts-challan/gst:', err);
+    req.flash('error', 'Could not load GST configuration');
+    res.redirect('/accounts-challan');
+  }
+});
+
+router.post('/gst', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  try {
+    const {
+      party_type,
+      name,
+      gstin,
+      address,
+      state,
+      pan,
+      place_of_supply,
+      short_code,
+      is_active
+    } = req.body;
+
+    if (!party_type || !name) {
+      req.flash('error', 'Party type and name are required');
+      return res.redirect('/accounts-challan/gst');
+    }
+
+    await pool.query(
+      `INSERT INTO dc_gst_parties
+        (party_type, name, gstin, address, state, pan, place_of_supply, short_code, is_active)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)` ,
+      [
+        party_type,
+        name.trim(),
+        gstin || null,
+        address || null,
+        state || null,
+        pan || null,
+        place_of_supply || null,
+        short_code || null,
+        is_active ? 1 : 0
+      ]
+    );
+
+    req.flash('success', 'GST party created');
+    res.redirect('/accounts-challan/gst');
+  } catch (err) {
+    console.error('[ERROR] POST /accounts-challan/gst:', err);
+    req.flash('error', 'Failed to create GST party');
+    res.redirect('/accounts-challan/gst');
+  }
+});
+
+router.post('/gst/:id(\\d+)', isAuthenticated, isAccountsAdmin, async (req, res) => {
+  try {
+    const id = parseInt(req.params.id, 10);
+    const {
+      party_type,
+      name,
+      gstin,
+      address,
+      state,
+      pan,
+      place_of_supply,
+      short_code,
+      is_active
+    } = req.body;
+
+    await pool.query(
+      `UPDATE dc_gst_parties
+         SET party_type = ?, name = ?, gstin = ?, address = ?, state = ?,
+             pan = ?, place_of_supply = ?, short_code = ?, is_active = ?
+       WHERE id = ?`,
+      [
+        party_type,
+        name.trim(),
+        gstin || null,
+        address || null,
+        state || null,
+        pan || null,
+        place_of_supply || null,
+        short_code || null,
+        is_active ? 1 : 0,
+        id
+      ]
+    );
+
+    req.flash('success', 'GST party updated');
+    res.redirect('/accounts-challan/gst');
+  } catch (err) {
+    console.error('[ERROR] POST /accounts-challan/gst/:id:', err);
+    req.flash('error', 'Failed to update GST party');
+    res.redirect('/accounts-challan/gst');
+  }
+});
+
+module.exports = router;

--- a/sql/accounts_dc_challan_tables.sql
+++ b/sql/accounts_dc_challan_tables.sql
@@ -1,0 +1,42 @@
+-- Accounts DC challan setup
+-- 1) GST master table for senders/consignees
+CREATE TABLE IF NOT EXISTS dc_gst_parties (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  party_type ENUM('sender','consignee') NOT NULL,
+  name VARCHAR(200) NOT NULL,
+  gstin VARCHAR(32),
+  address TEXT,
+  state VARCHAR(100),
+  pan VARCHAR(32),
+  place_of_supply VARCHAR(64),
+  short_code VARCHAR(10),
+  is_active TINYINT(1) DEFAULT 1,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+-- 2) Challan counter tracking per consignee + fiscal year
+CREATE TABLE IF NOT EXISTS dc_challan_counters (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  consignee_id INT NOT NULL,
+  year_range VARCHAR(12) NOT NULL,
+  current_counter INT NOT NULL DEFAULT 1,
+  UNIQUE KEY uniq_consignee_year (consignee_id, year_range),
+  CONSTRAINT fk_dc_counter_consignee FOREIGN KEY (consignee_id)
+    REFERENCES dc_gst_parties(id) ON DELETE CASCADE
+);
+
+-- 3) Items issued in each challan (supports partial lots)
+CREATE TABLE IF NOT EXISTS dc_challan_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  challan_id INT NOT NULL,
+  washing_id INT NOT NULL,
+  lot_no VARCHAR(64),
+  sku VARCHAR(64),
+  total_pieces INT NOT NULL,
+  issued_pieces INT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_dc_challan_items_washing (washing_id),
+  CONSTRAINT fk_dc_items_challan FOREIGN KEY (challan_id)
+    REFERENCES challan(id) ON DELETE CASCADE
+);

--- a/views/accountsChallanDashboard.ejs
+++ b/views/accountsChallanDashboard.ejs
@@ -1,0 +1,372 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Accounts DC Challan Dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  <link
+    rel="stylesheet"
+    href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
+    integrity="sha512-buD2vAa2mW1yj78BzFzM/6kWTHpveG62CmG0cy8bcS9A7cdsI1hD2eiGeBv1rCR3dOfh1JvHS5hLSG/T0YX1ZA=="
+    crossorigin="anonymous"
+    referrerpolicy="no-referrer"
+  />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/professional.css">
+  <style>
+    body {
+      background-color: #f8f9fa;
+    }
+    .navbrand-icon {
+      margin-right: 8px;
+    }
+    .action-btns {
+      display: flex;
+      gap: 10px;
+      flex-wrap: wrap;
+    }
+    .search-container {
+      margin-top: 20px;
+    }
+    .card {
+      margin-top: 20px;
+    }
+    .table-responsive {
+      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+    }
+    .load-more-container {
+      margin: 15px 0;
+    }
+    .badge-soft {
+      background: rgba(13, 110, 253, 0.12);
+      color: #0d6efd;
+      padding: 0.35rem 0.6rem;
+      border-radius: 999px;
+      font-weight: 600;
+    }
+    .qty-input {
+      width: 110px;
+      min-width: 110px;
+    }
+  </style>
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <a class="navbar-brand" href="#">
+      <i class="fas fa-file-invoice navbrand-icon"></i>
+      ACCOUNTS DC CHALLAN
+    </a>
+    <button
+      class="navbar-toggler"
+      type="button"
+      data-toggle="collapse"
+      data-target="#navbarNav"
+      aria-controls="navbarNav"
+      aria-expanded="false"
+      aria-label="Toggle navigation"
+    >
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav mr-auto"></ul>
+      <ul class="navbar-nav">
+        <li class="nav-item">
+          <a class="nav-link" href="/accounts-challan">
+            <i class="fas fa-tachometer-alt"></i> Dashboard
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/accounts-challan/list">
+            <i class="fas fa-list"></i> Challan List
+          </a>
+        </li>
+        <li class="nav-item">
+          <a class="nav-link" href="/accounts-challan/gst">
+            <i class="fas fa-receipt"></i> GST Master
+          </a>
+        </li>
+        <li class="nav-item">
+          <a href="/logout" class="btn btn-sm btn-danger ml-2">
+            <i class="fas fa-sign-out-alt"></i> Logout
+          </a>
+        </li>
+      </ul>
+    </div>
+  </nav>
+
+  <div class="container">
+    <% if (error && error.length) { %>
+      <div class="alert alert-danger mt-3">
+        <% error.forEach(msg => { %>
+          <p><%= msg %></p>
+        <% }); %>
+      </div>
+    <% } %>
+    <% if (success && success.length) { %>
+      <div class="alert alert-success mt-3">
+        <% success.forEach(msg => { %>
+          <p><%= msg %></p>
+        <% }); %>
+      </div>
+    <% } %>
+
+    <header class="d-flex justify-content-between align-items-center mt-3 flex-wrap gap-3">
+      <div>
+        <h2 class="mb-1">
+          <i class="fas fa-tachometer-alt"></i> Accounts DC Challan
+        </h2>
+        <div class="text-muted">Select lots with remaining pieces, enter quantities, and generate challans.</div>
+      </div>
+      <div class="action-btns">
+        <button id="selectAllBtn" class="btn btn-outline-primary">
+          <i class="fas fa-check-double"></i> Select All
+        </button>
+        <button id="generateChallanBtn" class="btn btn-primary" disabled>
+          <i class="fas fa-file-invoice"></i> Generate Challan
+        </button>
+      </div>
+    </header>
+
+    <div class="row search-container align-items-center">
+      <div class="col-md-6 mt-3">
+        <input
+          type="text"
+          id="searchInput"
+          class="form-control"
+          placeholder="Search by SKU, Lot No, or Cutting Remark"
+          value="<%= search %>"
+        />
+      </div>
+      <div class="col-md-3 mt-3">
+        <button class="btn btn-outline-secondary" id="searchBtn">
+          <i class="fas fa-search"></i> Search
+        </button>
+      </div>
+      <div class="col-md-3 mt-3 text-md-right">
+        <span class="badge-soft">Only lots with remaining pieces are shown</span>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-striped table-bordered mb-0" id="assignmentsTable">
+            <thead class="thead-light">
+              <tr>
+                <th style="width: 40px;"><input type="checkbox" id="selectAllCheckbox"></th>
+                <th>ID</th>
+                <th>Lot No</th>
+                <th>SKU</th>
+                <th>Total Pieces</th>
+                <th>Issued Pieces</th>
+                <th>Remaining</th>
+                <th>Challan Pieces</th>
+                <th>Assembly Remark</th>
+                <th>Cutting Remark</th>
+                <th>Target Day</th>
+                <th>Assigned On</th>
+                <th>Washer</th>
+                <th>Master</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% if (assignments && assignments.length) { %>
+                <% assignments.forEach(a => { %>
+                  <tr
+                    data-id="<%= a.washing_id %>"
+                    data-lot="<%= a.lot_no %>"
+                    data-sku="<%= a.sku %>"
+                    data-total="<%= a.total_pieces %>"
+                    data-remaining="<%= a.remaining_pieces %>"
+                  >
+                    <td><input type="checkbox" class="rowCheckbox"></td>
+                    <td><%= a.washing_id %></td>
+                    <td><%= a.lot_no %></td>
+                    <td><%= a.sku %></td>
+                    <td><%= a.total_pieces %></td>
+                    <td><%= a.issued_pieces %></td>
+                    <td><span class="badge badge-info"><%= a.remaining_pieces %></span></td>
+                    <td>
+                      <input
+                        type="number"
+                        class="form-control form-control-sm qty-input challan-qty"
+                        min="1"
+                        max="<%= a.remaining_pieces %>"
+                        value="<%= a.remaining_pieces %>"
+                      />
+                    </td>
+                    <td><%= a.assembly_remark %></td>
+                    <td><%= a.cutting_remark %></td>
+                    <td><%= a.target_day ? new Date(a.target_day).toLocaleDateString() : '' %></td>
+                    <td><%= a.assigned_on ? new Date(a.assigned_on).toLocaleString() : '' %></td>
+                    <td><%= a.washer_username %></td>
+                    <td><%= a.master_username %></td>
+                  </tr>
+                <% }); %>
+              <% } else { %>
+                <tr id="noRecordsRow">
+                  <td colspan="14" class="text-center">No records found.</td>
+                </tr>
+              <% } %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="load-more-container text-center">
+      <button class="btn btn-outline-secondary" id="loadMoreBtn">Load More</button>
+    </div>
+
+    <form id="generateForm" action="/accounts-challan/generate" method="POST" class="d-none">
+      <input type="hidden" name="selectedRows" id="selectedRowsInput">
+    </form>
+  </div>
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.bundle.min.js"></script>
+  <script>
+    let currentOffset = 0;
+    let currentSearchQuery = '<%= search %>';
+
+    const selectAllCheckbox = document.getElementById('selectAllCheckbox');
+    const selectAllBtn = document.getElementById('selectAllBtn');
+    const generateChallanBtn = document.getElementById('generateChallanBtn');
+    const loadMoreBtn = document.getElementById('loadMoreBtn');
+    const searchBtn = document.getElementById('searchBtn');
+    const searchInput = document.getElementById('searchInput');
+
+    function updateGenerateButton() {
+      const anyChecked = document.querySelectorAll('.rowCheckbox:checked').length > 0;
+      generateChallanBtn.disabled = !anyChecked;
+    }
+
+    function attachRowListeners() {
+      document.querySelectorAll('.rowCheckbox').forEach(cb => {
+        cb.addEventListener('change', updateGenerateButton);
+      });
+    }
+
+    function renderRows(assignments, append = false) {
+      const tbody = document.querySelector('#assignmentsTable tbody');
+      if (!append) {
+        tbody.innerHTML = '';
+      }
+      if (!assignments.length && !append) {
+        tbody.innerHTML = '<tr><td colspan="14" class="text-center">No records found.</td></tr>';
+        return;
+      }
+
+      assignments.forEach(a => {
+        const row = document.createElement('tr');
+        row.dataset.id = a.washing_id;
+        row.dataset.lot = a.lot_no;
+        row.dataset.sku = a.sku;
+        row.dataset.total = a.total_pieces;
+        row.dataset.remaining = a.remaining_pieces;
+        row.innerHTML = `
+          <td><input type="checkbox" class="rowCheckbox"></td>
+          <td>${a.washing_id}</td>
+          <td>${a.lot_no}</td>
+          <td>${a.sku}</td>
+          <td>${a.total_pieces}</td>
+          <td>${a.issued_pieces}</td>
+          <td><span class="badge badge-info">${a.remaining_pieces}</span></td>
+          <td>
+            <input
+              type="number"
+              class="form-control form-control-sm qty-input challan-qty"
+              min="1"
+              max="${a.remaining_pieces}"
+              value="${a.remaining_pieces}"
+            />
+          </td>
+          <td>${a.assembly_remark || ''}</td>
+          <td>${a.cutting_remark || ''}</td>
+          <td>${a.target_day ? new Date(a.target_day).toLocaleDateString() : ''}</td>
+          <td>${a.assigned_on ? new Date(a.assigned_on).toLocaleString() : ''}</td>
+          <td>${a.washer_username}</td>
+          <td>${a.master_username}</td>
+        `;
+        tbody.appendChild(row);
+      });
+      attachRowListeners();
+      updateGenerateButton();
+    }
+
+    selectAllBtn.addEventListener('click', () => {
+      const checkboxes = document.querySelectorAll('.rowCheckbox');
+      const shouldSelectAll = !selectAllCheckbox.checked;
+      selectAllCheckbox.checked = shouldSelectAll;
+      checkboxes.forEach(cb => cb.checked = shouldSelectAll);
+      updateGenerateButton();
+    });
+
+    selectAllCheckbox.addEventListener('change', () => {
+      const checkboxes = document.querySelectorAll('.rowCheckbox');
+      checkboxes.forEach(cb => cb.checked = selectAllCheckbox.checked);
+      updateGenerateButton();
+    });
+
+    searchBtn.addEventListener('click', async () => {
+      currentOffset = 0;
+      currentSearchQuery = searchInput.value.trim();
+      const url = `/accounts-challan/search?search=${encodeURIComponent(currentSearchQuery)}&offset=${currentOffset}`;
+      const res = await fetch(url);
+      const data = await res.json();
+      renderRows(data.assignments || [], false);
+    });
+
+    loadMoreBtn.addEventListener('click', async () => {
+      currentOffset += 50;
+      const url = `/accounts-challan/search?search=${encodeURIComponent(currentSearchQuery)}&offset=${currentOffset}`;
+      const res = await fetch(url);
+      const data = await res.json();
+      renderRows(data.assignments || [], true);
+    });
+
+    generateChallanBtn.addEventListener('click', () => {
+      const selected = [];
+      let hasInvalid = false;
+      const rows = document.querySelectorAll('#assignmentsTable tbody tr');
+      rows.forEach(row => {
+        const checkbox = row.querySelector('.rowCheckbox');
+        if (!checkbox || !checkbox.checked) return;
+
+        const remaining = parseInt(row.dataset.remaining, 10);
+        const qtyInput = row.querySelector('.challan-qty');
+        const qty = parseInt(qtyInput.value, 10);
+        if (!qty || qty <= 0 || qty > remaining) {
+          alert(`Invalid challan pieces for lot ${row.dataset.lot}.`);
+          hasInvalid = true;
+          return;
+        }
+        selected.push({
+          washing_id: row.dataset.id,
+          lot_no: row.dataset.lot,
+          sku: row.dataset.sku,
+          total_pieces: row.dataset.total,
+          challan_pieces: qty
+        });
+      });
+
+      if (hasInvalid) {
+        return;
+      }
+      if (!selected.length) {
+        alert('Please select at least one lot.');
+        return;
+      }
+
+      document.getElementById('selectedRowsInput').value = JSON.stringify(selected);
+      document.getElementById('generateForm').submit();
+    });
+
+    attachRowListeners();
+  </script>
+</body>
+</html>

--- a/views/accountsChallanGeneration.ejs
+++ b/views/accountsChallanGeneration.ejs
@@ -1,0 +1,154 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Generate DC Challan</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/professional.css">
+  <style>
+    body {
+      background-color: #f6f8fb;
+    }
+    .page-header {
+      margin: 20px 0;
+    }
+    .card {
+      box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+    }
+    .table-responsive {
+      border-radius: 8px;
+      overflow: hidden;
+    }
+  </style>
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <a class="navbar-brand" href="#">
+      <i class="bi bi-receipt"></i> Accounts DC Challan
+    </a>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item"><a class="nav-link" href="/accounts-challan">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="/accounts-challan/list">Challan List</a></li>
+        <li class="nav-item"><a class="nav-link" href="/accounts-challan/gst">GST Master</a></li>
+        <li class="nav-item"><a class="btn btn-sm btn-danger ml-2" href="/logout">Logout</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div class="container">
+    <% if (error && error.length) { %>
+      <div class="alert alert-danger mt-3">
+        <% error.forEach(msg => { %>
+          <p><%= msg %></p>
+        <% }); %>
+      </div>
+    <% } %>
+    <% if (success && success.length) { %>
+      <div class="alert alert-success mt-3">
+        <% success.forEach(msg => { %>
+          <p><%= msg %></p>
+        <% }); %>
+      </div>
+    <% } %>
+
+    <div class="page-header">
+      <h2 class="mb-1">Finalize DC Challan</h2>
+      <p class="text-muted">Review selected lots, choose GST parties, and generate the challan.</p>
+    </div>
+
+    <form action="/accounts-challan/create" method="POST">
+      <input type="hidden" name="selectedRows" value='<%- JSON.stringify(selectedRows) %>'>
+
+      <div class="row">
+        <div class="col-lg-4">
+          <div class="card mb-3">
+            <div class="card-body">
+              <h5 class="card-title">Challan Details</h5>
+              <div class="form-group">
+                <label for="challanDate">Challan Date</label>
+                <input type="date" id="challanDate" name="challanDate" class="form-control" required>
+              </div>
+              <div class="form-group">
+                <label for="senderId">Sender GST</label>
+                <select id="senderId" name="senderId" class="form-control" required>
+                  <option value="">Select Sender</option>
+                  <% senders.forEach(sender => { %>
+                    <option value="<%= sender.id %>"><%= sender.name %> (<%= sender.gstin %>)</option>
+                  <% }); %>
+                </select>
+              </div>
+              <div class="form-group">
+                <label for="consigneeId">Consignee GST</label>
+                <select id="consigneeId" name="consigneeId" class="form-control" required>
+                  <option value="">Select Consignee</option>
+                  <% consignees.forEach(consignee => { %>
+                    <option value="<%= consignee.id %>"><%= consignee.name %> (<%= consignee.gstin %>)</option>
+                  <% }); %>
+                </select>
+              </div>
+              <div class="form-group">
+                <label for="vehicleNumber">Vehicle Number</label>
+                <input type="text" id="vehicleNumber" name="vehicleNumber" class="form-control" placeholder="HR-XX-0000">
+              </div>
+              <div class="form-group">
+                <label for="purpose">Purpose</label>
+                <input type="text" id="purpose" name="purpose" class="form-control" placeholder="Job Work / Transfer">
+              </div>
+              <div class="form-group">
+                <label for="purposePrice">Purpose Price</label>
+                <input type="number" id="purposePrice" name="purposePrice" class="form-control" step="0.01" min="0">
+              </div>
+              <button type="submit" class="btn btn-primary w-100">
+                <i class="bi bi-check-circle"></i> Create Challan
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="col-lg-8">
+          <div class="card mb-3">
+            <div class="card-body">
+              <h5 class="card-title">Selected Lots</h5>
+              <div class="table-responsive">
+                <table class="table table-striped">
+                  <thead class="thead-light">
+                    <tr>
+                      <th>#</th>
+                      <th>Lot No</th>
+                      <th>SKU</th>
+                      <th>Total Pieces</th>
+                      <th>Challan Pieces</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% selectedRows.forEach((row, index) => { %>
+                      <tr>
+                        <td><%= index + 1 %></td>
+                        <td><%= row.lot_no %></td>
+                        <td><%= row.sku %></td>
+                        <td><%= row.total_pieces %></td>
+                        <td><%= row.challan_pieces %></td>
+                      </tr>
+                    <% }); %>
+                  </tbody>
+                </table>
+              </div>
+              <div class="alert alert-info mt-3">
+                <i class="bi bi-info-circle"></i>
+                Challan quantities are locked from the dashboard selection. To edit, go back and adjust quantities.
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </form>
+  </div>
+
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/accountsChallanGst.ejs
+++ b/views/accountsChallanGst.ejs
@@ -1,0 +1,273 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>GST Master - Accounts DC Challan</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/professional.css">
+  <style>
+    body {
+      background-color: #f8f9fa;
+    }
+    .card {
+      margin-top: 20px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.08);
+    }
+    .badge-type {
+      font-size: 0.75rem;
+      font-weight: 600;
+      padding: 0.35rem 0.6rem;
+      border-radius: 999px;
+    }
+    .badge-sender {
+      background: rgba(25,135,84,0.12);
+      color: #198754;
+    }
+    .badge-consignee {
+      background: rgba(13,110,253,0.12);
+      color: #0d6efd;
+    }
+  </style>
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <a class="navbar-brand" href="#">
+      <i class="bi bi-receipt"></i> Accounts DC Challan
+    </a>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item"><a class="nav-link" href="/accounts-challan">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="/accounts-challan/list">Challan List</a></li>
+        <li class="nav-item"><a class="nav-link" href="/accounts-challan/gst">GST Master</a></li>
+        <li class="nav-item"><a class="btn btn-sm btn-danger ml-2" href="/logout">Logout</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div class="container">
+    <% if (error && error.length) { %>
+      <div class="alert alert-danger mt-3">
+        <% error.forEach(msg => { %>
+          <p><%= msg %></p>
+        <% }); %>
+      </div>
+    <% } %>
+    <% if (success && success.length) { %>
+      <div class="alert alert-success mt-3">
+        <% success.forEach(msg => { %>
+          <p><%= msg %></p>
+        <% }); %>
+      </div>
+    <% } %>
+
+    <div class="row">
+      <div class="col-lg-4">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">Add GST Party</h5>
+            <form action="/accounts-challan/gst" method="POST">
+              <div class="form-group">
+                <label for="partyType">Party Type</label>
+                <select id="partyType" name="party_type" class="form-control" required>
+                  <option value="sender">Sender</option>
+                  <option value="consignee">Consignee</option>
+                </select>
+              </div>
+              <div class="form-group">
+                <label for="name">Name</label>
+                <input type="text" id="name" name="name" class="form-control" required>
+              </div>
+              <div class="form-group">
+                <label for="gstin">GSTIN</label>
+                <input type="text" id="gstin" name="gstin" class="form-control">
+              </div>
+              <div class="form-group">
+                <label for="state">State</label>
+                <input type="text" id="state" name="state" class="form-control">
+              </div>
+              <div class="form-group">
+                <label for="pan">PAN</label>
+                <input type="text" id="pan" name="pan" class="form-control">
+              </div>
+              <div class="form-group">
+                <label for="address">Address</label>
+                <textarea id="address" name="address" class="form-control" rows="3"></textarea>
+              </div>
+              <div class="form-group">
+                <label for="placeOfSupply">Place of Supply</label>
+                <input type="text" id="placeOfSupply" name="place_of_supply" class="form-control">
+              </div>
+              <div class="form-group">
+                <label for="shortCode">Short Code (for challan number)</label>
+                <input type="text" id="shortCode" name="short_code" class="form-control" maxlength="6">
+              </div>
+              <div class="form-check mb-3">
+                <input type="checkbox" class="form-check-input" id="isActive" name="is_active" checked>
+                <label class="form-check-label" for="isActive">Active</label>
+              </div>
+              <button type="submit" class="btn btn-primary w-100">Add GST Party</button>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-lg-8">
+        <div class="card">
+          <div class="card-body">
+            <h5 class="card-title">GST Party List</h5>
+            <div class="table-responsive">
+              <table class="table table-striped">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>GSTIN</th>
+                    <th>Short Code</th>
+                    <th>Status</th>
+                    <th>Update</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% if (parties && parties.length) { %>
+                    <% parties.forEach(party => { %>
+                      <tr>
+                        <td>
+                          <strong><%= party.name %></strong><br>
+                          <small class="text-muted"><%= party.address || '' %></small>
+                        </td>
+                        <td>
+                          <% if (party.party_type === 'sender') { %>
+                            <span class="badge-type badge-sender">Sender</span>
+                          <% } else { %>
+                            <span class="badge-type badge-consignee">Consignee</span>
+                          <% } %>
+                        </td>
+                        <td><%= party.gstin || '-' %></td>
+                        <td><%= party.short_code || '-' %></td>
+                        <td>
+                          <% if (party.is_active) { %>
+                            <span class="badge badge-success">Active</span>
+                          <% } else { %>
+                            <span class="badge badge-secondary">Inactive</span>
+                          <% } %>
+                        </td>
+                        <td>
+                          <form action="/accounts-challan/gst/<%= party.id %>" method="POST" class="d-grid gap-2">
+                            <input type="hidden" name="party_type" value="<%= party.party_type %>">
+                            <input type="hidden" name="name" value="<%= party.name %>">
+                            <input type="hidden" name="gstin" value="<%= party.gstin %>">
+                            <input type="hidden" name="address" value="<%= party.address %>">
+                            <input type="hidden" name="state" value="<%= party.state %>">
+                            <input type="hidden" name="pan" value="<%= party.pan %>">
+                            <input type="hidden" name="place_of_supply" value="<%= party.place_of_supply %>">
+                            <input type="hidden" name="short_code" value="<%= party.short_code %>">
+                            <input type="hidden" name="is_active" value="<%= party.is_active ? 1 : 0 %>">
+                            <button type="button" class="btn btn-sm btn-outline-primary" data-toggle="modal" data-target="#editModal-<%= party.id %>">
+                              Edit
+                            </button>
+                          </form>
+                        </td>
+                      </tr>
+                    <% }); %>
+                  <% } else { %>
+                    <tr>
+                      <td colspan="6" class="text-center">No GST parties found.</td>
+                    </tr>
+                  <% } %>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <% if (parties && parties.length) { %>
+    <% parties.forEach(party => { %>
+      <div class="modal fade" id="editModal-<%= party.id %>" tabindex="-1" role="dialog" aria-hidden="true">
+        <div class="modal-dialog modal-lg" role="document">
+          <form class="modal-content" action="/accounts-challan/gst/<%= party.id %>" method="POST">
+            <div class="modal-header">
+              <h5 class="modal-title">Edit GST Party</h5>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body">
+              <div class="row">
+                <div class="col-md-6">
+                  <div class="form-group">
+                    <label>Party Type</label>
+                    <select name="party_type" class="form-control">
+                      <option value="sender" <%= party.party_type === 'sender' ? 'selected' : '' %>>Sender</option>
+                      <option value="consignee" <%= party.party_type === 'consignee' ? 'selected' : '' %>>Consignee</option>
+                    </select>
+                  </div>
+                </div>
+                <div class="col-md-6">
+                  <div class="form-group">
+                    <label>Name</label>
+                    <input type="text" name="name" class="form-control" value="<%= party.name %>" required>
+                  </div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-6">
+                  <div class="form-group">
+                    <label>GSTIN</label>
+                    <input type="text" name="gstin" class="form-control" value="<%= party.gstin || '' %>">
+                  </div>
+                </div>
+                <div class="col-md-6">
+                  <div class="form-group">
+                    <label>State</label>
+                    <input type="text" name="state" class="form-control" value="<%= party.state || '' %>">
+                  </div>
+                </div>
+              </div>
+              <div class="row">
+                <div class="col-md-6">
+                  <div class="form-group">
+                    <label>PAN</label>
+                    <input type="text" name="pan" class="form-control" value="<%= party.pan || '' %>">
+                  </div>
+                </div>
+                <div class="col-md-6">
+                  <div class="form-group">
+                    <label>Place of Supply</label>
+                    <input type="text" name="place_of_supply" class="form-control" value="<%= party.place_of_supply || '' %>">
+                  </div>
+                </div>
+              </div>
+              <div class="form-group">
+                <label>Address</label>
+                <textarea name="address" class="form-control" rows="3"><%= party.address || '' %></textarea>
+              </div>
+              <div class="form-group">
+                <label>Short Code</label>
+                <input type="text" name="short_code" class="form-control" value="<%= party.short_code || '' %>" maxlength="6">
+              </div>
+              <div class="form-check">
+                <input type="checkbox" class="form-check-input" id="active-<%= party.id %>" name="is_active" <%= party.is_active ? 'checked' : '' %>>
+                <label class="form-check-label" for="active-<%= party.id %>">Active</label>
+              </div>
+            </div>
+            <div class="modal-footer">
+              <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
+              <button type="submit" class="btn btn-primary">Save Changes</button>
+            </div>
+          </form>
+        </div>
+      </div>
+    <% }); %>
+  <% } %>
+
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/accountsChallanList.ejs
+++ b/views/accountsChallanList.ejs
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Accounts DC Challan List</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/professional.css">
+  <style>
+    body {
+      background-color: #f8f9fa;
+    }
+    .card {
+      margin-top: 20px;
+    }
+  </style>
+</head>
+<body>
+  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+    <a class="navbar-brand" href="#">
+      <i class="bi bi-receipt"></i> Accounts DC Challan
+    </a>
+    <div class="collapse navbar-collapse" id="navbarNav">
+      <ul class="navbar-nav ml-auto">
+        <li class="nav-item"><a class="nav-link" href="/accounts-challan">Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="/accounts-challan/list">Challan List</a></li>
+        <li class="nav-item"><a class="nav-link" href="/accounts-challan/gst">GST Master</a></li>
+        <li class="nav-item"><a class="btn btn-sm btn-danger ml-2" href="/logout">Logout</a></li>
+      </ul>
+    </div>
+  </nav>
+
+  <div class="container">
+    <% if (error && error.length) { %>
+      <div class="alert alert-danger mt-3">
+        <% error.forEach(msg => { %>
+          <p><%= msg %></p>
+        <% }); %>
+      </div>
+    <% } %>
+    <% if (success && success.length) { %>
+      <div class="alert alert-success mt-3">
+        <% success.forEach(msg => { %>
+          <p><%= msg %></p>
+        <% }); %>
+      </div>
+    <% } %>
+
+    <div class="d-flex justify-content-between align-items-center mt-3 flex-wrap">
+      <h2 class="mb-0">DC Challan List</h2>
+      <form method="GET" action="/accounts-challan/list" class="form-inline my-3">
+        <input type="text" class="form-control mr-2" name="search" placeholder="Challan no or lot" value="<%= search %>">
+        <button class="btn btn-outline-primary" type="submit">Search</button>
+      </form>
+    </div>
+
+    <div class="card">
+      <div class="card-body p-0">
+        <div class="table-responsive">
+          <table class="table table-striped mb-0">
+            <thead class="thead-light">
+              <tr>
+                <th>#</th>
+                <th>Challan No</th>
+                <th>Challan Date</th>
+                <th>Consignee</th>
+                <th>Total Amount</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% if (challans && challans.length) { %>
+                <% challans.forEach(ch => { %>
+                  <tr>
+                    <td><%= ch.id %></td>
+                    <td><%= ch.challan_no %></td>
+                    <td><%= ch.challan_date ? ch.challan_date.toLocaleDateString('en-CA') : '' %></td>
+                    <td><%= ch.consignee_name %></td>
+                    <td>₹ <%= ch.total_amount ? parseFloat(ch.total_amount).toLocaleString('en-IN') : '' %></td>
+                    <td>
+                      <a href="/accounts-challan/view/<%= ch.id %>" class="btn btn-sm btn-info">View</a>
+                    </td>
+                  </tr>
+                <% }); %>
+              <% } else { %>
+                <tr>
+                  <td colspan="6" class="text-center">No challans found.</td>
+                </tr>
+              <% } %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Replace hardcoded GST/consignee data and allow the `accounts` role to manage GST parties and create DC challans from a dedicated UI. 
- Allow accounts to create challans against lots with partial issuance until the lot is fully issued, eliminating the previous all-or-nothing behaviour. 
- Keep existing department flows unchanged while providing an accounts-only workflow for challan generation and viewing. 
- Provide a clean, usable UI so accounts users can search lots, enter per-lot challan quantities and finalize challans. 

### Description
- Added a new route `routes/accountsChallanRoutes.js` with endpoints `GET /`, `GET /search`, `POST /generate`, `POST /create`, `GET /view/:challanId`, `GET /list`, and GST management endpoints `GET/POST /gst` to handle accounts-only challan flows and validation. 
- Introduced database-backed GST and tracking tables in `sql/accounts_dc_challan_tables.sql`: `dc_gst_parties`, `dc_challan_counters`, and `dc_challan_items`, and a transactional `getNextChallanCounter` helper to generate per-consignee challan numbers. 
- Added new views: `views/accountsChallanDashboard.ejs`, `views/accountsChallanGeneration.ejs`, `views/accountsChallanList.ejs`, and `views/accountsChallanGst.ejs` to provide the dashboard, generation form, challan list and GST master UI. 
- Wired routes into the application by updating `app.js`, added partial-lot support by storing issued pieces in `dc_challan_items` and by saving challan items as JSON in the existing `challan` table, and added client-side validation to the dashboard to prevent invalid quantities. 

### Testing
- No automated tests were run for this change. 
- The code was added and committed to the repository locally. 
- Manual runtime verification was not performed in this environment. 
- Database migration SQL has been added under `sql/accounts_dc_challan_tables.sql` and should be executed in staging before enabling the UI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a319eef188320a431c1f1c8da9a2c)