### PR TITLE
Refresh feature documentation and route map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,410 +1,86 @@
 # Kotty Track
 
-Kotty Track is a Node.js and Express application used to manage the production workflow and employee operations of a garment unit.  It features role based dashboards for administrators, operators, supervisors and store staff.  Data is stored in MySQL and views are rendered using EJS templates.
+Kotty Track is a Node.js and Express application that orchestrates the full garment production lifecycle—starting from procurement and indents, through cutting, stitching, washing, finishing, inventory, payroll, and billing—while keeping operators, supervisors, store teams, and finance users aligned. Dashboards are rendered with EJS, data is stored in MySQL, and role-aware middleware secures both HTML pages and APIs.
 
-## Features
-
-- **Authentication** â Users log in and are redirected to dashboards based on their role.
-- **Admin tools** â Manage roles, users and dynamically create dashboard tables.
-- **Production workflow** â Routes exist for fabric, cutting, stitching, finishing, washing and jeans assembly managers.
-- **Employee management** â Supervisors register employees, record attendance, handle salary calculations and upload night shift data.
-- **Store inventory** â Store admins maintain the list of goods while store employees add incoming stock and record dispatches.
-- **Bulk upload & search** â Operators can upload attendance files and perform bulk updates; Excel exports are available throughout the system.
-- **Supervisor cleanup** â Operators can remove a supervisor's employees and all related records in one action.
-- **Audit logging** â Important actions are written to log files for later review.
-- **Washer monthly summary** – Export monthly washer statistics including assigned, completed, pending pieces and completion percentage.
-- **Salary breakdown** – Monthly salary exports now show daily hours with corresponding earnings and the total count of miss punches.
-
-## Installation
+## Getting Started
 
 1. Install dependencies:
    ```bash
    npm install
    ```
-2. Create a `.env` file with your database and session details and encrypt it using [secure-env](https://www.npmjs.com/package/secure-env):
-   ```bash
-   DB_HOST=localhost
-   DB_PORT=3306
-   DB_USER=myuser
-   DB_PASSWORD=
-   DB_NAME=
-   SESSION_SECRET=your-session-secret
-   PORT=3000
-   NODE_ENV=development
-   # Token used to validate EasyEcom webhooks
-   EASYEECOM_ACCESS_TOKEN=
-  ```
-   Encrypt the file:
-   ```bash
-   npx secure-env .env -s {yourPassword}
-   ```
-   The generated `env.enc` must remain in the project root.
-3. Create the MySQL schema using the statements described below.
-
-## Running the Application
+2. Configure environment variables for the database, session secret, file storage, push keys, and any integration tokens. The project expects encrypted environment files managed with [`secure-env`](https://www.npmjs.com/package/secure-env); generate `env.enc` in the project root before running the app.
+3. Ensure a MySQL database is available with the tables used across production, payroll, procurement, and inventory modules.
 
 Start the server with:
 ```bash
 npm start
 ```
-The application listens on the port specified by `PORT` (default `3000`).
-
-## Database Schema
-
-Below are the tables used by the application.  Run these statements in your MySQL database before starting the server.
-
-### Inventory Management
-
-Create the following tables for the store employee dashboard:
-```sql
-CREATE TABLE table_name (
-
-);
-
-INSERT INTO goods_inventory () VALUES
-
-
-CREATE TABLE incoming_data (
-
-);
-
-CREATE TABLE dispatched_data (
- 
-);
-```
-`incoming_data` stores every addition with timestamp and user while `dispatched_data` tracks quantity sent out along with remarks.
-
-Create a table to persist inventory alerts triggered by the webhook:
-```sql
-CREATE TABLE inventory_alerts (
-
-);
-
-CREATE TABLE push_subscriptions (
- 
-);
-
-CREATE TABLE sku_thresholds (
- 
-);
-```
-
-`inventory_alerts` stores each threshold breach so operators can review past
-events. `push_subscriptions` holds browser push registration data for users
-who have allowed notifications. `sku_thresholds` keeps the threshold for each
-SKU so webhook alerts survive server restarts.
-
-Create a `store_admin` role in the `roles` table to allow managing the list of goods. Users with this role can add new items (description, size and unit) from the Store Admin dashboard. Newly created items automatically appear in the store inventory pages.
-
-### Department & Supervisor Tables
-
-Use the following tables to manage departments and the supervisors assigned to them:
-```sql
-CREATE TABLE departments (
-
-);
-
-CREATE TABLE department_supervisors (
- 
-);
-```
-Operators can create departments and assign `supervisor` users to them from the Department Management screen.
-
-### Supervisor Employees
-
-To let supervisors manage their own employees, create the following table:
-```sql
-CREATE TABLE employees (
- 
-);
-```
-The employees table now includes an optional `aadhar_card_number VARCHAR(20)` column for storing Aadhar information.
-
-Each supervisor must assign unique punching IDs to their employees. This ensures no duplicate entries. Employees earn leave and salary details stored in `employee_salaries`. These actions are available from the operator dashboard, which also lists each supervisor with their active employee count and total monthly salary.
-
-### Employee Leaves
-
-Supervisors can track leaves for their employees using this table:
-```sql
-CREATE TABLE employee_leaves (
- 
-);
-```
-Employees normally earn 1.5 days of leave starting in their third month of service.
-Supervisors may set the `leave_start_months` value per employee to change when this accrual begins.
-Each subsequent month after the start month grants another 1.5 days.
-Daily wage (`dihadi`) workers are paid only for hours worked and do not accumulate leaves.
-
-### Employee Debits & Advances
-
-Supervisors may record financial debits or advances for their employees. Use separate tables linked to the employee:
-```sql
-CREATE TABLE employee_debits (
-
-);
-
-CREATE TABLE employee_advances (
-
-);
-
-CREATE TABLE advance_deductions (
- 
-);
-```
-Debits represent losses caused by the employee, while advances are company funds lent to them.
-Any deduction of an advance from a salary is logged in the `advance_deductions` table with the month it was applied.
-
-Advance deductions always apply to the latest salary entry for an employee. If salaries are uploaded for half-month periods (e.g. only the first or second 15 days), the deduction is still linked to that month and can be recorded only once per entry.
-
-
-Advance deductions always apply to the latest salary entry for an employee. If salaries are uploaded for half-month periods (e.g. only the first or second 15 days), the deduction is still linked to that month and can be recorded only once per entry.
-
-
-Advance deductions always apply to the latest salary entry for an employee. If salaries are uploaded for half-month periods (e.g. only the first or second 15 days), the deduction is still linked to that month and can be recorded only once per entry.
-
-
-
-### Attendance & Salary
-
-Add tables to track daily attendance and calculate monthly salaries:
-```sql
-CREATE TABLE employee_attendance (
-
-);
-
-CREATE TABLE employee_salaries (
- 
-);
-```
-Update the `employees` table to store each worker's allotted hours per day:
-```sql
-ALTER TABLE employees ADD COLUMN column DECIMAL(4,2) NOT NULL DEFAULT 0;
-ALTER TABLE employees ADD COLUMN column BOOLEAN NOT NULL DEFAULT TRUE;
-```
-
-Lunch breaks are deducted from recorded hours only for workers paid on a `dihadi` (daily wage) basis. Monthly salary employees keep their full punch duration.
-
-`dihadi` workers do not receive any special treatment for Sundays. Their pay is purely based on hours worked.
-
-Punching in after **09:15** normally deducts **one hour** from the day's counted hours for **dihadi** (daily wage) workers. When the arrival is later than 40% of the allotted shift hours no late deduction is applied.
-
-Monthly employees paid hourly receive their full allotted hours when both punches are present and the punch in time is before **09:15**.
-
-### Sunday Attendance Rules
-
-- Sundays are paid at the normal day rate even when the employee is absent, unless the sandwich rule applies.
-- Worked Sundays always earn double pay.
-- **Mandatory Sundays** â if `paid_sunday_allowance` is greater than zero the employee must work that many Sundays in the month. Missing one counts as an absence and these required days never earn extra pay.
-
-For most teams, a Sunday becomes unpaid whenever the employee is absent on the adjacent Saturday or Monday. If both days are missed, all three (SaturdayâSundayâMonday) are deducted from salary. Teams supervised by **Rohit Shukla** follow the old rule where Sunday counts only when Saturday *and* Monday are absent. When the employee works on that Sunday, any adjacent absence is paid as usual.
-
-### Attendance Edit Logs
-
-Operators can adjust an employee's punch in/out times. A log table tracks these updates and limits each employee to thirty-five edits total:
-```sql
-CREATE TABLE attendance_edit_logs (
-  
-);
-```
-Operators can modify punch times from the dashboard, but once thirty-five rows exist in `attendance_edit_logs` for an employee no further edits are allowed. Every update recalculates the employee's salary for that month.
-
-### Attendance Edit Routes
-
-Several endpoints update attendance records and then recalculate salary using
-`helpers/salaryCalculator.js`:
-
-- `POST /operator/employees/:id/edit` â update a single day of attendance
-  for one employee.
-- `POST /operator/supervisors/:id/bulk-attendance` â bulk edit a specific date
-  for all employees under a supervisor.
-- `POST /operator/employees/:id/bulk-attendance` â edit an entire month of
-  attendance for one employee.
-- `POST /departments/fix-miss-punch` â automatically correct "one punch only"
-  entries for a single employee.
-- `POST /departments/bulk-fix-miss-punch` â upload an Excel file to fix many
-  employees at once.
-
-Each of these routes calls `calculateSalaryForMonth` after saving attendance so
-that both monthly and dihadi salaries are updated with any advance deductions.
-
-### Night Shift Uploads
-
-Operators can upload a monthly Excel sheet listing the night shifts worked by employees. Create a table to store these uploads:
-```sql
-CREATE TABLE employee_nights (
- 
-);
-```
-Uploading a sheet increases the employee's salary by `nights * (salary / days_in_month)` for the specified month. Duplicate uploads for the same employee and month are ignored. Operators can download an Excel template via the `/salary/night-template` route. The file includes the columns `supervisorname`, `supervisordepartment`, `punchingid`, `name`, `nights`, `month`.
-
-Advance and deduction uploads also provide templates. Use `/salary/advance-template` to download a spreadsheet with columns `employeeid`, `punchingid`, `name`, `amount` and `reason`. For recording salary deductions of an advance, download `/salary/advance-deduction-template` which lists `employeeid`, `punchingid`, `name`, `month` and `amount`.
-
-### Sandwich Dates
-
-Create a table so operators can mark certain dates as "sandwich" days:
-```sql
-CREATE TABLE sandwich_dates (
- 
-);
-```
-A sandwich day is normally a paid leave. However, if an employee is absent either the day before or the day after, the sandwich day becomes unpaid and is deducted from salary.
-
-Salaries are released 15 days after the end of the month so that any deductions for damage or misconduct can be applied before payout.
-
-### Attendance and Payroll Rules
-
-The application enforces a number of salary calculation rules. These come
-primarily from `helpers/salaryCalculator.js` and related routes.
-
-#### Daily Hours and Lunch Breaks
-
-- A lunch break is automatically deducted for **dihadi** (daily wage) workers
-  based on their punch‑out time:
-  - 0 minutes if the employee leaves before **13:10**.
-  - 30 minutes if the employee leaves between **13:10** and **18:10**.
-- 60 minutes for any punch‑out after **18:10** when the shift begins before the
-  40% mark; otherwise only **30 minutes** is deducted.
-Dihadi workers arriving after **09:15** lose **one hour** from their total
-working hours, unless their punch in time is later than **40%** of the allotted
-shift. Their day is still capped at **11 working hours**.
-
-#### Monthly Worker Attendance
-
-- Monthly employees have an `allotted_hours` value. When the hours worked for a
-  day are below certain thresholds the day is deducted:
-  - Less than **40%** of the allotted hours -> marked **Absent**.
-  - Between **40%** and **85%** -> counts as a **Half Day**.
-
-#### Sunday Rules
-
-- Employees are only paid for a Sunday when valid punch in/out times result in
-  positive working hours.
-- If an employee is absent on the Saturday or Monday adjacent to a Sunday, that
-  Sunday normally becomes unpaid. When both days are missed the entire
-  Saturday–Sunday–Monday period is deducted.
-- `paid_sunday_allowance` specifies how many Sundays per month are mandatory.
-  Missing one counts as an absence. After the allowance is met, Sundays worked
-  are paid double when neither Saturday nor Monday is absent.
-- Supervisors listed in `utils/supervisors.js` follow an older rule where Sunday
-  counts as an absence only when **both** Saturday *and* Monday are missed. A
-  worked Sunday under these supervisors is always paid.
-
-#### Sandwich Days
-
-- Dates stored in the `sandwich_dates` table are normally treated as paid leave.
-  However, if the employee is absent on the day before **or** the day after, the
-  sandwich day becomes unpaid and is deducted from salary.
-
-### Inventory Webhook Alerts
-
-The `/webhook/inventory` endpoint records incoming webhook data and broadcasts alerts via Server-Sent Events when stock levels fall below their configured threshold.
-Requests do not require a session but must include the `Access-Token` header provided by EasyEcom.
-Use `/webhook/config` to map each SKU to its own threshold.
-Enter one mapping per line in the form `SKU:THRESHOLD`.
-Values are stored in `sku_thresholds` so the configuration persists across
-server restarts.
-The configuration page also provides a **Remove All** button to clear all saved thresholds in one step.
-
-To receive browser push notifications you must generate VAPID keys and set
-`VAPID_PUBLIC_KEY` and `VAPID_PRIVATE_KEY` in your `.env` file. Clients visiting
-`/webhook/logs` will register a service worker that subscribes to push updates.
-Subscriptions are persisted in the `push_subscriptions` table so notifications
-continue working after server restarts.
-Inventory alerts are aggregated and a single push notification is sent every
-three hours. Clicking the notification opens `/inventory/alerts` where the
-latest low stock events are listed.
-
-### Stitching Payments
-
-Two new tables support recording payments to stitching masters.
-
-Create a table to store a per-SKU contract rate:
-```sql
-CREATE TABLE stitching_rates (
-  sku VARCHAR(50) PRIMARY KEY,
-  rate DECIMAL(10,2) NOT NULL
-);
-```
-
-Operation rates are kept in a separate table:
-```sql
-CREATE TABLE stitching_operation_rates (
-  operation VARCHAR(50) PRIMARY KEY,
-  rate DECIMAL(10,2) NOT NULL
-);
-```
-
-Contract payments are captured in `stitching_payments_contract`:
-```sql
-CREATE TABLE stitching_payments_contract (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  master_id INT NOT NULL,
-  lot_no VARCHAR(50) NOT NULL,
-  sku VARCHAR(50) NOT NULL,
-  qty INT NOT NULL,
-  rate DECIMAL(10,2) NOT NULL,
-  amount DECIMAL(10,2) NOT NULL,
-  paid_on DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-```
-
-Operation based payments use a separate table:
-```sql
-CREATE TABLE stitching_operation_payments (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  master_id INT NOT NULL,
-  lot_no VARCHAR(50) NOT NULL,
-  operation VARCHAR(50) NOT NULL,
-  worker_name VARCHAR(100) NOT NULL,
-  qty INT NOT NULL,
-  rate DECIMAL(10,2) NOT NULL,
-  amount DECIMAL(10,2) NOT NULL,
-  paid_on DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
-);
-```
-
-The operator dashboard exposes a page to maintain `stitching_rates` so contract
-amounts can be calculated automatically.
-
-### Washing Payments
-
-Store per-item washing rates in the `washing_item_rates` table:
-
-```sql
-CREATE TABLE washing_item_rates (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  description VARCHAR(100) NOT NULL UNIQUE,
-  rate DECIMAL(10,2) NOT NULL DEFAULT 0
-);
-```
-
-Operators can add items such as "ice wash" or "acid wash" and set the amount to be paid for each from the washing payment dashboard.
-
-### Purchase Dashboard
-
-The Purchase dashboard stores party and factory details along with simple
-payment terms.
-
-```sql
-CREATE TABLE parties (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  name VARCHAR(255) NOT NULL,
-  gst_number VARCHAR(50),
-  state VARCHAR(100),
-  pincode VARCHAR(20),
-  due_payment_days INT DEFAULT 0
-);
-
-CREATE TABLE factories (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  name VARCHAR(255) NOT NULL,
-  gst_number VARCHAR(50),
-  state VARCHAR(100)
-);
-
--- allow purchaseGRN users to sign in
-INSERT INTO roles (name) VALUES ('purchaseGRN');
-```
-
-`due_payment_days` records how many days after billing a payment becomes due.
-Accounts users can edit this number but only the day count is stored.
+The app listens on the port defined by `PORT` (defaults to `3000`).
+
+## Feature Map (by Route)
+
+The platform is organised by route files so you can trace how each module works and how data flows between them.
+
+### Platform Access, Sessions & Role Guards
+- `routes/authRoutes.js`, `routes/authRoutesOptimized.js`: Hash-based login, cached lookups, and logout with session teardown.
+- `middlewares/auth.js`, `middlewares/sessionActivity.js`: Role checks for every dashboard/API plus session activity logging for audits.
+
+### Administration, Audit & Dynamic Dashboards
+- `routes/adminRoutes.js`: Role, user, dashboard, and schema management with audit logging.
+- `routes/dashboardRoutes.js`: Role-aware dashboard listings with search, pagination, and export helpers.
+- `routes/searchRoutes.js`: Metadata-cached search that builds flexible SQL and streams Excel downloads.
+- `routes/featuresRoutes.js`: Renders the feature overview page.
+
+### Fabric Intake, Cutting & Department Hand-offs
+- `routes/fabricManagerRoutes.js`: Spreadsheet-driven invoice and roll onboarding with vendor reconciliation.
+- `routes/cuttingManagerRoutes.js`, `routes/editcuttinglots.js`: Lot generation, size splits, attachments, and corrections.
+- `routes/departmentRoutes.js`: Department users confirm partial progress so operators can verify and advance work.
+
+### Stitching Approvals, Assembly & Reassignments
+- `routes/stitchingRoutes.js`: Approve stitching assignments, capture per-size outputs with photos, and export logs.
+- `routes/jeansAssemblyRoutes.js`: Reconcile stitched lots, approve assembly output, and generate challans for downstream steps.
+- `routes/editWashingAssignments.js`: Fix or reassign washing links without losing history.
+
+### Washing Intake, Rewash & Finishing Dispatch
+- `routes/assigntowashingRoutes.js`: Pair assembly output with washer queues using cached dropdowns.
+- `routes/washingRoutes.js`, `routes/washingInRoutes.js`: Washing dashboards, arrival checks, rewash loops, Excel summaries, and challans.
+- `routes/finishingRoutes.js`: Validate totals, attach proofs, edit or revoke entries, and prepare dispatch documents.
+
+### Operator Command Center & Department Management
+- `routes/operatorRoutes.js`: Cached analytics for lot progress across denim/non-denim chains plus bottleneck highlights.
+- `routes/departmentMgmtRoutes.js`: Department configuration, supervisor assignment, and attendance correction uploads.
+- `routes/operatorEmployeeRoutes.js`: Supervisor rosters, incentives, advances, and salary recalculation hooks.
+
+### Workforce Rosters, Attendance & Payroll Rules
+- `routes/employeeRoutes.js`: Supervisor-facing CRUD for employees with roster exports.
+- `routes/dihadiRoutes.js`: Daily wage attendance capture with immediate salary recalculation and Excel templates.
+- `helpers/salaryCalculator.js`: Salary logic covering lunch breaks, allowances, leave rules, sandwich days, and night shifts.
+
+### Inventory, Out-of-Stock Alerts & Store Operations
+- `routes/storeAdminRoutes.js`: Goods master maintenance and dispatch history with cached lookups.
+- `routes/inventoryRoutes.js`: Incoming/outgoing stock with transactional updates and Excel downloads.
+- `routes/inventoryWebhook.js`: Webhook ingestion for stock thresholds, alert persistence, and SSE broadcasts.
+- `routes/skuRoutes.js`: SKU alert history and detail views so operators can react to out-of-stock signals.
+
+### Procurement, Indents, Purchase Orders & Vendor Files
+- `routes/purchaseRoutes.js`: Party and factory management with inline CRUD and templates.
+- `routes/indentRoutes.js`: Filler requests, store manager approvals, status changes, and audit logging.
+- `routes/poCreatorRoutes.js`, `routes/nowiPoRoutes.js`: PO dashboards, inward entries, brand/panel mapping, and exports.
+- `routes/vendorFilesRoutes.js`: S3-backed uploads, signed URLs, and archive downloads for vendor-facing documents.
+
+### Catalog Uploads, Templates & Bulk Automation
+- `routes/catalogupload.js`: Marketplace catalog uploads from S3 with header normalisation and cached marketplace metadata.
+- `routes/bulkUploadRoutes.js`: Excel templates and bulk inserts for lots or washing assignments with validation and rollbacks.
+
+### Integrations, Analytics & Partner APIs
+- `routes/apiAuthRoutes.js`, `routes/apiRoutes.js`, `routes/productionApiRoutes.js`: JWT-protected APIs for lot retrieval, status updates, and exports.
+- `routes/flipkartReturnRoutes.js`, `routes/flipkartIssueStatusRoutes.js`: Flipkart reconciliation for return consignments and issue statuses.
+- `routes/easyecomapi.js`, `routes/easyecomRoutes.js`: EasyEcom data ingestion plus stock momentum/runway analytics scoped by warehouse and out-of-stock roles.
+
+### Payments, Challans & Documentation
+- `routes/stitchingPaymentRoutes.js`, `routes/washingPaymentRoutes.js`: Rate configuration, payout calculations, and Excel exports for stitching and washing.
+- `routes/accountsChallanRoutes.js`, `routes/challanDashboardRoutes.js`: GST challan generation from approved washing assignments with counters, vehicle/purpose metadata, and printable PDFs.
+
+## Connecting the Dots
+
+Procurement teams create parties and POs, indents feed fabric intake, cutting lots drive stitching and assembly, washing and finishing record checkpoints, operators monitor flow health, payroll recalculates as attendance changes, and inventory webhooks trigger out-of-stock alerts that tie back to EasyEcom analytics and store dashboards. Finance teams finish the loop with payments and challans—every step guarded by the same authentication and audit layers.

--- a/routes/featuresRoutes.js
+++ b/routes/featuresRoutes.js
@@ -3,194 +3,148 @@ const router = express.Router();
 
 const featureSections = [
   {
-    id: 'auth',
-    title: 'Authentication & Role Guards',
+    id: 'platform-access',
+    title: 'Platform Access, Sessions & Role Guards',
     description:
-      'Login, session management, and role-aware middleware protect every workflow before a dashboard even loads.',
+      'Login, logout, and session protection keep every dashboard behind hashed credentials, cached lookups, and consistent authorization.',
     highlights: [
-      'Login verifies hashed passwords against active user accounts and captures role metadata before redirecting to the relevant module home.',
-      'Shared guards return JSON for API clients or flash messages for web flows so the same middleware protects HTML pages and REST endpoints.',
-      'Logout tears down session state so privileged dashboards stay inaccessible once a user signs out.'
+      'Username/password login validates hashed records, caches recent lookups, and redirects by role while capturing session metadata.',
+      'Reusable middleware gates each router by role, returning JSON for API callers and flash messaging for browser users.',
+      'Session activity logging closes audit trails on logout so privileged dashboards stay inaccessible once a user signs out.'
     ],
-    modules: ['routes/authRoutes.js', 'middlewares/auth.js']
+    modules: ['routes/authRoutes.js', 'routes/authRoutesOptimized.js', 'middlewares/auth.js', 'middlewares/sessionActivity.js']
   },
   {
-    id: 'admin',
-    title: 'Administration & Governance',
+    id: 'admin-governance',
+    title: 'Administration, Audit & Dynamic Dashboards',
     description:
-      'Admins orchestrate the operating model by managing users, dashboards, audit trails, and dynamic table schemas.',
+      'Admins curate roles, users, dashboards, and database-backed widgets while keeping audit logs and search utilities in sync.',
     highlights: [
-      'Dashboard loads combine role lists, user rosters, existing dashboards, and audit history to keep control room context in one place.',
-      'Schema builder forms create MySQL tables and matching dashboard metadata inside a single transaction with full validation.',
-      'Every structural change records an audit log entry so administrators can trace who changed what and when.'
+      'Admin console lists roles, users, dashboards, and audit history together, letting admins create schemas and dashboards in one flow.',
+      'Dashboard routes hydrate role-aware table views with pagination, search, and Excel export helpers for any configured dataset.',
+      'Search routes cache metadata, build flexible SQL on demand, and stream filtered results to Excel without exposing raw tables.'
     ],
-    modules: ['routes/adminRoutes.js', 'config/db.js']
+    modules: ['routes/adminRoutes.js', 'routes/dashboardRoutes.js', 'routes/searchRoutes.js', 'routes/featuresRoutes.js']
   },
   {
-    id: 'dashboards',
-    title: 'Dynamic Dashboards & Search',
+    id: 'fabric-cutting',
+    title: 'Fabric Intake, Cutting Lots & Department Hand-offs',
     description:
-      'Self-service dashboards let each role explore its authorised tables with pagination, filters, exports, and column-level control.',
+      'Fabric managers onboard invoices and rolls, cutting managers generate lots, and department users confirm work in partial waves.',
     highlights: [
-      'Role-aware listings show only dashboards mapped to the signed-in role and protect tables behind per-user access checks.',
-      'Table views support keyword search across concatenated columns, conditional filtering by ownership, and Excel downloads of the exact slice in view.',
-      'Operator-grade search tooling caches metadata, builds flexible SQL on the fly, and streams massive result sets straight to Excel files.'
+      'Fabric routes normalise spreadsheet uploads, reconcile vendors, and persist roll breakdowns for later consumption.',
+      'Cutting managers generate lot numbers, attach imagery, split quantities by size, and edit lots when specs change.',
+      'Department dashboards let team users mark partial completions so operators can verify and push lots forward.'
     ],
-    modules: ['routes/dashboardRoutes.js', 'routes/searchRoutes.js']
+    modules: ['routes/fabricManagerRoutes.js', 'routes/cuttingManagerRoutes.js', 'routes/editcuttinglots.js', 'routes/departmentRoutes.js']
   },
   {
-    id: 'fabric',
-    title: 'Fabric Procurement & Roll Intake',
+    id: 'stitching-assembly',
+    title: 'Stitching Approvals, Assembly & Reassignments',
     description:
-      'Fabric managers reconcile invoices, capture roll breakdowns, and accelerate bulk onboarding with spreadsheet uploads.',
+      'Stitching masters approve assignments, record piece-wise output, and feed assembly teams who prepare lots for washing.',
     highlights: [
-      'Dashboard views paginate invoices with vendor joins, search filters, and creator context for day-to-day tracking.',
-      'Utility helpers normalise Excel serial dates and cache vendor lookups so imports stay clean and performant.',
-      'Bulk upload endpoints parse XLSX files, upsert vendor references, and insert invoice and roll records inside managed transactions.'
+      'Approval queues and history pages enforce per-size totals, accept photos, and export structured evidence for auditors.',
+      'Assembly dashboards reconcile stitched lots, capture approvals, and surface PDF challans for downstream washing or dispatch.',
+      'Edit flows fix assignment issues and let operators reassign or correct washing links without breaking historical data.'
     ],
-    modules: ['routes/fabricManagerRoutes.js']
+    modules: ['routes/stitchingRoutes.js', 'routes/jeansAssemblyRoutes.js', 'routes/editWashingAssignments.js']
   },
   {
-    id: 'cutting',
-    title: 'Cutting Lots & Assignments',
+    id: 'washing-finishing',
+    title: 'Washing Intake, Rewash & Finishing Dispatch',
     description:
-      'Cutting managers generate lot numbers, attach imagery, track size splits, and push work downstream with full visibility.',
+      'Washing, washing-in, and finishing modules manage approvals, checkpoints, rewash loops, and final dispatch paperwork.',
     highlights: [
-      'Dashboard bootstraps transactional lot numbers per user session, hydrates recent lots, and caches available fabric rolls by fabric type.',
-      'Lot creation stores per-size breakdowns, optional reference photos, and user attribution before surfacing lots to other departments.',
-      'Assignment tooling targets stitching, washing, and QA roles while exposing PDF challan generation for hand-off paperwork.'
+      'Assignment tooling pairs assembly output with washer queues, preventing duplicate submissions and keeping remarks traceable.',
+      'Washing-in routes confirm arrivals, split toward rewash or finishing, and generate Excel summaries and challans.',
+      'Finishing captures proofs, validates totals, and supports edits or revocations before dispatch and document printing.'
     ],
-    modules: ['routes/cuttingManagerRoutes.js', 'routes/editcuttinglots.js']
+    modules: ['routes/assigntowashingRoutes.js', 'routes/washingRoutes.js', 'routes/washingInRoutes.js', 'routes/finishingRoutes.js']
   },
   {
-    id: 'stitching',
-    title: 'Stitching Execution & Records',
+    id: 'operator-oversight',
+    title: 'Operator Command Center & Department Management',
     description:
-      'Stitching masters approve work, capture progress with photos, and export evidence for finance and planning teams.',
+      'Operators monitor flow health, manage departments, and coordinate supervisors with cached analytics and Excel-friendly exports.',
     highlights: [
-      'Approval queues list pending assignments with search filters so supervisors can green-light or reject lots with remarks.',
-      'Data entry screens enforce per-size totals, attach upload evidence, and keep history paginated with incremental loading APIs.',
-      'Excel exports, challan creation, and edit routes help correct mistakes while keeping auditors supplied with structured data.'
+      'Performance widgets aggregate stitched, washed, and finished totals per lot, flagging bottlenecks across denim and non-denim chains.',
+      'Department management assigns supervisors, uploads attendance corrections, and reviews confirmation backlogs per stage.',
+      'Supervisor tooling shows rosters, incentives, and advances with salary recalculation hooks for every attendance adjustment.'
     ],
-    modules: ['routes/stitchingRoutes.js', 'routes/stitchingPaymentRoutes.js']
+    modules: ['routes/operatorRoutes.js', 'routes/departmentMgmtRoutes.js', 'routes/operatorEmployeeRoutes.js']
   },
   {
-    id: 'assembly',
-    title: 'Jeans Assembly & Washing Handovers',
+    id: 'workforce-payroll',
+    title: 'Workforce Rosters, Attendance & Payroll Rules',
     description:
-      'Assembly teams reconcile stitched output, approve inbound lots, and prepare washing assignments without leaving the module.',
+      'Supervisors and HR teams manage employee records, track daily wages, and upload attendance or night-shift data with templates.',
     highlights: [
-      'Controllers fetch pending stitching approvals, enforce role-based checks, and record per-size assembly totals with images.',
-      'Lists show historical assembly records with Excel downloads and PDF challans for downstream washing or dispatch.',
-      'Bulk approval and reassignment flows ensure only validated lots move into washing or rework pipelines.'
+      'Employee routes let supervisors register staff, edit metadata, and download structured rosters for offline updates.',
+      'Daily wage (“dihadi”) routes create attendance entries, enforce validations, and recalculate salaries immediately.',
+      'Shared salary helpers convert punch logs into monthly pay with leave, sandwich-day, and allowance logic baked in.'
     ],
-    modules: ['routes/jeansAssemblyRoutes.js', 'routes/assigntowashingRoutes.js']
+    modules: ['routes/employeeRoutes.js', 'routes/dihadiRoutes.js', 'helpers/salaryCalculator.js']
   },
   {
-    id: 'washing',
-    title: 'Washing Intake, Processing & Payments',
+    id: 'inventory-alerts',
+    title: 'Inventory, Out-of-Stock Alerts & Store Operations',
     description:
-      'Specialised dashboards manage washer approvals, washing-in checkpoints, rewash loops, and payout reconciliation.',
+      'Store admins and inventory operators reconcile goods, dispatch stock, and react to webhook-driven out-of-stock alerts.',
     highlights: [
-      'Washing dashboards surface approved lots, guard against duplicate submissions, and capture per-size washed totals with imagery.',
-      'Washing-in routes confirm inbound loads, split pieces towards finishing or rewash, and emit challans and Excel summaries.',
-      'Payment modules fetch rate cards, calculate invoices per washer, and give operators searchable histories of prior settlements.'
+      'Store admin dashboards maintain the goods master, dispatch history, and Excel exports for quick audits.',
+      'Inventory dashboards handle incoming and outgoing quantities with transactional updates and on-demand Excel downloads.',
+      'Webhook handlers persist threshold breaches, stream alerts via Server-Sent Events, and expose SKU alert history for operators.'
     ],
-    modules: ['routes/washingRoutes.js', 'routes/washingInRoutes.js', 'routes/washingPaymentRoutes.js']
+    modules: ['routes/storeAdminRoutes.js', 'routes/inventoryRoutes.js', 'routes/inventoryWebhook.js', 'routes/skuRoutes.js']
   },
   {
-    id: 'finishing',
-    title: 'Finishing & Dispatch Management',
+    id: 'procurement-po',
+    title: 'Procurement, Indents, Purchase Orders & Vendor Files',
     description:
-      'Finishing teams wrap production by validating quantities, creating challans, and coordinating dispatch readiness.',
+      'Accounts and procurement teams track parties, handle indents, generate POs, and share vendor files securely.',
     highlights: [
-      'Creation flows validate approvals from washing, enforce size-level totals, and support optional proof images before records post.',
-      'Operators can edit or revoke entries, generate department-wise challans, and review paginated histories of every finishing action.',
-      'Dispatch tooling handles partial or full loads, Excel-based bulk uploads, and printable documents for logistics partners.'
+      'Purchase dashboards manage parties and factories, while indent flows log filler requests, status changes, and audit history.',
+      'PO creator routes assemble inward entries with brand codes, panels, and exports, including specialised Nowi PO helpers.',
+      'Vendor file routes upload Excel or image packs to S3, generate signed URLs, and bundle archives for collaborators.'
     ],
-    modules: ['routes/finishingRoutes.js']
+    modules: ['routes/purchaseRoutes.js', 'routes/indentRoutes.js', 'routes/poCreatorRoutes.js', 'routes/nowiPoRoutes.js', 'routes/vendorFilesRoutes.js']
   },
   {
-    id: 'operator',
-    title: 'Operator Command Center & Department Oversight',
+    id: 'catalog-bulk',
+    title: 'Catalog Uploads, Templates & Bulk Automation',
     description:
-      'Operators monitor throughput, manage departments, and coordinate staffing from a single cached analytics hub.',
+      'Excel-driven utilities minimise manual entry for catalog data, washing assignments, and lot updates.',
     highlights: [
-      'Analytics aggregate stitched, washed, and finished totals per operator, highlight pending lots, and surface SKU momentum trends.',
-      'Department management screens assign supervisors, configure departments, and review confirmation backlogs per production stage.',
-      'Operator employee tools track workers, incentives, advances, and washing assignments with Excel exports for payroll teams.'
+      'Catalog upload routes parse marketplace sheets from S3, normalise headers, and cache marketplace metadata.',
+      'Bulk upload dashboards generate templates, validate rows, and insert lots or washing assignments with rollback safety.',
+      'Shared helpers keep date conversions, caching, and file handling consistent across upload-heavy flows.'
     ],
-    modules: [
-      'routes/operatorRoutes.js',
-      'routes/departmentMgmtRoutes.js',
-      'routes/operatorEmployeeRoutes.js'
-    ]
+    modules: ['routes/catalogupload.js', 'routes/bulkUploadRoutes.js']
   },
   {
-    id: 'workforce',
-    title: 'Supervisor & Workforce Tools',
+    id: 'integrations-apis',
+    title: 'Integrations, Analytics & Partner APIs',
     description:
-      'Supervisors and HR partners manage rosters, attendance, and daily wages with targeted utilities.',
+      'External touchpoints sync Flipkart returns, EasyEcom stock analytics, and production data over authenticated APIs.',
     highlights: [
-      'Supervisors review assigned employees, update worker metadata, and download structured rosters for offline use.',
-      'Daily wage (“dihadi”) routes create attendance entries, calculate pay, and support Excel templates for bulk imports.',
-      'Shared helpers keep flash messaging and validation consistent across workforce-facing forms.'
+      'API auth and production routes provide JWT-secured endpoints for lot retrieval, status updates, and metadata exports.',
+      'Flipkart routes reconcile return consignments and issue statuses, while EasyEcom UI charts orders, runway, and momentum.',
+      'Out-of-stock role support and warehouse scoping align EasyEcom analytics with inventory alerts seen in-store.'
     ],
-    modules: ['routes/employeeRoutes.js', 'routes/dihadiRoutes.js']
+    modules: ['routes/apiAuthRoutes.js', 'routes/apiRoutes.js', 'routes/productionApiRoutes.js', 'routes/flipkartReturnRoutes.js', 'routes/flipkartIssueStatusRoutes.js', 'routes/easyecomapi.js', 'routes/easyecomRoutes.js']
   },
   {
-    id: 'inventory',
-    title: 'Inventory & Store Operations',
+    id: 'payments-challans',
+    title: 'Payments, Challans & Documentation',
     description:
-      'Store admins reconcile goods in, goods out, and adjustments while keeping alerts and audit trails in sync.',
+      'Finance and accounts teams configure rates, reconcile payouts, and generate GST-ready challans from washing output.',
     highlights: [
-      'Dashboard joins stock masters with incoming and dispatched movements while caching catalog data for quick load times.',
-      'Stock adjustments run inside transactions to keep quantities balanced and capture who performed each movement.',
-      'Excel exports, SSE alert streams, and webhook log viewers give store teams real-time visibility into stock events.'
+      'Stitching and washing payment routes fetch rate cards, calculate amounts, and export Excel summaries per user or operation.',
+      'Accounts challan routes generate GST challans from approved washing assignments, enforce counters, and render printable PDFs.',
+      'Challan dashboards add vehicle and purpose metadata while keeping history searchable for audits.'
     ],
-    modules: ['routes/inventoryRoutes.js', 'routes/storeAdminRoutes.js', 'routes/inventoryWebhook.js']
-  },
-  {
-    id: 'procurement',
-    title: 'Purchase & Master Data Management',
-    description:
-      'Accounts teams maintain vendor, party, and factory masters alongside procurement utilities.',
-    highlights: [
-      'Purchase routes list parties and factories, support inline CRUD, and provide ready-made Excel templates.',
-      'SKU utilities centralise product definitions so cutting, stitching, and inventory flows stay aligned.',
-      'Data validations and flash messaging keep master data clean without direct database access.'
-    ],
-    modules: ['routes/purchaseRoutes.js', 'routes/skuRoutes.js']
-  },
-  {
-    id: 'integrations',
-    title: 'Integrations, APIs & Webhooks',
-    description:
-      'External touchpoints connect Flipkart services, internal APIs, and real-time webhooks to the production backbone.',
-    highlights: [
-      'Authenticated routes fetch Flipkart return consignments and issue statuses using seller credentials for reconciliation.',
-      'Inventory webhooks accept JSON payloads, persist change logs, and fan out alerts over Server-Sent Events.',
-      'JWT-protected APIs expose inventory summaries and fabric availability for partners and satellite tools.'
-    ],
-    modules: [
-      'routes/flipkartReturnRoutes.js',
-      'routes/flipkartIssueStatusRoutes.js',
-      'routes/apiAuthRoutes.js',
-      'routes/apiRoutes.js',
-      'routes/inventoryWebhook.js'
-    ]
-  },
-  {
-    id: 'bulk-automation',
-    title: 'Bulk Upload & Catalog Automation',
-    description:
-      'Excel-driven utilities reduce manual entry for SKU catalogs, washing assignments, and production updates.',
-    highlights: [
-      'Catalog upload routes parse Excel sheets, normalise headers, and batch insert catalog entries with progress feedback.',
-      'Bulk upload helpers reuse parsing logic to assign lots to washing or update production datasets safely.',
-      'Reusable date conversion and validation helpers keep spreadsheet data consistent across modules.'
-    ],
-    modules: ['routes/catalogupload.js', 'routes/bulkUploadRoutes.js', 'routes/assigntowashingRoutes.js']
+    modules: ['routes/stitchingPaymentRoutes.js', 'routes/washingPaymentRoutes.js', 'routes/accountsChallanRoutes.js', 'routes/challanDashboardRoutes.js']
   }
 ];
 

--- a/views/features.ejs
+++ b/views/features.ejs
@@ -190,9 +190,9 @@
           <span class="badge-pill mb-3">Kotty Track</span>
           <h1 class="display-5 mb-3">End-to-End Production Features</h1>
           <p>
-            Explore how every module in Kotty Track fits together—from onboarding fabric to dispatching finished pieces,
-            handling payroll, and syncing with partner platforms. Each section summarises the capabilities available to
-            the teams who rely on the app every day.
+            Explore how every module in Kotty Track fits together—from indents and cutting lots to washing, payroll,
+            out-of-stock alerts, and partner integrations. Each section maps the routes behind the UI so every team knows
+            what data flows into their dashboard and why.
           </p>
         </div>
         <div class="text-lg-end">


### PR DESCRIPTION
### Motivation
- Provide a single, up-to-date feature map that explains how every major route and module connects across the production pipeline. 
- Remove sensitive or environment/DB-specific credential examples and raw SQL snippets from the README so the project documentation is safe to share. 
- Make the in-app features page clearer about which routes back each capability so operators and developers can trace data flows. 
- Consolidate scattered descriptions into a route-by-route reference to reduce onboarding friction for new contributors.

### Description
- Rewrote the feature map in `routes/featuresRoutes.js` to expand and reorganise `featureSections`, grouping capabilities by logical areas such as `platform-access`, `fabric-cutting`, `inventory-alerts`, `procurement-po`, and `payments-challans` and listing the route files that implement each area. 
- Replaced the old `README.md` content with a concise getting-started section and a route-by-route feature map that omits credentials and raw table creation SQL while explaining how modules interact. 
- Updated the hero copy in `views/features.ejs` to emphasise end-to-end coverage, out-of-stock alerts and that the page maps UI areas to route files. 
- Kept references to the same route files so behaviour is unchanged; this change is documentation-first and does not alter runtime logic.

### Testing
- No automated tests were executed for this change. 
- Documentation updates were validated by rendering the `features` view locally (visual/content check) and verifying the `README.md` no longer contains credential or raw SQL snippets. 
- No runtime code paths or API behaviour were modified, so no integration or unit tests were required for functional changes. 
- If desired, run the test or lint tooling in your CI (`npm test`, `npm run lint`) after merging to confirm repository-wide checks pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695cd0ff41fc83209a84dcd7d814c2e3)