### PR TITLE
Add poadmin login redirects to PO admin dashboard

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -130,6 +130,10 @@ router.post('/login', async (req, res) => {
       case 'vendorfiles':
         res.redirect('/vendor-files');
         break;
+      case 'poadmin':
+      case 'poadmins':
+        res.redirect('/po-admin/dashboard');
+        break;
       case 'checking':
       case 'quality_assurance':
         res.redirect('/department/dashboard');

--- a/routes/authRoutesOptimized.js
+++ b/routes/authRoutesOptimized.js
@@ -85,6 +85,8 @@ router.post('/login', async (req, res) => {
       quality_assurance: '/department/dashboard',
       nowipoorganization: '/nowi-po/dashboard',
       vendorfiles: '/vendor-files',
+      poadmin: '/po-admin/dashboard',
+      poadmins: '/po-admin/dashboard',
     };
 
     const redirectPath = roleRedirectMap[user.roleName] || '/';


### PR DESCRIPTION
### Motivation
- Users with the `poadmin` / `poadmins` role were not being redirected to the PO Admin UI after login, preventing easy access to the PO admin dashboard.
- The `po-admin` routes are protected via `allowRoles(['poadmins','poadmin'])`, so login should map those roles to the `po-admin` entrypoint.

### Description
- Added `case 'poadmin'` and `case 'poadmins'` to the login switch in `routes/authRoutes.js` to redirect to `'/po-admin/dashboard'`.
- Added `poadmin` and `poadmins` entries to the `roleRedirectMap` in `routes/authRoutesOptimized.js` to maintain consistent behavior in the optimized auth flow.
- No other route or authorization logic was changed; access still depends on existing `allowRoles` protections in `routes/poAdminRoutes.js`.

### Testing
- No automated tests were run against these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f4a41ec5083209cffaa64c3276b17)