### PR TITLE
Fix environment initialization order for session middleware

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,11 +4,12 @@ const express = require('express');
 const session = require('express-session');
 const flash = require('connect-flash');
 const path = require('path');
-const { markSessionActivity } = require('./middlewares/sessionActivity');
 
-// Load environment variables securely using secure-env
+// Load environment variables securely using secure-env before loading modules that depend on them
 const secureEnv = require('secure-env');
 global.env = secureEnv({ secret: 'mySecretPassword' }); // Replace with your actual secret
+
+const { markSessionActivity } = require('./middlewares/sessionActivity');
 
 // Ensure the application runs in IST regardless of server settings
 process.env.TZ = 'Asia/Kolkata';


### PR DESCRIPTION
## Summary
- load secure-env before importing middleware that depends on database configuration to ensure global environment variables are available

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69556e684e088320aeab65950521dde6)