### PR TITLE
Add per-size quantity support for PO Creator lot entries

### DIFF
--- a/views/po-creator/lot-entry.ejs
+++ b/views/po-creator/lot-entry.ejs
@@ -47,12 +47,16 @@
             <input type="text" name="sku" class="form-control" required>
           </div>
           <div class="col-md-3">
-            <label class="form-label">Size (optional)</label>
-            <input type="text" name="size" class="form-control">
+            <label class="form-label">Size (comma separated)</label>
+            <input type="text" name="size" class="form-control" placeholder="e.g. S,M,L">
+            <small class="text-muted">Enter sizes separated by commas to add quantities for each size.</small>
           </div>
-          <div class="col-md-3">
+          <div class="col-md-6">
             <label class="form-label">Quantity *</label>
-            <input type="number" name="quantity" class="form-control" min="1" required>
+            <div id="single-quantity">
+              <input type="number" name="quantity" class="form-control" min="1" required>
+            </div>
+            <div id="size-quantity-list" class="row g-3 d-none"></div>
           </div>
         </div>
         <div class="mt-4">
@@ -100,5 +104,59 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+  <script>
+    const sizeInput = document.querySelector('input[name="size"]');
+    const singleQuantityWrapper = document.getElementById('single-quantity');
+    const singleQuantityInput = singleQuantityWrapper.querySelector('input');
+    const sizeQuantityList = document.getElementById('size-quantity-list');
+
+    function buildSizeQuantityFields() {
+      const sizes = sizeInput.value
+        .split(',')
+        .map(item => item.trim())
+        .filter(Boolean);
+
+      sizeQuantityList.innerHTML = '';
+
+      if (sizes.length === 0) {
+        singleQuantityWrapper.classList.remove('d-none');
+        singleQuantityInput.required = true;
+        sizeQuantityList.classList.add('d-none');
+        return;
+      }
+
+      singleQuantityWrapper.classList.add('d-none');
+      singleQuantityInput.required = false;
+      sizeQuantityList.classList.remove('d-none');
+
+      sizes.forEach((sizeValue) => {
+        const col = document.createElement('div');
+        col.className = 'col-md-4';
+
+        const label = document.createElement('label');
+        label.className = 'form-label';
+        label.textContent = `Quantity (${sizeValue})`;
+
+        const hiddenInput = document.createElement('input');
+        hiddenInput.type = 'hidden';
+        hiddenInput.name = 'size_values[]';
+        hiddenInput.value = sizeValue;
+
+        const quantityInput = document.createElement('input');
+        quantityInput.type = 'number';
+        quantityInput.name = 'size_quantities[]';
+        quantityInput.className = 'form-control';
+        quantityInput.min = '1';
+        quantityInput.required = true;
+
+        col.appendChild(label);
+        col.appendChild(hiddenInput);
+        col.appendChild(quantityInput);
+        sizeQuantityList.appendChild(col);
+      });
+    }
+
+    sizeInput.addEventListener('input', buildSizeQuantityFields);
+  </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Allow entering a lot with multiple sizes and save each size/quantity pair as separate rows in `po_creator_lot_entries`.
- The previous flow only accepted a single `quantity` (and optionally a single `size`) which did not support per-size quantities.
- Provide a UI that accepts comma-separated sizes and lets the user specify a quantity for each size.

### Description
- Update `POST /po-creator/lot-entry` in `routes/poCreatorRoutes.js` to accept `size_values[]` and `size_quantities[]` or a comma-separated `size` string and perform a bulk `INSERT` of rows when sizes are provided.
- Add validation to ensure the number of provided quantities matches the number of sizes and that each quantity is a positive number, otherwise show an error and redirect.
- Update `views/po-creator/lot-entry.ejs` to allow entering comma-separated sizes and dynamically render per-size quantity inputs with client-side JS, while preserving the single-quantity input for legacy/size-less entries.
- Insert a single row with `size = NULL` when no sizes are provided to preserve existing behavior.

### Testing
- Attempted to start the app with `node app.js`, which failed with `MODULE_NOT_FOUND: secure-env`, preventing full runtime verification.
- No automated unit or integration tests were executed after the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695f91f589a8832088f0647f415e13fb)