### PR TITLE
Add Nowi PO mapping uploads and vendor PO generation

### DIFF
--- a/app.js
+++ b/app.js
@@ -103,6 +103,7 @@ const easyecomUiRoutes = require('./routes/easyecomRoutes');
 const featuresRoutes = require('./routes/featuresRoutes');
 const indentRoutes = require('./routes/indentRoutes');
 const poCreatorRoutes = require('./routes/poCreatorRoutes');
+const nowiPoRoutes = require('./routes/nowiPoRoutes');
 
 // Use Routes
 app.use('/', authRoutes);
@@ -146,6 +147,7 @@ app.use('/easyecom', easyecomUiRoutes);
 app.use('/', featuresRoutes);
 app.use('/indent', indentRoutes);
 app.use('/po-creator', poCreatorRoutes);
+app.use('/nowi-po', nowiPoRoutes);
 
 // Home Route
 app.get('/', (req, res) => {

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -160,6 +160,10 @@ function isPOCreator(req, res, next) {
   return hasRole('po_creator')(req, res, next);
 }
 
+function isNowiPOOrganization(req, res, next) {
+  return hasRole('nowipoorganization')(req, res, next);
+}
+
 // ---------------------------------------------------------------------------
 // Helper to restrict routes to specific user ids
 function allowUserIds(ids) {
@@ -215,6 +219,7 @@ module.exports = {
     isMohitOperator,
     isOnlyMohitOperator,
     isPOCreator,
+    isNowiPOOrganization,
     allowUserIds,
     allowRoles
 };

--- a/routes/nowiPoRoutes.js
+++ b/routes/nowiPoRoutes.js
@@ -1,0 +1,421 @@
+// routes/nowiPoRoutes.js
+const express = require('express');
+const multer = require('multer');
+const xlsx = require('xlsx');
+const { pool } = require('../config/db');
+const { isAuthenticated, isNowiPOOrganization } = require('../middlewares/auth');
+
+const router = express.Router();
+const upload = multer();
+
+const REQUIRED_MAPPING_FIELDS = ['sku', 'vendor_code'];
+const OPTIONAL_MAPPING_FIELDS = ['color', 'link', 'image', 'weight'];
+const REQUIRED_PO_FIELDS = ['sku', 'size', 'quantity'];
+
+const headerAliases = {
+  sku: ['sku'],
+  vendor_code: ['vendorcode', 'vendor_code', 'vendor code'],
+  color: ['color', 'colour'],
+  link: ['link', 'url'],
+  image: ['image', 'imageurl', 'image url'],
+  weight: ['weight', 'wt']
+};
+
+const poHeaderAliases = {
+  sku: ['sku'],
+  size: ['size', 'product size', 'productsize'],
+  quantity: ['quantity', 'qty']
+};
+
+function normalizeHeader(value) {
+  return String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, '');
+}
+
+function resolveHeaderIndexes(headers, requiredFields, aliases) {
+  const normalizedHeaders = headers.map(normalizeHeader);
+  const indexMap = {};
+
+  Object.entries(aliases).forEach(([field, candidates]) => {
+    const normalizedCandidates = candidates.map(normalizeHeader);
+    const index = normalizedHeaders.findIndex(header => normalizedCandidates.includes(header));
+    if (index !== -1) {
+      indexMap[field] = index;
+    }
+  });
+
+  const missing = requiredFields.filter(field => typeof indexMap[field] !== 'number');
+  return { indexMap, missing };
+}
+
+function parseSheet(buffer) {
+  const workbook = xlsx.read(buffer, { type: 'buffer' });
+  const [sheetName] = workbook.SheetNames;
+  if (!sheetName) {
+    return { headers: [], rows: [] };
+  }
+  const sheet = workbook.Sheets[sheetName];
+  const rows = xlsx.utils.sheet_to_json(sheet, { header: 1, defval: '' });
+  const headers = rows.length > 0 ? rows[0] : [];
+  return { headers, rows: rows.slice(1) };
+}
+
+function isEmptyRow(values) {
+  return values.every(value => String(value || '').trim() === '');
+}
+
+router.get('/dashboard', isAuthenticated, isNowiPOOrganization, async (req, res) => {
+  try {
+    const [[mappingCount]] = await pool.query(
+      'SELECT COUNT(*) AS count FROM nowi_po_sku_mappings'
+    );
+    const [[poCount]] = await pool.query('SELECT COUNT(*) AS count FROM nowi_po_headers');
+    const [recentPos] = await pool.query(
+      `SELECT id, po_number, vendor_code, created_at
+       FROM nowi_po_headers
+       ORDER BY created_at DESC
+       LIMIT 5`
+    );
+
+    res.render('nowi-po/dashboard', {
+      user: req.session.user,
+      mappingCount: mappingCount?.count || 0,
+      poCount: poCount?.count || 0,
+      recentPos
+    });
+  } catch (error) {
+    console.error('Error loading nowi-po dashboard:', error);
+    req.flash('error', 'Unable to load dashboard data.');
+    res.render('nowi-po/dashboard', {
+      user: req.session.user,
+      mappingCount: 0,
+      poCount: 0,
+      recentPos: []
+    });
+  }
+});
+
+router.post(
+  '/mappings/upload',
+  isAuthenticated,
+  isNowiPOOrganization,
+  upload.single('mappingFile'),
+  async (req, res) => {
+    if (!req.file) {
+      req.flash('error', 'Please upload a mapping sheet to continue.');
+      return res.redirect('/nowi-po/dashboard');
+    }
+
+    const { headers, rows } = parseSheet(req.file.buffer);
+    const { indexMap, missing } = resolveHeaderIndexes(
+      headers,
+      REQUIRED_MAPPING_FIELDS,
+      headerAliases
+    );
+
+    if (missing.length > 0) {
+      req.flash(
+        'error',
+        `Missing required columns: ${missing.join(', ')}.`
+      );
+      return res.redirect('/nowi-po/dashboard');
+    }
+
+    const mappingValues = [];
+    const errors = [];
+
+    rows.forEach((row, idx) => {
+      if (isEmptyRow(row)) {
+        return;
+      }
+
+      const rowNumber = idx + 2;
+      const sku = String(row[indexMap.sku] || '').trim();
+      const vendorCode = String(row[indexMap.vendor_code] || '').trim();
+      const color = String(row[indexMap.color] || '').trim();
+      const link = String(row[indexMap.link] || '').trim();
+      const image = String(row[indexMap.image] || '').trim();
+      const weightRaw = String(row[indexMap.weight] || '').trim();
+      const weight = weightRaw ? Number(weightRaw) : null;
+
+      if (!sku || !vendorCode) {
+        errors.push(`Row ${rowNumber}: SKU and Vendor Code are required.`);
+        return;
+      }
+
+      if (weightRaw && Number.isNaN(weight)) {
+        errors.push(`Row ${rowNumber}: Weight must be a number.`);
+        return;
+      }
+
+      mappingValues.push([
+        sku,
+        vendorCode,
+        color || null,
+        link || null,
+        image || null,
+        weight
+      ]);
+    });
+
+    if (errors.length > 0) {
+      req.flash('error', errors.slice(0, 5).join(' '));
+      return res.redirect('/nowi-po/dashboard');
+    }
+
+    if (mappingValues.length === 0) {
+      req.flash('error', 'No valid rows were found in the mapping sheet.');
+      return res.redirect('/nowi-po/dashboard');
+    }
+
+    try {
+      await pool.query(
+        `INSERT INTO nowi_po_sku_mappings
+          (sku, vendor_code, color, link, image, weight)
+         VALUES ?
+         ON DUPLICATE KEY UPDATE
+          vendor_code = VALUES(vendor_code),
+          color = VALUES(color),
+          link = VALUES(link),
+          image = VALUES(image),
+          weight = VALUES(weight)`,
+        [mappingValues]
+      );
+
+      req.flash(
+        'success',
+        `Uploaded ${mappingValues.length} SKU mapping rows successfully.`
+      );
+      return res.redirect('/nowi-po/dashboard');
+    } catch (error) {
+      console.error('Error uploading SKU mappings:', error);
+      req.flash('error', 'Failed to upload mapping sheet.');
+      return res.redirect('/nowi-po/dashboard');
+    }
+  }
+);
+
+router.post(
+  '/po/upload',
+  isAuthenticated,
+  isNowiPOOrganization,
+  upload.single('poFile'),
+  async (req, res) => {
+    if (!req.file) {
+      req.flash('error', 'Please upload a PO sheet to continue.');
+      return res.redirect('/nowi-po/dashboard');
+    }
+
+    const { headers, rows } = parseSheet(req.file.buffer);
+    const { indexMap, missing } = resolveHeaderIndexes(
+      headers,
+      REQUIRED_PO_FIELDS,
+      poHeaderAliases
+    );
+
+    if (missing.length > 0) {
+      req.flash('error', `Missing required columns: ${missing.join(', ')}.`);
+      return res.redirect('/nowi-po/dashboard');
+    }
+
+    const poRows = [];
+    const errors = [];
+
+    rows.forEach((row, idx) => {
+      if (isEmptyRow(row)) {
+        return;
+      }
+
+      const rowNumber = idx + 2;
+      const sku = String(row[indexMap.sku] || '').trim();
+      const size = String(row[indexMap.size] || '').trim();
+      const quantityRaw = String(row[indexMap.quantity] || '').trim();
+      const quantity = Number(quantityRaw);
+
+      if (!sku || !size || !quantityRaw) {
+        errors.push(`Row ${rowNumber}: SKU, Size, and Quantity are required.`);
+        return;
+      }
+
+      if (!Number.isInteger(quantity) || quantity <= 0) {
+        errors.push(`Row ${rowNumber}: Quantity must be a positive integer.`);
+        return;
+      }
+
+      poRows.push({ sku, size, quantity });
+    });
+
+    if (errors.length > 0) {
+      req.flash('error', errors.slice(0, 5).join(' '));
+      return res.redirect('/nowi-po/dashboard');
+    }
+
+    if (poRows.length === 0) {
+      req.flash('error', 'No valid rows were found in the PO sheet.');
+      return res.redirect('/nowi-po/dashboard');
+    }
+
+    const uniqueSkus = [...new Set(poRows.map(row => row.sku))];
+
+    try {
+      const [mappingRows] = await pool.query(
+        'SELECT sku, vendor_code, color, link, image, weight FROM nowi_po_sku_mappings WHERE sku IN (?)',
+        [uniqueSkus]
+      );
+
+      const mappingMap = new Map(mappingRows.map(row => [row.sku, row]));
+      const missingSkus = uniqueSkus.filter(sku => !mappingMap.has(sku));
+
+      if (missingSkus.length > 0) {
+        req.flash(
+          'error',
+          `Missing SKU mappings for: ${missingSkus.slice(0, 5).join(', ')}.`
+        );
+        return res.redirect('/nowi-po/dashboard');
+      }
+
+      const groupedByVendor = poRows.reduce((acc, row) => {
+        const mapping = mappingMap.get(row.sku);
+        const vendorCode = mapping.vendor_code;
+        if (!acc[vendorCode]) {
+          acc[vendorCode] = [];
+        }
+        acc[vendorCode].push({
+          ...row,
+          color: mapping.color,
+          link: mapping.link,
+          image: mapping.image,
+          weight: mapping.weight,
+          vendor_code: vendorCode
+        });
+        return acc;
+      }, {});
+
+      const connection = await pool.getConnection();
+      const createdPoIds = [];
+
+      try {
+        await connection.beginTransaction();
+
+        for (const [vendorCode, lines] of Object.entries(groupedByVendor)) {
+          const [headerResult] = await connection.query(
+            'INSERT INTO nowi_po_headers (vendor_code, created_by) VALUES (?, ?)',
+            [vendorCode, req.session.user.id]
+          );
+
+          const poId = headerResult.insertId;
+          const poNumber = `NOWI-PO-${poId}`;
+          await connection.query(
+            'UPDATE nowi_po_headers SET po_number = ? WHERE id = ?',
+            [poNumber, poId]
+          );
+
+          const lineValues = lines.map(line => [
+            poId,
+            line.sku,
+            line.size,
+            line.quantity,
+            line.color || null,
+            line.image || null,
+            line.link || null,
+            line.weight ?? null,
+            vendorCode
+          ]);
+
+          await connection.query(
+            `INSERT INTO nowi_po_lines
+              (po_id, sku, size, quantity, color, image, link, weight, vendor_code)
+             VALUES ?`,
+            [lineValues]
+          );
+
+          createdPoIds.push(poId);
+        }
+
+        await connection.commit();
+      } catch (error) {
+        await connection.rollback();
+        throw error;
+      } finally {
+        connection.release();
+      }
+
+      req.flash(
+        'success',
+        `Generated ${createdPoIds.length} vendor PO(s) successfully.`
+      );
+      return res.redirect('/nowi-po/po');
+    } catch (error) {
+      console.error('Error generating PO:', error);
+      req.flash('error', 'Failed to generate vendor PO files.');
+      return res.redirect('/nowi-po/dashboard');
+    }
+  }
+);
+
+router.get('/po', isAuthenticated, isNowiPOOrganization, async (req, res) => {
+  try {
+    const [poRows] = await pool.query(
+      `SELECT h.id, h.po_number, h.vendor_code, h.created_at, u.username,
+              COUNT(l.id) AS line_count, COALESCE(SUM(l.quantity), 0) AS total_quantity
+         FROM nowi_po_headers h
+         LEFT JOIN users u ON h.created_by = u.id
+         LEFT JOIN nowi_po_lines l ON l.po_id = h.id
+        GROUP BY h.id
+        ORDER BY h.created_at DESC`
+    );
+
+    res.render('nowi-po/po-list', {
+      user: req.session.user,
+      poRows
+    });
+  } catch (error) {
+    console.error('Error loading PO list:', error);
+    req.flash('error', 'Unable to load PO list.');
+    res.render('nowi-po/po-list', {
+      user: req.session.user,
+      poRows: []
+    });
+  }
+});
+
+router.get('/po/:id', isAuthenticated, isNowiPOOrganization, async (req, res) => {
+  try {
+    const { id } = req.params;
+
+    const [[header]] = await pool.query(
+      `SELECT h.id, h.po_number, h.vendor_code, h.created_at, u.username
+         FROM nowi_po_headers h
+         LEFT JOIN users u ON h.created_by = u.id
+        WHERE h.id = ?`,
+      [id]
+    );
+
+    if (!header) {
+      req.flash('error', 'PO not found.');
+      return res.redirect('/nowi-po/po');
+    }
+
+    const [lines] = await pool.query(
+      `SELECT sku, size, quantity, color, image, link, weight, vendor_code
+         FROM nowi_po_lines
+        WHERE po_id = ?
+        ORDER BY id ASC`,
+      [id]
+    );
+
+    res.render('nowi-po/po-view', {
+      user: req.session.user,
+      header,
+      lines
+    });
+  } catch (error) {
+    console.error('Error loading PO details:', error);
+    req.flash('error', 'Unable to load PO details.');
+    return res.redirect('/nowi-po/po');
+  }
+});
+
+module.exports = router;

--- a/sql/nowi_po_tables.sql
+++ b/sql/nowi_po_tables.sql
@@ -1,0 +1,47 @@
+-- sql/nowi_po_tables.sql
+-- Tables for Nowi PO mapping and vendor purchase order generation
+
+CREATE TABLE IF NOT EXISTS nowi_po_sku_mappings (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  sku VARCHAR(100) NOT NULL,
+  vendor_code VARCHAR(100) NOT NULL,
+  color VARCHAR(100) DEFAULT NULL,
+  link TEXT DEFAULT NULL,
+  image TEXT DEFAULT NULL,
+  weight DECIMAL(10,3) DEFAULT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_nowi_po_sku (sku),
+  INDEX idx_nowi_po_vendor_code (vendor_code)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS nowi_po_headers (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  po_number VARCHAR(50) DEFAULT NULL,
+  vendor_code VARCHAR(100) NOT NULL,
+  created_by INT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_nowi_po_headers_creator FOREIGN KEY (created_by) REFERENCES users(id) ON DELETE CASCADE,
+  UNIQUE KEY uq_nowi_po_number (po_number),
+  INDEX idx_nowi_po_vendor_code (vendor_code),
+  INDEX idx_nowi_po_created_by (created_by)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS nowi_po_lines (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  po_id BIGINT UNSIGNED NOT NULL,
+  sku VARCHAR(100) NOT NULL,
+  size VARCHAR(30) NOT NULL,
+  quantity INT NOT NULL,
+  color VARCHAR(100) DEFAULT NULL,
+  image TEXT DEFAULT NULL,
+  link TEXT DEFAULT NULL,
+  weight DECIMAL(10,3) DEFAULT NULL,
+  vendor_code VARCHAR(100) NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_nowi_po_lines_po FOREIGN KEY (po_id) REFERENCES nowi_po_headers(id) ON DELETE CASCADE,
+  INDEX idx_nowi_po_lines_po (po_id),
+  INDEX idx_nowi_po_lines_vendor (vendor_code),
+  INDEX idx_nowi_po_lines_sku (sku)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/views/nowi-po/dashboard.ejs
+++ b/views/nowi-po/dashboard.ejs
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nowi PO Dashboard - Kotty Track</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', sans-serif; background: #f8f9fa; color: #1e293b; }
+    .top-nav { background: white; border-bottom: 2px solid #e2e8f0; padding: 16px 24px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+    .nav-brand { font-size: 20px; font-weight: 700; color: #1e293b; }
+    .container-main { max-width: 1200px; margin: 0 auto; padding: 24px; }
+    .page-title { font-size: 28px; font-weight: 700; margin-bottom: 4px; }
+    .page-subtitle { font-size: 14px; color: #64748b; margin-bottom: 24px; }
+    .stat-card { border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; background: white; }
+    .stat-card h3 { font-size: 14px; color: #64748b; margin-bottom: 8px; }
+    .stat-card .stat-value { font-size: 20px; font-weight: 700; }
+    .card { border: 1px solid #e2e8f0; border-radius: 10px; }
+    .card-title { font-weight: 600; }
+    .table-responsive { max-height: 320px; }
+    .btn-logout { background: #ef4444; color: white; border: none; padding: 10px 20px; border-radius: 6px; font-weight: 600; }
+    .btn-logout:hover { background: #dc2626; }
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="d-flex justify-content-between align-items-center">
+      <span class="nav-brand">Nowi PO Dashboard</span>
+      <form action="/logout" method="POST">
+        <button type="submit" class="btn-logout"><i class="bi bi-box-arrow-right"></i> Logout</button>
+      </form>
+    </div>
+  </nav>
+
+  <div class="container-main">
+    <h1 class="page-title">Welcome, <%= user.username %></h1>
+    <p class="page-subtitle">Upload SKU mappings and generate vendor PO sheets.</p>
+
+    <%- include('../partials/flashMessages') %>
+
+    <div class="row g-3 mb-4">
+      <div class="col-md-6">
+        <div class="stat-card">
+          <h3>SKU Mappings</h3>
+          <div class="stat-value"><%= mappingCount %> entries</div>
+        </div>
+      </div>
+      <div class="col-md-6">
+        <div class="stat-card">
+          <h3>Vendor POs</h3>
+          <div class="stat-value"><%= poCount %> created</div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row g-4">
+      <div class="col-lg-6">
+        <div class="card p-4 h-100">
+          <h5 class="card-title mb-3"><i class="bi bi-cloud-upload"></i> Upload SKU Mapping Sheet</h5>
+          <p class="text-muted mb-3">Required columns: SKU, Vendor Code. Optional: Color, Link, Image, Weight.</p>
+          <form action="/nowi-po/mappings/upload" method="POST" enctype="multipart/form-data">
+            <div class="mb-3">
+              <input class="form-control" type="file" name="mappingFile" accept=".xlsx,.xls" required>
+            </div>
+            <button type="submit" class="btn btn-primary">Upload Mapping</button>
+          </form>
+        </div>
+      </div>
+      <div class="col-lg-6">
+        <div class="card p-4 h-100">
+          <h5 class="card-title mb-3"><i class="bi bi-file-earmark-plus"></i> Upload SKU/Size/Quantity Sheet</h5>
+          <p class="text-muted mb-3">Required columns: SKU, Size, Quantity. This will generate vendor POs.</p>
+          <form action="/nowi-po/po/upload" method="POST" enctype="multipart/form-data">
+            <div class="mb-3">
+              <input class="form-control" type="file" name="poFile" accept=".xlsx,.xls" required>
+            </div>
+            <button type="submit" class="btn btn-success">Generate Vendor POs</button>
+          </form>
+        </div>
+      </div>
+    </div>
+
+    <div class="card mt-4">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center mb-3">
+          <h5 class="card-title mb-0">Recent Vendor POs</h5>
+          <a href="/nowi-po/po" class="btn btn-outline-secondary btn-sm">View All</a>
+        </div>
+        <div class="table-responsive">
+          <table class="table table-hover align-middle">
+            <thead>
+              <tr>
+                <th>PO Number</th>
+                <th>Vendor Code</th>
+                <th>Created At</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% if (recentPos.length === 0) { %>
+                <tr>
+                  <td colspan="4" class="text-center text-muted">No POs created yet.</td>
+                </tr>
+              <% } %>
+              <% recentPos.forEach(po => { %>
+                <tr>
+                  <td><%= po.po_number || ('NOWI-PO-' + po.id) %></td>
+                  <td><%= po.vendor_code %></td>
+                  <td><%= new Date(po.created_at).toLocaleDateString('en-IN') %></td>
+                  <td class="text-end"><a href="/nowi-po/po/<%= po.id %>" class="btn btn-sm btn-outline-primary">View</a></td>
+                </tr>
+              <% }) %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/nowi-po/po-list.ejs
+++ b/views/nowi-po/po-list.ejs
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Vendor POs - Nowi PO</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background: #f8f9fa; color: #1e293b; }
+    .top-nav { background: white; border-bottom: 2px solid #e2e8f0; padding: 16px 24px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+    .nav-brand { font-size: 20px; font-weight: 700; color: #1e293b; }
+    .container-main { max-width: 1200px; margin: 0 auto; padding: 24px; }
+    .page-title { font-size: 24px; font-weight: 700; }
+    .btn-logout { background: #ef4444; color: white; border: none; padding: 10px 20px; border-radius: 6px; font-weight: 600; }
+    .btn-logout:hover { background: #dc2626; }
+    .table thead th { background: #f1f5f9; }
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="d-flex justify-content-between align-items-center">
+      <div>
+        <span class="nav-brand">Vendor PO List</span>
+      </div>
+      <div class="d-flex gap-2">
+        <a href="/nowi-po/dashboard" class="btn btn-outline-secondary"><i class="bi bi-house"></i> Dashboard</a>
+        <form action="/logout" method="POST">
+          <button type="submit" class="btn-logout"><i class="bi bi-box-arrow-right"></i> Logout</button>
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container-main">
+    <h1 class="page-title mb-3">Vendor Purchase Orders</h1>
+    <%- include('../partials/flashMessages') %>
+
+    <div class="card">
+      <div class="card-body">
+        <div class="table-responsive">
+          <table class="table table-striped align-middle">
+            <thead>
+              <tr>
+                <th>PO Number</th>
+                <th>Vendor Code</th>
+                <th>Created By</th>
+                <th>Created At</th>
+                <th>Lines</th>
+                <th>Total Qty</th>
+                <th></th>
+              </tr>
+            </thead>
+            <tbody>
+              <% if (poRows.length === 0) { %>
+                <tr>
+                  <td colspan="7" class="text-center text-muted">No vendor POs created yet.</td>
+                </tr>
+              <% } %>
+              <% poRows.forEach(po => { %>
+                <tr>
+                  <td><%= po.po_number || ('NOWI-PO-' + po.id) %></td>
+                  <td><%= po.vendor_code %></td>
+                  <td><%= po.username || 'N/A' %></td>
+                  <td><%= new Date(po.created_at).toLocaleDateString('en-IN') %></td>
+                  <td><%= po.line_count %></td>
+                  <td><%= po.total_quantity %></td>
+                  <td class="text-end">
+                    <a href="/nowi-po/po/<%= po.id %>" class="btn btn-sm btn-outline-primary">View</a>
+                  </td>
+                </tr>
+              <% }) %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/nowi-po/po-view.ejs
+++ b/views/nowi-po/po-view.ejs
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title><%= header.po_number %> - Vendor PO</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    body { font-family: 'Inter', sans-serif; background: #f8f9fa; color: #1e293b; }
+    .top-nav { background: white; border-bottom: 2px solid #e2e8f0; padding: 16px 24px; box-shadow: 0 2px 4px rgba(0,0,0,0.05); }
+    .nav-brand { font-size: 20px; font-weight: 700; color: #1e293b; }
+    .container-main { max-width: 1200px; margin: 0 auto; padding: 24px; }
+    .badge-vendor { background: #2563eb; }
+    .btn-logout { background: #ef4444; color: white; border: none; padding: 10px 20px; border-radius: 6px; font-weight: 600; }
+    .btn-logout:hover { background: #dc2626; }
+    .table thead th { background: #f1f5f9; }
+    .image-preview { width: 50px; height: 50px; object-fit: cover; border-radius: 6px; border: 1px solid #e2e8f0; }
+  </style>
+</head>
+<body>
+  <nav class="top-nav">
+    <div class="d-flex justify-content-between align-items-center">
+      <span class="nav-brand">Vendor PO Details</span>
+      <div class="d-flex gap-2">
+        <a href="/nowi-po/po" class="btn btn-outline-secondary"><i class="bi bi-arrow-left"></i> Back to POs</a>
+        <form action="/logout" method="POST">
+          <button type="submit" class="btn-logout"><i class="bi bi-box-arrow-right"></i> Logout</button>
+        </form>
+      </div>
+    </div>
+  </nav>
+
+  <div class="container-main">
+    <div class="d-flex flex-wrap justify-content-between align-items-center mb-3">
+      <div>
+        <h1 class="h3 mb-1"><%= header.po_number %></h1>
+        <p class="text-muted mb-0">Created by <%= header.username || 'N/A' %> on <%= new Date(header.created_at).toLocaleDateString('en-IN') %></p>
+      </div>
+      <span class="badge badge-vendor text-white px-3 py-2">Vendor: <%= header.vendor_code %></span>
+    </div>
+
+    <div class="card">
+      <div class="card-body">
+        <div class="table-responsive">
+          <table class="table table-striped align-middle">
+            <thead>
+              <tr>
+                <th>Vendor Code</th>
+                <th>Image</th>
+                <th>Color</th>
+                <th>SKU</th>
+                <th>Product Size</th>
+                <th>Quantity</th>
+                <th>Weight</th>
+                <th>Link</th>
+              </tr>
+            </thead>
+            <tbody>
+              <% if (lines.length === 0) { %>
+                <tr>
+                  <td colspan="8" class="text-center text-muted">No line items found.</td>
+                </tr>
+              <% } %>
+              <% lines.forEach(line => { %>
+                <tr>
+                  <td><%= line.vendor_code %></td>
+                  <td>
+                    <% if (line.image) { %>
+                      <img src="<%= line.image %>" alt="SKU Image" class="image-preview">
+                    <% } else { %>
+                      <span class="text-muted">N/A</span>
+                    <% } %>
+                  </td>
+                  <td><%= line.color || 'N/A' %></td>
+                  <td><%= line.sku %></td>
+                  <td><%= line.size %></td>
+                  <td><%= line.quantity %></td>
+                  <td><%= line.weight ?? 'N/A' %></td>
+                  <td>
+                    <% if (line.link) { %>
+                      <a href="<%= line.link %>" target="_blank" rel="noopener">Open</a>
+                    <% } else { %>
+                      <span class="text-muted">N/A</span>
+                    <% } %>
+                  </td>
+                </tr>
+              <% }) %>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a dedicated flow to upload SKU→vendor mappings and to generate vendor-specific POs from simple `sku,size,quantity` sheets.  
- Persist mappings and generated POs so downstream users/roles can view standardised PO outputs containing vendor code, image, color, size, quantity, weight and link.  
- Restrict the new functionality to the organization role that will manage POs via a role-specific middleware.  
- Keep the PO output format consistent and easily consumable by vendors and internal viewers.

### Description
- Added a new router `routes/nowiPoRoutes.js` which implements Excel parsing for mapping sheets and PO sheets, validation, grouping by `vendor_code`, and transactional insertion of `nowi_po_headers` and `nowi_po_lines` rows.  
- Introduced DB table definitions in `sql/nowi_po_tables.sql` for `nowi_po_sku_mappings`, `nowi_po_headers`, and `nowi_po_lines` to store mappings and generated POs.  
- Wired the new routes into the app via `app.use('/nowi-po', nowiPoRoutes)` and added a role-check middleware `isNowiPOOrganization` in `middlewares/auth.js`.  
- Added EJS views under `views/nowi-po/` (`dashboard.ejs`, `po-list.ejs`, `po-view.ejs`) that expose upload forms and fixed-format vendor PO list/detail pages.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a74e6d4a08320a5c4ab6ce58b3815)