### PR TITLE
Improve Accounts Challan UI and add Purchase tab

### DIFF
--- a/public/css/professional.css
+++ b/public/css/professional.css
@@ -181,6 +181,71 @@ p {
   color: var(--primary-color);
 }
 
+/* Accounts Challan UI Enhancements */
+.accounts-challan-shell {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+}
+
+.accounts-challan-hero {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 24px;
+  box-shadow: var(--shadow-sm);
+}
+
+.accounts-challan-hero p {
+  margin-bottom: 0;
+}
+
+.accounts-challan-tabs {
+  margin: 20px 0 24px;
+}
+
+.accounts-challan-tabs .nav-link {
+  border: 1px solid var(--border-color);
+  color: var(--text-primary);
+  background: var(--bg-primary);
+  font-weight: 500;
+  padding: 0.5rem 0.9rem;
+}
+
+.accounts-challan-tabs .nav-link.active,
+.accounts-challan-tabs .nav-link:hover {
+  background: var(--primary-color);
+  color: #fff;
+  border-color: var(--primary-color);
+}
+
+.accounts-challan-card {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.accounts-challan-card .card-header {
+  background: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+  font-weight: 600;
+}
+
+.accounts-badge-soft {
+  background: rgba(37, 99, 235, 0.12);
+  color: var(--primary-color);
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.75rem;
+}
+
+.accounts-muted {
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
 /* Stats Grid */
 .stats-grid {
   display: grid;

--- a/views/accountsChallanDashboard.ejs
+++ b/views/accountsChallanDashboard.ejs
@@ -31,25 +31,18 @@
     .search-container {
       margin-top: 20px;
     }
-    .card {
-      margin-top: 20px;
-    }
-    .table-responsive {
-      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-    }
     .load-more-container {
       margin: 15px 0;
-    }
-    .badge-soft {
-      background: rgba(13, 110, 253, 0.12);
-      color: #0d6efd;
-      padding: 0.35rem 0.6rem;
-      border-radius: 999px;
-      font-weight: 600;
     }
     .qty-input {
       width: 110px;
       min-width: 110px;
+    }
+    .search-controls {
+      background: #fff;
+      border-radius: 12px;
+      padding: 16px;
+      border: 1px solid #e2e8f0;
     }
   </style>
 </head>
@@ -98,7 +91,7 @@
     </div>
   </nav>
 
-  <div class="container">
+  <div class="accounts-challan-shell">
     <% if (error && error.length) { %>
       <div class="alert alert-danger mt-3">
         <% error.forEach(msg => { %>
@@ -114,47 +107,81 @@
       </div>
     <% } %>
 
-    <header class="d-flex justify-content-between align-items-center mt-3 flex-wrap gap-3">
-      <div>
-        <h2 class="mb-1">
-          <i class="fas fa-tachometer-alt"></i> Accounts DC Challan
-        </h2>
-        <div class="text-muted">Select lots with remaining pieces, enter quantities, and generate challans.</div>
-      </div>
-      <div class="action-btns">
-        <button id="selectAllBtn" class="btn btn-outline-primary">
-          <i class="fas fa-check-double"></i> Select All
-        </button>
-        <button id="generateChallanBtn" class="btn btn-primary" disabled>
-          <i class="fas fa-file-invoice"></i> Generate Challan
-        </button>
-      </div>
-    </header>
-
-    <div class="row search-container align-items-center">
-      <div class="col-md-6 mt-3">
-        <input
-          type="text"
-          id="searchInput"
-          class="form-control"
-          placeholder="Search by SKU, Lot No, or Cutting Remark"
-          value="<%= search %>"
-        />
-      </div>
-      <div class="col-md-3 mt-3">
-        <button class="btn btn-outline-secondary" id="searchBtn">
-          <i class="fas fa-search"></i> Search
-        </button>
-      </div>
-      <div class="col-md-3 mt-3 text-md-right">
-        <span class="badge-soft">Only lots with remaining pieces are shown</span>
+    <div class="accounts-challan-hero">
+      <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
+        <div>
+          <h2 class="mb-1">
+            <i class="fas fa-tachometer-alt"></i> Accounts DC Challan
+          </h2>
+          <div class="accounts-muted">Select lots with remaining pieces, enter quantities, and generate challans.</div>
+        </div>
+        <div class="action-btns">
+          <button id="selectAllBtn" class="btn btn-outline-primary">
+            <i class="fas fa-check-double"></i> Select All
+          </button>
+          <button id="generateChallanBtn" class="btn btn-primary" disabled>
+            <i class="fas fa-file-invoice"></i> Generate Challan
+          </button>
+        </div>
       </div>
     </div>
 
-    <div class="card">
+    <ul class="nav nav-pills gap-2 accounts-challan-tabs">
+      <li class="nav-item">
+        <a class="nav-link active" href="/accounts-challan">
+          <i class="fas fa-tachometer-alt"></i> Dashboard
+        </a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/accounts-challan/list">
+          <i class="fas fa-list"></i> Challan List
+        </a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/accounts-challan/gst">
+          <i class="fas fa-receipt"></i> GST Master
+        </a>
+      </li>
+      <li class="nav-item">
+        <a class="nav-link" href="/purchase">
+          <i class="fas fa-cart-shopping"></i> Purchase
+        </a>
+      </li>
+    </ul>
+
+    <div class="search-controls">
+      <div class="row align-items-center g-3">
+        <div class="col-md-6">
+          <label class="form-label fw-semibold mb-1">Search lots</label>
+          <input
+            type="text"
+            id="searchInput"
+            class="form-control"
+            placeholder="Search by SKU, Lot No, or Cutting Remark"
+            value="<%= search %>"
+          />
+        </div>
+        <div class="col-md-3">
+          <label class="form-label fw-semibold mb-1 d-block">&nbsp;</label>
+          <button class="btn btn-outline-secondary w-100" id="searchBtn">
+            <i class="fas fa-search"></i> Search
+          </button>
+        </div>
+        <div class="col-md-3 text-md-right">
+          <label class="form-label fw-semibold mb-1 d-block">&nbsp;</label>
+          <span class="accounts-badge-soft">Only lots with remaining pieces are shown</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="accounts-challan-card mt-3">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Lots awaiting challan</span>
+        <span class="accounts-muted">Pick lots and set challan pieces.</span>
+      </div>
       <div class="card-body p-0">
         <div class="table-responsive">
-          <table class="table table-striped table-bordered mb-0" id="assignmentsTable">
+          <table class="table table-striped table-hover mb-0" id="assignmentsTable">
             <thead class="thead-light">
               <tr>
                 <th style="width: 40px;"><input type="checkbox" id="selectAllCheckbox"></th>

--- a/views/accountsChallanGeneration.ejs
+++ b/views/accountsChallanGeneration.ejs
@@ -13,12 +13,6 @@
     body {
       background-color: #f6f8fb;
     }
-    .page-header {
-      margin: 20px 0;
-    }
-    .card {
-      box-shadow: 0 2px 6px rgba(0,0,0,0.08);
-    }
     .table-responsive {
       border-radius: 8px;
       overflow: hidden;
@@ -40,7 +34,7 @@
     </div>
   </nav>
 
-  <div class="container">
+  <div class="accounts-challan-shell">
     <% if (error && error.length) { %>
       <div class="alert alert-danger mt-3">
         <% error.forEach(msg => { %>
@@ -56,17 +50,31 @@
       </div>
     <% } %>
 
-    <div class="page-header">
-      <h2 class="mb-1">Finalize DC Challan</h2>
-      <p class="text-muted">Review selected lots, choose GST parties, and generate the challan.</p>
+    <div class="accounts-challan-hero">
+      <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
+        <div>
+          <h2 class="mb-1">Finalize DC Challan</h2>
+          <div class="accounts-muted">Review selected lots, choose GST parties, and generate the challan.</div>
+        </div>
+        <a href="/accounts-challan" class="btn btn-outline-primary">
+          <i class="bi bi-arrow-left"></i> Back to Dashboard
+        </a>
+      </div>
     </div>
+
+    <ul class="nav nav-pills gap-2 accounts-challan-tabs">
+      <li class="nav-item"><a class="nav-link active" href="/accounts-challan">Dashboard</a></li>
+      <li class="nav-item"><a class="nav-link" href="/accounts-challan/list">Challan List</a></li>
+      <li class="nav-item"><a class="nav-link" href="/accounts-challan/gst">GST Master</a></li>
+      <li class="nav-item"><a class="nav-link" href="/purchase">Purchase</a></li>
+    </ul>
 
     <form action="/accounts-challan/create" method="POST">
       <input type="hidden" name="selectedRows" value='<%- JSON.stringify(selectedRows) %>'>
 
       <div class="row">
         <div class="col-lg-4">
-          <div class="card mb-3">
+          <div class="accounts-challan-card mb-3">
             <div class="card-body">
               <h5 class="card-title">Challan Details</h5>
               <div class="form-group">
@@ -111,9 +119,12 @@
         </div>
 
         <div class="col-lg-8">
-          <div class="card mb-3">
+          <div class="accounts-challan-card mb-3">
+            <div class="card-header d-flex justify-content-between align-items-center">
+              <span>Selected Lots</span>
+              <span class="accounts-muted">Quantities are locked from the dashboard.</span>
+            </div>
             <div class="card-body">
-              <h5 class="card-title">Selected Lots</h5>
               <div class="table-responsive">
                 <table class="table table-striped">
                   <thead class="thead-light">

--- a/views/accountsChallanGst.ejs
+++ b/views/accountsChallanGst.ejs
@@ -13,10 +13,6 @@
     body {
       background-color: #f8f9fa;
     }
-    .card {
-      margin-top: 20px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.08);
-    }
     .badge-type {
       font-size: 0.75rem;
       font-weight: 600;
@@ -48,7 +44,7 @@
     </div>
   </nav>
 
-  <div class="container">
+  <div class="accounts-challan-shell">
     <% if (error && error.length) { %>
       <div class="alert alert-danger mt-3">
         <% error.forEach(msg => { %>
@@ -64,9 +60,28 @@
       </div>
     <% } %>
 
+    <div class="accounts-challan-hero">
+      <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
+        <div>
+          <h2 class="mb-1">GST Master</h2>
+          <div class="accounts-muted">Manage sender and consignee GST profiles used in challans.</div>
+        </div>
+        <a href="/accounts-challan" class="btn btn-outline-primary">
+          <i class="bi bi-arrow-left"></i> Back to Dashboard
+        </a>
+      </div>
+    </div>
+
+    <ul class="nav nav-pills gap-2 accounts-challan-tabs">
+      <li class="nav-item"><a class="nav-link" href="/accounts-challan">Dashboard</a></li>
+      <li class="nav-item"><a class="nav-link" href="/accounts-challan/list">Challan List</a></li>
+      <li class="nav-item"><a class="nav-link active" href="/accounts-challan/gst">GST Master</a></li>
+      <li class="nav-item"><a class="nav-link" href="/purchase">Purchase</a></li>
+    </ul>
+
     <div class="row">
       <div class="col-lg-4">
-        <div class="card">
+        <div class="accounts-challan-card mb-3">
           <div class="card-body">
             <h5 class="card-title">Add GST Party</h5>
             <form action="/accounts-challan/gst" method="POST">
@@ -116,9 +131,12 @@
       </div>
 
       <div class="col-lg-8">
-        <div class="card">
+        <div class="accounts-challan-card">
+          <div class="card-header d-flex justify-content-between align-items-center">
+            <span>GST Party List</span>
+            <span class="accounts-muted">Edit details to keep challan data current.</span>
+          </div>
           <div class="card-body">
-            <h5 class="card-title">GST Party List</h5>
             <div class="table-responsive">
               <table class="table table-striped">
                 <thead>

--- a/views/accountsChallanList.ejs
+++ b/views/accountsChallanList.ejs
@@ -13,8 +13,11 @@
     body {
       background-color: #f8f9fa;
     }
-    .card {
-      margin-top: 20px;
+    .page-actions {
+      background: #fff;
+      border-radius: 12px;
+      padding: 16px;
+      border: 1px solid #e2e8f0;
     }
   </style>
 </head>
@@ -33,7 +36,7 @@
     </div>
   </nav>
 
-  <div class="container">
+  <div class="accounts-challan-shell">
     <% if (error && error.length) { %>
       <div class="alert alert-danger mt-3">
         <% error.forEach(msg => { %>
@@ -49,18 +52,45 @@
       </div>
     <% } %>
 
-    <div class="d-flex justify-content-between align-items-center mt-3 flex-wrap">
-      <h2 class="mb-0">DC Challan List</h2>
-      <form method="GET" action="/accounts-challan/list" class="form-inline my-3">
-        <input type="text" class="form-control mr-2" name="search" placeholder="Challan no or lot" value="<%= search %>">
-        <button class="btn btn-outline-primary" type="submit">Search</button>
+    <div class="accounts-challan-hero">
+      <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
+        <div>
+          <h2 class="mb-1">DC Challan List</h2>
+          <div class="accounts-muted">Track every challan and open detailed views.</div>
+        </div>
+        <a href="/accounts-challan" class="btn btn-outline-primary">
+          <i class="bi bi-arrow-left"></i> Back to Dashboard
+        </a>
+      </div>
+    </div>
+
+    <ul class="nav nav-pills gap-2 accounts-challan-tabs">
+      <li class="nav-item"><a class="nav-link" href="/accounts-challan">Dashboard</a></li>
+      <li class="nav-item"><a class="nav-link active" href="/accounts-challan/list">Challan List</a></li>
+      <li class="nav-item"><a class="nav-link" href="/accounts-challan/gst">GST Master</a></li>
+      <li class="nav-item"><a class="nav-link" href="/purchase">Purchase</a></li>
+    </ul>
+
+    <div class="page-actions mb-3">
+      <form method="GET" action="/accounts-challan/list" class="row g-2 align-items-end">
+        <div class="col-md-6">
+          <label class="form-label fw-semibold">Search challans</label>
+          <input type="text" class="form-control" name="search" placeholder="Challan no or lot" value="<%= search %>">
+        </div>
+        <div class="col-md-3">
+          <button class="btn btn-outline-primary w-100" type="submit">Search</button>
+        </div>
       </form>
     </div>
 
-    <div class="card">
+    <div class="accounts-challan-card">
+      <div class="card-header d-flex justify-content-between align-items-center">
+        <span>Recent challans</span>
+        <span class="accounts-muted">Click view to open the challan PDF.</span>
+      </div>
       <div class="card-body p-0">
         <div class="table-responsive">
-          <table class="table table-striped mb-0">
+          <table class="table table-striped table-hover mb-0">
             <thead class="thead-light">
               <tr>
                 <th>#</th>


### PR DESCRIPTION
### Motivation
- Improve the visual layout and usability of the Accounts DC Challan screens which were cluttered and hard to scan.
- Provide consistent hero, tabbed navigation and card styling across the challan-related pages to match the app theme.
- Surface a quick link to the `Purchase` area from accounts challan screens for faster navigation. 

### Description
- Added Accounts Challan styles in `public/css/professional.css` (`.accounts-challan-shell`, `.accounts-challan-hero`, `.accounts-challan-tabs`, `.accounts-challan-card`, etc.).
- Refactored the dashboard view `views/accountsChallanDashboard.ejs` to use a hero, tabs, compact search controls and a styled card/table layout. 
- Updated `views/accountsChallanList.ejs`, `views/accountsChallanGst.ejs`, and `views/accountsChallanGeneration.ejs` to use the shared hero/tabs/cards layout and to include a `Purchase` tab linking to `/purchase`.
- Kept existing server-side routes and JavaScript logic intact while improving markup and presentation (UI-only changes). 

### Testing
- Attempted to start the app with `node app.js`, but the process failed with `MODULE_NOT_FOUND: secure-env`, so the server could not be started and the UI could not be validated end-to-end.
- No automated UI/unit tests were run for these template/CSS changes in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a377c59e48320bf3cac092f34f20d)