### PR TITLE
Add all-warehouses option for out-of-stock dashboard

### DIFF
--- a/views/stockMarket.ejs
+++ b/views/stockMarket.ejs
@@ -661,6 +661,7 @@
 <body>
 <% const isMohitOperator = (user?.username || '').toLowerCase() === 'mohitoperator'; %>
 <% const hasWarehouseChoice = (accessibleWarehouses || []).length > 1; %>
+<% const isAllWarehousesSelected = String(selectedWarehouseId) === 'all'; %>
 
 <div class="topbar">
   <div class="container-fluid d-flex align-items-center justify-content-between gap-3">
@@ -744,6 +745,7 @@
           <div class="control-chip w-100">
             <label for="warehouse-select">Warehouse</label>
             <select class="form-select" id="warehouse-select" name="warehouseId" data-bs-toggle="tooltip" data-bs-title="Switch warehouses to see out-of-stock gaps per site">
+              <option value="all" <%= isAllWarehousesSelected ? 'selected' : '' %>>All warehouses</option>
               <% accessibleWarehouses.forEach((wh) => { %>
                 <option value="<%= wh.id %>" <%= Number(selectedWarehouseId) === Number(wh.id) ? 'selected' : '' %>>
                   <%= wh.label %>


### PR DESCRIPTION
## Summary
- ensure stock market endpoints default to showing all accessible warehouses when users can view multiple locations
- add an explicit "All warehouses" selector option on the out-of-stock dashboard

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695217c24e9083209da79d85df3bf92c)