### PR TITLE
Fix Nowi PO login redirect

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -103,6 +103,9 @@ router.post('/login', async (req, res) => {
       case 'po_creator':
         res.redirect('/po-creator/dashboard');
         break;
+      case 'nowipoorganization':
+        res.redirect('/nowi-po/dashboard');
+        break;
       case 'checking':
       case 'quality_assurance':
         res.redirect('/department/dashboard');

--- a/routes/authRoutesOptimized.js
+++ b/routes/authRoutesOptimized.js
@@ -82,6 +82,7 @@ router.post('/login', async (req, res) => {
       store_employee: '/inventory/dashboard',
       checking: '/department/dashboard',
       quality_assurance: '/department/dashboard',
+      nowipoorganization: '/nowi-po/dashboard',
     };
 
     const redirectPath = roleRedirectMap[user.roleName] || '/';


### PR DESCRIPTION
### Motivation
- Users with the Nowi PO organization role (`nowipoorganization`) were being sent to the wrong page after login.
- The login flow needs to route that role to the Nowi PO module so users land on the correct dashboard.
- The codebase contains an optimized redirect map and a conventional switch; both must be kept in sync.

### Description
- Added a `nowipoorganization` case in `routes/authRoutes.js` to redirect to `/nowi-po/dashboard` after login.
- Updated the role-to-path mapping in `routes/authRoutesOptimized.js` to include `nowipoorganization: '/nowi-po/dashboard'` so the cached/optimized path matches behavior.
- Changes are limited to login redirect logic and do not modify authentication checks or middleware behavior.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694a8438ed748320bedfbc39031816bc)