### PR TITLE
Ensure `entry_date` column exists for po_creator_lot_entries

### DIFF
--- a/helpers/poCreatorData.js
+++ b/helpers/poCreatorData.js
@@ -1,0 +1,31 @@
+const { pool } = require('../config/db');
+
+let poCreatorLotEntriesSchemaReady = false;
+
+async function ensurePoCreatorLotEntriesSchema() {
+  if (poCreatorLotEntriesSchemaReady) {
+    return;
+  }
+
+  const [[row]] = await pool.query(
+    `
+    SELECT COUNT(*) AS count
+    FROM information_schema.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'po_creator_lot_entries'
+      AND COLUMN_NAME = 'entry_date'
+    `
+  );
+
+  if (row.count === 0) {
+    await pool.query(
+      'ALTER TABLE po_creator_lot_entries ADD COLUMN entry_date DATE DEFAULT NULL'
+    );
+  }
+
+  poCreatorLotEntriesSchemaReady = true;
+}
+
+module.exports = {
+  ensurePoCreatorLotEntriesSchema
+};

--- a/routes/poAdminRoutes.js
+++ b/routes/poAdminRoutes.js
@@ -13,6 +13,7 @@ const {
   fetchMarketplaces,
   hashAccessKey
 } = require('../helpers/poAdminData');
+const { ensurePoCreatorLotEntriesSchema } = require('../helpers/poCreatorData');
 
 const upload = multer({
   dest: 'uploads/',
@@ -166,6 +167,7 @@ router.get('/api/keys', isAuthenticated, allowRoles(['poadmins', 'poadmin']), as
 
 router.get('/lot-entries', isAuthenticated, allowRoles(['poadmins', 'poadmin']), async (req, res) => {
   try {
+    await ensurePoCreatorLotEntriesSchema();
     const { date, search } = req.query;
     const selectedDate = date || getTodayDateString();
     const filters = [];
@@ -219,6 +221,7 @@ router.get('/lot-entries', isAuthenticated, allowRoles(['poadmins', 'poadmin']),
 
 router.get('/lot-entries/export', isAuthenticated, allowRoles(['poadmins', 'poadmin']), async (req, res) => {
   try {
+    await ensurePoCreatorLotEntriesSchema();
     const { date, search } = req.query;
     const filters = [];
     const params = [];

--- a/routes/poCreatorRoutes.js
+++ b/routes/poCreatorRoutes.js
@@ -4,6 +4,7 @@ const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/db');
 const { isPOCreator, isAuthenticated, isOperator } = require('../middlewares/auth');
+const { ensurePoCreatorLotEntriesSchema } = require('../helpers/poCreatorData');
 const ExcelJS = require('exceljs');
 const multer = require('multer');
 const fs = require('fs');
@@ -95,6 +96,7 @@ router.get('/dashboard', isPOCreator, async (req, res) => {
 // Lot entry - Entry form page
 router.get('/lot-entry', isPOCreator, async (req, res) => {
   try {
+    await ensurePoCreatorLotEntriesSchema();
     const [entries] = await pool.query(
       `SELECT id, lot_code, sku, size, quantity, entry_date, created_at,
               COALESCE(entry_date, DATE(created_at)) AS display_date
@@ -120,6 +122,7 @@ router.get('/lot-entry', isPOCreator, async (req, res) => {
 // Lot entry - Submit data
 router.post('/lot-entry', isPOCreator, async (req, res) => {
   try {
+    await ensurePoCreatorLotEntriesSchema();
     const { lot_code, sku, size, quantity, size_values, size_quantities, entry_date } = req.body;
     const normalizedEntryDate = normalizeEntryDate(entry_date);
 
@@ -776,6 +779,7 @@ router.get('/operator/view-all', isOperator, async (req, res) => {
 // Operator view - Lot entries by date
 router.get('/operator/lot-entries', isOperator, async (req, res) => {
   try {
+    await ensurePoCreatorLotEntriesSchema();
     const { date, search } = req.query;
     const filters = [];
     const params = [];


### PR DESCRIPTION
### Motivation
- Fix runtime SQL errors caused by missing `entry_date` column when querying lot entries (error: "Unknown column 'le.entry_date' in 'field list'").
- Support older databases that may not have the `entry_date` column so admin/operator/creator routes don't crash.
- Make the application resilient to schema drift without requiring a manual migration step.

### Description
- Added `helpers/poCreatorData.js` with `ensurePoCreatorLotEntriesSchema()` that checks `information_schema.COLUMNS` and runs `ALTER TABLE po_creator_lot_entries ADD COLUMN entry_date DATE DEFAULT NULL` when the column is missing.
- Imported and invoked `ensurePoCreatorLotEntriesSchema()` in `routes/poCreatorRoutes.js` for the lot entry list (`GET /lot-entry`), lot entry submit (`POST /lot-entry`), and operator lot entries (`GET /operator/lot-entries`).
- Imported and invoked `ensurePoCreatorLotEntriesSchema()` in `routes/poAdminRoutes.js` for the admin lot entries pages (`GET /lot-entries` and `GET /lot-entries/export`).
- Adjusted route flow to perform the schema check before executing queries that reference `entry_date`.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fa71201888320aa5f3ee819456160)