### PR TITLE
Refresh purchase and accounts challan UI

### DIFF
--- a/public/css/professional.css
+++ b/public/css/professional.css
@@ -23,6 +23,7 @@
   --shadow-sm: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
   --shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
   --shadow-lg: 0 10px 15px -3px rgba(0, 0, 0, 0.1);
+  --shadow-xl: 0 18px 30px -12px rgba(15, 23, 42, 0.2);
 
   --radius-sm: 6px;
   --radius-md: 8px;
@@ -33,6 +34,9 @@
   --spacing-md: 16px;
   --spacing-lg: 24px;
   --spacing-xl: 32px;
+
+  --accent-gradient: linear-gradient(135deg, #1d4ed8 0%, #0ea5e9 100%);
+  --accent-soft: rgba(37, 99, 235, 0.12);
 }
 
 /* Dark Mode Variables */
@@ -61,7 +65,7 @@
 
 body {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-  background: var(--bg-secondary);
+  background: #f4f6fb;
   color: var(--text-primary);
   line-height: 1.6;
   -webkit-font-smoothing: antialiased;
@@ -95,6 +99,38 @@ p {
   box-shadow: var(--shadow-sm);
 }
 
+.app-navbar {
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-color);
+  box-shadow: var(--shadow-sm);
+}
+
+.app-navbar .navbar-brand {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.app-navbar .navbar-brand:hover {
+  color: var(--primary-color);
+}
+
+.app-navbar .nav-link {
+  color: var(--text-secondary);
+  font-weight: 500;
+  margin-left: 0.5rem;
+}
+
+.app-navbar .nav-link.active,
+.app-navbar .nav-link:hover {
+  color: var(--primary-color);
+}
+
+.app-shell {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 24px 16px 60px;
+}
+
 .nav-brand {
   font-size: 1.25rem;
   font-weight: 600;
@@ -114,6 +150,17 @@ p {
   padding: var(--spacing-lg);
   box-shadow: var(--shadow-sm);
   margin-bottom: var(--spacing-lg);
+}
+
+.surface-card {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.surface-card + .surface-card {
+  margin-top: var(--spacing-lg);
 }
 
 .card-header-custom {
@@ -246,6 +293,90 @@ p {
   font-size: 0.85rem;
 }
 
+.page-hero {
+  background: var(--accent-gradient);
+  color: #fff;
+  border-radius: var(--radius-lg);
+  padding: 28px;
+  position: relative;
+  overflow: hidden;
+  box-shadow: var(--shadow-md);
+  margin-bottom: 24px;
+}
+
+.page-hero::after {
+  content: '';
+  position: absolute;
+  top: -40%;
+  right: -15%;
+  width: 260px;
+  height: 260px;
+  background: rgba(255, 255, 255, 0.16);
+  border-radius: 999px;
+}
+
+.page-hero h2,
+.page-hero h1 {
+  color: #fff;
+}
+
+.page-hero p {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.page-hero .hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.page-hero .hero-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: rgba(255, 255, 255, 0.18);
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+}
+
+.action-btns {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.qty-input {
+  width: 110px;
+  min-width: 110px;
+}
+
+.app-tabs {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 999px;
+  padding: 0.35rem;
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.app-tabs .nav-link {
+  border-radius: 999px;
+  padding: 0.45rem 0.9rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  border: 1px solid transparent;
+}
+
+.app-tabs .nav-link.active,
+.app-tabs .nav-link:hover {
+  background: var(--accent-soft);
+  color: var(--primary-color);
+  border-color: rgba(37, 99, 235, 0.2);
+}
+
 /* Stats Grid */
 .stats-grid {
   display: grid;
@@ -346,6 +477,26 @@ p {
   border-color: var(--secondary-color);
 }
 
+.btn-soft {
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.btn-soft:hover {
+  background: rgba(255, 255, 255, 0.25);
+  color: #fff;
+}
+
+.icon-btn {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.icon-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
 /* Forms */
 .form-label {
   font-size: 0.8125rem;
@@ -370,6 +521,25 @@ p {
   outline: none;
   border-color: var(--primary-color);
   box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
+}
+
+.form-panel {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.form-panel .form-label {
+  font-weight: 600;
+}
+
+.form-section {
+  background: var(--bg-secondary);
+  border: 1px dashed var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 1.25rem;
 }
 
 /* Tables */
@@ -404,6 +574,11 @@ p {
 .table-responsive {
   overflow-x: auto;
   -webkit-overflow-scrolling: touch;
+}
+
+.table-card .card-header {
+  background: var(--bg-primary);
+  border-bottom: 1px solid var(--border-color);
 }
 
 /* Badges */
@@ -468,15 +643,32 @@ p {
   margin-bottom: var(--spacing-lg);
 }
 
+.page-header.surface-card {
+  position: relative;
+  overflow: hidden;
+}
+
+.page-header.surface-card::before {
+  content: '';
+  position: absolute;
+  top: -40%;
+  right: -10%;
+  width: 240px;
+  height: 240px;
+  background: var(--accent-gradient);
+  opacity: 0.08;
+  border-radius: 999px;
+}
+
 .page-title {
-  font-size: 1.75rem;
-  font-weight: 600;
+  font-size: 1.85rem;
+  font-weight: 700;
   color: var(--text-primary);
   margin-bottom: 0.25rem;
 }
 
 .page-subtitle {
-  font-size: 0.875rem;
+  font-size: 0.95rem;
   color: var(--text-secondary);
 }
 
@@ -484,6 +676,98 @@ p {
   max-width: 1400px;
   margin: 0 auto;
   padding: var(--spacing-lg);
+}
+
+.section-card {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+  overflow: hidden;
+}
+
+.section-card:hover {
+  box-shadow: var(--shadow-md);
+}
+
+.section-header {
+  background: var(--accent-gradient);
+  color: #fff;
+  padding: 1.5rem 2rem;
+}
+
+.section-header h4 {
+  color: #fff;
+  font-weight: 600;
+  margin-bottom: 0.25rem;
+}
+
+.section-header small {
+  color: rgba(255, 255, 255, 0.8);
+}
+
+.section-body {
+  padding: 1.75rem;
+}
+
+.empty-state {
+  padding: 3.5rem 2rem;
+  text-align: center;
+}
+
+.empty-state i {
+  font-size: 3rem;
+  color: #cbd5e1;
+  margin-bottom: 1rem;
+}
+
+.empty-state p {
+  color: var(--text-secondary);
+  font-size: 1rem;
+}
+
+.page-actions {
+  background: var(--bg-primary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.search-controls {
+  background: var(--bg-primary);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-sm);
+}
+
+.stat-badge {
+  background: rgba(255, 255, 255, 0.2);
+  padding: 0.45rem 0.85rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.badge-type {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+}
+
+.badge-sender {
+  background: rgba(16, 185, 129, 0.16);
+  color: #047857;
+}
+
+.badge-consignee {
+  background: rgba(59, 130, 246, 0.16);
+  color: #1d4ed8;
 }
 
 /* Panels */

--- a/views/accountsChallanDashboard.ejs
+++ b/views/accountsChallanDashboard.ejs
@@ -8,50 +8,9 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/professional.css">
-  <style>
-    body {
-      background-color: #f8f9fa;
-    }
-    .action-btns {
-      display: flex;
-      gap: 10px;
-      flex-wrap: wrap;
-    }
-    .qty-input {
-      width: 110px;
-      min-width: 110px;
-    }
-    .search-controls {
-      background: #fff;
-      border-radius: 12px;
-      padding: 20px;
-      border: 1px solid #e2e8f0;
-      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-    }
-    .hero-section {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      color: white;
-      padding: 2rem;
-      border-radius: 12px;
-      margin-bottom: 1.5rem;
-    }
-    .stat-badge {
-      background: rgba(255,255,255,0.2);
-      padding: 0.5rem 1rem;
-      border-radius: 8px;
-      display: inline-block;
-    }
-    .icon-btn {
-      transition: all 0.2s;
-    }
-    .icon-btn:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 4px 8px rgba(0,0,0,0.15);
-    }
-  </style>
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <nav class="navbar navbar-expand-lg navbar-light app-navbar">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">
         <i class="bi bi-file-earmark-text me-2"></i>Accounts DC Challan
@@ -82,7 +41,7 @@
             </a>
           </li>
           <li class="nav-item">
-            <a href="/logout" class="btn btn-outline-light btn-sm ms-2">
+            <a href="/logout" class="btn btn-outline-secondary btn-sm ms-2">
               <i class="bi bi-box-arrow-right"></i> Logout
             </a>
           </li>
@@ -91,7 +50,7 @@
     </div>
   </nav>
 
-  <div class="container my-4">
+  <div class="app-shell">
     <% if (error && error.length) { %>
       <div class="alert alert-danger alert-dismissible fade show" role="alert">
         <i class="bi bi-exclamation-triangle me-2"></i>
@@ -112,7 +71,7 @@
     <% } %>
 
     <!-- Tab Navigation -->
-    <ul class="nav nav-pills mb-4 gap-2">
+    <ul class="nav nav-pills app-tabs mb-4">
       <li class="nav-item">
         <a class="nav-link" href="/purchase">
           <i class="bi bi-cart-fill"></i> Purchase
@@ -136,19 +95,19 @@
     </ul>
 
     <!-- Hero Section -->
-    <div class="hero-section">
+    <div class="page-hero">
       <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
         <div>
           <h2 class="mb-2">
             <i class="bi bi-file-earmark-text me-2"></i>DC Challan Dashboard
           </h2>
           <p class="mb-3 opacity-90">Select lots with remaining pieces, enter quantities, and generate delivery challans.</p>
-          <div class="stat-badge">
+          <div class="hero-note">
             <i class="bi bi-info-circle me-2"></i>Only lots with remaining pieces are shown
           </div>
         </div>
-        <div class="action-btns">
-          <button id="selectAllBtn" class="btn btn-light icon-btn" data-bs-toggle="tooltip" title="Select or deselect all visible lots">
+        <div class="hero-actions">
+          <button id="selectAllBtn" class="btn btn-soft icon-btn" data-bs-toggle="tooltip" title="Select or deselect all visible lots">
             <i class="bi bi-check-all me-1"></i> Select All
           </button>
           <button id="generateChallanBtn" class="btn btn-success icon-btn" disabled data-bs-toggle="tooltip" title="Generate challan for selected lots">
@@ -184,8 +143,8 @@
     </div>
 
     <!-- Lots Table Card -->
-    <div class="card border-0 shadow-sm">
-      <div class="card-header bg-white border-bottom">
+    <div class="surface-card table-card">
+      <div class="card-header">
         <div class="d-flex justify-content-between align-items-center">
           <h5 class="mb-0">
             <i class="bi bi-box-seam me-2"></i>Lots Awaiting Challan

--- a/views/accountsChallanGeneration.ejs
+++ b/views/accountsChallanGeneration.ejs
@@ -8,35 +8,9 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/professional.css">
-  <style>
-    body {
-      background-color: #f8f9fa;
-    }
-    .hero-section {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      color: white;
-      padding: 2rem;
-      border-radius: 12px;
-      margin-bottom: 1.5rem;
-    }
-    .form-card {
-      background: #fff;
-      border-radius: 12px;
-      padding: 1.5rem;
-      border: 1px solid #e2e8f0;
-      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-    }
-    .icon-btn {
-      transition: all 0.2s;
-    }
-    .icon-btn:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 4px 8px rgba(0,0,0,0.15);
-    }
-  </style>
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <nav class="navbar navbar-expand-lg navbar-light app-navbar">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">
         <i class="bi bi-file-earmark-text me-2"></i>Accounts DC Challan
@@ -67,7 +41,7 @@
             </a>
           </li>
           <li class="nav-item">
-            <a href="/logout" class="btn btn-outline-light btn-sm ms-2">
+            <a href="/logout" class="btn btn-outline-secondary btn-sm ms-2">
               <i class="bi bi-box-arrow-right"></i> Logout
             </a>
           </li>
@@ -76,7 +50,7 @@
     </div>
   </nav>
 
-  <div class="container my-4">
+  <div class="app-shell">
     <% if (error && error.length) { %>
       <div class="alert alert-danger alert-dismissible fade show" role="alert">
         <i class="bi bi-exclamation-triangle me-2"></i>
@@ -97,7 +71,7 @@
     <% } %>
 
     <!-- Tab Navigation -->
-    <ul class="nav nav-pills mb-4 gap-2">
+    <ul class="nav nav-pills app-tabs mb-4">
       <li class="nav-item">
         <a class="nav-link" href="/purchase">
           <i class="bi bi-cart-fill"></i> Purchase
@@ -121,7 +95,7 @@
     </ul>
 
     <!-- Hero Section -->
-    <div class="hero-section">
+    <div class="page-hero">
       <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
         <div>
           <h2 class="mb-2">
@@ -129,7 +103,7 @@
           </h2>
           <p class="mb-0 opacity-90">Review selected lots, choose GST parties, and generate the delivery challan.</p>
         </div>
-        <a href="/accounts-challan" class="btn btn-light icon-btn" data-bs-toggle="tooltip" title="Back to Dashboard">
+        <a href="/accounts-challan" class="btn btn-soft icon-btn" data-bs-toggle="tooltip" title="Back to Dashboard">
           <i class="bi bi-arrow-left me-1"></i> Back to Dashboard
         </a>
       </div>
@@ -140,7 +114,7 @@
 
       <div class="row">
         <div class="col-lg-4">
-          <div class="form-card mb-3">
+          <div class="form-panel mb-3">
             <h5 class="mb-4">
               <i class="bi bi-file-earmark-text me-2"></i>Challan Details
             </h5>
@@ -201,8 +175,8 @@
         </div>
 
         <div class="col-lg-8">
-          <div class="card border-0 shadow-sm mb-3">
-            <div class="card-header bg-white border-bottom">
+          <div class="surface-card table-card mb-3">
+            <div class="card-header">
               <div class="d-flex justify-content-between align-items-center">
                 <h5 class="mb-0">
                   <i class="bi bi-box-seam me-2"></i>Selected Lots

--- a/views/accountsChallanGst.ejs
+++ b/views/accountsChallanGst.ejs
@@ -8,49 +8,9 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/professional.css">
-  <style>
-    body {
-      background-color: #f8f9fa;
-    }
-    .badge-type {
-      font-size: 0.75rem;
-      font-weight: 600;
-      padding: 0.35rem 0.6rem;
-      border-radius: 999px;
-    }
-    .badge-sender {
-      background: rgba(25,135,84,0.12);
-      color: #198754;
-    }
-    .badge-consignee {
-      background: rgba(13,110,253,0.12);
-      color: #0d6efd;
-    }
-    .hero-section {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      color: white;
-      padding: 2rem;
-      border-radius: 12px;
-      margin-bottom: 1.5rem;
-    }
-    .form-card {
-      background: #fff;
-      border-radius: 12px;
-      padding: 1.5rem;
-      border: 1px solid #e2e8f0;
-      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-    }
-    .icon-btn {
-      transition: all 0.2s;
-    }
-    .icon-btn:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 4px 8px rgba(0,0,0,0.15);
-    }
-  </style>
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <nav class="navbar navbar-expand-lg navbar-light app-navbar">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">
         <i class="bi bi-file-earmark-text me-2"></i>Accounts DC Challan
@@ -81,7 +41,7 @@
             </a>
           </li>
           <li class="nav-item">
-            <a href="/logout" class="btn btn-outline-light btn-sm ms-2">
+            <a href="/logout" class="btn btn-outline-secondary btn-sm ms-2">
               <i class="bi bi-box-arrow-right"></i> Logout
             </a>
           </li>
@@ -90,7 +50,7 @@
     </div>
   </nav>
 
-  <div class="container my-4">
+  <div class="app-shell">
     <% if (error && error.length) { %>
       <div class="alert alert-danger alert-dismissible fade show" role="alert">
         <i class="bi bi-exclamation-triangle me-2"></i>
@@ -111,7 +71,7 @@
     <% } %>
 
     <!-- Tab Navigation -->
-    <ul class="nav nav-pills mb-4 gap-2">
+    <ul class="nav nav-pills app-tabs mb-4">
       <li class="nav-item">
         <a class="nav-link" href="/purchase">
           <i class="bi bi-cart-fill"></i> Purchase
@@ -135,7 +95,7 @@
     </ul>
 
     <!-- Hero Section -->
-    <div class="hero-section">
+    <div class="page-hero">
       <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
         <div>
           <h2 class="mb-2">
@@ -143,7 +103,7 @@
           </h2>
           <p class="mb-0 opacity-90">Manage sender and consignee GST profiles used in delivery challans.</p>
         </div>
-        <a href="/accounts-challan" class="btn btn-light icon-btn" data-bs-toggle="tooltip" title="Back to Dashboard">
+        <a href="/accounts-challan" class="btn btn-soft icon-btn" data-bs-toggle="tooltip" title="Back to Dashboard">
           <i class="bi bi-arrow-left me-1"></i> Back to Dashboard
         </a>
       </div>
@@ -151,7 +111,7 @@
 
     <div class="row">
       <div class="col-lg-4">
-        <div class="form-card mb-3">
+        <div class="form-panel mb-3">
           <h5 class="mb-4">
             <i class="bi bi-plus-circle me-2"></i>Add GST Party
           </h5>

--- a/views/accountsChallanList.ejs
+++ b/views/accountsChallanList.ejs
@@ -8,35 +8,9 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/professional.css">
-  <style>
-    body {
-      background-color: #f8f9fa;
-    }
-    .page-actions {
-      background: #fff;
-      border-radius: 12px;
-      padding: 20px;
-      border: 1px solid #e2e8f0;
-      box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-    }
-    .hero-section {
-      background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      color: white;
-      padding: 2rem;
-      border-radius: 12px;
-      margin-bottom: 1.5rem;
-    }
-    .icon-btn {
-      transition: all 0.2s;
-    }
-    .icon-btn:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 4px 8px rgba(0,0,0,0.15);
-    }
-  </style>
 </head>
 <body>
-  <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+  <nav class="navbar navbar-expand-lg navbar-light app-navbar">
     <div class="container-fluid">
       <a class="navbar-brand" href="#">
         <i class="bi bi-file-earmark-text me-2"></i>Accounts DC Challan
@@ -67,7 +41,7 @@
             </a>
           </li>
           <li class="nav-item">
-            <a href="/logout" class="btn btn-outline-light btn-sm ms-2">
+            <a href="/logout" class="btn btn-outline-secondary btn-sm ms-2">
               <i class="bi bi-box-arrow-right"></i> Logout
             </a>
           </li>
@@ -76,7 +50,7 @@
     </div>
   </nav>
 
-  <div class="container my-4">
+  <div class="app-shell">
     <% if (error && error.length) { %>
       <div class="alert alert-danger alert-dismissible fade show" role="alert">
         <i class="bi bi-exclamation-triangle me-2"></i>
@@ -97,7 +71,7 @@
     <% } %>
 
     <!-- Tab Navigation -->
-    <ul class="nav nav-pills mb-4 gap-2">
+    <ul class="nav nav-pills app-tabs mb-4">
       <li class="nav-item">
         <a class="nav-link" href="/purchase">
           <i class="bi bi-cart-fill"></i> Purchase
@@ -121,7 +95,7 @@
     </ul>
 
     <!-- Hero Section -->
-    <div class="hero-section">
+    <div class="page-hero">
       <div class="d-flex justify-content-between align-items-start flex-wrap gap-3">
         <div>
           <h2 class="mb-2">
@@ -129,7 +103,7 @@
           </h2>
           <p class="mb-0 opacity-90">Track every challan and open detailed views.</p>
         </div>
-        <a href="/accounts-challan" class="btn btn-light icon-btn" data-bs-toggle="tooltip" title="Back to Dashboard">
+        <a href="/accounts-challan" class="btn btn-soft icon-btn" data-bs-toggle="tooltip" title="Back to Dashboard">
           <i class="bi bi-arrow-left me-1"></i> Back to Dashboard
         </a>
       </div>
@@ -161,8 +135,8 @@
     </div>
 
     <!-- Challans Table -->
-    <div class="card border-0 shadow-sm">
-      <div class="card-header bg-white border-bottom">
+    <div class="surface-card table-card">
+      <div class="card-header">
         <div class="d-flex justify-content-between align-items-center">
           <h5 class="mb-0">
             <i class="bi bi-file-earmark-text me-2"></i>Recent Challans

--- a/views/purchaseDashboard.ejs
+++ b/views/purchaseDashboard.ejs
@@ -9,279 +9,9 @@
   <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/professional.css">
-  <style>
-    :root {
-      --primary-gradient: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-      --success-gradient: linear-gradient(135deg, #11998e 0%, #38ef7d 100%);
-      --shadow-sm: 0 2px 4px rgba(0,0,0,0.04);
-      --shadow-md: 0 4px 12px rgba(0,0,0,0.08);
-      --shadow-lg: 0 8px 24px rgba(0,0,0,0.12);
-      --shadow-xl: 0 12px 40px rgba(0,0,0,0.15);
-      --radius-sm: 8px;
-      --radius-md: 12px;
-      --radius-lg: 16px;
-    }
-
-    body {
-      background: linear-gradient(to bottom, #f8f9fa 0%, #e9ecef 100%);
-      min-height: 100vh;
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    }
-
-    .navbar {
-      box-shadow: var(--shadow-md);
-      border-bottom: 1px solid rgba(255,255,255,0.1);
-    }
-
-    .page-header {
-      background: white;
-      padding: 2rem;
-      border-radius: var(--radius-lg);
-      box-shadow: var(--shadow-md);
-      margin-bottom: 2rem;
-      position: relative;
-      overflow: hidden;
-    }
-
-    .page-header::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      right: 0;
-      width: 300px;
-      height: 300px;
-      background: var(--primary-gradient);
-      opacity: 0.05;
-      border-radius: 50%;
-      transform: translate(30%, -30%);
-    }
-
-    .page-title {
-      font-size: 2rem;
-      font-weight: 700;
-      color: #1e293b;
-      margin-bottom: 0.5rem;
-    }
-
-    .page-subtitle {
-      color: #64748b;
-      font-size: 1rem;
-    }
-
-    .nav-pills .nav-link {
-      border-radius: var(--radius-sm);
-      padding: 0.75rem 1.5rem;
-      font-weight: 500;
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-      border: 2px solid transparent;
-    }
-
-    .nav-pills .nav-link:hover {
-      background: rgba(102, 126, 234, 0.1);
-      transform: translateY(-2px);
-    }
-
-    .nav-pills .nav-link.active {
-      background: var(--primary-gradient);
-      box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
-    }
-
-    .section-card {
-      background: white;
-      border-radius: var(--radius-lg);
-      box-shadow: var(--shadow-md);
-      margin-bottom: 2.5rem;
-      overflow: hidden;
-      transition: all 0.3s ease;
-    }
-
-    .section-card:hover {
-      box-shadow: var(--shadow-lg);
-      transform: translateY(-4px);
-    }
-
-    .section-header {
-      background: var(--primary-gradient);
-      color: white;
-      padding: 1.5rem 2rem;
-      border-bottom: 3px solid rgba(255,255,255,0.2);
-    }
-
-    .section-header h4 {
-      font-size: 1.5rem;
-      font-weight: 600;
-      margin-bottom: 0.25rem;
-    }
-
-    .section-header small {
-      opacity: 0.9;
-      font-size: 0.875rem;
-    }
-
-    .section-body {
-      padding: 2rem;
-    }
-
-    .form-section {
-      background: linear-gradient(to bottom, #f8fafc 0%, #f1f5f9 100%);
-      border: 2px dashed #cbd5e1;
-      border-radius: var(--radius-md);
-      padding: 1.5rem;
-      margin-bottom: 2rem;
-    }
-
-    .form-label {
-      font-weight: 600;
-      color: #475569;
-      margin-bottom: 0.5rem;
-      font-size: 0.875rem;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-    }
-
-    .form-control, .form-select {
-      border: 2px solid #e2e8f0;
-      border-radius: var(--radius-sm);
-      padding: 0.75rem 1rem;
-      transition: all 0.2s ease;
-      font-size: 0.95rem;
-    }
-
-    .form-control:focus, .form-select:focus {
-      border-color: #667eea;
-      box-shadow: 0 0 0 4px rgba(102, 126, 234, 0.1);
-      transform: translateY(-1px);
-    }
-
-    .btn-primary {
-      background: var(--primary-gradient);
-      border: none;
-      padding: 0.75rem 1.5rem;
-      border-radius: var(--radius-sm);
-      font-weight: 600;
-      box-shadow: 0 4px 12px rgba(102, 126, 234, 0.3);
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    }
-
-    .btn-primary:hover {
-      transform: translateY(-2px);
-      box-shadow: 0 6px 20px rgba(102, 126, 234, 0.4);
-    }
-
-    .btn-outline-secondary {
-      border: 2px solid #e2e8f0;
-      color: #475569;
-      font-weight: 600;
-      transition: all 0.2s ease;
-    }
-
-    .btn-outline-secondary:hover {
-      background: #f1f5f9;
-      border-color: #cbd5e1;
-      color: #1e293b;
-      transform: translateY(-1px);
-    }
-
-    .table {
-      margin-bottom: 0;
-    }
-
-    .table thead th {
-      background: #f8fafc;
-      border-bottom: 2px solid #e2e8f0;
-      color: #475569;
-      font-weight: 700;
-      font-size: 0.875rem;
-      text-transform: uppercase;
-      letter-spacing: 0.5px;
-      padding: 1rem;
-    }
-
-    .table tbody tr {
-      transition: all 0.2s ease;
-      border-bottom: 1px solid #f1f5f9;
-    }
-
-    .table tbody tr:hover {
-      background: #f8fafc;
-      box-shadow: inset 4px 0 0 #667eea;
-    }
-
-    .table tbody td {
-      padding: 1rem;
-      vertical-align: middle;
-    }
-
-    .table tbody td .form-control-sm {
-      border: 1px solid #e2e8f0;
-      background: white;
-    }
-
-    .table tbody td .form-control-sm:focus {
-      border-color: #667eea;
-      box-shadow: 0 0 0 3px rgba(102, 126, 234, 0.1);
-    }
-
-    .empty-state {
-      padding: 4rem 2rem;
-      text-align: center;
-    }
-
-    .empty-state i {
-      font-size: 4rem;
-      color: #cbd5e1;
-      margin-bottom: 1rem;
-      opacity: 0.5;
-    }
-
-    .empty-state p {
-      color: #94a3b8;
-      font-size: 1.125rem;
-    }
-
-    .alert-info {
-      background: linear-gradient(135deg, #3b82f6 0%, #2563eb 100%);
-      border: none;
-      color: white;
-      border-radius: var(--radius-md);
-      box-shadow: var(--shadow-sm);
-    }
-
-    .alert-info .alert-heading {
-      color: white;
-      font-weight: 600;
-    }
-
-    @keyframes fadeInUp {
-      from {
-        opacity: 0;
-        transform: translateY(20px);
-      }
-      to {
-        opacity: 1;
-        transform: translateY(0);
-      }
-    }
-
-    .section-card {
-      animation: fadeInUp 0.5s ease-out;
-    }
-
-    .icon-btn {
-      transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-    }
-
-    .icon-btn:hover {
-      transform: translateY(-2px) scale(1.02);
-    }
-
-    .icon-btn:active {
-      transform: translateY(0) scale(0.98);
-    }
-  </style>
 </head>
 <body>
-<nav class="navbar navbar-expand-lg navbar-dark bg-dark">
+<nav class="navbar navbar-expand-lg navbar-light app-navbar">
   <div class="container-fluid">
     <a class="navbar-brand" href="#">
       <i class="bi bi-cart-fill me-2"></i>Purchase Management
@@ -312,7 +42,7 @@
           </a>
         </li>
         <li class="nav-item">
-          <a href="/logout" class="btn btn-outline-light btn-sm ms-2">
+          <a href="/logout" class="btn btn-outline-secondary btn-sm ms-2">
             <i class="bi bi-box-arrow-right"></i> Logout
           </a>
         </li>
@@ -320,11 +50,11 @@
     </div>
   </div>
 </nav>
-<div class="container my-4">
+<div class="app-shell">
   <%- include('partials/flashMessages') %>
 
   <!-- Page Header -->
-  <div class="page-header">
+  <div class="page-header surface-card p-4 position-relative overflow-hidden">
     <h1 class="page-title">
       <i class="bi bi-cart-fill me-3"></i>Purchase Management
     </h1>
@@ -332,7 +62,7 @@
   </div>
 
   <!-- Tab Navigation -->
-  <ul class="nav nav-pills mb-4 gap-2">
+  <ul class="nav nav-pills app-tabs mb-4">
     <li class="nav-item">
       <a class="nav-link active" href="/purchase">
         <i class="bi bi-cart-fill"></i> Purchase


### PR DESCRIPTION
### Motivation

- Improve and modernize the look-and-feel for the Purchase and Accounts‑Challan areas to a professional, consistent design.  
- Reduce duplicated inline styles and centralize visual tokens in a single theme file.  
- Make the Accounts Challan workflows (dashboard, generation, list, GST) visually consistent with the Purchase dashboard.  
- Provide reusable layout utilities and components for future UI work.

### Description

- Extended `public/css/professional.css` with new variables, gradients, shadows and reusable classes such as `app-navbar`, `app-shell`, `page-hero`, `app-tabs`, `surface-card`, `form-panel`, `table-card`, and `btn-soft`.  
- Replaced per-view inline styling with shared theme classes in `views/accountsChallanDashboard.ejs`, `views/accountsChallanGeneration.ejs`, `views/accountsChallanGst.ejs`, `views/accountsChallanList.ejs`, and `views/purchaseDashboard.ejs`.  
- Unified navigation, tab styles, hero/section appearance, and card/table treatments across modified EJS templates.  
- Cleaned up spacing and utility styles (badges, icon button hover, search/forms panels) to centralize look-and-feel in the global stylesheet.

### Testing

- Attempted to start the app with `node app.js`, which failed due to a missing runtime dependency: `Error: Cannot find module 'secure-env'`.  
- This PR is UI-only and no visual regression or end-to-end tests were executed as part of the rollout.  
- Files changed and committed: `public/css/professional.css`, `views/accountsChallanDashboard.ejs`, `views/accountsChallanGeneration.ejs`, `views/accountsChallanGst.ejs`, `views/accountsChallanList.ejs`, and `views/purchaseDashboard.ejs`.  
- Local commit was created with message `Refresh purchase and accounts challan UI`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a46c4b19483209668dc4188e1a85e)