### PR TITLE
Validate PO uploads against marketplace master data

### DIFF
--- a/views/po-admin/dashboard.ejs
+++ b/views/po-admin/dashboard.ejs
@@ -31,6 +31,9 @@
     .stat-pill { background: #f1f5f9; border-radius: 999px; padding: 6px 12px; font-weight: 600; font-size: 12px; color: #475569; }
     .tab-pane { padding-top: 18px; }
     .column-list { display: flex; flex-wrap: wrap; gap: 8px; }
+    .validation-list { max-height: 160px; overflow: auto; border: 1px dashed #cbd5f5; border-radius: 10px; padding: 10px; background: #f8fafc; }
+    .validation-list li { font-size: 12px; color: #1e293b; margin-bottom: 6px; }
+    .validation-list li:last-child { margin-bottom: 0; }
   </style>
 </head>
 <body>
@@ -152,6 +155,18 @@
                   <div class="progress-bar" id="poProgress" role="progressbar" style="width: 0%"></div>
                 </div>
                 <div class="upload-status mt-2" id="poStatus">Awaiting upload.</div>
+              </div>
+              <div class="mb-3">
+                <div class="form-label">PO Validation Summary</div>
+                <div class="upload-status" id="poValidationSummary">No validation run yet.</div>
+                <div class="mt-2">
+                  <div class="section-subtitle">Missing in master data</div>
+                  <ul class="list-unstyled validation-list mb-2" id="poMissingList"></ul>
+                </div>
+                <div>
+                  <div class="section-subtitle">Updated master data values</div>
+                  <ul class="list-unstyled validation-list" id="poChangedList"></ul>
+                </div>
               </div>
               <div>
                 <div class="form-label">Expected Columns</div>
@@ -359,6 +374,42 @@
       request.send(formData);
     }
 
+    function renderValidationList(target, items, emptyMessage) {
+      target.innerHTML = '';
+      if (!items || items.length === 0) {
+        const li = document.createElement('li');
+        li.textContent = emptyMessage;
+        target.appendChild(li);
+        return;
+      }
+      items.forEach(item => {
+        const li = document.createElement('li');
+        li.textContent = item;
+        target.appendChild(li);
+      });
+    }
+
+    function updatePoValidationSummary(response, marketplaceName) {
+      const updatedCount = response.updatedCount || 0;
+      const missingCount = response.missingIdentifiers?.length || 0;
+      const summary = `${marketplaceName}: ${updatedCount} master records updated. ${missingCount} identifiers missing in master data.`;
+      document.getElementById('poValidationSummary').textContent = summary;
+
+      const missingItems = (response.missingIdentifiers || []).map(item => `${item}`);
+      renderValidationList(document.getElementById('poMissingList'), missingItems, 'No missing identifiers detected.');
+
+      const changedItems = (response.changeSummaries || []).map(change => {
+        const changeText = change.changes
+          .map(item => `${item.field}: "${item.from || '-'}" → "${item.to || '-'}"`)
+          .join('; ');
+        return `${change.identifier}: ${changeText}`;
+      });
+      if (response.changesTruncated) {
+        changedItems.push('Additional changes are available but truncated in this summary.');
+      }
+      renderValidationList(document.getElementById('poChangedList'), changedItems, 'No master data updates were required.');
+    }
+
     document.addEventListener('DOMContentLoaded', () => {
       const masterMarketplace = document.getElementById('masterMarketplace');
       const poMarketplace = document.getElementById('poMarketplace');
@@ -368,6 +419,8 @@
       updateColumnDisplays();
       loadMasterData();
       loadPoData();
+      renderValidationList(document.getElementById('poMissingList'), [], 'No validation run yet.');
+      renderValidationList(document.getElementById('poChangedList'), [], 'No validation run yet.');
 
       masterMarketplace.addEventListener('change', () => {
         masterState.page = 1;
@@ -406,6 +459,8 @@
           endpoint: '/po-admin/upload-po',
           onSuccess: (response) => {
             document.getElementById('poStatus').textContent = `Inserted ${response.insertedCount || 0} rows.`;
+            const marketplaceName = getMarketplaceById(poMarketplace.value)?.name || 'Marketplace';
+            updatePoValidationSummary(response, marketplaceName);
             loadPoData();
           }
         });


### PR DESCRIPTION
### Motivation

- Provide automatic validation when a PO sheet is uploaded by matching PO rows to master data using marketplace-specific identifiers (e.g. Amazon ASIN, Myntra StyleCode/Style Id, Flipkart FSN).
- When master values differ from PO values, update master records or surface differences so admins can see what changed.
- Highlight PO identifiers not present in the marketplace master data so missing entries are visible during upload.

### Description

- Added `MARKETPLACE_MATCH_RULES` and helper functions `getValueByHeader` and `applyPoUpdatesToMaster` in `routes/poAdminRoutes.js` to locate identifiers and compute field-level changes between PO rows and master data.
- Extended the `POST /po-admin/upload-po` handler to build `poRows`, match each row to master data using the marketplace rule, record `missingIdentifiers`, apply updates to `po_admin_master_data` when differences are found, and store change summaries; PO rows are still stored in `po_admin_po_uploads`.
- Updated the PO admin UI (`views/po-admin/dashboard.ejs`) to show a PO Validation Summary and lists for missing identifiers and updated master values, and added client-side functions `renderValidationList` and `updatePoValidationSummary` to render server responses.
- Change summaries are truncated for the response (configurable via `maxChanges`) and `search_blob` is updated for any masters that were changed.

### Testing

- No automated unit tests or integration test suite were run against the changes.
- A Playwright attempt to render a screenshot of the EJS dashboard template was executed but failed with a `net::ERR_FILE_NOT_FOUND` because the EJS file could not be loaded directly as a static HTML file.
- Manual verification steps were not run in CI; the code was committed locally and the new endpoints return JSON with `insertedCount`, `updatedCount`, `missingIdentifiers`, and `changeSummaries` for clients to render.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f743a19188320b4060372f3892908)