### PR TITLE
feat(vms): AWB video recorder + Ajio shipment ingestion

### DIFF
--- a/app.js
+++ b/app.js
@@ -253,6 +253,18 @@ app.use('/return-grn', returnGrnRoutes);
 const { pool } = require('./config/db');
 initHealthQueue(pool);
 
+// Start scheduled jobs (Ajio recon, mail auto-reply, etc.)
+const { startCronJobs } = require('./utils/scheduler');
+startCronJobs();
+
+// Manual trigger + stats for the Ajio recon cron (admin only)
+const ajioReconRoutes = require('./routes/ajioReconRoutes');
+app.use('/admin/ajio-recon', ajioReconRoutes);
+
+// VMS (AWB Video Recorder)
+const vmsRoutes = require('./routes/vmsRoutes');
+app.use('/vms', vmsRoutes);
+
 // Home Route
 app.get('/', (req, res) => {
     res.redirect('/login');

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -181,6 +181,25 @@ function isVideoFinder(req, res, next) {
   return hasRole('videofinder')(req, res, next);
 }
 
+// Allow VMS recorder access: explicit videocreator role, mohitOperator
+// (for ops/debug), or any user the project's broader operator group can use.
+function isVideoCreator(req, res, next) {
+  const user = req.session?.user;
+  if (!user) {
+    req.flash('error', 'Please login first.');
+    return res.redirect('/login');
+  }
+  const username = (user.username || '').toLowerCase();
+  const role = user.roleName;
+  if (role === 'videocreator' || role === 'videofinder' || username === 'mohitoperator') {
+    return next();
+  }
+  const wantsJson = req.headers.accept?.includes('application/json') || req.xhr;
+  if (wantsJson) return res.status(403).json({ error: 'Permission denied' });
+  req.flash('error', 'You do not have permission to access the VMS recorder.');
+  return res.redirect('/');
+}
+
 function isProductViewer(req, res, next) {
   return hasRole('productviewer')(req, res, next);
 }
@@ -260,6 +279,7 @@ module.exports = {
     isNowiPOOrganization,
     isVendorFiles,
     isVideoFinder,
+    isVideoCreator,
     isProductViewer,
     allowUserIds,
     allowRoles,

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "moment": "^2.30.1",
         "multer": "^1.4.5-lts.1",
         "mysql2": "^3.12.0",
+        "node-cron": "^3.0.3",
         "pdfkit": "^0.16.0",
         "secure-env": "^1.2.0",
         "web-push": "^3.6.7",
@@ -4712,6 +4713,18 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
       "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA==",
       "license": "MIT"
+    },
+    "node_modules/node-cron": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-3.0.3.tgz",
+      "integrity": "sha512-dOal67//nohNgYWb+nWmg5dkFdIwDm8EpeGYMekPMrngV3637lqnX0lbUcCtgibHTz6SEz7DAIjKvKDFYCnO1A==",
+      "license": "ISC",
+      "dependencies": {
+        "uuid": "8.3.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "moment": "^2.30.1",
     "multer": "^1.4.5-lts.1",
     "mysql2": "^3.12.0",
+    "node-cron": "^3.0.3",
     "pdfkit": "^0.16.0",
     "secure-env": "^1.2.0",
     "web-push": "^3.6.7",

--- a/public/js/vmsRecorder.js
+++ b/public/js/vmsRecorder.js
@@ -1,0 +1,364 @@
+// VMS Recorder client — ERP version.
+// - Records via canvas-overlay capture so the watermark is burned into pixels.
+// - Watermark uses *server* time (no trust on local clock).
+// - 2-minute hard cap.
+// - Uploads directly to S3 via presigned PUT.
+
+(() => {
+  const $ = (id) => document.getElementById(id);
+
+  const els = {
+    video: $('vmsVideo'),
+    canvas: $('vmsCanvas'),
+    awb: $('vmsAwb'),
+    packer: $('vmsPacker'),
+    marketplace: $('vmsMarketplace'),
+    start: $('vmsStart'),
+    stop: $('vmsStop'),
+    switch: $('vmsSwitch'),
+    status: $('vmsStatus'),
+    awbInfo: $('vmsAwbInfo'),
+    progress: $('vmsProgress'),
+    uploadMsg: $('vmsUploadMsg'),
+    awbTable: $('vmsAwbTable'),
+    pendingCount: $('vmsPendingCount'),
+    recentTable: $('vmsRecentTable'),
+    refresh: $('vmsRefresh'),
+  };
+
+  const state = {
+    stream: null,
+    cameras: [],
+    cameraIndex: 0,
+    recorder: null,
+    chunks: [],
+    recording: false,
+    serverOffsetMs: 0, // serverNow - clientNow
+    currentAwb: null,
+    autoStopTimer: null,
+    startedAt: null,
+    mimeType: null,
+  };
+
+  const MAX_DURATION_MS = 2 * 60 * 1000;
+
+  // ---------- helpers ----------
+  function setStatus(text, cls) {
+    els.status.textContent = text;
+    els.status.classList.remove('connected', 'recording');
+    if (cls) els.status.classList.add(cls);
+  }
+
+  function setProgress(pct, msg) {
+    els.progress.style.width = `${Math.max(0, Math.min(100, pct))}%`;
+    if (msg !== undefined) els.uploadMsg.textContent = msg;
+  }
+
+  function fmtBytes(n) {
+    if (!n) return '—';
+    const u = ['B', 'KB', 'MB', 'GB'];
+    let i = 0;
+    while (n > 1024 && i < u.length - 1) { n /= 1024; i++; }
+    return `${n.toFixed(1)} ${u[i]}`;
+  }
+
+  function serverNow() {
+    return new Date(Date.now() + state.serverOffsetMs);
+  }
+
+  function fmtServerTime(d) {
+    const pad = (n) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} `
+      + `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  }
+
+  async function syncServerTime() {
+    try {
+      const t0 = Date.now();
+      const res = await fetch('/vms/api/server-time', { credentials: 'same-origin' });
+      const data = await res.json();
+      const t1 = Date.now();
+      const rtt = t1 - t0;
+      const serverMs = new Date(data.now).getTime();
+      // best-effort: assume request and response symmetric
+      state.serverOffsetMs = serverMs - (t0 + rtt / 2);
+    } catch (err) {
+      console.warn('server-time sync failed', err);
+    }
+  }
+
+  // ---------- camera ----------
+  async function listCameras() {
+    try {
+      const devices = await navigator.mediaDevices.enumerateDevices();
+      state.cameras = devices.filter((d) => d.kind === 'videoinput');
+    } catch (err) { console.warn(err); }
+  }
+
+  async function startCamera(deviceId) {
+    if (state.stream) state.stream.getTracks().forEach((t) => t.stop());
+    try {
+      state.stream = await navigator.mediaDevices.getUserMedia({
+        video: deviceId ? { deviceId: { exact: deviceId } } : { facingMode: 'environment' },
+        audio: false, // explicit: no audio (per requirement)
+      });
+      els.video.srcObject = state.stream;
+      await new Promise((res) => {
+        if (els.video.readyState >= 1) return res();
+        els.video.onloadedmetadata = () => res();
+      });
+      els.canvas.width = els.video.videoWidth || 640;
+      els.canvas.height = els.video.videoHeight || 480;
+      setStatus('Camera connected', 'connected');
+    } catch (err) {
+      setStatus('Camera unavailable: ' + err.message);
+      throw err;
+    }
+  }
+
+  async function switchCamera() {
+    if (state.cameras.length < 2) return;
+    state.cameraIndex = (state.cameraIndex + 1) % state.cameras.length;
+    await startCamera(state.cameras[state.cameraIndex].deviceId);
+  }
+
+  // ---------- watermark ----------
+  function drawWatermark() {
+    if (!state.recording) return;
+    const ctx = els.canvas.getContext('2d');
+    ctx.drawImage(els.video, 0, 0, els.canvas.width, els.canvas.height);
+
+    const lines = [
+      `Server Time: ${fmtServerTime(serverNow())}`,
+      `Packer: ${els.packer.value || '-'}`,
+      `AWB: ${state.currentAwb || ''}`,
+      `Marketplace: ${els.marketplace.value || ''}`,
+    ];
+    const boxW = Math.min(els.canvas.width - 20, 600);
+    ctx.fillStyle = 'rgba(0,0,0,0.6)';
+    ctx.fillRect(10, 10, boxW, 22 * lines.length + 16);
+    ctx.fillStyle = '#fff';
+    ctx.font = '18px Arial';
+    lines.forEach((l, i) => ctx.fillText(l, 20, 32 + i * 22));
+
+    requestAnimationFrame(drawWatermark);
+  }
+
+  // ---------- recording ----------
+  function pickMimeType() {
+    const candidates = [
+      'video/mp4;codecs=h264',
+      'video/webm;codecs=vp9',
+      'video/webm;codecs=vp8',
+      'video/webm',
+    ];
+    for (const c of candidates) {
+      if (window.MediaRecorder && MediaRecorder.isTypeSupported(c)) return c;
+    }
+    return 'video/webm';
+  }
+
+  async function startRecording() {
+    const awb = (els.awb.value || '').trim();
+    const marketplace = (els.marketplace.value || '').trim();
+    const packer = (els.packer.value || '').trim();
+    if (!awb) return alert('Enter AWB');
+    if (!marketplace) return alert('Select marketplace');
+    if (!packer) return alert('Enter packer name');
+    if (!state.stream) return alert('Camera not ready');
+    if (state.recording) return;
+
+    // Pre-flight: check existing video for this AWB and surface info.
+    try {
+      const r = await fetch(`/vms/api/awb/${encodeURIComponent(awb)}`, { credentials: 'same-origin' });
+      const j = await r.json();
+      if (j?.video) {
+        if (!confirm(`Video already exists for ${awb}. Re-record will be rejected. Continue anyway?`)) return;
+      }
+      if (j?.shipment) {
+        els.awbInfo.innerHTML = `<span class="vms-tag ok">In ee_shipments</span> Ref: ${j.shipment.reference_code || '-'} • Status: ${j.shipment.current_status || '-'}`;
+      } else {
+        els.awbInfo.innerHTML = `<span class="vms-tag warn">Not yet in ee_shipments</span> — recording allowed; will reconcile later.`;
+      }
+    } catch (e) { /* non-fatal */ }
+
+    state.currentAwb = awb;
+    state.chunks = [];
+    state.mimeType = pickMimeType();
+
+    const canvasStream = els.canvas.captureStream(30);
+    state.recorder = new MediaRecorder(canvasStream, { mimeType: state.mimeType });
+    state.recorder.ondataavailable = (ev) => { if (ev.data?.size) state.chunks.push(ev.data); };
+    state.recorder.onstop = () => onRecordingStopped(awb, marketplace, packer);
+
+    state.recording = true;
+    state.startedAt = Date.now();
+    state.recorder.start();
+    setStatus(`Recording AWB ${awb}`, 'recording');
+    els.start.disabled = true;
+    els.stop.disabled = false;
+
+    // 2-min auto-stop
+    state.autoStopTimer = setTimeout(() => {
+      if (state.recording) {
+        setStatus('2-min limit reached, stopping…', 'recording');
+        stopRecording();
+      }
+    }, MAX_DURATION_MS);
+
+    requestAnimationFrame(drawWatermark);
+  }
+
+  function stopRecording() {
+    if (!state.recording) return;
+    state.recording = false;
+    if (state.autoStopTimer) clearTimeout(state.autoStopTimer);
+    if (state.recorder && state.recorder.state !== 'inactive') state.recorder.stop();
+    els.start.disabled = false;
+    els.stop.disabled = true;
+    setStatus('Camera connected', 'connected');
+  }
+
+  async function onRecordingStopped(awb, marketplace, packer) {
+    if (!state.chunks.length) {
+      setProgress(0, 'No data captured');
+      return;
+    }
+    const blob = new Blob(state.chunks, { type: state.mimeType });
+    const durationMs = Date.now() - state.startedAt;
+    const clientStartedAt = new Date(state.startedAt).toISOString();
+
+    setProgress(5, 'Requesting upload URL…');
+
+    let presign;
+    try {
+      const r = await fetch('/vms/api/upload-url', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ awb, packerName: packer, marketplace, mimeType: state.mimeType }),
+      });
+      presign = await r.json();
+      if (!r.ok || !presign.ok) throw new Error(presign?.error || 'upload-url failed');
+    } catch (err) {
+      setProgress(0, `❌ ${err.message}`);
+      return;
+    }
+
+    setProgress(15, 'Uploading to S3…');
+    try {
+      await uploadWithProgress(presign.url, blob, presign.contentType, (p) => {
+        setProgress(15 + p * 75, `Uploading ${Math.round(p * 100)}%`);
+      });
+    } catch (err) {
+      setProgress(0, `❌ Upload failed: ${err.message}`);
+      return;
+    }
+
+    setProgress(95, 'Confirming…');
+    try {
+      const r = await fetch('/vms/api/confirm', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          awb, key: presign.key, marketplace, packerName: packer,
+          mimeType: state.mimeType, durationMs, clientStartedAt,
+        }),
+      });
+      const j = await r.json();
+      if (!r.ok || !j.ok) throw new Error(j?.error || 'confirm failed');
+    } catch (err) {
+      setProgress(0, `❌ Confirm failed: ${err.message}`);
+      return;
+    }
+
+    setProgress(100, `✅ Saved ${awb}`);
+    els.awb.value = '';
+    els.awb.focus();
+    refreshAwbList();
+    refreshRecent();
+  }
+
+  function uploadWithProgress(url, blob, contentType, onProgress) {
+    return new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.open('PUT', url);
+      xhr.setRequestHeader('Content-Type', contentType);
+      xhr.upload.onprogress = (e) => {
+        if (e.lengthComputable) onProgress(e.loaded / e.total);
+      };
+      xhr.onload = () => {
+        if (xhr.status >= 200 && xhr.status < 300) resolve();
+        else reject(new Error(`S3 ${xhr.status}: ${xhr.responseText?.slice(0, 200)}`));
+      };
+      xhr.onerror = () => reject(new Error('network error'));
+      xhr.send(blob);
+    });
+  }
+
+  // ---------- AWB list ----------
+  async function refreshAwbList() {
+    try {
+      const r = await fetch('/vms/api/awbs', { credentials: 'same-origin' });
+      const j = await r.json();
+      if (!j.ok) throw new Error(j.error || 'failed');
+      const pending = j.rows.filter((r) => !r.has_video);
+      els.pendingCount.textContent = pending.length;
+      els.awbTable.innerHTML = pending.length
+        ? pending.slice(0, 200).map((r) => `<tr>
+            <td><a href="#" data-awb="${r.awb}" class="vms-pick">${r.awb}</a></td>
+            <td>${r.reference_code || '-'}</td>
+            <td>${r.label_printed_at ? new Date(r.label_printed_at).toLocaleString() : '-'}</td>
+            <td>${r.current_status || '-'}</td>
+          </tr>`).join('')
+        : `<tr><td colspan="4" style="text-align:center;color:#64748b;">No pending AWBs</td></tr>`;
+      els.awbTable.querySelectorAll('.vms-pick').forEach((a) => {
+        a.addEventListener('click', (e) => {
+          e.preventDefault();
+          els.awb.value = a.dataset.awb;
+          els.awb.focus();
+        });
+      });
+    } catch (err) {
+      els.awbTable.innerHTML = `<tr><td colspan="4" style="color:#dc2626;">${err.message}</td></tr>`;
+    }
+  }
+
+  async function refreshRecent() {
+    try {
+      const r = await fetch('/vms/api/recent?limit=20', { credentials: 'same-origin' });
+      const j = await r.json();
+      if (!j.ok) throw new Error(j.error);
+      els.recentTable.innerHTML = j.rows.length
+        ? j.rows.map((r) => `<tr>
+            <td>${new Date(r.created_at).toLocaleString()}</td>
+            <td>${r.awb}</td>
+            <td>${r.packer_name || '-'}</td>
+            <td>${fmtBytes(r.size_bytes)}</td>
+          </tr>`).join('')
+        : `<tr><td colspan="4" style="text-align:center;color:#64748b;">No uploads yet</td></tr>`;
+    } catch (err) {
+      els.recentTable.innerHTML = `<tr><td colspan="4" style="color:#dc2626;">${err.message}</td></tr>`;
+    }
+  }
+
+  // ---------- wiring ----------
+  els.start.addEventListener('click', startRecording);
+  els.stop.addEventListener('click', stopRecording);
+  els.switch.addEventListener('click', switchCamera);
+  els.refresh.addEventListener('click', () => { refreshAwbList(); refreshRecent(); });
+  els.awb.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter') { e.preventDefault(); startRecording(); }
+  });
+
+  (async () => {
+    await syncServerTime();
+    setInterval(syncServerTime, 5 * 60 * 1000);
+    await listCameras();
+    try { await startCamera(); } catch (_) {}
+    refreshAwbList();
+    refreshRecent();
+    setInterval(refreshAwbList, 60 * 1000);
+  })();
+})();

--- a/routes/ajioReconRoutes.js
+++ b/routes/ajioReconRoutes.js
@@ -1,0 +1,41 @@
+// Manual trigger + status endpoint for the Ajio shipment reconciliation cron.
+// Useful for testing without waiting 30 min, and for ops visibility.
+
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isAdmin } = require('../middlewares/auth');
+const { syncAjioShipments } = require('../utils/ajioShipmentSync');
+
+router.post('/run', isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    const lookbackDays = Math.min(parseInt(req.body?.lookbackDays || '7', 10), 30);
+    const result = await syncAjioShipments({ lookbackDays });
+    res.json({ ok: true, ...result });
+  } catch (err) {
+    console.error('Manual Ajio recon failed:', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/stats', isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    const [[counts]] = await pool.query(`
+      SELECT
+        COUNT(*) AS total_shipments,
+        SUM(source = 'webhook')   AS from_webhook,
+        SUM(source = 'reconcile') AS from_reconcile,
+        SUM(label_printed_at IS NOT NULL) AS label_printed,
+        SUM(dispatched_at IS NOT NULL) AS dispatched,
+        SUM(delivered_at IS NOT NULL) AS delivered,
+        MAX(updated_at) AS last_update
+      FROM ee_shipments
+      WHERE marketplace LIKE '%ajio%'
+    `);
+    res.json({ ok: true, stats: counts });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+module.exports = router;

--- a/routes/inventoryWebhook.js
+++ b/routes/inventoryWebhook.js
@@ -155,11 +155,105 @@ async function persistInventorySnapshots(inventoryData = [], allowedSkus = new S
   return preparedRows;
 }
 
+// Marketplaces we want to track per-AWB shipments for. Ajio only for now.
+const SHIPMENT_TRACKED_MARKETPLACES = /ajio/i;
+
+function pickFirst(...vals) {
+  for (const v of vals) {
+    if (v !== undefined && v !== null && v !== '') return v;
+  }
+  return null;
+}
+
+function extractShipmentRow(order) {
+  // EasyEcom places awb_number at order level once a label is printed.
+  // Some payloads also surface it on suborder[0]. Accept both.
+  const awb =
+    pickFirst(order.awb_number, order.awbNumber, order.awb) ||
+    (Array.isArray(order.suborders) ? pickFirst(...order.suborders.map((s) => s?.awb_number)) : null);
+  if (!awb) return null;
+
+  const marketplace = order.marketplace || '';
+  if (!SHIPMENT_TRACKED_MARKETPLACES.test(marketplace)) return null;
+
+  const status = order.order_status || null;
+  const labelPrintedAt =
+    pickFirst(order.label_printed_at, order.print_date, order.label_print_date) ||
+    (status && /print/i.test(status) ? order.last_update_date || order.import_date : null);
+  const dispatchedAt =
+    pickFirst(order.dispatched_date, order.dispatch_date, order.shipped_date) ||
+    (status && /dispatch|shipp|manifest/i.test(status) ? order.last_update_date : null);
+  const deliveredAt = status && /delivered/i.test(status) ? order.last_update_date : null;
+  const rtoAt = status && /rto|return/i.test(status) ? order.last_update_date : null;
+
+  return {
+    awb: String(awb).trim(),
+    order_id: order.order_id,
+    invoice_id: order.invoice_id || null,
+    reference_code: order.reference_code || null,
+    marketplace,
+    marketplace_id: order.marketplace_id || null,
+    warehouse_id: order.warehouseId || order.import_warehouse_id || null,
+    courier_name: pickFirst(order.courier_aggregator_name, order.courier_name, order.courier),
+    manifest_id: pickFirst(order.manifest_id, order.manifestId),
+    tracking_url: pickFirst(order.tracking_url, order.track_url),
+    label_status: status && /print/i.test(status) ? status : null,
+    current_status: status,
+    order_status_id: order.order_status_id || null,
+    label_printed_at: labelPrintedAt,
+    dispatched_at: dispatchedAt,
+    delivered_at: deliveredAt,
+    rto_at: rtoAt,
+    last_seen_at: order.last_update_date || null,
+    raw: JSON.stringify(order),
+  };
+}
+
+async function persistShipments(shipmentRows) {
+  if (!shipmentRows.length) return 0;
+  const values = shipmentRows.map((s) => [
+    s.awb, s.order_id, s.invoice_id, s.reference_code, s.marketplace, s.marketplace_id,
+    s.warehouse_id, s.courier_name, s.manifest_id, s.tracking_url, s.label_status,
+    s.current_status, s.order_status_id, s.label_printed_at, s.dispatched_at,
+    s.delivered_at, s.rto_at, s.last_seen_at, 'webhook', s.raw,
+  ]);
+  await pool.query(
+    `INSERT INTO ee_shipments
+       (awb, order_id, invoice_id, reference_code, marketplace, marketplace_id,
+        warehouse_id, courier_name, manifest_id, tracking_url, label_status,
+        current_status, order_status_id, label_printed_at, dispatched_at,
+        delivered_at, rto_at, last_seen_at, source, raw)
+     VALUES ?
+     ON DUPLICATE KEY UPDATE
+       order_id = VALUES(order_id),
+       invoice_id = COALESCE(VALUES(invoice_id), invoice_id),
+       reference_code = COALESCE(VALUES(reference_code), reference_code),
+       marketplace = COALESCE(VALUES(marketplace), marketplace),
+       marketplace_id = COALESCE(VALUES(marketplace_id), marketplace_id),
+       warehouse_id = COALESCE(VALUES(warehouse_id), warehouse_id),
+       courier_name = COALESCE(VALUES(courier_name), courier_name),
+       manifest_id = COALESCE(VALUES(manifest_id), manifest_id),
+       tracking_url = COALESCE(VALUES(tracking_url), tracking_url),
+       label_status = COALESCE(VALUES(label_status), label_status),
+       current_status = VALUES(current_status),
+       order_status_id = COALESCE(VALUES(order_status_id), order_status_id),
+       label_printed_at = COALESCE(ee_shipments.label_printed_at, VALUES(label_printed_at)),
+       dispatched_at = COALESCE(ee_shipments.dispatched_at, VALUES(dispatched_at)),
+       delivered_at = COALESCE(ee_shipments.delivered_at, VALUES(delivered_at)),
+       rto_at = COALESCE(ee_shipments.rto_at, VALUES(rto_at)),
+       last_seen_at = VALUES(last_seen_at),
+       raw = VALUES(raw)`,
+    [values]
+  );
+  return values.length;
+}
+
 async function persistOrders(orders = [], allowedSkus = new Set()) {
   if (!Array.isArray(orders) || !orders.length) return [];
 
   const orderRows = [];
   const subOrderRows = [];
+  const shipmentRows = [];
 
   for (const order of orders) {
     if (!order || !order.order_id) continue;
@@ -219,6 +313,9 @@ async function persistOrders(orders = [], allowedSkus = new Set()) {
       // Save order even without suborders
       orderRows.push(orderPayload);
     }
+
+    const shipmentRow = extractShipmentRow(order);
+    if (shipmentRow) shipmentRows.push(shipmentRow);
   }
 
   if (!orderRows.length) return [];
@@ -337,6 +434,17 @@ async function persistOrders(orders = [], allowedSkus = new Set()) {
   } finally {
     connection.release();
   }
+
+  // Outside the orders/suborders transaction so a shipment-table issue
+  // can never roll back the primary ee_orders write.
+  if (shipmentRows.length) {
+    try {
+      await persistShipments(shipmentRows);
+    } catch (err) {
+      console.error('persistShipments failed (orders saved OK):', err);
+    }
+  }
+
   return orderRows;
 }
 

--- a/routes/vmsRoutes.js
+++ b/routes/vmsRoutes.js
@@ -1,0 +1,253 @@
+// VMS (AWB Video Recorder) — server side.
+// Browser records video, uploads via presigned PUT directly to S3,
+// then confirms via /confirm so we can persist a row in vms_videos.
+
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isVideoCreator } = require('../middlewares/auth');
+const {
+  generatePresignedPutUrl,
+  generatePresignedUrl,
+  headObject,
+  S3_BUCKET,
+  S3_PREFIX,
+} = require('../utils/s3Client');
+
+const MAX_UPLOAD_BYTES = 250 * 1024 * 1024; // 250 MB hard cap
+const MAX_DURATION_MS = 2 * 60 * 1000;       // 2 min hard cap (matches client)
+
+// ---------- helpers ----------
+function sanitizeChunk(s) {
+  return String(s || '').replace(/[^A-Za-z0-9._-]+/g, '_').slice(0, 80);
+}
+
+function buildKey({ awb, packerName, marketplace, ext }) {
+  const now = new Date();
+  const datePart = now.toISOString().slice(0, 10); // YYYY-MM-DD (folder)
+  const compactDate = datePart.replace(/-/g, '');
+  let hh = now.getHours();
+  const mm = String(now.getMinutes()).padStart(2, '0');
+  const ss = String(now.getSeconds()).padStart(2, '0');
+  const ampm = hh >= 12 ? 'PM' : 'AM';
+  hh = hh % 12 || 12;
+  const timePart = `${String(hh).padStart(2, '0')}-${mm}-${ss}_${ampm}`;
+  const file = `${sanitizeChunk(packerName)}_${sanitizeChunk(awb)}_${compactDate}_${timePart}.${ext}`;
+  const folder = `${S3_PREFIX || ''}${datePart}/`;
+  return `${folder}${file}`;
+}
+
+function pickExtensionFromMime(mime) {
+  if (!mime) return 'webm';
+  if (mime.includes('mp4')) return 'mp4';
+  if (mime.includes('webm')) return 'webm';
+  if (mime.includes('ogg')) return 'ogv';
+  return 'bin';
+}
+
+// ---------- page ----------
+router.get('/', isAuthenticated, isVideoCreator, (req, res) => {
+  res.render('vmsRecorder', {
+    user: req.session.user,
+  });
+});
+
+// ---------- server time (watermark) ----------
+// Returned as ISO so the client can compute a fixed offset and refuse to
+// trust the local clock for the watermark.
+router.get('/api/server-time', isAuthenticated, isVideoCreator, (req, res) => {
+  res.json({ now: new Date().toISOString() });
+});
+
+// ---------- AWB list ----------
+// Pending = printed-label Ajio AWBs without a video, last N days.
+router.get('/api/awbs', isAuthenticated, isVideoCreator, async (req, res) => {
+  try {
+    const days = Math.min(parseInt(req.query.days || '7', 10), 30);
+    const [rows] = await pool.query(
+      `SELECT s.awb, s.marketplace, s.reference_code, s.warehouse_id,
+              s.label_printed_at, s.current_status,
+              v.id IS NOT NULL AS has_video
+         FROM ee_shipments s
+         LEFT JOIN vms_videos v ON v.awb = s.awb
+        WHERE s.marketplace LIKE '%ajio%'
+          AND s.label_printed_at IS NOT NULL
+          AND s.label_printed_at >= NOW() - INTERVAL ? DAY
+        ORDER BY s.label_printed_at DESC
+        LIMIT 5000`,
+      [days]
+    );
+    res.json({
+      ok: true,
+      total: rows.length,
+      pending: rows.filter((r) => !r.has_video).length,
+      rows,
+    });
+  } catch (err) {
+    console.error('VMS awbs error:', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// Lookup a single AWB so we can warn the operator if the AWB isn't
+// in the printed-Ajio set (still allow recording — we don't want to
+// block them — but flag it on the UI).
+router.get('/api/awb/:awb', isAuthenticated, isVideoCreator, async (req, res) => {
+  try {
+    const awb = String(req.params.awb || '').trim();
+    if (!awb) return res.status(400).json({ ok: false, error: 'awb required' });
+    const [[shipment]] = await pool.query(
+      `SELECT awb, marketplace, current_status, reference_code, label_printed_at
+         FROM ee_shipments WHERE awb = ? LIMIT 1`,
+      [awb]
+    );
+    const [[video]] = await pool.query(
+      `SELECT id, s3_key, created_at FROM vms_videos WHERE awb = ? LIMIT 1`,
+      [awb]
+    );
+    res.json({ ok: true, awb, shipment: shipment || null, video: video || null });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// ---------- upload URL ----------
+router.post('/api/upload-url', isAuthenticated, isVideoCreator, async (req, res) => {
+  try {
+    const awb = String(req.body?.awb || '').trim();
+    const packerName = String(req.body?.packerName || req.session.user?.username || 'unknown').trim();
+    const marketplace = String(req.body?.marketplace || '').trim();
+    const mimeType = String(req.body?.mimeType || 'video/webm').trim();
+
+    if (!awb) return res.status(400).json({ ok: false, error: 'awb required' });
+    if (!marketplace) return res.status(400).json({ ok: false, error: 'marketplace required' });
+
+    // Reject re-upload (UNIQUE on awb in vms_videos enforces it too, but
+    // surface a friendly error before the upload happens).
+    const [[existing]] = await pool.query(
+      `SELECT id FROM vms_videos WHERE awb = ? LIMIT 1`,
+      [awb]
+    );
+    if (existing) {
+      return res.status(409).json({ ok: false, error: 'video_already_exists', awb });
+    }
+
+    const ext = pickExtensionFromMime(mimeType);
+    const key = buildKey({ awb, packerName, marketplace, ext });
+    const url = await generatePresignedPutUrl(key, mimeType, 900);
+    res.json({
+      ok: true,
+      key,
+      url,
+      bucket: S3_BUCKET,
+      expiresInSeconds: 900,
+      contentType: mimeType,
+    });
+  } catch (err) {
+    console.error('VMS upload-url error:', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// ---------- confirm ----------
+// After the browser PUTs to S3 it calls this to record the video.
+// We HEAD the object to verify it actually arrived at the expected key
+// before inserting — prevents fake "I uploaded" calls.
+router.post('/api/confirm', isAuthenticated, isVideoCreator, async (req, res) => {
+  try {
+    const {
+      awb,
+      key,
+      marketplace,
+      packerName,
+      mimeType,
+      durationMs,
+      clientStartedAt,
+    } = req.body || {};
+
+    if (!awb || !key) return res.status(400).json({ ok: false, error: 'awb and key required' });
+    if (!key.endsWith('.webm') && !key.endsWith('.mp4') && !key.endsWith('.ogv')) {
+      return res.status(400).json({ ok: false, error: 'unexpected key extension' });
+    }
+    if (durationMs && durationMs > MAX_DURATION_MS + 5000) {
+      return res.status(400).json({ ok: false, error: 'video too long' });
+    }
+
+    const head = await headObject(key);
+    if (!head.exists) {
+      return res.status(404).json({ ok: false, error: 'object_not_found_in_s3', key });
+    }
+    if (head.size > MAX_UPLOAD_BYTES) {
+      return res.status(413).json({ ok: false, error: 'object_too_large', size: head.size });
+    }
+
+    try {
+      await pool.query(
+        `INSERT INTO vms_videos
+           (awb, marketplace, packer_id, packer_name, s3_bucket, s3_key,
+            size_bytes, mime_type, duration_ms,
+            client_started_at, server_started_at, server_finished_at,
+            ip_address, user_agent)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW(), ?, ?)`,
+        [
+          awb.trim(),
+          marketplace || null,
+          req.session.user?.id || null,
+          packerName || req.session.user?.username || null,
+          S3_BUCKET,
+          key,
+          head.size,
+          mimeType || head.contentType || null,
+          durationMs || null,
+          clientStartedAt ? new Date(clientStartedAt) : null,
+          // server_started_at — we don't know the exact moment recording began;
+          // approximate from now - duration so we can sanity-check later.
+          durationMs ? new Date(Date.now() - durationMs) : null,
+          (req.headers['x-forwarded-for'] || req.ip || '').toString().slice(0, 64),
+          (req.headers['user-agent'] || '').toString().slice(0, 500),
+        ]
+      );
+    } catch (err) {
+      if (err.code === 'ER_DUP_ENTRY') {
+        return res.status(409).json({ ok: false, error: 'video_already_exists', awb });
+      }
+      throw err;
+    }
+
+    res.json({ ok: true, awb, key });
+  } catch (err) {
+    console.error('VMS confirm error:', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// ---------- recent uploads (for the recorder UI) ----------
+router.get('/api/recent', isAuthenticated, isVideoCreator, async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit || '50', 10), 200);
+    const [rows] = await pool.query(
+      `SELECT id, awb, marketplace, packer_name, s3_key, size_bytes, duration_ms, created_at
+         FROM vms_videos
+        ORDER BY created_at DESC
+        LIMIT ?`,
+      [limit]
+    );
+    res.json({ ok: true, rows });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// Generate a fresh GET presign for playback
+router.get('/api/playback-url', isAuthenticated, isVideoCreator, async (req, res) => {
+  try {
+    const key = String(req.query.key || '');
+    if (!key) return res.status(400).json({ ok: false, error: 'key required' });
+    const url = await generatePresignedUrl(key);
+    res.json({ ok: true, url });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+module.exports = router;

--- a/sql/vms_and_shipments_tables.sql
+++ b/sql/vms_and_shipments_tables.sql
@@ -1,0 +1,63 @@
+-- VMS (AWB Video Recorder) + EasyEcom shipment ingestion
+-- Run order:
+--   1. Requires existing ee_orders, users tables.
+--   2. Creates ee_shipments (one row per AWB) and vms_videos.
+
+-- One row per AWB. Populated from EasyEcom order webhook (order_update)
+-- whenever awb_number is present, and from a reconciliation pull cron
+-- that hits EasyEcom for printed-label Ajio orders.
+CREATE TABLE IF NOT EXISTS ee_shipments (
+  awb VARCHAR(64) NOT NULL PRIMARY KEY,
+  order_id BIGINT NOT NULL,
+  invoice_id BIGINT NULL,
+  reference_code VARCHAR(255) NULL,
+  marketplace VARCHAR(120) NULL,
+  marketplace_id BIGINT NULL,
+  warehouse_id BIGINT NULL,
+  courier_name VARCHAR(120) NULL,
+  manifest_id VARCHAR(120) NULL,
+  tracking_url TEXT NULL,
+  label_status VARCHAR(60) NULL,
+  current_status VARCHAR(60) NULL,
+  order_status_id INT NULL,
+  label_printed_at DATETIME NULL,
+  dispatched_at DATETIME NULL,
+  delivered_at DATETIME NULL,
+  rto_at DATETIME NULL,
+  last_seen_at DATETIME NULL,
+  source ENUM('webhook','reconcile','manual') NOT NULL DEFAULT 'webhook',
+  raw JSON NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_ee_shipments_order (order_id),
+  INDEX idx_ee_shipments_marketplace (marketplace_id),
+  INDEX idx_ee_shipments_status (current_status),
+  INDEX idx_ee_shipments_label_printed_at (label_printed_at),
+  INDEX idx_ee_shipments_reference_code (reference_code)
+);
+
+-- One row per uploaded video. AWB is the natural key (one video per AWB).
+-- Re-uploads should be rejected at the API layer; if retention rules ever
+-- require versions, drop the UNIQUE and add (awb, version).
+CREATE TABLE IF NOT EXISTS vms_videos (
+  id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  awb VARCHAR(64) NOT NULL,
+  marketplace VARCHAR(120) NULL,
+  packer_id INT NULL,
+  packer_name VARCHAR(120) NULL,
+  s3_bucket VARCHAR(120) NULL,
+  s3_key VARCHAR(500) NOT NULL,
+  size_bytes BIGINT NULL,
+  mime_type VARCHAR(60) NULL,
+  duration_ms INT NULL,
+  client_started_at DATETIME NULL,
+  server_started_at DATETIME NULL,
+  server_finished_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  ip_address VARCHAR(64) NULL,
+  user_agent VARCHAR(500) NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_vms_awb (awb),
+  INDEX idx_vms_packer (packer_id),
+  INDEX idx_vms_created_at (created_at),
+  CONSTRAINT fk_vms_packer FOREIGN KEY (packer_id) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/utils/ajioShipmentSync.js
+++ b/utils/ajioShipmentSync.js
@@ -1,0 +1,237 @@
+// Ajio shipment reconciliation: pulls printed/shipped orders from EasyEcom
+// across both warehouses (Faridabad, Delhi) and upserts into ee_shipments.
+//
+// Why this exists: discovery showed `awb_number` is never present in the
+// EasyEcom order webhook payload, so the only way to learn an AWB is to ask
+// the orders API after a label has been printed.
+
+const axios = require('axios');
+const { pool } = require('../config/db');
+
+const EASYECOM_API_BASE = global.env?.EASYECOM_API_BASE || process.env.EASYECOM_API_BASE || 'https://api.easyecom.io';
+
+// Reuse same warehouse credentials as the returns client.
+const WAREHOUSES = [
+  {
+    key: 'faridabad',
+    email: global.env?.EASYECOM_EMAIL || process.env.EASYECOM_EMAIL || '',
+    password: global.env?.EASYECOM_PASSWORD || process.env.EASYECOM_PASSWORD || '',
+    warehouse_id: 173983,
+  },
+  {
+    key: 'delhi',
+    email: global.env?.EASYECOM_DELHI_EMAIL || process.env.EASYECOM_DELHI_EMAIL || '',
+    password: global.env?.EASYECOM_DELHI_PASSWORD || process.env.EASYECOM_DELHI_PASSWORD || '',
+    warehouse_id: 176318,
+  },
+];
+
+const STATUS_FILTERS = ['Printed', 'Shipped']; // statuses that can carry an AWB
+const LOOKBACK_DAYS = parseInt(process.env.AJIO_RECON_LOOKBACK_DAYS || '7', 10);
+
+// Token cache per warehouse (mirrors easyecomReturnsClient pattern)
+const tokenCache = {};
+
+async function getToken(wh) {
+  const cached = tokenCache[wh.key];
+  if (cached?.token && cached.expiry > Date.now()) return cached.token;
+  if (!wh.email || !wh.password) return null;
+
+  try {
+    const { data } = await axios.post(
+      `${EASYECOM_API_BASE}/getApiToken`,
+      { email: wh.email, password: wh.password },
+      { headers: { 'Content-Type': 'application/json' }, timeout: 30000 }
+    );
+    const token = data?.data?.jwt_token || data?.jwt_token || data?.token;
+    if (!token) return null;
+    tokenCache[wh.key] = { token, expiry: Date.now() + 23 * 60 * 60 * 1000 };
+    return token;
+  } catch (err) {
+    console.error(`[ajioRecon] auth failed for ${wh.key}:`, err.response?.data || err.message);
+    return null;
+  }
+}
+
+function fmtDate(d) {
+  // EasyEcom expects YYYY-MM-DD HH:MM:SS
+  const pad = (n) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+}
+
+// EasyEcom V2 list endpoint. Both GET /orders and POST /orders/V2/getAllOrders
+// exist; V2 supports cursor pagination and is the documented one for bulk pulls.
+async function fetchOrdersPage(token, { status, fromDate, toDate, cursor }) {
+  const url = `${EASYECOM_API_BASE}/orders/V2/getAllOrders`;
+  const params = {
+    order_status: status,
+    start_date: fmtDate(fromDate),
+    end_date: fmtDate(toDate),
+  };
+  if (cursor) params.cursor = cursor;
+
+  const { data } = await axios.get(url, {
+    params,
+    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+    timeout: 60000,
+  });
+  // Normalise: EasyEcom responses wrap data under .data with optional next_url/cursor.
+  const payload = data?.data || data || {};
+  const orders = payload.orders || payload.data || payload.results || [];
+  const nextCursor = payload.next_cursor || payload.cursor || payload.nextCursor || null;
+  return { orders: Array.isArray(orders) ? orders : [], nextCursor };
+}
+
+function isAjio(order) {
+  const m = (order.marketplace || order.channel || '').toLowerCase();
+  return m.includes('ajio');
+}
+
+function pickFirst(...vals) {
+  for (const v of vals) {
+    if (v !== undefined && v !== null && v !== '') return v;
+  }
+  return null;
+}
+
+function extractAwb(order) {
+  const direct = pickFirst(order.awb_number, order.awbNumber, order.awb);
+  if (direct) return String(direct).trim();
+  if (Array.isArray(order.suborders)) {
+    const sub = pickFirst(...order.suborders.map((s) => s?.awb_number));
+    if (sub) return String(sub).trim();
+  }
+  return null;
+}
+
+function buildShipmentRow(order, warehouseFallback) {
+  const awb = extractAwb(order);
+  if (!awb) return null;
+  const status = order.order_status || null;
+  return {
+    awb,
+    order_id: order.order_id,
+    invoice_id: order.invoice_id || null,
+    reference_code: order.reference_code || null,
+    marketplace: order.marketplace || 'Ajio',
+    marketplace_id: order.marketplace_id || null,
+    warehouse_id: order.warehouseId || order.import_warehouse_id || warehouseFallback,
+    courier_name: pickFirst(order.courier_aggregator_name, order.courier_name, order.courier),
+    manifest_id: pickFirst(order.manifest_id, order.manifestId),
+    tracking_url: pickFirst(order.tracking_url, order.track_url),
+    label_status: status && /print/i.test(status) ? status : null,
+    current_status: status,
+    order_status_id: order.order_status_id || null,
+    label_printed_at: pickFirst(order.label_printed_at, order.print_date, order.label_print_date)
+      || (status && /print/i.test(status) ? order.last_update_date : null),
+    dispatched_at: pickFirst(order.dispatched_date, order.dispatch_date, order.shipped_date)
+      || (status && /shipp|dispatch|manifest/i.test(status) ? order.last_update_date : null),
+    delivered_at: status && /delivered/i.test(status) ? order.last_update_date : null,
+    rto_at: status && /rto|return/i.test(status) ? order.last_update_date : null,
+    last_seen_at: order.last_update_date || null,
+    raw: JSON.stringify(order),
+  };
+}
+
+async function upsertShipments(rows) {
+  if (!rows.length) return 0;
+  const values = rows.map((s) => [
+    s.awb, s.order_id, s.invoice_id, s.reference_code, s.marketplace, s.marketplace_id,
+    s.warehouse_id, s.courier_name, s.manifest_id, s.tracking_url, s.label_status,
+    s.current_status, s.order_status_id, s.label_printed_at, s.dispatched_at,
+    s.delivered_at, s.rto_at, s.last_seen_at, 'reconcile', s.raw,
+  ]);
+  await pool.query(
+    `INSERT INTO ee_shipments
+       (awb, order_id, invoice_id, reference_code, marketplace, marketplace_id,
+        warehouse_id, courier_name, manifest_id, tracking_url, label_status,
+        current_status, order_status_id, label_printed_at, dispatched_at,
+        delivered_at, rto_at, last_seen_at, source, raw)
+     VALUES ?
+     ON DUPLICATE KEY UPDATE
+       order_id = VALUES(order_id),
+       invoice_id = COALESCE(VALUES(invoice_id), invoice_id),
+       reference_code = COALESCE(VALUES(reference_code), reference_code),
+       marketplace = COALESCE(VALUES(marketplace), marketplace),
+       marketplace_id = COALESCE(VALUES(marketplace_id), marketplace_id),
+       warehouse_id = COALESCE(VALUES(warehouse_id), warehouse_id),
+       courier_name = COALESCE(VALUES(courier_name), courier_name),
+       manifest_id = COALESCE(VALUES(manifest_id), manifest_id),
+       tracking_url = COALESCE(VALUES(tracking_url), tracking_url),
+       label_status = COALESCE(VALUES(label_status), label_status),
+       current_status = VALUES(current_status),
+       order_status_id = COALESCE(VALUES(order_status_id), order_status_id),
+       label_printed_at = COALESCE(ee_shipments.label_printed_at, VALUES(label_printed_at)),
+       dispatched_at   = COALESCE(ee_shipments.dispatched_at,   VALUES(dispatched_at)),
+       delivered_at    = COALESCE(ee_shipments.delivered_at,    VALUES(delivered_at)),
+       rto_at          = COALESCE(ee_shipments.rto_at,          VALUES(rto_at)),
+       last_seen_at = VALUES(last_seen_at),
+       raw = VALUES(raw)`,
+    [values]
+  );
+  return values.length;
+}
+
+async function syncWarehouse(wh, { lookbackDays = LOOKBACK_DAYS } = {}) {
+  const token = await getToken(wh);
+  if (!token) return { warehouse: wh.key, fetched: 0, ajio: 0, withAwb: 0, upserted: 0, skipped: 'no_token' };
+
+  const toDate = new Date();
+  const fromDate = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000);
+
+  let fetched = 0;
+  let ajioCount = 0;
+  let withAwb = 0;
+  const rowsToUpsert = [];
+
+  for (const status of STATUS_FILTERS) {
+    let cursor = null;
+    let pages = 0;
+    do {
+      let page;
+      try {
+        page = await fetchOrdersPage(token, { status, fromDate, toDate, cursor });
+      } catch (err) {
+        console.error(`[ajioRecon] ${wh.key} ${status} page error:`, err.response?.data || err.message);
+        break;
+      }
+      fetched += page.orders.length;
+      for (const o of page.orders) {
+        if (!isAjio(o)) continue;
+        ajioCount++;
+        const row = buildShipmentRow(o, wh.warehouse_id);
+        if (row) {
+          withAwb++;
+          rowsToUpsert.push(row);
+        }
+      }
+      cursor = page.nextCursor;
+      pages++;
+      if (pages > 200) break; // safety cap
+    } while (cursor);
+  }
+
+  // Dedup within a single run on awb
+  const dedup = Array.from(new Map(rowsToUpsert.map((r) => [r.awb, r])).values());
+  const upserted = await upsertShipments(dedup);
+  return { warehouse: wh.key, fetched, ajio: ajioCount, withAwb, upserted };
+}
+
+async function syncAjioShipments(opts = {}) {
+  const startedAt = Date.now();
+  const results = [];
+  for (const wh of WAREHOUSES) {
+    try {
+      const r = await syncWarehouse(wh, opts);
+      results.push(r);
+    } catch (err) {
+      console.error(`[ajioRecon] ${wh.key} sync failed:`, err.message);
+      results.push({ warehouse: wh.key, error: err.message });
+    }
+  }
+  const tookMs = Date.now() - startedAt;
+  console.log(`[ajioRecon] done in ${tookMs}ms`, results);
+  return { tookMs, results };
+}
+
+module.exports = { syncAjioShipments, syncWarehouse };

--- a/utils/s3Client.js
+++ b/utils/s3Client.js
@@ -3,7 +3,7 @@
  * Used by Video Finder and Mail Manager features
  */
 
-const { S3Client, ListObjectsV2Command, GetObjectCommand, DeleteObjectCommand } = require('@aws-sdk/client-s3');
+const { S3Client, ListObjectsV2Command, GetObjectCommand, DeleteObjectCommand, PutObjectCommand, HeadObjectCommand } = require('@aws-sdk/client-s3');
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 
 // Configuration from environment
@@ -81,6 +81,34 @@ async function generatePresignedUrl(key, expiresIn = PRESIGN_TTL_SECONDS) {
   } catch (err) {
     console.error('S3 presign error:', err);
     return null;
+  }
+}
+
+/**
+ * Generate a presigned PUT URL for browser uploads.
+ * The browser must send the same Content-Type used here.
+ */
+async function generatePresignedPutUrl(key, contentType, expiresIn = 900) {
+  const command = new PutObjectCommand({
+    Bucket: S3_BUCKET,
+    Key: key,
+    ContentType: contentType,
+  });
+  return getSignedUrl(s3Client, command, { expiresIn });
+}
+
+/**
+ * HEAD an object to confirm it exists and read its size after upload.
+ */
+async function headObject(key) {
+  try {
+    const out = await s3Client.send(new HeadObjectCommand({ Bucket: S3_BUCKET, Key: key }));
+    return { exists: true, size: out.ContentLength, contentType: out.ContentType };
+  } catch (err) {
+    if (err?.$metadata?.httpStatusCode === 404 || err.name === 'NotFound') {
+      return { exists: false };
+    }
+    throw err;
   }
 }
 
@@ -275,6 +303,8 @@ function clearCache() {
 module.exports = {
   listObjects,
   generatePresignedUrl,
+  generatePresignedPutUrl,
+  headObject,
   deleteObject,
   findVideosByAwb,
   findVideoByAwb,

--- a/utils/scheduler.js
+++ b/utils/scheduler.js
@@ -1,0 +1,39 @@
+// Central place to register all node-cron jobs. Started once from app.js.
+//
+// Disable on a per-instance basis with DISABLE_CRON=1 (e.g. local dev,
+// or to make sure only one Cloud Run revision runs them).
+
+const cron = require('node-cron');
+const { syncAjioShipments } = require('./ajioShipmentSync');
+
+const TZ = process.env.CRON_TIMEZONE || 'Asia/Kolkata';
+const disabled = process.env.DISABLE_CRON === '1' || process.env.DISABLE_CRON === 'true';
+
+let started = false;
+
+function startCronJobs() {
+  if (started) return;
+  started = true;
+  if (disabled) {
+    console.log('[cron] DISABLE_CRON set, no jobs scheduled');
+    return;
+  }
+
+  // Ajio shipment reconciliation: every 30 min.
+  // Pulls Printed/Shipped Ajio orders and upserts AWBs into ee_shipments.
+  cron.schedule(
+    process.env.AJIO_RECON_CRON || '*/30 * * * *',
+    async () => {
+      try {
+        await syncAjioShipments();
+      } catch (err) {
+        console.error('[cron] ajio recon failed:', err);
+      }
+    },
+    { timezone: TZ }
+  );
+
+  console.log(`[cron] scheduled ajio shipment recon (every 30 min, TZ=${TZ})`);
+}
+
+module.exports = { startCronJobs };

--- a/views/vmsRecorder.ejs
+++ b/views/vmsRecorder.ejs
@@ -1,0 +1,84 @@
+<%- include('partials/header', { pageTitle: 'AWB Video Recorder' }) %>
+<%- include('partials/navbar', { user: user }) %>
+
+<style>
+  .vms-content { margin-top: var(--navbar-height); padding: 20px; }
+  .vms-card { background: #fff; border-radius: 10px; padding: 18px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); margin-bottom: 18px; }
+  .vms-video { width: 100%; max-height: 60vh; background: #000; border-radius: 8px; }
+  .vms-toolbar { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; margin-bottom: 10px; }
+  .vms-status { font-size: 0.9rem; }
+  .vms-status.connected { color: #16a34a; }
+  .vms-status.recording { color: #dc2626; font-weight: 600; }
+  .vms-tag { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 0.78rem; }
+  .vms-tag.ok { background: #dcfce7; color: #166534; }
+  .vms-tag.warn { background: #fef9c3; color: #854d0e; }
+  .vms-tag.err { background: #fee2e2; color: #991b1b; }
+  .vms-table { width: 100%; border-collapse: collapse; font-size: 0.9rem; }
+  .vms-table th, .vms-table td { padding: 6px 8px; border-bottom: 1px solid #eee; text-align: left; }
+  .vms-table th { background: #f8fafc; font-weight: 600; }
+  .vms-progress { height: 6px; background: #f1f5f9; border-radius: 4px; overflow: hidden; }
+  .vms-progress-bar { height: 100%; background: #2563eb; width: 0%; transition: width .2s; }
+</style>
+
+<div class="vms-content">
+  <h2 style="margin-top: 0;">📦 AWB Video Recorder</h2>
+
+  <div class="row" style="display: grid; grid-template-columns: 1fr 1fr; gap: 18px;">
+    <!-- LEFT: camera + controls -->
+    <div class="vms-card">
+      <div class="vms-toolbar">
+        <input type="text" id="vmsPacker" class="form-control form-control-sm"
+               value="<%= user.username %>" placeholder="Packer">
+        <input type="text" id="vmsAwb" class="form-control form-control-sm" placeholder="AWB" autofocus>
+        <select id="vmsMarketplace" class="form-select form-select-sm">
+          <option value="Ajio" selected>Ajio</option>
+        </select>
+      </div>
+
+      <video id="vmsVideo" class="vms-video" autoplay playsinline muted></video>
+      <canvas id="vmsCanvas" style="display:none;"></canvas>
+
+      <div class="vms-toolbar" style="margin-top: 10px;">
+        <button id="vmsStart" class="btn btn-success btn-sm">▶ Start</button>
+        <button id="vmsStop" class="btn btn-danger btn-sm" disabled>⏹ Stop</button>
+        <button id="vmsSwitch" class="btn btn-secondary btn-sm">🔄 Switch camera</button>
+        <span id="vmsStatus" class="vms-status">Camera: not connected</span>
+      </div>
+
+      <div id="vmsAwbInfo" style="margin-top:6px; font-size:0.88rem; color:#475569;"></div>
+      <div class="vms-progress" style="margin-top:10px;"><div id="vmsProgress" class="vms-progress-bar"></div></div>
+      <div id="vmsUploadMsg" style="margin-top:6px; font-size:0.85rem;"></div>
+    </div>
+
+    <!-- RIGHT: AWB queue + recent -->
+    <div class="vms-card">
+      <div class="vms-toolbar" style="justify-content: space-between;">
+        <div>
+          <strong>Pending AWBs</strong>
+          <span id="vmsPendingCount" class="vms-tag warn">0</span>
+        </div>
+        <div>
+          <button id="vmsRefresh" class="btn btn-secondary btn-sm">⟳ Refresh</button>
+        </div>
+      </div>
+      <div style="max-height: 32vh; overflow-y: auto;">
+        <table class="vms-table">
+          <thead><tr><th>AWB</th><th>Reference</th><th>Printed</th><th>Status</th></tr></thead>
+          <tbody id="vmsAwbTable"><tr><td colspan="4" style="text-align:center;color:#64748b;">Loading…</td></tr></tbody>
+        </table>
+      </div>
+
+      <div style="margin-top: 14px;">
+        <strong>Recent uploads</strong>
+        <div style="max-height: 24vh; overflow-y: auto; margin-top: 6px;">
+          <table class="vms-table">
+            <thead><tr><th>Time</th><th>AWB</th><th>Packer</th><th>Size</th></tr></thead>
+            <tbody id="vmsRecentTable"><tr><td colspan="4" style="text-align:center;color:#64748b;">—</td></tr></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script src="/public/js/vmsRecorder.js"></script>


### PR DESCRIPTION
- New ee_shipments + vms_videos tables (sql/vms_and_shipments_tables.sql)
- EasyEcom order webhook now upserts ee_shipments when awb_number is present
- Ajio reconciliation cron (every 30 min) pulls Printed/Shipped orders from EasyEcom V2 across both warehouses; needed because awb_number is never in webhook payload — pull is the primary AWB ingestion path
- node-cron scheduler with DISABLE_CRON kill switch
- Admin manual-trigger + stats at /admin/ajio-recon
- /vms recorder page: presigned-PUT direct-to-S3 upload, server-time watermark, 2-min hard cap, no audio, MP4 preferred with WebM fallback, re-record blocked, AWB list driven by ee_shipments
- Reuses existing S3_BUCKET/S3_PREFIX so Video Finder + Mail Manager pick up these videos with no further changes
- New isVideoCreator middleware (videocreator role | videofinder | mohitOperator)