### PR TITLE
Add master-data bulk update (SKU/identifier) and download export

### DIFF
--- a/views/po-admin/dashboard.ejs
+++ b/views/po-admin/dashboard.ejs
@@ -79,7 +79,8 @@
       <div class="tab-pane fade show active" id="master" role="tabpanel">
         <div class="row g-4">
           <div class="col-lg-4">
-            <div class="card-surface">
+            <div class="d-flex flex-column gap-4">
+              <div class="card-surface">
               <div class="mb-3">
                 <div class="section-title">Master Data Upload</div>
                 <div class="section-subtitle">Unique SKU values are enforced per marketplace.</div>
@@ -104,6 +105,34 @@
               <div>
                 <div class="form-label">Expected Columns</div>
                 <div class="column-list" id="masterColumns"></div>
+              </div>
+              </div>
+              <div class="card-surface">
+                <div class="mb-3">
+                  <div class="section-title">Master Data Update</div>
+                  <div class="section-subtitle">Upload a sheet with SKU/ASIN and only the fields you want to change.</div>
+                </div>
+                <div class="mb-3">
+                  <label class="form-label">Upload Excel (.xlsx)</label>
+                  <input type="file" class="form-control" id="masterUpdateFile" accept=".xlsx">
+                </div>
+                <div class="mb-3">
+                  <button class="btn btn-primary w-100" id="masterUpdateBtn">
+                    <i class="bi bi-pencil-square"></i> Update Master Data
+                  </button>
+                </div>
+                <div class="mb-3">
+                  <div class="progress">
+                    <div class="progress-bar" id="masterUpdateProgress" role="progressbar" style="width: 0%"></div>
+                  </div>
+                  <div class="upload-status mt-2" id="masterUpdateStatus">Awaiting update upload.</div>
+                </div>
+                <div class="mb-3">
+                  <button class="btn btn-outline w-100" id="masterDownloadBtn">
+                    <i class="bi bi-download"></i> Download Master Data
+                  </button>
+                  <div class="upload-status mt-2">Exports the full master data for the selected marketplace.</div>
+                </div>
               </div>
             </div>
           </div>
@@ -682,6 +711,29 @@
             loadMasterData();
           }
         });
+      });
+
+      document.getElementById('masterUpdateBtn').addEventListener('click', () => {
+        uploadFile({
+          fileInput: document.getElementById('masterUpdateFile'),
+          marketplaceSelect: masterMarketplace,
+          progressBar: document.getElementById('masterUpdateProgress'),
+          statusTarget: document.getElementById('masterUpdateStatus'),
+          endpoint: '/po-admin/upload-master-update',
+          onSuccess: (response) => {
+            const missingCount = response.missingIdentifiers?.length || 0;
+            const unchangedCount = response.unchangedCount || 0;
+            const skippedEmpty = response.skippedEmpty || 0;
+            document.getElementById('masterUpdateStatus').textContent = `Updated ${response.updatedCount || 0} records. Missing ${missingCount}, unchanged ${unchangedCount}, skipped ${skippedEmpty} empty rows.`;
+            loadMasterData();
+          }
+        });
+      });
+
+      document.getElementById('masterDownloadBtn').addEventListener('click', () => {
+        const marketplaceId = masterMarketplace.value;
+        if (!marketplaceId) return;
+        window.location.href = `/po-admin/download-master?marketplaceId=${marketplaceId}`;
       });
 
       document.getElementById('poUploadBtn').addEventListener('click', () => {


### PR DESCRIPTION
### Motivation
- Provide a way to update master records in bulk by uploading a sheet that contains only identifiers (SKU / marketplace identifier) and the columns to change. 
- Allow admins to export the full master data for a marketplace directly from the PO Admin UI for offline editing or audit. 
- Reuse existing master matching rules so marketplace-specific identifiers like `ASIN`/`FSN`/`STYLECODE` can be used for updates. 

### Description
- Added a new API endpoint `POST /po-admin/upload-master-update` that accepts an `.xlsx` file, matches rows by `SKU` or the marketplace match key, and applies only the provided column edits to `po_admin_master_data` (implemented in `routes/poAdminRoutes.js`).
- Added a new download endpoint `GET /po-admin/download-master` that builds an Excel workbook containing all master rows for a marketplace and streams it to the client (implemented in `routes/poAdminRoutes.js`).
- Introduced `parseJsonData` helper and reused utilities like `buildJsonPath` and `buildSearchBlob` to safely parse and update JSON master rows; update logic skips empty/duplicate rows and reports `updatedCount`, `unchangedCount`, `missingIdentifiers`, and `duplicateIdentifiers` in the response.
- Updated the PO Admin dashboard UI (`views/po-admin/dashboard.ejs`) to add a Master Data Update card with file input, progress/status display, and a Download button wired to the new endpoints (`/po-admin/upload-master-update` and `/po-admin/download-master`).

### Testing
- No unit tests were added or executed as part of this change. 
- Attempted an automated UI render/screenshot with Playwright to validate the dashboard, but the request failed because the application server was not running (`net::ERR_EMPTY_RESPONSE`).
- Basic input validation paths are exercised by the endpoint (missing file/marketplace/columns) and will return HTTP 4xx/5xx as implemented; full integration tests were not run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961e3abfb508320a7cf7b3b3e34fcd0)