### PR TITLE
Track user screen time and stabilize sessions

### DIFF
--- a/app.js
+++ b/app.js
@@ -38,6 +38,7 @@ app.use(session({
     secret: global.env.SESSION_SECRET || 'your_session_secret',
     resave: false,
     saveUninitialized: false,
+    rolling: true, // refresh expiry on each request so active users are not logged out unexpectedly
     cookie: {
         secure: false,           // <— force false while using http://13.203.180.77
         httpOnly: true,

--- a/middlewares/sessionActivity.js
+++ b/middlewares/sessionActivity.js
@@ -5,6 +5,15 @@
 const { pool } = require("../config/db");
 
 const ACTIVITY_UPDATE_INTERVAL_MS = 60 * 1000;
+const MAX_IDLE_CREDIT_MS = 5 * 60 * 1000; // Cap idle gaps so we only count realistic screen time
+
+function calculateActiveSeconds(now, lastUpdate) {
+  const elapsedMs = now - (lastUpdate || 0);
+  if (elapsedMs <= 0) return 0;
+
+  const boundedMs = Math.min(elapsedMs, MAX_IDLE_CREDIT_MS);
+  return Math.floor(boundedMs / 1000);
+}
 
 /**
  * Update the last_activity_time for the active session log.
@@ -19,14 +28,17 @@ async function markSessionActivity(req, res, next) {
     const lastUpdate = req.session.lastActivityUpdate || 0;
     if (now - lastUpdate < ACTIVITY_UPDATE_INTERVAL_MS) return next();
 
+    const incrementSeconds = calculateActiveSeconds(now, lastUpdate);
     req.session.lastActivityUpdate = now;
+
     await pool.query(
       `
         UPDATE user_session_logs
-           SET last_activity_time = NOW()
+           SET last_activity_time = NOW(),
+               duration_seconds = duration_seconds + ?
          WHERE id = ?
       `,
-      [sessionLogId]
+      [incrementSeconds, sessionLogId]
     );
     return next();
   } catch (err) {
@@ -38,18 +50,24 @@ async function markSessionActivity(req, res, next) {
 /**
  * Finalize the session log on logout or session destruction.
  */
-async function closeSessionLog(sessionLogId) {
+async function closeSessionLog(sessionLogId, lastActivityUpdate) {
   if (!sessionLogId) return;
   try {
+    const now = Date.now();
+    const incrementSeconds = calculateActiveSeconds(now, lastActivityUpdate || now);
+
     await pool.query(
       `
         UPDATE user_session_logs
            SET last_activity_time = NOW(),
                logout_time = NOW(),
-               duration_seconds = TIMESTAMPDIFF(SECOND, login_time, NOW())
+               duration_seconds = GREATEST(
+                 duration_seconds + ?,
+                 TIMESTAMPDIFF(SECOND, login_time, NOW())
+               )
          WHERE id = ? AND logout_time IS NULL
       `,
-      [sessionLogId]
+      [incrementSeconds, sessionLogId]
     );
   } catch (err) {
     console.error("Error closing session log:", err);

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -147,9 +147,8 @@ router.post('/login', async (req, res) => {
 // GET /logout
 router.get('/logout', async (req, res) => {
   const sessionLogId = req.session?.sessionLogId;
-
   if (sessionLogId) {
-    await closeSessionLog(sessionLogId);
+    await closeSessionLog(sessionLogId, req.session?.lastActivityUpdate);
   }
 
   req.session.destroy(err => {


### PR DESCRIPTION
## Summary
- refresh session cookies on each request to reduce unexpected logouts
- record active screen time by incrementing duration on heartbeats with idle caps
- ensure logout finalizes session duration using latest activity timestamps

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69556fc9b6ac83208f1d1aec5745617e)