### PR TITLE
Add key-based PO lookup API and API key management

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,6 +112,7 @@ const poCreatorRoutes = require('./routes/poCreatorRoutes');
 const nowiPoRoutes = require('./routes/nowiPoRoutes');
 const vendorFilesRoutes = require('./routes/vendorFilesRoutes');
 const poAdminRoutes = require('./routes/poAdminRoutes');
+const poAdminApiRoutes = require('./routes/poAdminApiRoutes');
 
 // Use Routes
 app.use('/', authRoutes);
@@ -158,6 +159,7 @@ app.use('/po-creator', poCreatorRoutes);
 app.use('/nowi-po', nowiPoRoutes);
 app.use('/vendor-files', vendorFilesRoutes);
 app.use('/po-admin', poAdminRoutes);
+app.use('/api/po-admin', poAdminApiRoutes);
 
 // Home Route
 app.get('/', (req, res) => {

--- a/helpers/poAdminData.js
+++ b/helpers/poAdminData.js
@@ -1,0 +1,224 @@
+const crypto = require('crypto');
+const { pool } = require('../config/db');
+
+const DEFAULT_MARKETPLACES = [
+  {
+    name: 'Flipkart',
+    masterColumns: ['FSN', 'TITLE', 'MRP', 'STYLECODE', 'COLOR', 'SIZE', 'GENERIC NAME', 'SKU'],
+    poColumns: [
+      'Product Name',
+      'FSN',
+      'SKU Id',
+      'Brand',
+      'Size',
+      'Style Code',
+      'Color',
+      'Isbn',
+      'Model Id',
+      'Quantity Sent',
+      'Quantity Received',
+      'Inwarded to Store',
+      'QC Fail',
+      'QC In Progress',
+      'QC Passed',
+      'Cost Price',
+      'Length(In cms)',
+      'Breadth(In cms)',
+      'Height(In cms)',
+      'Weight(In kgs)',
+      'Consignment Number'
+    ]
+  },
+  {
+    name: 'Amazon',
+    masterColumns: ['SKU', 'ASIN', 'SIZE', 'MRP', 'COLOR', 'STYLE ID', 'TITLE', 'GENERIC NAME', 'Condition'],
+    poColumns: [
+      'PO+ASIN',
+      'PO',
+      'Vendor',
+      'Ship to location',
+      'ASIN',
+      'External Id',
+      'External Id Type',
+      'Model Number',
+      'Title',
+      'Availability',
+      'Window Type',
+      'Window start',
+      'Window end',
+      'Expected date',
+      'Quantity Requested',
+      'Accepted quantity',
+      'Quantity received',
+      'Quantity Outstanding',
+      'Unit Cost',
+      'Total cost'
+    ]
+  },
+  {
+    name: 'Myntra',
+    masterColumns: [
+      'SKU',
+      'ARTICLENUMBER',
+      'SKUCODE',
+      'STYLECODE',
+      'Quantity',
+      'Size',
+      'Color',
+      'Warehouse References',
+      'MRP',
+      'Title'
+    ],
+    poColumns: [
+      'PO NUMBER',
+      'SKU Id',
+      'Style Id',
+      'SKU Code',
+      'HSN Code',
+      'Brand',
+      'GTIN',
+      'Vendor Article Number',
+      'Vendor Article Name',
+      'Size',
+      'Colour',
+      'Mrp',
+      'Credit Period',
+      'Margin Type',
+      'Agreed Margin',
+      'Gross Margin',
+      'Quantity',
+      'FOB Amount',
+      'List price(FOB+Transport-Excise)',
+      'Landing Price',
+      'Estimated Delivery Date',
+      'Tax BCD',
+      'Tax BCD Amount',
+      'Buying Tax IGST',
+      'Buying Tax IGST Amount',
+      'Tax SWT',
+      'Tax SWT Amount',
+      'Selling Tax CGST',
+      'Selling Tax CGST Amount',
+      'Selling Tax IGST',
+      'Selling Tax IGST Amount',
+      'Selling Tax SGST',
+      'Selling Tax SGST Amount'
+    ]
+  }
+];
+
+const MARKETPLACE_MATCH_RULES = {
+  Amazon: { masterKey: 'ASIN', poKey: 'ASIN' },
+  Myntra: { masterKey: 'STYLECODE', poKey: 'Style Id' },
+  Flipkart: { masterKey: 'FSN', poKey: 'FSN' }
+};
+
+function hashAccessKey(accessKey) {
+  return crypto.createHash('sha256').update(String(accessKey)).digest('hex');
+}
+
+async function ensurePoAdminSetup() {
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS po_admin_marketplaces (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      name VARCHAR(60) NOT NULL UNIQUE,
+      master_columns JSON NOT NULL,
+      po_columns JSON NOT NULL,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS po_admin_master_data (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      marketplace_id INT NOT NULL,
+      sku VARCHAR(150) NOT NULL,
+      data JSON NOT NULL,
+      search_blob LONGTEXT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE KEY uniq_marketplace_sku (marketplace_id, sku),
+      INDEX idx_master_marketplace (marketplace_id),
+      CONSTRAINT fk_po_admin_master_marketplace
+        FOREIGN KEY (marketplace_id) REFERENCES po_admin_marketplaces(id)
+        ON DELETE CASCADE
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS po_admin_po_uploads (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      marketplace_id INT NOT NULL,
+      data JSON NOT NULL,
+      search_blob LONGTEXT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      INDEX idx_po_marketplace (marketplace_id),
+      CONSTRAINT fk_po_admin_po_marketplace
+        FOREIGN KEY (marketplace_id) REFERENCES po_admin_marketplaces(id)
+        ON DELETE CASCADE
+    )
+  `);
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS po_admin_api_keys (
+      id INT AUTO_INCREMENT PRIMARY KEY,
+      key_name VARCHAR(120) NOT NULL UNIQUE,
+      key_hash CHAR(64) NOT NULL UNIQUE,
+      key_prefix CHAR(10) NOT NULL,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    )
+  `);
+
+  const [[marketplaceCount]] = await pool.query(
+    'SELECT COUNT(*) AS count FROM po_admin_marketplaces'
+  );
+
+  if (marketplaceCount.count === 0) {
+    const values = DEFAULT_MARKETPLACES.map(marketplace => [
+      marketplace.name,
+      JSON.stringify(marketplace.masterColumns),
+      JSON.stringify(marketplace.poColumns)
+    ]);
+    await pool.query(
+      'INSERT INTO po_admin_marketplaces (name, master_columns, po_columns) VALUES ?',
+      [values]
+    );
+  } else {
+    const [rows] = await pool.query(
+      'SELECT id, name, po_columns AS poColumns FROM po_admin_marketplaces'
+    );
+    const flipkartRow = rows.find(row => row.name === 'Flipkart');
+    if (flipkartRow) {
+      const currentColumns = Array.isArray(flipkartRow.poColumns)
+        ? flipkartRow.poColumns
+        : JSON.parse(flipkartRow.poColumns || '[]');
+      if (!currentColumns.includes('Consignment Number')) {
+        currentColumns.push('Consignment Number');
+        await pool.query(
+          'UPDATE po_admin_marketplaces SET po_columns = ? WHERE id = ?',
+          [JSON.stringify(currentColumns), flipkartRow.id]
+        );
+      }
+    }
+  }
+}
+
+async function fetchMarketplaces() {
+  const [rows] = await pool.query(
+    'SELECT id, name, master_columns AS masterColumns, po_columns AS poColumns FROM po_admin_marketplaces ORDER BY name'
+  );
+
+  return rows.map(row => ({
+    id: row.id,
+    name: row.name,
+    masterColumns: Array.isArray(row.masterColumns) ? row.masterColumns : JSON.parse(row.masterColumns || '[]'),
+    poColumns: Array.isArray(row.poColumns) ? row.poColumns : JSON.parse(row.poColumns || '[]')
+  }));
+}
+
+module.exports = {
+  DEFAULT_MARKETPLACES,
+  MARKETPLACE_MATCH_RULES,
+  ensurePoAdminSetup,
+  fetchMarketplaces,
+  hashAccessKey
+};

--- a/routes/poAdminApiRoutes.js
+++ b/routes/poAdminApiRoutes.js
@@ -1,0 +1,158 @@
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const {
+  MARKETPLACE_MATCH_RULES,
+  ensurePoAdminSetup,
+  hashAccessKey
+} = require('../helpers/poAdminData');
+
+const API_MARKETPLACE_CONFIG = {
+  Amazon: {
+    requestField: 'poNumber',
+    requestLabel: 'PO number',
+    poNumberKey: 'PO',
+    quantityKey: 'Quantity Requested',
+    responseKey: 'asin'
+  },
+  Myntra: {
+    requestField: 'poNumber',
+    requestLabel: 'PO number',
+    poNumberKey: 'PO NUMBER',
+    quantityKey: 'Quantity',
+    responseKey: 'styleCode'
+  },
+  Flipkart: {
+    requestField: 'consignmentNumber',
+    requestLabel: 'consignment number',
+    poNumberKey: 'Consignment Number',
+    quantityKey: 'Quantity Sent',
+    responseKey: 'fsn'
+  }
+};
+
+function normalizeHeader(header) {
+  return String(header || '').trim().toLowerCase();
+}
+
+function getValueByHeader(rowData, headerName) {
+  const target = normalizeHeader(headerName);
+  for (const [key, value] of Object.entries(rowData || {})) {
+    if (normalizeHeader(key) === target) {
+      return String(value || '').trim();
+    }
+  }
+  return '';
+}
+
+function buildJsonPath(columnName) {
+  const safeName = String(columnName || '').replace(/"/g, '\\"');
+  return `$.\"${safeName}\"`;
+}
+
+async function validateAccessKey(accessKey, keyName) {
+  const keyHash = hashAccessKey(accessKey);
+  const [rows] = await pool.query(
+    'SELECT id FROM po_admin_api_keys WHERE key_name = ? AND key_hash = ? LIMIT 1',
+    [keyName, keyHash]
+  );
+  return rows.length > 0;
+}
+
+router.post('/lookup', async (req, res) => {
+  const accessKey = String(req.body.accessKey || '').trim();
+  const keyName = String(req.body.keyName || '').trim();
+  const marketplaceInput = String(req.body.marketplace || '').trim();
+
+  if (!accessKey || !keyName || !marketplaceInput) {
+    return res.status(400).json({ error: 'Access key, key name, and marketplace are required.' });
+  }
+
+  try {
+    await ensurePoAdminSetup();
+    const isValidKey = await validateAccessKey(accessKey, keyName);
+    if (!isValidKey) {
+      return res.status(401).json({ error: 'Invalid access key.' });
+    }
+
+    const marketplaceName = Object.keys(API_MARKETPLACE_CONFIG).find(
+      key => key.toLowerCase() === marketplaceInput.toLowerCase()
+    );
+    if (!marketplaceName) {
+      return res.status(400).json({ error: 'Marketplace not supported.' });
+    }
+
+    const config = API_MARKETPLACE_CONFIG[marketplaceName];
+    const identifierValue = String(req.body[config.requestField] || '').trim();
+    if (!identifierValue) {
+      return res.status(400).json({ error: `Please provide ${config.requestLabel}.` });
+    }
+
+    const [[marketplaceRow]] = await pool.query(
+      'SELECT id FROM po_admin_marketplaces WHERE name = ? LIMIT 1',
+      [marketplaceName]
+    );
+    if (!marketplaceRow) {
+      return res.status(400).json({ error: 'Marketplace not configured.' });
+    }
+
+    const poNumberPath = buildJsonPath(config.poNumberKey);
+    const [poRows] = await pool.query(
+      `SELECT data FROM po_admin_po_uploads
+       WHERE marketplace_id = ? AND JSON_UNQUOTE(JSON_EXTRACT(data, ?)) = ?`,
+      [marketplaceRow.id, poNumberPath, identifierValue]
+    );
+
+    if (poRows.length === 0) {
+      return res.json({ marketplace: marketplaceName, results: [] });
+    }
+
+    const matchRule = MARKETPLACE_MATCH_RULES[marketplaceName];
+    const quantityMap = new Map();
+
+    poRows.forEach(row => {
+      const data = typeof row.data === 'string' ? JSON.parse(row.data || '{}') : row.data;
+      const identifier = getValueByHeader(data, matchRule.poKey).toUpperCase();
+      if (!identifier) return;
+      const qtyRaw = getValueByHeader(data, config.quantityKey);
+      const qty = Number(qtyRaw || 0);
+      quantityMap.set(identifier, (quantityMap.get(identifier) || 0) + (Number.isFinite(qty) ? qty : 0));
+    });
+
+    const identifiers = Array.from(quantityMap.keys());
+    if (identifiers.length === 0) {
+      return res.json({ marketplace: marketplaceName, results: [] });
+    }
+
+    const masterPath = buildJsonPath(matchRule.masterKey);
+    const [masterRows] = await pool.query(
+      `SELECT data FROM po_admin_master_data
+       WHERE marketplace_id = ? AND JSON_UNQUOTE(JSON_EXTRACT(data, ?)) IN (?)`,
+      [marketplaceRow.id, masterPath, identifiers]
+    );
+
+    const masterMap = new Map();
+    masterRows.forEach(row => {
+      const data = typeof row.data === 'string' ? JSON.parse(row.data || '{}') : row.data;
+      const identifier = getValueByHeader(data, matchRule.masterKey).toUpperCase();
+      if (!identifier) return;
+      masterMap.set(identifier, data);
+    });
+
+    const results = identifiers.map(identifier => {
+      const masterData = masterMap.get(identifier) || {};
+      return {
+        [config.responseKey]: identifier,
+        quantity: quantityMap.get(identifier) || 0,
+        ...masterData
+      };
+    });
+
+    return res.json({ marketplace: marketplaceName, results });
+  } catch (error) {
+    console.error('Error fetching PO lookup data:', error);
+    return res.status(500).json({ error: 'Unable to fetch PO data.' });
+  }
+});
+
+module.exports = router;

--- a/views/po-admin/dashboard.ejs
+++ b/views/po-admin/dashboard.ejs
@@ -66,6 +66,11 @@
           <i class="bi bi-receipt"></i> PO Uploads
         </button>
       </li>
+      <li class="nav-item" role="presentation">
+        <button class="nav-link" id="keys-tab" data-bs-toggle="tab" data-bs-target="#keys" type="button" role="tab">
+          <i class="bi bi-key"></i> API Keys
+        </button>
+      </li>
     </ul>
 
     <div class="tab-content" id="poAdminTabContent">
@@ -204,6 +209,50 @@
           </div>
         </div>
       </div>
+
+      <div class="tab-pane fade" id="keys" role="tabpanel">
+        <div class="row g-4">
+          <div class="col-lg-4">
+            <div class="card-surface">
+              <div class="mb-3">
+                <div class="section-title">Create API Key</div>
+                <div class="section-subtitle">Generate access keys for the PO lookup API.</div>
+              </div>
+              <div class="mb-3">
+                <label class="form-label">Key Name</label>
+                <input type="text" class="form-control" id="apiKeyName" placeholder="e.g. Partner App">
+              </div>
+              <div class="mb-3">
+                <button class="btn btn-primary w-100" id="apiKeyCreateBtn"><i class="bi bi-plus-circle"></i> Create Key</button>
+              </div>
+              <div class="upload-status" id="apiKeyStatus">No keys created in this session.</div>
+            </div>
+          </div>
+          <div class="col-lg-8">
+            <div class="card-surface">
+              <div class="d-flex justify-content-between align-items-center mb-3">
+                <div>
+                  <div class="section-title">Active Keys</div>
+                  <div class="section-subtitle">Use the prefix to identify keys in use.</div>
+                </div>
+                <span class="stat-pill" id="apiKeyCount">0 keys</span>
+              </div>
+              <div class="table-wrapper">
+                <table class="table table-sm align-middle">
+                  <thead>
+                    <tr>
+                      <th>Key Name</th>
+                      <th>Key Prefix</th>
+                      <th>Created At</th>
+                    </tr>
+                  </thead>
+                  <tbody id="apiKeyTableBody"></tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 
@@ -212,6 +261,7 @@
     const marketplaces = <%- JSON.stringify(marketplaces || []) %>;
     const masterState = { page: 1, search: '' };
     const poState = { page: 1, search: '' };
+    const apiKeyState = { keys: [] };
 
     function populateMarketplaceOptions(selectElement) {
       selectElement.innerHTML = '';
@@ -222,6 +272,63 @@
         if (index === 0) option.selected = true;
         selectElement.appendChild(option);
       });
+    }
+
+    function renderApiKeys() {
+      const body = document.getElementById('apiKeyTableBody');
+      body.innerHTML = '';
+      apiKeyState.keys.forEach(key => {
+        const row = document.createElement('tr');
+        row.innerHTML = `
+          <td>${key.keyName}</td>
+          <td>${key.keyPrefix}</td>
+          <td>${new Date(key.createdAt).toLocaleString()}</td>
+        `;
+        body.appendChild(row);
+      });
+      document.getElementById('apiKeyCount').textContent = `${apiKeyState.keys.length} keys`;
+    }
+
+    async function loadApiKeys() {
+      try {
+        const res = await fetch('/po-admin/api/keys', { headers: { Accept: 'application/json' } });
+        if (!res.ok) return;
+        const data = await res.json();
+        apiKeyState.keys = data.keys || [];
+        renderApiKeys();
+      } catch (error) {
+        console.error('Failed to load API keys', error);
+      }
+    }
+
+    async function createApiKey() {
+      const nameInput = document.getElementById('apiKeyName');
+      const status = document.getElementById('apiKeyStatus');
+      const keyName = nameInput.value.trim();
+      if (!keyName) {
+        status.textContent = 'Please enter a key name.';
+        return;
+      }
+
+      status.textContent = 'Creating key...';
+      try {
+        const res = await fetch('/po-admin/api/keys', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+          body: JSON.stringify({ keyName })
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          status.textContent = data.error || 'Unable to create key.';
+          return;
+        }
+        status.textContent = `Key created: ${data.accessKey} (save this now)`;
+        nameInput.value = '';
+        await loadApiKeys();
+      } catch (error) {
+        console.error('Failed to create API key', error);
+        status.textContent = 'Unable to create key.';
+      }
     }
 
     function renderColumnList(target, columns) {
@@ -501,6 +608,9 @@
         poState.page += 1;
         loadPoData();
       });
+
+      document.getElementById('apiKeyCreateBtn').addEventListener('click', createApiKey);
+      loadApiKeys();
     });
   </script>
 </body>


### PR DESCRIPTION
### Motivation
- Provide a key-based API so external consumers can lookup PO/consignment data without requiring user roles or UI sessions.
- Return consolidated master-data rows (with marketplace-specific identifiers like `ASIN`/`STYLECODE`/`FSN`) combined with mapped quantities from PO uploads.
- Ensure Flipkart PO uploads include a `Consignment Number` column by default so lookups by consignment work correctly.
- Allow PO admins to create/manage access keys which are stored hashed and used to authenticate the new API.

### Description
- Added `helpers/poAdminData.js` to centralize marketplace defaults, match rules, DB setup and key hashing (`hashAccessKey`) and to ensure `Consignment Number` is present for Flipkart.
- Implemented a new key-authenticated lookup API at `POST /api/po-admin/lookup` in `routes/poAdminApiRoutes.js` which accepts `accessKey`, `keyName`, `marketplace` and `poNumber`/`consignmentNumber`, aggregates quantities from PO uploads and returns matching master-data rows along with `quantity` and the marketplace-specific response key (e.g. `asin`/`styleCode`/`fsn`).
- Added key management endpoints to `routes/poAdminRoutes.js`: `GET /po-admin/api/keys` to list keys and `POST /po-admin/api/keys` to generate a new access key (stored hashed in `po_admin_api_keys`) and updated the PO admin dashboard UI (`views/po-admin/dashboard.ejs`) to create/list keys.
- Wired the API routes into `app.js` at `app.use('/api/po-admin', require('./routes/poAdminApiRoutes'))` and created the DB table `po_admin_api_keys` via `ensurePoAdminSetup`.

### Testing
- Attempted to start the app with `node app.js` to exercise route mounting and DB setup but it failed to start due to a missing dependency: `Cannot find module 'secure-env'`.
- No further automated tests were run because the application could not be started in the current environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f8785c1348320b43d4e486eb327cc)