### PR TITLE
Harden making-time SKU gating and improve stock-market downloads

### DIFF
--- a/routes/easyecomRoutes.js
+++ b/routes/easyecomRoutes.js
@@ -153,10 +153,14 @@ router.get('/stock-market/download', isAuthenticated, allowStockMarketAccess, as
       ordersSheet.addRow({ ...row, growth: Number(row.growth || 0).toFixed(1) });
     });
 
+    const fileName = `stock-market-${periodKey}.xlsx`;
+    const buffer = await workbook.xlsx.writeBuffer();
+    const outputBuffer = Buffer.isBuffer(buffer) ? buffer : Buffer.from(buffer);
     res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-    res.setHeader('Content-Disposition', `attachment; filename=\"stock-market-${periodKey}.xlsx\"`);
-    await workbook.xlsx.write(res);
-    res.end();
+    res.setHeader('Content-Disposition', `attachment; filename=\"${fileName}\"`);
+    res.setHeader('Access-Control-Expose-Headers', 'Content-Disposition');
+    res.setHeader('Content-Length', outputBuffer.length);
+    res.send(outputBuffer);
   } catch (err) {
     console.error('Failed to download stock market Excel:', err);
     res.status(500).json({ error: 'Unable to download Excel' });

--- a/routes/easyecomapi.js
+++ b/routes/easyecomapi.js
@@ -96,6 +96,9 @@ router.post('/inventory/refresh', async (req, res) => {
       inventory: Number(inventory),
       periodKey: normalizePeriod(period),
     });
+    if (!health) {
+      return res.status(400).json({ error: 'SKU is not in the bulk making-time list' });
+    }
     res.json({ ok: true, health });
   } catch (err) {
     console.error('Failed to refresh inventory health', err);

--- a/views/stockMarket.ejs
+++ b/views/stockMarket.ejs
@@ -33,6 +33,9 @@
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
       font-size: 16px;
       line-height: 1.6;
+      min-height: 100vh;
+      padding: env(safe-area-inset-top) env(safe-area-inset-right) calc(env(safe-area-inset-bottom) + 12px) env(safe-area-inset-left);
+      -webkit-text-size-adjust: 100%;
     }
 
     .topbar {
@@ -89,7 +92,8 @@
     .stock-shell {
       max-width: 1200px;
       margin: 0 auto;
-      padding: 1.25rem 1rem 3rem;
+      padding: clamp(1rem, 2vw, 1.35rem) clamp(0.75rem, 2vw, 1.25rem) 3rem;
+      width: min(1200px, 100%);
     }
 
     .hero-card {
@@ -508,6 +512,7 @@
           </a>
         <% } %>
         <button class="btn btn-success d-flex align-items-center justify-content-center gap-2" id="download-excel" type="button">
+          <span class="spinner-border spinner-border-sm d-none" role="status" aria-hidden="true"></span>
           <i class="bi bi-file-earmark-excel"></i><span>Download Excel</span>
         </button>
       </div>
@@ -726,6 +731,16 @@
     icon?.classList.toggle('d-none', isLoading);
   }
 
+  function parseFilenameFromHeader(disposition) {
+    if (!disposition) return '';
+    const utfMatch = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+    if (utfMatch && utfMatch[1]) {
+      return decodeURIComponent(utfMatch[1]);
+    }
+    const asciiMatch = disposition.match(/filename=\"?([^\";]+)\"?/i);
+    return asciiMatch && asciiMatch[1] ? asciiMatch[1] : '';
+  }
+
   function formatNumber(value) {
     if (value === null || value === undefined) return '0';
     return Number(value).toLocaleString();
@@ -835,10 +850,42 @@
   attachSearch(ordersSearch, 'orders-table');
   periodSelect?.addEventListener('change', () => refreshData());
   refreshBtn?.addEventListener('click', () => refreshData(true));
-  downloadBtn?.addEventListener('click', () => {
-    const period = periodSelect?.value || initialData.periodKey;
-    const params = new URLSearchParams({ period });
-    window.location.href = `${window.location.pathname}/download?${params.toString()}`;
+  downloadBtn?.addEventListener('click', async () => {
+    const spinner = downloadBtn.querySelector('.spinner-border');
+    const icon = downloadBtn.querySelector('.bi-file-earmark-excel');
+    downloadBtn.disabled = true;
+    spinner?.classList.remove('d-none');
+    icon?.classList.add('d-none');
+
+    try {
+      const period = periodSelect?.value || initialData.periodKey;
+      const params = new URLSearchParams({ period });
+      const response = await fetch(`${window.location.pathname}/download?${params.toString()}`, {
+        headers: {
+          Accept: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+        },
+      });
+      if (!response.ok) throw new Error('Failed to download Excel');
+
+      const blob = await response.blob();
+      const filename = parseFilenameFromHeader(response.headers.get('content-disposition')) || `stock-market-${period}.xlsx`;
+      const link = document.createElement('a');
+      link.href = URL.createObjectURL(blob);
+      link.download = filename;
+      document.body.appendChild(link);
+      link.click();
+      setTimeout(() => {
+        URL.revokeObjectURL(link.href);
+        link.remove();
+      }, 400);
+    } catch (err) {
+      console.error('Download failed:', err);
+      alert('Could not download the Excel file. Please try again.');
+    } finally {
+      spinner?.classList.add('d-none');
+      icon?.classList.remove('d-none');
+      downloadBtn.disabled = false;
+    }
   });
 
   // Hydrate from initial payload so formatting is consistent


### PR DESCRIPTION
## Summary
- enforce the bulk making-time SKU list across webhooks, API refreshes, and analytics queries so only configured SKUs are stored and shown in the tracker
- guard the stock-market Excel export with buffer-based responses and in-app friendly download handling (spinner, blob save) to work inside Capacitor
- polish the stock-market layout for embedded/mobile views with safe-area padding and tighter spacing

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e5521c9248320bf1e11a4e85cee1d)