### PR TITLE
Add bulk inward Excel template download and upload

### DIFF
--- a/routes/poCreatorRoutes.js
+++ b/routes/poCreatorRoutes.js
@@ -5,6 +5,61 @@ const router = express.Router();
 const { pool } = require('../config/db');
 const { isPOCreator, isAuthenticated, isOperator } = require('../middlewares/auth');
 const ExcelJS = require('exceljs');
+const multer = require('multer');
+const fs = require('fs');
+
+const upload = multer({
+  dest: 'uploads/',
+  limits: { fileSize: 5 * 1024 * 1024 },
+  fileFilter: (req, file, cb) => {
+    if (file.mimetype === 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet') {
+      cb(null, true);
+    } else {
+      cb(new Error('Only .xlsx files are allowed!'), false);
+    }
+  }
+});
+
+const fsPromises = fs.promises;
+
+function excelSerialDateToJSDate(serial) {
+  const excelEpoch = new Date(Date.UTC(1899, 11, 30));
+  const daysInMs = serial * 24 * 60 * 60 * 1000;
+  return new Date(excelEpoch.getTime() + daysInMs);
+}
+
+function formatDateToMySQL(dateObj) {
+  const year = dateObj.getUTCFullYear();
+  const month = String(dateObj.getUTCMonth() + 1).padStart(2, '0');
+  const day = String(dateObj.getUTCDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function getCellText(value) {
+  if (value === null || value === undefined) return '';
+  if (typeof value === 'object') {
+    if (value.text) return String(value.text).trim();
+    if (value.richText) return value.richText.map(item => item.text).join('').trim();
+    if (value.result) return String(value.result).trim();
+    if (value.hyperlink) return String(value.text || value.hyperlink).trim();
+  }
+  return String(value).trim();
+}
+
+function parseDateValue(value) {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return formatDateToMySQL(value);
+  }
+  if (typeof value === 'number') {
+    return formatDateToMySQL(excelSerialDateToJSDate(value));
+  }
+  const parsed = new Date(value);
+  if (!Number.isNaN(parsed.getTime())) {
+    return formatDateToMySQL(parsed);
+  }
+  return null;
+}
 
 // Dashboard - Main page
 router.get('/dashboard', isPOCreator, async (req, res) => {
@@ -37,6 +92,285 @@ router.get('/inward', isPOCreator, async (req, res) => {
     console.error('Error loading inward form:', error);
     req.flash('error', 'Error loading inward form');
     res.redirect('/po-creator/dashboard');
+  }
+});
+
+router.get('/inward/template', isPOCreator, async (req, res) => {
+  try {
+    const [brandCodes] = await pool.query('SELECT code FROM sku_brand_codes WHERE is_active = 1 ORDER BY code');
+    const [categories] = await pool.query('SELECT name FROM sku_categories WHERE is_active = 1 ORDER BY name');
+    const [panelNames] = await pool.query('SELECT name FROM panel_names WHERE is_active = 1 ORDER BY name');
+
+    const workbook = new ExcelJS.Workbook();
+    const templateSheet = workbook.addWorksheet('Inward Template');
+    const listSheet = workbook.addWorksheet('Lists');
+    listSheet.state = 'veryHidden';
+
+    const panelList = panelNames.length ? panelNames.map(panel => panel.name) : ['N/A'];
+    const brandList = brandCodes.length ? brandCodes.map(brand => brand.code) : ['N/A'];
+    const categoryList = categories.length ? categories.map(category => category.name) : ['N/A'];
+
+    listSheet.getRow(1).values = ['Panel Name', 'Brand Code', 'Category'];
+    panelList.forEach((name, index) => {
+      listSheet.getCell(index + 2, 1).value = name;
+    });
+    brandList.forEach((code, index) => {
+      listSheet.getCell(index + 2, 2).value = code;
+    });
+    categoryList.forEach((name, index) => {
+      listSheet.getCell(index + 2, 3).value = name;
+    });
+
+    templateSheet.columns = [
+      { header: 'Carton Reference (optional)', key: 'carton_reference', width: 24 },
+      { header: 'Panel Name', key: 'panel_name', width: 20 },
+      { header: 'Date of Packing (YYYY-MM-DD)', key: 'date_of_packing', width: 22 },
+      { header: 'Packed By', key: 'packed_by', width: 18 },
+      { header: 'Brand Code', key: 'brand_code', width: 14 },
+      { header: 'Category', key: 'category', width: 20 },
+      { header: 'SKU Code', key: 'sku_code', width: 14 },
+      { header: 'Size', key: 'size', width: 12 },
+      { header: 'Quantity', key: 'quantity', width: 12 }
+    ];
+
+    templateSheet.getRow(1).font = { bold: true, color: { argb: 'FFFFFFFF' } };
+    templateSheet.getRow(1).fill = {
+      type: 'pattern',
+      pattern: 'solid',
+      fgColor: { argb: 'FF2563EB' }
+    };
+    templateSheet.views = [{ state: 'frozen', ySplit: 1 }];
+    templateSheet.getColumn(3).numFmt = 'yyyy-mm-dd';
+
+    const maxRows = 500;
+    const panelRange = `Lists!$A$2:$A$${panelList.length + 1}`;
+    const brandRange = `Lists!$B$2:$B$${brandList.length + 1}`;
+    const categoryRange = `Lists!$C$2:$C$${categoryList.length + 1}`;
+
+    templateSheet.dataValidations.add(`B2:B${maxRows}`, {
+      type: 'list',
+      allowBlank: false,
+      formulae: [panelRange],
+      showErrorMessage: true,
+      errorTitle: 'Invalid Panel Name',
+      error: 'Please select a panel name from the list.'
+    });
+
+    templateSheet.dataValidations.add(`E2:E${maxRows}`, {
+      type: 'list',
+      allowBlank: false,
+      formulae: [brandRange],
+      showErrorMessage: true,
+      errorTitle: 'Invalid Brand Code',
+      error: 'Please select a brand code from the list.'
+    });
+
+    templateSheet.dataValidations.add(`F2:F${maxRows}`, {
+      type: 'list',
+      allowBlank: false,
+      formulae: [categoryRange],
+      showErrorMessage: true,
+      errorTitle: 'Invalid Category',
+      error: 'Please select a category from the list.'
+    });
+
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', 'attachment; filename=inward-bulk-template.xlsx');
+    await workbook.xlsx.write(res);
+    res.end();
+  } catch (error) {
+    console.error('Error generating inward template:', error);
+    req.flash('error', 'Error generating inward template');
+    res.redirect('/po-creator/inward');
+  }
+});
+
+router.post('/inward/bulk-upload', isPOCreator, upload.single('inwardFile'), async (req, res) => {
+  if (!req.file) {
+    req.flash('error', 'Please upload a valid .xlsx file');
+    return res.redirect('/po-creator/inward');
+  }
+
+  let workbook;
+  try {
+    workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.readFile(req.file.path);
+
+    const worksheet = workbook.worksheets[0];
+    if (!worksheet) {
+      req.flash('error', 'No worksheet found in the uploaded file');
+      return res.redirect('/po-creator/inward');
+    }
+
+    const [brandCodes] = await pool.query('SELECT code FROM sku_brand_codes WHERE is_active = 1');
+    const [categories] = await pool.query('SELECT name FROM sku_categories WHERE is_active = 1');
+    const [panelNames] = await pool.query('SELECT name FROM panel_names WHERE is_active = 1');
+    const brandSet = new Set(brandCodes.map(item => item.code));
+    const categorySet = new Set(categories.map(item => item.name));
+    const panelSet = new Set(panelNames.map(item => item.name));
+
+    const headerRow = worksheet.getRow(1);
+    const headerMap = new Map();
+    headerRow.eachCell((cell, colNumber) => {
+      const header = getCellText(cell.value);
+      if (header) {
+        headerMap.set(header, colNumber);
+      }
+    });
+
+    const requiredHeaders = [
+      'Panel Name',
+      'Date of Packing (YYYY-MM-DD)',
+      'Packed By',
+      'Brand Code',
+      'Category',
+      'SKU Code',
+      'Size',
+      'Quantity'
+    ];
+
+    const missingHeaders = requiredHeaders.filter(header => !headerMap.has(header));
+    if (missingHeaders.length) {
+      req.flash('error', `Missing columns: ${missingHeaders.join(', ')}`);
+      return res.redirect('/po-creator/inward');
+    }
+
+    const cartonsMap = new Map();
+    const errors = [];
+    let totalSkuCount = 0;
+
+    worksheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+      if (rowNumber === 1) return;
+
+      const panelName = getCellText(row.getCell(headerMap.get('Panel Name')).value);
+      const dateRaw = row.getCell(headerMap.get('Date of Packing (YYYY-MM-DD)')).value;
+      const dateOfPacking = parseDateValue(dateRaw);
+      const packedBy = getCellText(row.getCell(headerMap.get('Packed By')).value);
+      const brandCode = getCellText(row.getCell(headerMap.get('Brand Code')).value);
+      const category = getCellText(row.getCell(headerMap.get('Category')).value);
+      const skuCode = getCellText(row.getCell(headerMap.get('SKU Code')).value);
+      const size = getCellText(row.getCell(headerMap.get('Size')).value);
+      const quantityValue = row.getCell(headerMap.get('Quantity')).value;
+      const cartonReferenceCol = headerMap.get('Carton Reference (optional)');
+      const cartonReference = cartonReferenceCol
+        ? getCellText(row.getCell(cartonReferenceCol).value)
+        : '';
+      const quantity = Number.parseInt(getCellText(quantityValue), 10);
+
+      const rowErrors = [];
+      if (!panelName) rowErrors.push('Panel Name is required');
+      if (!dateOfPacking) rowErrors.push('Date of Packing is required');
+      if (!packedBy) rowErrors.push('Packed By is required');
+      if (!brandCode) rowErrors.push('Brand Code is required');
+      if (!category) rowErrors.push('Category is required');
+      if (!skuCode) rowErrors.push('SKU Code is required');
+      if (!size) rowErrors.push('Size is required');
+      if (!quantity || quantity <= 0) rowErrors.push('Quantity must be a positive number');
+      if (panelName && !panelSet.has(panelName)) rowErrors.push('Invalid Panel Name');
+      if (brandCode && !brandSet.has(brandCode)) rowErrors.push('Invalid Brand Code');
+      if (category && !categorySet.has(category)) rowErrors.push('Invalid Category');
+
+      if (rowErrors.length) {
+        errors.push(`Row ${rowNumber}: ${rowErrors.join(', ')}`);
+        return;
+      }
+
+      const cartonKey = cartonReference || `row-${rowNumber}`;
+      if (!cartonsMap.has(cartonKey)) {
+        cartonsMap.set(cartonKey, {
+          panel_name: panelName,
+          date_of_packing: dateOfPacking,
+          packed_by: packedBy,
+          skus: []
+        });
+      }
+
+      const carton = cartonsMap.get(cartonKey);
+      if (carton.panel_name !== panelName || carton.date_of_packing !== dateOfPacking || carton.packed_by !== packedBy) {
+        errors.push(`Row ${rowNumber}: Carton Reference "${cartonKey}" has inconsistent carton details`);
+        return;
+      }
+
+      carton.skus.push({
+        brand_code: brandCode,
+        category,
+        sku_code: skuCode,
+        size,
+        quantity
+      });
+      totalSkuCount += 1;
+    });
+
+    if (errors.length) {
+      req.flash('error', errors.slice(0, 5).join(' | '));
+      return res.redirect('/po-creator/inward');
+    }
+
+    if (cartonsMap.size === 0) {
+      req.flash('error', 'No valid rows found in the uploaded sheet');
+      return res.redirect('/po-creator/inward');
+    }
+
+    const connection = await pool.getConnection();
+    try {
+      await connection.beginTransaction();
+
+      for (const carton of cartonsMap.values()) {
+        const [panelInfo] = await connection.query(
+          'SELECT prefix, current_number FROM panel_names WHERE name = ? FOR UPDATE',
+          [carton.panel_name]
+        );
+
+        if (panelInfo.length === 0) {
+          throw new Error(`Invalid panel name ${carton.panel_name}`);
+        }
+
+        const prefix = panelInfo[0].prefix;
+        const nextNumber = panelInfo[0].current_number + 1;
+        const carton_number = `${prefix}${nextNumber}`;
+
+        await connection.query(
+          'UPDATE panel_names SET current_number = ? WHERE name = ?',
+          [nextNumber, carton.panel_name]
+        );
+
+        const [cartonResult] = await connection.query(
+          'INSERT INTO cartons (carton_number, panel_name, date_of_packing, packed_by, creator_user_id) VALUES (?, ?, ?, ?, ?)',
+          [carton_number, carton.panel_name, carton.date_of_packing, carton.packed_by, req.session.user.id]
+        );
+
+        const cartonId = cartonResult.insertId;
+        for (const sku of carton.skus) {
+          const fullSKU = `${sku.brand_code}${sku.category}${sku.sku_code}`;
+          await connection.query(
+            `INSERT INTO carton_skus (carton_id, brand_code, category, sku_code, full_sku, size, quantity)
+             VALUES (?, ?, ?, ?, ?, ?, ?)`,
+            [cartonId, sku.brand_code, sku.category, sku.sku_code, fullSKU, sku.size, sku.quantity]
+          );
+        }
+      }
+
+      await connection.commit();
+      req.flash('success', `Bulk upload complete: ${cartonsMap.size} carton(s), ${totalSkuCount} SKU(s).`);
+      return res.redirect('/po-creator/inward/view');
+    } catch (error) {
+      await connection.rollback();
+      console.error('Error saving bulk inward data:', error);
+      req.flash('error', 'Error saving bulk inward data');
+      return res.redirect('/po-creator/inward');
+    } finally {
+      connection.release();
+    }
+  } catch (error) {
+    console.error('Error processing inward upload:', error);
+    req.flash('error', 'Error processing upload file');
+    return res.redirect('/po-creator/inward');
+  } finally {
+    try {
+      await fsPromises.unlink(req.file.path);
+    } catch (cleanupError) {
+      console.error('Error cleaning up uploaded file:', cleanupError);
+    }
   }
 });
 

--- a/views/po-creator/dashboard.ejs
+++ b/views/po-creator/dashboard.ejs
@@ -64,6 +64,12 @@
         <div class="action-card-desc">Create PO and dispatch entries for your cartons</div>
       </a>
 
+      <a href="/po-creator/inward#bulk-upload" class="action-card">
+        <div class="action-card-icon success"><i class="bi bi-cloud-arrow-up"></i></div>
+        <div class="action-card-title">Bulk Inward Upload</div>
+        <div class="action-card-desc">Upload an Excel template to create inward entries in bulk</div>
+      </a>
+
       <a href="/po-creator/download/inward-excel" class="action-card">
         <div class="action-card-icon success"><i class="bi bi-file-earmark-spreadsheet"></i></div>
         <div class="action-card-title">Download Excel</div>

--- a/views/po-creator/inward.ejs
+++ b/views/po-creator/inward.ejs
@@ -152,6 +152,59 @@
       margin-bottom: 20px;
       display: none;
     }
+
+    .bulk-upload-card {
+      background: #ffffff;
+      border: 1px solid #e2e8f0;
+      border-radius: 8px;
+      padding: 16px 20px;
+      margin-bottom: 20px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+      justify-content: space-between;
+    }
+
+    .bulk-upload-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 12px;
+      align-items: center;
+    }
+
+    .bulk-upload-actions .form-control {
+      min-width: 240px;
+    }
+
+    .template-btn {
+      background: #0ea5e9;
+      color: white;
+      border: none;
+      padding: 10px 18px;
+      border-radius: 6px;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+    }
+
+    .template-btn:hover {
+      background: #0284c7;
+      color: white;
+    }
+
+    .upload-btn {
+      background: #16a34a;
+      color: white;
+      border: none;
+      padding: 10px 18px;
+      border-radius: 6px;
+    }
+
+    .upload-btn:hover {
+      background: #15803d;
+    }
   </style>
 </head>
 <body>
@@ -169,6 +222,24 @@
 
     <div class="success-msg" id="successMsg">
       <i class="bi bi-check-circle"></i> <span id="successText"></span>
+    </div>
+
+    <div class="bulk-upload-card" id="bulk-upload">
+      <div>
+        <h5 class="mb-1"><i class="bi bi-upload"></i> Bulk Upload via Excel</h5>
+        <div class="text-muted">Download the template, fill in carton + SKU rows, and upload to create entries in bulk.</div>
+      </div>
+      <div class="bulk-upload-actions">
+        <a class="template-btn" href="/po-creator/inward/template">
+          <i class="bi bi-file-earmark-arrow-down"></i> Download Template
+        </a>
+        <form action="/po-creator/inward/bulk-upload" method="POST" enctype="multipart/form-data" class="d-flex gap-2 align-items-center">
+          <input type="file" name="inwardFile" class="form-control" accept=".xlsx" required>
+          <button type="submit" class="upload-btn">
+            <i class="bi bi-cloud-arrow-up"></i> Upload Excel
+          </button>
+        </form>
+      </div>
     </div>
 
     <form id="inwardForm">


### PR DESCRIPTION
### Motivation
- Provide a bulk option for PO Creator inward entry so users can upload multiple carton/SKU rows via Excel instead of filling the UI one-by-one.
- Offer a downloadable template that mirrors frontend dropdowns (panel, brand, category) so users can validate values offline.
- Ensure server-side parsing validates rows and safely creates cartons and SKUs in the same flow as the existing single-entry API.

### Description
- Added `GET /po-creator/inward/template` which builds an `.xlsx` template with a hidden `Lists` sheet and data validations (dropdowns) for `Panel Name`, `Brand Code`, and `Category` using `ExcelJS`.
- Added `POST /po-creator/inward/bulk-upload` which accepts `.xlsx` files via `multer`, parses the workbook, validates required columns and values against DB sets, groups rows into cartons (by optional `Carton Reference`), and inserts cartons and `carton_skus` inside a DB transaction; temporary upload files are cleaned up after processing.
- Implemented helper utilities in the route file (`getCellText`, `parseDateValue`, `excelSerialDateToJSDate`) and hardened parsing for dates/numbers and various Excel cell value types.
- Exposed the feature in the UI by adding a bulk upload card to `views/po-creator/inward.ejs` (template download + upload form) and a dashboard action link in `views/po-creator/dashboard.ejs`.

### Testing
- No automated tests were run on the modified code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e32ab97f8832097320a1b59770ffc)