### PR TITLE
Serve public CSS at /css to fix professional.css 404

### DIFF
--- a/app.js
+++ b/app.js
@@ -51,6 +51,7 @@ app.set('views', path.join(__dirname, 'views'));
 
 // Serve Static Files
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
+app.use('/css', express.static(path.join(__dirname, 'public', 'css')));
 app.use('/public', express.static(path.join(__dirname, 'public')));
 
 // Global Variables for Views


### PR DESCRIPTION
### Motivation
- Views reference `professional.css` via `/css/professional.css` but the server did not expose a `/css` static route, causing 404s.
- The existing static middleware served `/public` and `/uploads` but not the `public/css` folder directly.
- Restoring access to the stylesheet fixes visual regressions across many EJS views that include `professional.css`.

### Description
- Added a static middleware route in `app.js`: `app.use('/css', express.static(path.join(__dirname, 'public', 'css')))` to serve CSS files from `public/css`.
- Retained the existing `app.use('/uploads', ...)` and `app.use('/public', ...)` middleware so other static assets remain unchanged.
- This change makes `public/css/professional.css` available at `/css/professional.css` and addresses the 404 for that asset.

### Testing
- No automated tests were run for this change.
- (No CI or test suite executed as part of this update.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a6176b488832088d165718af3c4da)