### PR TITLE
Add PO creator lot entry workflow and operator report view

### DIFF
--- a/sql/po_creator_tables.sql
+++ b/sql/po_creator_tables.sql
@@ -75,6 +75,22 @@ CREATE TABLE IF NOT EXISTS carton_outward (
   INDEX idx_creator_user_id (creator_user_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+-- Table to store PO creator lot entries
+CREATE TABLE IF NOT EXISTS po_creator_lot_entries (
+  id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  creator_user_id INT NOT NULL,
+  lot_code VARCHAR(100) NOT NULL,
+  sku VARCHAR(100) NOT NULL,
+  size VARCHAR(50),
+  quantity INT NOT NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_po_creator_lot_entries_user FOREIGN KEY (creator_user_id) REFERENCES users(id) ON DELETE CASCADE,
+  INDEX idx_po_creator_lot_entries_creator (creator_user_id),
+  INDEX idx_po_creator_lot_entries_lot_code (lot_code),
+  INDEX idx_po_creator_lot_entries_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 -- Table to store brand codes (hardcoded values)
 CREATE TABLE IF NOT EXISTS sku_brand_codes (
   id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,

--- a/views/po-creator/dashboard.ejs
+++ b/views/po-creator/dashboard.ejs
@@ -70,6 +70,12 @@
         <div class="action-card-desc">Upload an Excel template to create inward entries in bulk</div>
       </a>
 
+      <a href="/po-creator/lot-entry" class="action-card">
+        <div class="action-card-icon primary"><i class="bi bi-tags"></i></div>
+        <div class="action-card-title">Lot Entry</div>
+        <div class="action-card-desc">Enter lot code, SKU, size, and quantity</div>
+      </a>
+
       <a href="/po-creator/download/inward-excel" class="action-card">
         <div class="action-card-icon success"><i class="bi bi-file-earmark-spreadsheet"></i></div>
         <div class="action-card-title">Download Excel</div>

--- a/views/po-creator/lot-entry.ejs
+++ b/views/po-creator/lot-entry.ejs
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lot Entry - Kotty Track</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', sans-serif; background: #f8f9fa; color: #1e293b; padding: 20px; }
+    .top-nav { background: white; border-bottom: 1px solid #e2e8f0; padding: 16px 24px; margin: -20px -20px 20px -20px; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05); }
+    .form-card { background: white; border: 1px solid #e2e8f0; border-radius: 10px; padding: 24px; margin-bottom: 24px; }
+    .form-label { font-weight: 600; color: #1e293b; margin-bottom: 6px; }
+    .form-control { border: 1px solid #e2e8f0; border-radius: 6px; padding: 10px; }
+    .form-control:focus { border-color: #2563eb; box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1); }
+    .submit-btn { background: #2563eb; color: white; border: none; padding: 10px 24px; border-radius: 6px; font-weight: 600; }
+    .submit-btn:hover { background: #1d4ed8; }
+    .back-btn { background: #6c757d; color: white; padding: 10px 20px; border-radius: 6px; text-decoration: none; }
+    .back-btn:hover { background: #5c636a; color: white; }
+    .table-card { background: white; border: 1px solid #e2e8f0; border-radius: 10px; overflow: hidden; }
+    .table thead { background: #f8f9fa; }
+    .table thead th { font-weight: 600; color: #1e293b; padding: 14px; border-bottom: 2px solid #e2e8f0; }
+  </style>
+</head>
+<body>
+  <div class="top-nav">
+    <div class="d-flex justify-content-between align-items-center">
+      <h4 class="mb-0"><i class="bi bi-tags"></i> Lot Entry</h4>
+      <a href="/po-creator/dashboard" class="back-btn"><i class="bi bi-arrow-left"></i> Back</a>
+    </div>
+  </div>
+
+  <div class="container">
+    <%- include('../partials/flashMessages') %>
+
+    <div class="form-card">
+      <form action="/po-creator/lot-entry" method="POST">
+        <div class="row g-3">
+          <div class="col-md-3">
+            <label class="form-label">Lot Code *</label>
+            <input type="text" name="lot_code" class="form-control" required>
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">SKU *</label>
+            <input type="text" name="sku" class="form-control" required>
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">Size (optional)</label>
+            <input type="text" name="size" class="form-control">
+          </div>
+          <div class="col-md-3">
+            <label class="form-label">Quantity *</label>
+            <input type="number" name="quantity" class="form-control" min="1" required>
+          </div>
+        </div>
+        <div class="mt-4">
+          <button type="submit" class="submit-btn"><i class="bi bi-check2-circle"></i> Save Entry</button>
+        </div>
+      </form>
+    </div>
+
+    <div class="table-card">
+      <div class="p-3 border-bottom">
+        <h5 class="mb-0">Recent Entries</h5>
+        <small class="text-muted">Showing last 50 entries</small>
+      </div>
+      <div class="table-responsive">
+        <table class="table mb-0">
+          <thead>
+            <tr>
+              <th>Lot Code</th>
+              <th>SKU</th>
+              <th>Size</th>
+              <th>Quantity</th>
+              <th>Created At</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% if (entries.length === 0) { %>
+              <tr>
+                <td colspan="5" class="text-center py-4">No entries yet.</td>
+              </tr>
+            <% } else { %>
+              <% entries.forEach(entry => { %>
+                <tr>
+                  <td><%= entry.lot_code %></td>
+                  <td><%= entry.sku %></td>
+                  <td><%= entry.size || '-' %></td>
+                  <td><%= entry.quantity %></td>
+                  <td><%= new Date(entry.created_at).toLocaleString() %></td>
+                </tr>
+              <% }) %>
+            <% } %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/po-creator/operator-lot-entries.ejs
+++ b/views/po-creator/operator-lot-entries.ejs
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Lot Entries - Kotty Track</title>
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: 'Inter', sans-serif; background: #f8f9fa; color: #1e293b; padding: 20px; }
+    .top-nav { background: white; border-bottom: 1px solid #e2e8f0; padding: 16px 24px; margin: -20px -20px 20px -20px; box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05); }
+    .back-btn { background: #6c757d; color: white; padding: 10px 20px; border-radius: 6px; text-decoration: none; }
+    .back-btn:hover { background: #5c636a; color: white; }
+    .filter-card { background: white; border: 1px solid #e2e8f0; border-radius: 8px; padding: 16px; margin-bottom: 20px; }
+    .table-card { background: white; border: 1px solid #e2e8f0; border-radius: 8px; overflow: hidden; }
+    .table thead { background: #f8f9fa; }
+    .table thead th { font-weight: 600; color: #1e293b; padding: 14px; border-bottom: 2px solid #e2e8f0; }
+  </style>
+</head>
+<body>
+  <div class="top-nav">
+    <div class="d-flex justify-content-between align-items-center">
+      <h4 class="mb-0"><i class="bi bi-calendar-range"></i> Lot Entries by Date</h4>
+      <a href="/operator/dashboard" class="back-btn"><i class="bi bi-arrow-left"></i> Back</a>
+    </div>
+  </div>
+
+  <div class="container-fluid">
+    <%- include('../partials/flashMessages') %>
+
+    <div class="filter-card">
+      <form class="row g-3" method="GET" action="/po-creator/operator/lot-entries">
+        <div class="col-md-4">
+          <label class="form-label">Filter by Date</label>
+          <input type="date" name="date" class="form-control" value="<%= selectedDate %>">
+        </div>
+        <div class="col-md-4 d-flex align-items-end">
+          <button type="submit" class="btn btn-primary me-2"><i class="bi bi-funnel"></i> Apply</button>
+          <a href="/po-creator/operator/lot-entries" class="btn btn-outline-secondary"><i class="bi bi-x-circle"></i> Clear</a>
+        </div>
+      </form>
+    </div>
+
+    <div class="table-card">
+      <div class="p-3 border-bottom">
+        <strong>Total Entries:</strong> <%= entries.length %>
+      </div>
+      <div class="table-responsive">
+        <table class="table mb-0">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Creator</th>
+              <th>Lot Code</th>
+              <th>SKU</th>
+              <th>Size</th>
+              <th>Quantity</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% if (entries.length === 0) { %>
+              <tr>
+                <td colspan="6" class="text-center py-4">No lot entries found.</td>
+              </tr>
+            <% } else { %>
+              <% entries.forEach(entry => { %>
+                <tr>
+                  <td><%= new Date(entry.created_at).toLocaleDateString() %></td>
+                  <td><%= entry.creator_username %></td>
+                  <td><%= entry.lot_code %></td>
+                  <td><%= entry.sku %></td>
+                  <td><%= entry.size || '-' %></td>
+                  <td><%= entry.quantity %></td>
+                </tr>
+              <% }) %>
+            <% } %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/views/po-operator-dashboard.ejs
+++ b/views/po-operator-dashboard.ejs
@@ -78,6 +78,11 @@
         </button>
       </li>
       <li class="nav-item" role="presentation">
+        <button class="nav-link" id="lot-tab" data-bs-toggle="tab" data-bs-target="#lot" type="button">
+          <i class="bi bi-tags"></i> Lot Entries
+        </button>
+      </li>
+      <li class="nav-item" role="presentation">
         <button class="nav-link" id="settings-tab" data-bs-toggle="tab" data-bs-target="#settings" type="button">
           <i class="bi bi-gear"></i> Settings
         </button>
@@ -142,6 +147,14 @@
           <h2 class="section-title">SKU-wise Analysis</h2>
         </div>
         <iframe src="/po-creator/operator/view-sku-wise" style="width: 100%; height: 800px; border: 1px solid #e2e8f0; border-radius: 8px;"></iframe>
+      </div>
+
+      <!-- Lot Entries Tab -->
+      <div class="tab-pane fade" id="lot" role="tabpanel">
+        <div class="section-header">
+          <h2 class="section-title">Lot Entries by Date</h2>
+        </div>
+        <iframe src="/po-creator/operator/lot-entries" style="width: 100%; height: 800px; border: 1px solid #e2e8f0; border-radius: 8px;"></iframe>
       </div>
 
       <!-- Settings Tab -->


### PR DESCRIPTION
### Motivation
- Provide `po_creator` users a lightweight form to record `lot_code`, `sku`, optional `size`, and `quantity` as requested.  
- Make the entries visible to PO admin/operator users with a date-filtered view to audit who submitted data.  
- Persist entries in the database with a dedicated table for tracking and indexing.  
- Integrate the feature into existing creator and operator dashboards for easy access.

### Description
- Added creator routes `GET /lot-entry` and `POST /lot-entry` with input validation and a recent 50-entry listing in `routes/poCreatorRoutes.js`.  
- Added operator route `GET /operator/lot-entries` that supports filtering by `date` and renders a report view; query joins `users` to show the submitting username.  
- Created new views: `views/po-creator/lot-entry.ejs` for creators and `views/po-creator/operator-lot-entries.ejs` for operator reporting, and added a dashboard shortcut in `views/po-creator/dashboard.ejs`.  
- Added `po_creator_lot_entries` table to `sql/po_creator_tables.sql` with FK to `users(id)`, timestamps, and indexes for `creator_user_id`, `lot_code`, and `created_at`.

### Testing
- No automated tests were run for this change.  
- Routes and views were implemented with server-side validations in place and will require integration testing against the database schema.  
- Manual/functional test plan not executed in this rollout.  
- Database migration is additive (`CREATE TABLE IF NOT EXISTS`) and safe to apply in environments with the `users` table present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f8fcff39c8320b3817b903ceb527c)