### PR TITLE
Add PO Organization workflow for vendor-wise PO generation

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,6 +103,7 @@ const easyecomUiRoutes = require('./routes/easyecomRoutes');
 const featuresRoutes = require('./routes/featuresRoutes');
 const indentRoutes = require('./routes/indentRoutes');
 const poCreatorRoutes = require('./routes/poCreatorRoutes');
+const poOrganizationRoutes = require('./routes/poOrganizationRoutes');
 
 // Use Routes
 app.use('/', authRoutes);
@@ -146,6 +147,7 @@ app.use('/easyecom', easyecomUiRoutes);
 app.use('/', featuresRoutes);
 app.use('/indent', indentRoutes);
 app.use('/po-creator', poCreatorRoutes);
+app.use('/po-organization', poOrganizationRoutes);
 
 // Home Route
 app.get('/', (req, res) => {

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -160,6 +160,10 @@ function isPOCreator(req, res, next) {
   return hasRole('po_creator')(req, res, next);
 }
 
+function isNowIPOOrganization(req, res, next) {
+  return hasRole('nowipoorganization')(req, res, next);
+}
+
 // ---------------------------------------------------------------------------
 // Helper to restrict routes to specific user ids
 function allowUserIds(ids) {
@@ -215,6 +219,7 @@ module.exports = {
     isMohitOperator,
     isOnlyMohitOperator,
     isPOCreator,
+    isNowIPOOrganization,
     allowUserIds,
     allowRoles
 };

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -103,6 +103,9 @@ router.post('/login', async (req, res) => {
       case 'po_creator':
         res.redirect('/po-creator/dashboard');
         break;
+      case 'nowipoorganization':
+        res.redirect('/po-organization/dashboard');
+        break;
       case 'checking':
       case 'quality_assurance':
         res.redirect('/department/dashboard');

--- a/routes/poOrganizationRoutes.js
+++ b/routes/poOrganizationRoutes.js
@@ -1,0 +1,526 @@
+const express = require('express');
+const multer = require('multer');
+const ExcelJS = require('exceljs');
+const { pool } = require('../config/db');
+const { isNowIPOOrganization } = require('../middlewares/auth');
+
+const router = express.Router();
+const upload = multer({ storage: multer.memoryStorage() });
+
+const normalizeHeader = (value) =>
+  value ? value.toString().trim().toLowerCase().replace(/\s+/g, '_') : '';
+
+const buildHeaderIndex = (worksheet) => {
+  const headerRow = worksheet.getRow(1);
+  const index = {};
+  headerRow.eachCell((cell, colNumber) => {
+    const key = normalizeHeader(cell.value);
+    if (key) {
+      index[key] = colNumber;
+    }
+  });
+  return index;
+};
+
+const readCell = (row, colIndex) => {
+  if (!colIndex) {
+    return '';
+  }
+  const cellValue = row.getCell(colIndex).value;
+  if (cellValue === null || typeof cellValue === 'undefined') {
+    return '';
+  }
+  if (typeof cellValue === 'object' && cellValue.text) {
+    return cellValue.text.toString().trim();
+  }
+  return cellValue.toString().trim();
+};
+
+const parseNumber = (value) => {
+  if (value === '' || value === null || typeof value === 'undefined') {
+    return null;
+  }
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? null : parsed;
+};
+
+router.get('/dashboard', isNowIPOOrganization, async (req, res) => {
+  try {
+    const [batches] = await pool.query(
+      `
+      SELECT
+        b.id,
+        b.created_at,
+        u.username AS created_by,
+        COUNT(DISTINCT o.id) AS vendor_count,
+        COALESCE(SUM(i.quantity), 0) AS total_quantity
+      FROM po_vendor_batches b
+      LEFT JOIN users u ON b.created_by = u.id
+      LEFT JOIN po_vendor_orders o ON o.batch_id = b.id
+      LEFT JOIN po_vendor_order_items i ON i.order_id = o.id
+      GROUP BY b.id
+      ORDER BY b.created_at DESC
+      LIMIT 10
+      `
+    );
+
+    res.render('po-organization/dashboard', {
+      user: req.session.user,
+      batches
+    });
+  } catch (error) {
+    console.error('Error loading PO Organization dashboard:', error);
+    req.flash('error', 'Error loading dashboard.');
+    res.redirect('/');
+  }
+});
+
+router.post(
+  '/mappings/upload',
+  isNowIPOOrganization,
+  upload.single('mappingFile'),
+  async (req, res) => {
+    if (!req.file) {
+      req.flash('error', 'Please upload a mapping file.');
+      return res.redirect('/po-organization/dashboard');
+    }
+
+    try {
+      const workbook = new ExcelJS.Workbook();
+      await workbook.xlsx.load(req.file.buffer);
+      const worksheet = workbook.worksheets[0];
+
+      if (!worksheet) {
+        req.flash('error', 'Uploaded file is empty.');
+        return res.redirect('/po-organization/dashboard');
+      }
+
+      const headerIndex = buildHeaderIndex(worksheet);
+      const vendorCol =
+        headerIndex.vendor_code || headerIndex.vendor || headerIndex.vendorcode;
+      const skuCol = headerIndex.sku;
+      const colorCol = headerIndex.color;
+      const linkCol = headerIndex.link || headerIndex.product_link;
+      const imageCol = headerIndex.image || headerIndex.image_url;
+      const weightCol = headerIndex.weight;
+
+      if (!vendorCol || !skuCol) {
+        req.flash('error', 'File must include vendor_code and sku columns.');
+        return res.redirect('/po-organization/dashboard');
+      }
+
+      const rows = [];
+      const errors = [];
+      worksheet.eachRow((row, rowNumber) => {
+        if (rowNumber === 1) return;
+        const sku = readCell(row, skuCol);
+        const vendorCode = readCell(row, vendorCol);
+        const color = readCell(row, colorCol);
+        const link = readCell(row, linkCol);
+        const imageUrl = readCell(row, imageCol);
+        const weight = parseNumber(readCell(row, weightCol));
+
+        if (!sku && !vendorCode) {
+          return;
+        }
+        if (!sku || !vendorCode) {
+          errors.push(`Row ${rowNumber}: sku and vendor_code are required.`);
+          return;
+        }
+
+        rows.push({
+          sku,
+          vendorCode,
+          color,
+          link,
+          imageUrl,
+          weight
+        });
+      });
+
+      if (errors.length) {
+        req.flash('error', errors.join(' '));
+        return res.redirect('/po-organization/dashboard');
+      }
+
+      if (!rows.length) {
+        req.flash('error', 'No valid rows found in the mapping file.');
+        return res.redirect('/po-organization/dashboard');
+      }
+
+      const connection = await pool.getConnection();
+      try {
+        await connection.beginTransaction();
+        for (const row of rows) {
+          await connection.query(
+            `
+            INSERT INTO po_sku_vendor_mappings
+              (sku, vendor_code, color, image_url, weight, link)
+            VALUES (?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+              vendor_code = VALUES(vendor_code),
+              color = VALUES(color),
+              image_url = VALUES(image_url),
+              weight = VALUES(weight),
+              link = VALUES(link)
+            `,
+            [
+              row.sku,
+              row.vendorCode,
+              row.color || null,
+              row.imageUrl || null,
+              row.weight,
+              row.link || null
+            ]
+          );
+        }
+        await connection.commit();
+      } catch (error) {
+        await connection.rollback();
+        throw error;
+      } finally {
+        connection.release();
+      }
+
+      req.flash('success', 'SKU mapping file processed successfully.');
+      return res.redirect('/po-organization/dashboard');
+    } catch (error) {
+      console.error('Error uploading SKU mappings:', error);
+      req.flash('error', 'Failed to process the mapping file.');
+      return res.redirect('/po-organization/dashboard');
+    }
+  }
+);
+
+router.post(
+  '/po/upload',
+  isNowIPOOrganization,
+  upload.single('poFile'),
+  async (req, res) => {
+    if (!req.file) {
+      req.flash('error', 'Please upload a PO file.');
+      return res.redirect('/po-organization/dashboard');
+    }
+
+    try {
+      const workbook = new ExcelJS.Workbook();
+      await workbook.xlsx.load(req.file.buffer);
+      const worksheet = workbook.worksheets[0];
+
+      if (!worksheet) {
+        req.flash('error', 'Uploaded file is empty.');
+        return res.redirect('/po-organization/dashboard');
+      }
+
+      const headerIndex = buildHeaderIndex(worksheet);
+      const skuCol = headerIndex.sku;
+      const sizeCol = headerIndex.size || headerIndex.product_size;
+      const quantityCol = headerIndex.quantity || headerIndex.qty;
+
+      if (!skuCol || !sizeCol || !quantityCol) {
+        req.flash('error', 'File must include sku, size, and quantity columns.');
+        return res.redirect('/po-organization/dashboard');
+      }
+
+      const items = [];
+      const errors = [];
+      worksheet.eachRow((row, rowNumber) => {
+        if (rowNumber === 1) return;
+        const sku = readCell(row, skuCol);
+        const size = readCell(row, sizeCol);
+        const quantity = parseNumber(readCell(row, quantityCol));
+
+        if (!sku && !size && !quantity) {
+          return;
+        }
+        if (!sku || !size || !quantity) {
+          errors.push(`Row ${rowNumber}: sku, size, and quantity are required.`);
+          return;
+        }
+        if (quantity <= 0) {
+          errors.push(`Row ${rowNumber}: quantity must be greater than 0.`);
+          return;
+        }
+        items.push({ sku, size, quantity });
+      });
+
+      if (errors.length) {
+        req.flash('error', errors.join(' '));
+        return res.redirect('/po-organization/dashboard');
+      }
+
+      if (!items.length) {
+        req.flash('error', 'No valid rows found in the PO file.');
+        return res.redirect('/po-organization/dashboard');
+      }
+
+      const uniqueSkus = [...new Set(items.map((item) => item.sku))];
+      const [mappingRows] = await pool.query(
+        'SELECT * FROM po_sku_vendor_mappings WHERE sku IN (?)',
+        [uniqueSkus]
+      );
+
+      const mappingMap = new Map(mappingRows.map((row) => [row.sku, row]));
+      const missingSkus = uniqueSkus.filter((sku) => !mappingMap.has(sku));
+
+      if (missingSkus.length) {
+        req.flash(
+          'error',
+          `Missing mappings for SKU(s): ${missingSkus.join(', ')}`
+        );
+        return res.redirect('/po-organization/dashboard');
+      }
+
+      const groupedByVendor = new Map();
+      for (const item of items) {
+        const mapping = mappingMap.get(item.sku);
+        const vendorCode = mapping.vendor_code;
+        if (!groupedByVendor.has(vendorCode)) {
+          groupedByVendor.set(vendorCode, []);
+        }
+        groupedByVendor.get(vendorCode).push({
+          sku: item.sku,
+          size: item.size,
+          quantity: item.quantity,
+          color: mapping.color,
+          image_url: mapping.image_url,
+          weight: mapping.weight,
+          link: mapping.link
+        });
+      }
+
+      const connection = await pool.getConnection();
+      let batchId;
+      try {
+        await connection.beginTransaction();
+        const [batchResult] = await connection.query(
+          'INSERT INTO po_vendor_batches (created_by) VALUES (?)',
+          [req.session.user.id]
+        );
+        batchId = batchResult.insertId;
+
+        for (const [vendorCode, vendorItems] of groupedByVendor.entries()) {
+          const [orderResult] = await connection.query(
+            'INSERT INTO po_vendor_orders (batch_id, vendor_code) VALUES (?, ?)',
+            [batchId, vendorCode]
+          );
+          const orderId = orderResult.insertId;
+          const values = vendorItems.map((row) => [
+            orderId,
+            row.sku,
+            row.size,
+            row.quantity,
+            row.color,
+            row.image_url,
+            row.weight,
+            row.link
+          ]);
+          await connection.query(
+            `
+            INSERT INTO po_vendor_order_items
+              (order_id, sku, product_size, quantity, color, image_url, weight, link)
+            VALUES ?
+            `,
+            [values]
+          );
+        }
+
+        await connection.commit();
+      } catch (error) {
+        await connection.rollback();
+        throw error;
+      } finally {
+        connection.release();
+      }
+
+      req.flash('success', 'PO batch generated successfully.');
+      return res.redirect(`/po-organization/batch/${batchId}`);
+    } catch (error) {
+      console.error('Error generating PO batch:', error);
+      req.flash('error', 'Failed to generate PO batch.');
+      return res.redirect('/po-organization/dashboard');
+    }
+  }
+);
+
+router.get('/batch/:id', isNowIPOOrganization, async (req, res) => {
+  try {
+    const [batches] = await pool.query(
+      `
+      SELECT
+        b.id,
+        b.created_at,
+        u.username AS created_by
+      FROM po_vendor_batches b
+      LEFT JOIN users u ON b.created_by = u.id
+      WHERE b.id = ?
+      `,
+      [req.params.id]
+    );
+
+    if (!batches.length) {
+      req.flash('error', 'Batch not found.');
+      return res.redirect('/po-organization/dashboard');
+    }
+
+    const [orders] = await pool.query(
+      `
+      SELECT
+        o.id,
+        o.vendor_code,
+        o.created_at,
+        COUNT(i.id) AS item_count,
+        COALESCE(SUM(i.quantity), 0) AS total_quantity
+      FROM po_vendor_orders o
+      LEFT JOIN po_vendor_order_items i ON i.order_id = o.id
+      WHERE o.batch_id = ?
+      GROUP BY o.id
+      ORDER BY o.vendor_code
+      `,
+      [req.params.id]
+    );
+
+    res.render('po-organization/batch', {
+      user: req.session.user,
+      batch: batches[0],
+      orders
+    });
+  } catch (error) {
+    console.error('Error loading batch details:', error);
+    req.flash('error', 'Error loading batch details.');
+    res.redirect('/po-organization/dashboard');
+  }
+});
+
+router.get('/order/:id', isNowIPOOrganization, async (req, res) => {
+  try {
+    const [orders] = await pool.query(
+      `
+      SELECT o.*, b.id AS batch_id
+      FROM po_vendor_orders o
+      JOIN po_vendor_batches b ON b.id = o.batch_id
+      WHERE o.id = ?
+      `,
+      [req.params.id]
+    );
+
+    if (!orders.length) {
+      req.flash('error', 'PO order not found.');
+      return res.redirect('/po-organization/dashboard');
+    }
+
+    const [items] = await pool.query(
+      `
+      SELECT
+        sku,
+        color,
+        product_size,
+        quantity,
+        weight,
+        link,
+        image_url
+      FROM po_vendor_order_items
+      WHERE order_id = ?
+      ORDER BY sku
+      `,
+      [req.params.id]
+    );
+
+    res.render('po-organization/order', {
+      user: req.session.user,
+      order: orders[0],
+      items
+    });
+  } catch (error) {
+    console.error('Error loading PO order:', error);
+    req.flash('error', 'Error loading PO order.');
+    res.redirect('/po-organization/dashboard');
+  }
+});
+
+router.get('/order/:id/download', isNowIPOOrganization, async (req, res) => {
+  try {
+    const [orders] = await pool.query(
+      `
+      SELECT id, vendor_code, created_at
+      FROM po_vendor_orders
+      WHERE id = ?
+      `,
+      [req.params.id]
+    );
+
+    if (!orders.length) {
+      req.flash('error', 'PO order not found.');
+      return res.redirect('/po-organization/dashboard');
+    }
+
+    const [items] = await pool.query(
+      `
+      SELECT
+        sku,
+        color,
+        product_size,
+        quantity,
+        weight,
+        link,
+        image_url
+      FROM po_vendor_order_items
+      WHERE order_id = ?
+      ORDER BY sku
+      `,
+      [req.params.id]
+    );
+
+    const workbook = new ExcelJS.Workbook();
+    const worksheet = workbook.addWorksheet('Vendor PO');
+    worksheet.columns = [
+      { header: 'Vendor Code', key: 'vendor_code', width: 18 },
+      { header: 'SKU', key: 'sku', width: 20 },
+      { header: 'Color', key: 'color', width: 15 },
+      { header: 'Product Size', key: 'product_size', width: 15 },
+      { header: 'Quantity', key: 'quantity', width: 12 },
+      { header: 'Weight', key: 'weight', width: 12 },
+      { header: 'Link', key: 'link', width: 40 },
+      { header: 'Image', key: 'image_url', width: 40 }
+    ];
+
+    worksheet.getRow(1).font = { bold: true };
+    worksheet.getRow(1).fill = {
+      type: 'pattern',
+      pattern: 'solid',
+      fgColor: { argb: 'FF2563EB' }
+    };
+    worksheet.getRow(1).font = { bold: true, color: { argb: 'FFFFFFFF' } };
+
+    items.forEach((item) => {
+      worksheet.addRow({
+        vendor_code: orders[0].vendor_code,
+        sku: item.sku,
+        color: item.color,
+        product_size: item.product_size,
+        quantity: item.quantity,
+        weight: item.weight,
+        link: item.link,
+        image_url: item.image_url
+      });
+    });
+
+    res.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    );
+    res.setHeader(
+      'Content-Disposition',
+      `attachment; filename=vendor-po-${orders[0].vendor_code}-${Date.now()}.xlsx`
+    );
+
+    await workbook.xlsx.write(res);
+    res.end();
+  } catch (error) {
+    console.error('Error downloading PO order:', error);
+    req.flash('error', 'Failed to download PO order.');
+    res.redirect('/po-organization/dashboard');
+  }
+});
+
+module.exports = router;

--- a/sql/po_organization_tables.sql
+++ b/sql/po_organization_tables.sql
@@ -1,0 +1,40 @@
+CREATE TABLE po_sku_vendor_mappings (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  sku VARCHAR(64) NOT NULL UNIQUE,
+  vendor_code VARCHAR(64) NOT NULL,
+  color VARCHAR(64),
+  image_url TEXT,
+  weight DECIMAL(10, 3),
+  link TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);
+
+CREATE TABLE po_vendor_batches (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  created_by INT NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (created_by) REFERENCES users(id)
+);
+
+CREATE TABLE po_vendor_orders (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  batch_id INT NOT NULL,
+  vendor_code VARCHAR(64) NOT NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (batch_id) REFERENCES po_vendor_batches(id)
+);
+
+CREATE TABLE po_vendor_order_items (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  order_id INT NOT NULL,
+  sku VARCHAR(64) NOT NULL,
+  product_size VARCHAR(32) NOT NULL,
+  quantity INT NOT NULL,
+  color VARCHAR(64),
+  image_url TEXT,
+  weight DECIMAL(10, 3),
+  link TEXT,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (order_id) REFERENCES po_vendor_orders(id)
+);

--- a/views/po-organization/batch.ejs
+++ b/views/po-organization/batch.ejs
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PO Batch <%= batch.id %> - Kotty Track</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', sans-serif; background: #f8f9fa; color: #1e293b; }
+    .top-nav { background: white; border-bottom: 2px solid #e2e8f0; padding: 16px 24px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); margin-bottom: 24px; }
+    .nav-brand { font-size: 20px; font-weight: 700; color: #1e293b; }
+    .btn-logout { background: #ef4444; color: white; border: none; padding: 10px 20px; border-radius: 6px; font-weight: 600; }
+    .btn-logout:hover { background: #dc2626; }
+    .container-main { max-width: 1400px; margin: 0 auto; padding: 24px; }
+    .page-title { font-size: 28px; font-weight: 700; color: #1e293b; margin-bottom: 8px; }
+    .page-subtitle { font-size: 14px; color: #64748b; margin-bottom: 24px; }
+    .card { border: 1px solid #e2e8f0; border-radius: 10px; box-shadow: 0 4px 10px rgba(15, 23, 42, 0.05); }
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="d-flex justify-content-between align-items-center">
+      <span class="nav-brand">PO Batch #<%= batch.id %></span>
+      <div class="d-flex gap-2 align-items-center">
+        <a href="/po-organization/dashboard" class="btn btn-outline-secondary">Back</a>
+        <form action="/logout" method="POST">
+          <button type="submit" class="btn-logout"><i class="bi bi-box-arrow-right"></i> Logout</button>
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container-main">
+    <h1 class="page-title">Vendor Orders</h1>
+    <p class="page-subtitle">Created by <strong><%= batch.created_by || 'N/A' %></strong> on <%= new Date(batch.created_at).toLocaleString('en-IN') %></p>
+
+    <%- include('../partials/flashMessages') %>
+
+    <div class="card">
+      <div class="card-body">
+        <% if (!orders.length) { %>
+          <p class="text-muted mb-0">No vendor orders found in this batch.</p>
+        <% } else { %>
+          <div class="table-responsive">
+            <table class="table table-hover align-middle">
+              <thead>
+                <tr>
+                  <th>Vendor Code</th>
+                  <th>Order ID</th>
+                  <th>Items</th>
+                  <th>Total Quantity</th>
+                  <th>Created At</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                <% orders.forEach(order => { %>
+                  <tr>
+                    <td><%= order.vendor_code %></td>
+                    <td>#<%= order.id %></td>
+                    <td><%= order.item_count %></td>
+                    <td><%= order.total_quantity %></td>
+                    <td><%= new Date(order.created_at).toLocaleString('en-IN') %></td>
+                    <td class="text-end">
+                      <a href="/po-organization/order/<%= order.id %>" class="btn btn-sm btn-outline-primary">View</a>
+                    </td>
+                  </tr>
+                <% }); %>
+              </tbody>
+            </table>
+          </div>
+        <% } %>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/po-organization/dashboard.ejs
+++ b/views/po-organization/dashboard.ejs
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>PO Organization Dashboard - Kotty Track</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', sans-serif; background: #f8f9fa; color: #1e293b; }
+    .top-nav { background: white; border-bottom: 2px solid #e2e8f0; padding: 16px 24px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); margin-bottom: 24px; }
+    .nav-brand { font-size: 20px; font-weight: 700; color: #1e293b; }
+    .btn-logout { background: #ef4444; color: white; border: none; padding: 10px 20px; border-radius: 6px; font-weight: 600; }
+    .btn-logout:hover { background: #dc2626; }
+    .container-main { max-width: 1400px; margin: 0 auto; padding: 24px; }
+    .page-title { font-size: 28px; font-weight: 700; color: #1e293b; margin-bottom: 8px; }
+    .page-subtitle { font-size: 14px; color: #64748b; margin-bottom: 32px; }
+    .card { border: 1px solid #e2e8f0; border-radius: 10px; box-shadow: 0 4px 10px rgba(15, 23, 42, 0.05); }
+    .card-title { font-weight: 600; color: #1e293b; }
+    .form-text { color: #64748b; }
+    .badge-soft { background: #eff6ff; color: #2563eb; font-weight: 600; }
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="d-flex justify-content-between align-items-center">
+      <span class="nav-brand">PO Organization Dashboard</span>
+      <form action="/logout" method="POST">
+        <button type="submit" class="btn-logout"><i class="bi bi-box-arrow-right"></i> Logout</button>
+      </form>
+    </div>
+  </nav>
+
+  <div class="container-main">
+    <h1 class="page-title">Welcome, <%= user.username %></h1>
+    <p class="page-subtitle">Upload SKU mappings, generate vendor-wise POs, and track batches.</p>
+
+    <%- include('../partials/flashMessages') %>
+
+    <div class="row g-4 mb-4">
+      <div class="col-lg-6">
+        <div class="card h-100">
+          <div class="card-body">
+            <h5 class="card-title mb-3"><i class="bi bi-cloud-upload"></i> Upload SKU Mappings</h5>
+            <p class="form-text mb-3">Required columns: <strong>vendor_code</strong>, <strong>sku</strong>. Optional: color, link, image, weight.</p>
+            <form action="/po-organization/mappings/upload" method="POST" enctype="multipart/form-data">
+              <div class="mb-3">
+                <input type="file" class="form-control" name="mappingFile" accept=".xlsx,.xls" required>
+              </div>
+              <button type="submit" class="btn btn-primary"><i class="bi bi-upload"></i> Upload Mapping</button>
+            </form>
+          </div>
+        </div>
+      </div>
+
+      <div class="col-lg-6">
+        <div class="card h-100">
+          <div class="card-body">
+            <h5 class="card-title mb-3"><i class="bi bi-file-earmark-plus"></i> Upload SKU Size & Quantity</h5>
+            <p class="form-text mb-3">Required columns: <strong>sku</strong>, <strong>size</strong>, <strong>quantity</strong>. Generates vendor-wise POs.</p>
+            <form action="/po-organization/po/upload" method="POST" enctype="multipart/form-data">
+              <div class="mb-3">
+                <input type="file" class="form-control" name="poFile" accept=".xlsx,.xls" required>
+              </div>
+              <button type="submit" class="btn btn-success"><i class="bi bi-lightning-charge"></i> Generate PO</button>
+            </form>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-body">
+        <h5 class="card-title mb-3"><i class="bi bi-clock-history"></i> Recent PO Batches</h5>
+        <% if (!batches.length) { %>
+          <p class="text-muted mb-0">No batches created yet.</p>
+        <% } else { %>
+          <div class="table-responsive">
+            <table class="table table-hover align-middle">
+              <thead>
+                <tr>
+                  <th>Batch ID</th>
+                  <th>Created By</th>
+                  <th>Created At</th>
+                  <th>Vendors</th>
+                  <th>Total Quantity</th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                <% batches.forEach(batch => { %>
+                  <tr>
+                    <td><span class="badge badge-soft">#<%= batch.id %></span></td>
+                    <td><%= batch.created_by || 'N/A' %></td>
+                    <td><%= new Date(batch.created_at).toLocaleString('en-IN') %></td>
+                    <td><%= batch.vendor_count %></td>
+                    <td><%= batch.total_quantity %></td>
+                    <td class="text-end">
+                      <a href="/po-organization/batch/<%= batch.id %>" class="btn btn-sm btn-outline-primary">View</a>
+                    </td>
+                  </tr>
+                <% }); %>
+              </tbody>
+            </table>
+          </div>
+        <% } %>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/po-organization/order.ejs
+++ b/views/po-organization/order.ejs
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vendor PO <%= order.vendor_code %> - Kotty Track</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', sans-serif; background: #f8f9fa; color: #1e293b; }
+    .top-nav { background: white; border-bottom: 2px solid #e2e8f0; padding: 16px 24px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); margin-bottom: 24px; }
+    .nav-brand { font-size: 20px; font-weight: 700; color: #1e293b; }
+    .btn-logout { background: #ef4444; color: white; border: none; padding: 10px 20px; border-radius: 6px; font-weight: 600; }
+    .btn-logout:hover { background: #dc2626; }
+    .container-main { max-width: 1400px; margin: 0 auto; padding: 24px; }
+    .page-title { font-size: 28px; font-weight: 700; color: #1e293b; margin-bottom: 8px; }
+    .page-subtitle { font-size: 14px; color: #64748b; margin-bottom: 24px; }
+    .card { border: 1px solid #e2e8f0; border-radius: 10px; box-shadow: 0 4px 10px rgba(15, 23, 42, 0.05); }
+    .table td a { color: #2563eb; text-decoration: none; }
+    .table td a:hover { text-decoration: underline; }
+    .image-preview { width: 56px; height: 56px; object-fit: cover; border-radius: 6px; border: 1px solid #e2e8f0; }
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="d-flex justify-content-between align-items-center">
+      <span class="nav-brand">Vendor PO - <%= order.vendor_code %></span>
+      <div class="d-flex gap-2 align-items-center">
+        <a href="/po-organization/batch/<%= order.batch_id %>" class="btn btn-outline-secondary">Back</a>
+        <a href="/po-organization/order/<%= order.id %>/download" class="btn btn-primary"><i class="bi bi-file-earmark-arrow-down"></i> Download Excel</a>
+        <form action="/logout" method="POST">
+          <button type="submit" class="btn-logout"><i class="bi bi-box-arrow-right"></i> Logout</button>
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container-main">
+    <h1 class="page-title">Vendor Code: <%= order.vendor_code %></h1>
+    <p class="page-subtitle">Order ID #<%= order.id %> • Created on <%= new Date(order.created_at).toLocaleString('en-IN') %></p>
+
+    <%- include('../partials/flashMessages') %>
+
+    <div class="card">
+      <div class="card-body">
+        <% if (!items.length) { %>
+          <p class="text-muted mb-0">No items found for this vendor.</p>
+        <% } else { %>
+          <div class="table-responsive">
+            <table class="table table-hover align-middle">
+              <thead>
+                <tr>
+                  <th>SKU</th>
+                  <th>Color</th>
+                  <th>Product Size</th>
+                  <th>Quantity</th>
+                  <th>Weight</th>
+                  <th>Link</th>
+                  <th>Image</th>
+                </tr>
+              </thead>
+              <tbody>
+                <% items.forEach(item => { %>
+                  <tr>
+                    <td><%= item.sku %></td>
+                    <td><%= item.color || 'N/A' %></td>
+                    <td><%= item.product_size %></td>
+                    <td><%= item.quantity %></td>
+                    <td><%= item.weight || 'N/A' %></td>
+                    <td>
+                      <% if (item.link) { %>
+                        <a href="<%= item.link %>" target="_blank" rel="noopener">Open</a>
+                      <% } else { %>
+                        N/A
+                      <% } %>
+                    </td>
+                    <td>
+                      <% if (item.image_url) { %>
+                        <img src="<%= item.image_url %>" alt="Product image" class="image-preview">
+                      <% } else { %>
+                        N/A
+                      <% } %>
+                    </td>
+                  </tr>
+                <% }); %>
+              </tbody>
+            </table>
+          </div>
+        <% } %>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a workflow to upload SKU↔vendor mappings and subsequently upload SKU/size/quantity sheets to generate vendor-specific POs saved in the database.  
- Ensure vendor PO output contains the requested fields: Vendor Code, image, color, product size, quantity, weight and link and is accessible to users with the `nowipoorganization` role.  
- Offer a simple web UI for mapping uploads, PO uploads, batch browsing and vendor order downloads.  
- Keep mapping updates idempotent and PO generation atomic so multiple vendors and items are grouped and written transactionally.

### Description
- Added a new role middleware `isNowIPOOrganization` and wired login redirect to `/po-organization/dashboard` for users with that role by updating `middlewares/auth.js` and `routes/authRoutes.js`.  
- Implemented `routes/poOrganizationRoutes.js` which provides `GET /po-organization/dashboard`, `POST /po-organization/mappings/upload`, `POST /po-organization/po/upload`, `GET /po-organization/batch/:id`, `GET /po-organization/order/:id` and `/order/:id/download` endpoints that parse Excel files using `multer` + `exceljs` and perform transactional DB inserts.  
- Added EJS views under `views/po-organization/` (`dashboard.ejs`, `batch.ejs`, `order.ejs`) and registered the new router in `app.js`.  
- Introduced SQL schema `sql/po_organization_tables.sql` defining `po_sku_vendor_mappings`, `po_vendor_batches`, `po_vendor_orders` and `po_vendor_order_items` and implemented upsert logic for mappings and grouped vendor order/item inserts inside transactions.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a7336b0fc8320989a8d369348c1b2)