### PR TITLE
Use Quantity Outstanding for Amazon PO totals

### DIFF
--- a/helpers/poAdminData.js
+++ b/helpers/poAdminData.js
@@ -119,7 +119,7 @@ const API_MARKETPLACE_CONFIG = {
     requestField: 'poNumber',
     requestLabel: 'PO number',
     poNumberKey: 'PO',
-    quantityKey: 'Quantity Requested',
+    quantityKey: 'Quantity Outstanding',
     responseKey: 'asin'
   },
   Myntra: {


### PR DESCRIPTION
### Motivation
- PO summary and deletion endpoints were summing the wrong field for Amazon POs, causing totals to include requested/accepted values instead of the remaining outstanding quantity.
- The change makes Amazon PO quantity calculations use the actual outstanding amount reported in PO uploads.

### Description
- Updated `API_MARKETPLACE_CONFIG` for `Amazon` in `helpers/poAdminData.js` to set `quantityKey` from `Quantity Requested` to `Quantity Outstanding`.
- This makes endpoints that read `config.quantityKey` (such as PO summary and deletion) use the `Quantity Outstanding` column for totals.

### Testing
- No automated tests were run for this change.
- Basic repository operations (file update and commit) were performed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa6e221bc8320bd65c4b5703f7120)