### PR TITLE
Fix dashboard render when `tableName` is missing

### DIFF
--- a/routes/dashboardRoutes.js
+++ b/routes/dashboardRoutes.js
@@ -49,7 +49,8 @@ router.get('/', isAuthenticated, async (req, res) => {
     );
     return res.render('dashboard', {
       user: req.session.user,
-      dashboards
+      dashboards,
+      tableName: null
     });
   } catch (err) {
     console.error('Error listing dashboards:', err);


### PR DESCRIPTION
### Motivation
- The EJS view `views/dashboard.ejs` references `tableName`, which caused a `ReferenceError` when rendering the dashboard index without a selected table.  
- Provide an explicit value so the template can safely check `tableName` (e.g., `if (tableName)`).

### Description
- Set `tableName: null` in the object passed to `res.render('dashboard', ...)` in the GET `/dashboard` route.  
- Change made in `routes/dashboardRoutes.js` to ensure the template always receives a `tableName` variable.  
- This prevents the EJS conditional checks from throwing when no table is selected.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f5b3adb708320b91637d32662fe93)