### PR TITLE
Tighten stock market layout and sizing

### DIFF
--- a/views/stockMarket.ejs
+++ b/views/stockMarket.ejs
@@ -28,11 +28,11 @@
     }
 
     body {
-      background: linear-gradient(180deg, #eef2ff 0%, #f5f7fb 36%, #f5f7fb 100%);
+      background: #f6f7fb;
       color: var(--color-text-primary);
       font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-      font-size: 16px;
-      line-height: 1.6;
+      font-size: 15px;
+      line-height: 1.55;
       min-height: 100vh;
       padding: env(safe-area-inset-top) env(safe-area-inset-right) calc(env(safe-area-inset-bottom) + 12px) env(safe-area-inset-left);
       -webkit-text-size-adjust: 100%;
@@ -90,26 +90,26 @@
     .user-chip i { color: var(--color-accent); }
 
     .stock-shell {
-      max-width: 1200px;
+      max-width: 1140px;
       margin: 0 auto;
-      padding: clamp(1rem, 2vw, 1.35rem) clamp(0.75rem, 2vw, 1.25rem) 3rem;
-      width: min(1200px, 100%);
+      padding: clamp(0.75rem, 2vw, 1.25rem) clamp(0.75rem, 2vw, 1.25rem) 2.25rem;
+      width: min(1140px, 100%);
     }
 
     .hero-card {
-      background: linear-gradient(145deg, rgba(15, 82, 186, 0.12), rgba(15, 82, 186, 0.03));
-      border: 1px solid rgba(15, 82, 186, 0.12);
-      border-radius: 18px;
-      padding: 1.4rem 1.15rem;
-      box-shadow: var(--shadow-soft);
+      background: #ffffff;
+      border: 1px solid rgba(15, 82, 186, 0.1);
+      border-radius: 16px;
+      padding: 1.15rem 1rem;
+      box-shadow: 0 6px 16px rgba(15, 82, 186, 0.06);
       display: grid;
-      gap: 1rem;
+      gap: 0.85rem;
     }
 
     .hero-heading {
       display: flex;
       flex-direction: column;
-      gap: 0.35rem;
+      gap: 0.25rem;
     }
 
     .eyebrow {
@@ -126,7 +126,7 @@
     h1.page-title {
       font-weight: 800;
       letter-spacing: -0.02em;
-      font-size: clamp(1.4rem, 4vw, 2.15rem);
+      font-size: clamp(1.25rem, 3.3vw, 1.8rem);
       margin: 0;
     }
 
@@ -134,6 +134,7 @@
       color: var(--color-text-secondary);
       font-weight: 500;
       margin: 0;
+      line-height: 1.5;
     }
 
     .note-inline {
@@ -146,14 +147,14 @@
 
     .hero-actions {
       display: grid;
-      gap: 0.65rem;
+      gap: 0.5rem;
       width: 100%;
     }
 
     .action-row {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(0, 1fr));
-      gap: 0.65rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 0.5rem;
       align-items: center;
     }
 
@@ -161,7 +162,7 @@
       display: flex;
       align-items: center;
       gap: 0.6rem;
-      padding: 0.65rem 0.85rem;
+      padding: 0.55rem 0.75rem;
       border-radius: 12px;
       background: var(--color-surface);
       border: 1px solid rgba(15, 82, 186, 0.12);
@@ -172,44 +173,46 @@
       font-weight: 700;
       color: var(--color-text-secondary);
       margin: 0;
-      font-size: 0.95rem;
+      font-size: 0.9rem;
     }
 
     .control-chip select {
       border-radius: 10px;
       border: 1px solid var(--color-border);
-      padding: 0.55rem 0.75rem;
+      padding: 0.5rem 0.7rem;
       font-weight: 600;
       color: var(--color-text-primary);
+      font-size: 0.95rem;
+      min-height: 40px;
     }
 
     .hero-actions .btn { width: 100%; }
 
     .stat-card {
-      border-radius: 16px;
+      border-radius: 14px;
       border: 1px solid rgba(15, 82, 186, 0.08);
       background: var(--color-surface);
-      box-shadow: var(--shadow-md);
-      padding: 1rem 1.1rem;
+      box-shadow: var(--shadow-soft);
+      padding: 0.9rem 0.95rem;
       display: grid;
-      gap: 0.2rem;
+      gap: 0.15rem;
     }
 
-    .stat-label { color: var(--color-text-muted); font-weight: 700; font-size: 0.95rem; }
-    .stat-value { font-size: clamp(1.7rem, 5vw, 2.1rem); font-weight: 800; letter-spacing: -0.02em; }
-    .stat-subtle { color: var(--color-text-secondary); font-weight: 600; font-size: 0.95rem; }
+    .stat-label { color: var(--color-text-muted); font-weight: 700; font-size: 0.9rem; }
+    .stat-value { font-size: clamp(1.4rem, 4vw, 1.8rem); font-weight: 800; letter-spacing: -0.02em; }
+    .stat-subtle { color: var(--color-text-secondary); font-weight: 600; font-size: 0.9rem; }
 
     .action-card {
-      border: 1px dashed rgba(15, 82, 186, 0.22);
+      border: 1px dashed rgba(15, 82, 186, 0.2);
       border-radius: 14px;
-      background: rgba(15, 82, 186, 0.06);
+      background: rgba(15, 82, 186, 0.04);
       color: var(--color-accent);
       box-shadow: var(--shadow-soft);
-      padding: 1rem 1.1rem;
-      height: 100%;
-      font-size: 1rem;
+      padding: 0.85rem 0.95rem;
+      font-size: 0.95rem;
       display: flex;
       justify-content: space-between;
+      align-items: center;
       gap: 0.5rem;
     }
 


### PR DESCRIPTION
## Summary
- Reduce stock market page typography and padding for a calmer feel
- Normalize hero, stat, and action card spacing to avoid oversized blocks
- Constrain container width for better readability on large screens

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694e81e53cf0832084aa49a9ab0a92cc)