### PR TITLE
Add master data column delete shortcut

### DIFF
--- a/views/po-admin/dashboard.ejs
+++ b/views/po-admin/dashboard.ejs
@@ -472,9 +472,10 @@
       return Array.from(columnSet);
     }
 
-    function renderTable(headTarget, bodyTarget, columns, rows) {
+    function renderTable(headTarget, bodyTarget, columns, rows, options = {}) {
       headTarget.innerHTML = '';
       bodyTarget.innerHTML = '';
+      const showDelete = options.showDelete === true;
 
       if (!rows.length) {
         bodyTarget.innerHTML = '<tr><td colspan="100%" class="text-center text-muted py-4">No records found.</td></tr>';
@@ -483,7 +484,23 @@
 
       columns.forEach(column => {
         const th = document.createElement('th');
-        th.textContent = column;
+        const headerWrap = document.createElement('div');
+        headerWrap.className = 'd-flex align-items-center gap-2';
+
+        const label = document.createElement('span');
+        label.textContent = column;
+        headerWrap.appendChild(label);
+
+        if (showDelete) {
+          const deleteButton = document.createElement('button');
+          deleteButton.type = 'button';
+          deleteButton.className = 'btn btn-link btn-sm text-danger p-0 master-delete-column-btn';
+          deleteButton.dataset.column = column;
+          deleteButton.innerHTML = '<i class="bi bi-trash"></i>';
+          headerWrap.appendChild(deleteButton);
+        }
+
+        th.appendChild(headerWrap);
         headTarget.appendChild(th);
       });
 
@@ -514,7 +531,8 @@
         document.getElementById('masterTableHead'),
         document.getElementById('masterTableBody'),
         columns,
-        data.rows || []
+        data.rows || [],
+        { showDelete: true }
       );
       document.getElementById('masterCount').textContent = `${data.total || 0} records`;
       document.getElementById('masterPage').textContent = `Page ${data.page || 1}`;
@@ -560,6 +578,22 @@
         }
         select.appendChild(option);
       });
+    }
+
+    function openMasterDeleteModal(columnName) {
+      const statusTarget = document.getElementById('masterDeleteStatus');
+      if (!columnName) {
+        statusTarget.textContent = 'Please select a column to delete.';
+        return;
+      }
+      masterDeleteState.columnName = columnName;
+      const select = document.getElementById('masterDeleteColumn');
+      if (select) {
+        select.value = columnName;
+      }
+      document.getElementById('masterDeleteColumnName').textContent = columnName;
+      const modal = new bootstrap.Modal(document.getElementById('masterDeleteModal'));
+      modal.show();
     }
 
     function uploadFile({ fileInput, marketplaceSelect, progressBar, statusTarget, endpoint, onSuccess }) {
@@ -891,15 +925,13 @@
 
       document.getElementById('masterDeleteBtn').addEventListener('click', () => {
         const columnName = document.getElementById('masterDeleteColumn').value;
-        const statusTarget = document.getElementById('masterDeleteStatus');
-        if (!columnName) {
-          statusTarget.textContent = 'Please select a column to delete.';
-          return;
-        }
-        masterDeleteState.columnName = columnName;
-        document.getElementById('masterDeleteColumnName').textContent = columnName;
-        const modal = new bootstrap.Modal(document.getElementById('masterDeleteModal'));
-        modal.show();
+        openMasterDeleteModal(columnName);
+      });
+
+      document.getElementById('masterTableHead').addEventListener('click', (event) => {
+        const deleteButton = event.target.closest('.master-delete-column-btn');
+        if (!deleteButton) return;
+        openMasterDeleteModal(deleteButton.dataset.column);
       });
 
       document.getElementById('masterDeleteConfirmBtn').addEventListener('click', async () => {


### PR DESCRIPTION
### Motivation
- Provide a faster way to remove a master-data column from every row directly from the table header instead of only using the select+modal flow. 
- Improve UX for PO Admin users by surfacing a delete control on each master data table column header. 

### Description
- Added header delete controls to the master data table by updating `renderTable` to optionally render a trash `button` with class `master-delete-column-btn`. 
- Introduced `openMasterDeleteModal(columnName)` to centralize modal setup and re-used it for both the existing select/button flow and header delete clicks. 
- Wired header clicks to open the same delete modal and updated `loadMasterData` to call `renderTable` with `showDelete: true`. 
- All changes are in `views/po-admin/dashboard.ejs` and reuse the existing `masterDelete` modal and `deleteMasterColumn` API flow. 

### Testing
- Attempted to start the app with `node app.js` to exercise the change end-to-end but the process failed due to a missing dependency: `Cannot find module 'secure-env'`. 
- No automated unit or integration tests were run as part of this change due to the failure to start the app.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961f81ab3248320a0aa39a76e43eb1b)