### PR TITLE
feat(vms): missing-video status report + mail auto-reply cron

### DIFF
--- a/app.js
+++ b/app.js
@@ -265,6 +265,14 @@ app.use('/admin/ajio-recon', ajioReconRoutes);
 const vmsRoutes = require('./routes/vmsRoutes');
 app.use('/vms', vmsRoutes);
 
+// VMS status report
+const vmsReportRoutes = require('./routes/vmsReportRoutes');
+app.use('/vms-report', vmsReportRoutes);
+
+// Mail auto-reply (admin manual trigger + stats)
+const mailAutoReplyRoutes = require('./routes/mailAutoReplyRoutes');
+app.use('/admin/mail-auto-reply', mailAutoReplyRoutes);
+
 // Home Route
 app.get('/', (req, res) => {
     res.redirect('/login');

--- a/routes/mailAutoReplyRoutes.js
+++ b/routes/mailAutoReplyRoutes.js
@@ -1,0 +1,36 @@
+// Manual trigger + status for the mail auto-reply cron.
+
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isAdmin } = require('../middlewares/auth');
+const { runMailAutoReply } = require('../utils/mailAutoReplyJob');
+
+router.post('/run', isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    const result = await runMailAutoReply();
+    res.json({ ok: true, ...result });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/stats', isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    const [[counts]] = await pool.query(`
+      SELECT
+        SUM(status='initial') AS initial,
+        SUM(status='proceeding') AS proceeding,
+        SUM(status='replied') AS replied,
+        SUM(status='error') AS error_,
+        MAX(updated_at) AS last_update
+      FROM mail_replies
+      WHERE created_at > NOW() - INTERVAL 7 DAY
+    `);
+    res.json({ ok: true, last_7_days: counts });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+module.exports = router;

--- a/routes/vmsReportRoutes.js
+++ b/routes/vmsReportRoutes.js
@@ -1,0 +1,143 @@
+// VMS status report — joins ee_shipments with vms_videos to find
+// AWBs that shipped without a video, AWBs awaiting a video, etc.
+//
+// Computed (not stored) so it always reflects the current state — no flag
+// to keep in sync.
+
+const express = require('express');
+const router = express.Router();
+const ExcelJS = require('exceljs');
+const { pool } = require('../config/db');
+const { isAuthenticated, isVideoCreator } = require('../middlewares/auth');
+
+// Status the query produces:
+//   video_created   — vms_videos row exists for this AWB
+//   video_missing   — shipped/dispatched/delivered/RTO and no video
+//   video_pending   — label printed, not yet shipped, no video
+//   awb_not_ready   — fallback (label not printed yet)
+const STATUS_CASE = `
+  CASE
+    WHEN v.id IS NOT NULL THEN 'video_created'
+    WHEN s.current_status IN ('Shipped','Dispatched','Manifested','Delivered','Returned','RTO')
+      THEN 'video_missing'
+    WHEN s.label_printed_at IS NOT NULL THEN 'video_pending'
+    ELSE 'awb_not_ready'
+  END
+`;
+
+function buildWhereAndArgs(req) {
+  const where = ["s.marketplace LIKE '%ajio%'"];
+  const args = [];
+  const days = Math.min(parseInt(req.query.days || '30', 10), 365);
+  where.push('s.label_printed_at >= NOW() - INTERVAL ? DAY');
+  args.push(days);
+  if (req.query.warehouse_id) {
+    where.push('s.warehouse_id = ?');
+    args.push(req.query.warehouse_id);
+  }
+  return { where: where.join(' AND '), args, days };
+}
+
+router.get('/', isAuthenticated, isVideoCreator, async (req, res) => {
+  try {
+    const { where, args, days } = buildWhereAndArgs(req);
+    const [[summary]] = await pool.query(
+      `SELECT
+         COUNT(*) AS total,
+         SUM(CASE WHEN v.id IS NOT NULL THEN 1 ELSE 0 END) AS video_created,
+         SUM(CASE WHEN v.id IS NULL AND s.current_status IN
+              ('Shipped','Dispatched','Manifested','Delivered','Returned','RTO') THEN 1 ELSE 0 END) AS video_missing,
+         SUM(CASE WHEN v.id IS NULL AND s.label_printed_at IS NOT NULL AND s.current_status NOT IN
+              ('Shipped','Dispatched','Manifested','Delivered','Returned','RTO') THEN 1 ELSE 0 END) AS video_pending
+       FROM ee_shipments s
+       LEFT JOIN vms_videos v ON v.awb = s.awb
+       WHERE ${where}`,
+      args
+    );
+    res.render('vmsReport', { user: req.session.user, summary, days, query: req.query });
+  } catch (err) {
+    console.error('VMS report error:', err);
+    res.status(500).send('Report failed: ' + err.message);
+  }
+});
+
+router.get('/api/rows', isAuthenticated, isVideoCreator, async (req, res) => {
+  try {
+    const { where, args } = buildWhereAndArgs(req);
+    const status = String(req.query.status || '').trim();
+    const limit = Math.min(parseInt(req.query.limit || '500', 10), 5000);
+
+    let extra = '';
+    if (status === 'video_missing') {
+      extra = ` AND v.id IS NULL AND s.current_status IN ('Shipped','Dispatched','Manifested','Delivered','Returned','RTO')`;
+    } else if (status === 'video_pending') {
+      extra = ` AND v.id IS NULL AND s.label_printed_at IS NOT NULL
+               AND s.current_status NOT IN ('Shipped','Dispatched','Manifested','Delivered','Returned','RTO')`;
+    } else if (status === 'video_created') {
+      extra = ` AND v.id IS NOT NULL`;
+    }
+
+    const [rows] = await pool.query(
+      `SELECT s.awb, s.order_id, s.reference_code, s.warehouse_id,
+              s.current_status, s.label_printed_at, s.dispatched_at,
+              s.delivered_at, s.rto_at,
+              v.s3_key, v.created_at AS video_at, v.packer_name,
+              ${STATUS_CASE} AS computed_status
+         FROM ee_shipments s
+         LEFT JOIN vms_videos v ON v.awb = s.awb
+        WHERE ${where} ${extra}
+        ORDER BY s.label_printed_at DESC
+        LIMIT ?`,
+      [...args, limit]
+    );
+    res.json({ ok: true, rows });
+  } catch (err) {
+    console.error('VMS report rows error:', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/export.xlsx', isAuthenticated, isVideoCreator, async (req, res) => {
+  try {
+    const { where, args } = buildWhereAndArgs(req);
+    const [rows] = await pool.query(
+      `SELECT s.awb, s.order_id, s.reference_code, s.warehouse_id,
+              s.current_status, s.label_printed_at, s.dispatched_at,
+              s.delivered_at, s.rto_at,
+              v.s3_key, v.created_at AS video_at, v.packer_name,
+              ${STATUS_CASE} AS computed_status
+         FROM ee_shipments s
+         LEFT JOIN vms_videos v ON v.awb = s.awb
+        WHERE ${where}
+        ORDER BY s.label_printed_at DESC
+        LIMIT 50000`,
+      args
+    );
+    const wb = new ExcelJS.Workbook();
+    const ws = wb.addWorksheet('VMS report');
+    ws.columns = [
+      { header: 'AWB', key: 'awb', width: 22 },
+      { header: 'Order ID', key: 'order_id', width: 14 },
+      { header: 'Ajio Order #', key: 'reference_code', width: 22 },
+      { header: 'Warehouse', key: 'warehouse_id', width: 12 },
+      { header: 'Status', key: 'current_status', width: 14 },
+      { header: 'Computed', key: 'computed_status', width: 16 },
+      { header: 'Label Printed', key: 'label_printed_at', width: 20 },
+      { header: 'Dispatched', key: 'dispatched_at', width: 20 },
+      { header: 'Delivered', key: 'delivered_at', width: 20 },
+      { header: 'Video Key', key: 's3_key', width: 50 },
+      { header: 'Video At', key: 'video_at', width: 20 },
+      { header: 'Packer', key: 'packer_name', width: 18 },
+    ];
+    rows.forEach((r) => ws.addRow(r));
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', `attachment; filename="vms_report_${Date.now()}.xlsx"`);
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error('VMS report export error:', err);
+    res.status(500).send('Export failed: ' + err.message);
+  }
+});
+
+module.exports = router;

--- a/utils/mailAutoReplyJob.js
+++ b/utils/mailAutoReplyJob.js
@@ -1,0 +1,198 @@
+// Mail auto-reply cron — at 9 AM and 9 PM IST.
+//
+// Picks Zoho inbox emails (last N days) that haven't been replied to,
+// resolves AWB via:
+//   (1) order_awb_mapping (Excel uploads)
+//   (2) ee_orders.reference_code (Ajio order # → order_id → ee_shipments.awb)
+//   (3) skipped — kept for the next run / manual intervention
+// then checks S3 for a matching video and replies via Zoho if found.
+
+const { pool } = require('../config/db');
+const zohoMail = require('./zohoMailClient');
+const { findVideoByAwb, formatFileSize } = require('./s3Client');
+
+const LOOKBACK_DAYS = parseInt(process.env.MAIL_REPLY_LOOKBACK_DAYS || '7', 10);
+const MAX_EMAILS_PER_RUN = parseInt(process.env.MAIL_REPLY_MAX_PER_RUN || '200', 10);
+const OUR_SENDER = (process.env.OUR_SENDER_EMAIL || 'sales@kotty.in').toLowerCase();
+
+async function isAlreadyReplied(messageId) {
+  const [[row]] = await pool.query(
+    `SELECT status FROM mail_replies WHERE message_id = ? LIMIT 1`,
+    [messageId]
+  );
+  return row && row.status === 'replied';
+}
+
+async function lookupAwbForOrder(orderId) {
+  if (!orderId) return null;
+
+  // (1) order_awb_mapping (manual Excel upload)
+  const [[mapped]] = await pool.query(
+    `SELECT awb FROM order_awb_mapping WHERE order_id = ? LIMIT 1`,
+    [orderId.toUpperCase()]
+  );
+  if (mapped?.awb) return { awb: mapped.awb, source: 'mapping' };
+
+  // (2) ee_orders.reference_code (the Ajio customer order number) → ee_shipments
+  const [[ref]] = await pool.query(
+    `SELECT s.awb
+       FROM ee_orders o
+       JOIN ee_shipments s ON s.order_id = o.order_id
+      WHERE UPPER(o.reference_code) = UPPER(?)
+        AND o.marketplace LIKE '%ajio%'
+      ORDER BY s.updated_at DESC
+      LIMIT 1`,
+    [orderId]
+  );
+  if (ref?.awb) return { awb: ref.awb, source: 'ee_shipments' };
+
+  return null;
+}
+
+async function recordInitial(email, classification, orderId) {
+  await pool.query(
+    `INSERT INTO mail_replies
+       (message_id, thread_id, from_address, to_address, subject, order_id,
+        status, classification)
+     VALUES (?, ?, ?, ?, ?, ?, 'initial', ?)
+     ON DUPLICATE KEY UPDATE
+       order_id = COALESCE(VALUES(order_id), order_id),
+       classification = COALESCE(VALUES(classification), classification)`,
+    [
+      email.messageId, email.threadId || null,
+      email.fromAddress || null, email.toAddress || null,
+      (email.subject || '').slice(0, 500),
+      orderId || null, classification || null,
+    ]
+  );
+}
+
+async function recordReplied(email, orderId, awb, videoUrl) {
+  await pool.query(
+    `INSERT INTO mail_replies
+       (message_id, thread_id, from_address, to_address, subject, order_id,
+        awb, video_url, status, replied_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'replied', NOW())
+     ON DUPLICATE KEY UPDATE
+       awb = VALUES(awb),
+       video_url = VALUES(video_url),
+       order_id = COALESCE(VALUES(order_id), order_id),
+       status = 'replied',
+       replied_at = NOW()`,
+    [
+      email.messageId, email.threadId || null,
+      email.fromAddress || null, email.toAddress || null,
+      (email.subject || '').slice(0, 500),
+      orderId || null, awb, videoUrl,
+    ]
+  );
+}
+
+async function processOneEmail(email, stats) {
+  // Skip our own outbound mails (anti-loop)
+  if ((email.fromAddress || '').toLowerCase().includes(OUR_SENDER)) {
+    stats.skipped_own++;
+    return;
+  }
+
+  if (await isAlreadyReplied(email.messageId)) {
+    stats.skipped_already_replied++;
+    return;
+  }
+
+  // Get full body for order-id extraction
+  let bodyText = email.summary || '';
+  try {
+    const content = await zohoMail.getEmailContent(email.messageId);
+    bodyText = content?.content || content?.body || bodyText;
+  } catch (err) {
+    // continue with summary if fetch fails
+  }
+
+  const details = zohoMail.extractOrderDetails(bodyText, email.subject || '');
+  const classification = zohoMail.classifyEmail(email.subject || '', bodyText);
+  await recordInitial(email, classification, details.orderId);
+
+  if (!details.orderId) {
+    stats.skipped_no_order_id++;
+    return;
+  }
+
+  const awbResult = await lookupAwbForOrder(details.orderId);
+  if (!awbResult) {
+    stats.skipped_no_awb++;
+    return;
+  }
+
+  const video = await findVideoByAwb(awbResult.awb);
+  if (!video) {
+    stats.skipped_no_video++;
+    return;
+  }
+
+  // Send reply
+  try {
+    const html = zohoMail.buildVideoReplyHtml(details.orderId, [{
+      awb: awbResult.awb,
+      url: video.url,
+      filename: video.key.split('/').pop(),
+    }]);
+    await zohoMail.sendReply(
+      email.messageId,
+      email.threadId,
+      email.fromAddress,
+      email.subject || `Re: Order ${details.orderId}`,
+      html,
+      ''
+    );
+    await recordReplied(email, details.orderId, awbResult.awb, video.url);
+    stats.replied++;
+  } catch (err) {
+    stats.errors++;
+    console.error(`[mailAutoReply] reply failed for ${email.messageId}:`, err.message);
+  }
+}
+
+async function runMailAutoReply() {
+  if (!zohoMail.isConfigured()) {
+    console.log('[mailAutoReply] Zoho not configured, skipping');
+    return { skipped: 'not_configured' };
+  }
+  const startedAt = Date.now();
+  const stats = {
+    fetched: 0, processed: 0, replied: 0, errors: 0,
+    skipped_own: 0, skipped_already_replied: 0,
+    skipped_no_order_id: 0, skipped_no_awb: 0, skipped_no_video: 0,
+  };
+
+  let emails = [];
+  try {
+    emails = await zohoMail.getEmails('inbox', MAX_EMAILS_PER_RUN, 0);
+  } catch (err) {
+    console.error('[mailAutoReply] fetch failed:', err.message);
+    return { error: err.message };
+  }
+  stats.fetched = emails.length;
+
+  // Filter to last LOOKBACK_DAYS
+  const cutoff = Date.now() - LOOKBACK_DAYS * 24 * 60 * 60 * 1000;
+  const recent = emails.filter((e) => {
+    const t = parseInt(e.receivedTime || e.receivedAt || '0', 10);
+    return t > cutoff;
+  });
+
+  for (const email of recent) {
+    stats.processed++;
+    try {
+      await processOneEmail(email, stats);
+    } catch (err) {
+      stats.errors++;
+      console.error('[mailAutoReply] error on', email.messageId, err.message);
+    }
+  }
+
+  console.log(`[mailAutoReply] done in ${Date.now() - startedAt}ms`, stats);
+  return stats;
+}
+
+module.exports = { runMailAutoReply };

--- a/utils/scheduler.js
+++ b/utils/scheduler.js
@@ -5,6 +5,7 @@
 
 const cron = require('node-cron');
 const { syncAjioShipments } = require('./ajioShipmentSync');
+const { runMailAutoReply } = require('./mailAutoReplyJob');
 
 const TZ = process.env.CRON_TIMEZONE || 'Asia/Kolkata';
 const disabled = process.env.DISABLE_CRON === '1' || process.env.DISABLE_CRON === 'true';
@@ -34,6 +35,23 @@ function startCronJobs() {
   );
 
   console.log(`[cron] scheduled ajio shipment recon (every 30 min, TZ=${TZ})`);
+
+  // Mail auto-reply: 9 AM and 9 PM IST.
+  // Scans inbox, resolves AWB via order_awb_mapping → ee_orders.reference_code,
+  // sends Zoho reply with video link if found.
+  cron.schedule(
+    process.env.MAIL_REPLY_CRON || '0 9,21 * * *',
+    async () => {
+      try {
+        await runMailAutoReply();
+      } catch (err) {
+        console.error('[cron] mail auto-reply failed:', err);
+      }
+    },
+    { timezone: TZ }
+  );
+
+  console.log(`[cron] scheduled mail auto-reply (9 AM, 9 PM ${TZ})`);
 }
 
 module.exports = { startCronJobs };

--- a/views/vmsReport.ejs
+++ b/views/vmsReport.ejs
@@ -1,0 +1,131 @@
+<%- include('partials/header', { pageTitle: 'VMS Report' }) %>
+<%- include('partials/navbar', { user: user }) %>
+
+<style>
+  .vmsr-content { margin-top: var(--navbar-height); padding: 22px; }
+  .vmsr-cards { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; margin-bottom: 18px; }
+  .vmsr-card { background: #fff; padding: 16px; border-radius: 10px; box-shadow: 0 1px 3px rgba(0,0,0,0.06); cursor: pointer; }
+  .vmsr-card.active { outline: 2px solid #2563eb; }
+  .vmsr-card .label { font-size: 0.85rem; color: #64748b; }
+  .vmsr-card .value { font-size: 1.6rem; font-weight: 700; margin-top: 4px; }
+  .vmsr-card.green .value { color: #16a34a; }
+  .vmsr-card.red .value { color: #dc2626; }
+  .vmsr-card.yellow .value { color: #ca8a04; }
+  .vmsr-toolbar { display: flex; gap: 10px; align-items: center; margin-bottom: 12px; flex-wrap: wrap; }
+  .vmsr-table { width: 100%; border-collapse: collapse; background: #fff; border-radius: 8px; overflow: hidden; font-size: 0.88rem; }
+  .vmsr-table th, .vmsr-table td { padding: 8px 10px; border-bottom: 1px solid #eee; text-align: left; }
+  .vmsr-table th { background: #f8fafc; font-weight: 600; }
+  .pill { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 0.78rem; }
+  .pill.green { background: #dcfce7; color: #166534; }
+  .pill.red   { background: #fee2e2; color: #991b1b; }
+  .pill.yellow{ background: #fef9c3; color: #854d0e; }
+  .pill.gray  { background: #f1f5f9; color: #475569; }
+</style>
+
+<div class="vmsr-content">
+  <div class="vmsr-toolbar">
+    <h2 style="margin:0;">📊 VMS Report (Ajio)</h2>
+    <span style="color:#64748b;">last <%= days %> days</span>
+    <span style="flex:1;"></span>
+    <select id="vmsrDays" class="form-select form-select-sm" style="width:140px;">
+      <% [7,14,30,60,90].forEach(d => { %>
+        <option value="<%= d %>" <%= d === days ? 'selected' : '' %>>last <%= d %> days</option>
+      <% }) %>
+    </select>
+    <a id="vmsrExport" class="btn btn-secondary btn-sm" href="/vms-report/export.xlsx?days=<%= days %>">⬇ Export Excel</a>
+  </div>
+
+  <div class="vmsr-cards">
+    <div class="vmsr-card" data-status="">
+      <div class="label">Total shipments</div>
+      <div class="value"><%= summary.total || 0 %></div>
+    </div>
+    <div class="vmsr-card green" data-status="video_created">
+      <div class="label">Video created</div>
+      <div class="value"><%= summary.video_created || 0 %></div>
+    </div>
+    <div class="vmsr-card yellow" data-status="video_pending">
+      <div class="label">Pending video (label printed)</div>
+      <div class="value"><%= summary.video_pending || 0 %></div>
+    </div>
+    <div class="vmsr-card red" data-status="video_missing">
+      <div class="label">Missing video (shipped)</div>
+      <div class="value"><%= summary.video_missing || 0 %></div>
+    </div>
+  </div>
+
+  <div id="vmsrTableWrap">
+    <table class="vmsr-table">
+      <thead>
+        <tr>
+          <th>AWB</th><th>Ajio Order #</th><th>Status</th><th>Computed</th>
+          <th>Label printed</th><th>Dispatched</th><th>Video</th><th>Packer</th>
+        </tr>
+      </thead>
+      <tbody id="vmsrRows"><tr><td colspan="8" style="text-align:center;color:#64748b;">Pick a card to load rows.</td></tr></tbody>
+    </table>
+  </div>
+</div>
+
+<script>
+(() => {
+  const cards = document.querySelectorAll('.vmsr-card');
+  const rows = document.getElementById('vmsrRows');
+  const daysSel = document.getElementById('vmsrDays');
+  const exportLink = document.getElementById('vmsrExport');
+  let currentStatus = '';
+
+  function pillFor(s) {
+    if (s === 'video_created') return '<span class="pill green">video_created</span>';
+    if (s === 'video_missing') return '<span class="pill red">video_missing</span>';
+    if (s === 'video_pending') return '<span class="pill yellow">video_pending</span>';
+    return '<span class="pill gray">' + s + '</span>';
+  }
+
+  async function load(status) {
+    rows.innerHTML = '<tr><td colspan="8" style="text-align:center;color:#64748b;">Loading…</td></tr>';
+    cards.forEach(c => c.classList.toggle('active', c.dataset.status === status));
+    const days = daysSel.value;
+    const url = '/vms-report/api/rows?days=' + days + (status ? '&status=' + encodeURIComponent(status) : '');
+    try {
+      const r = await fetch(url, { credentials: 'same-origin' });
+      const j = await r.json();
+      if (!j.ok) throw new Error(j.error);
+      if (!j.rows.length) {
+        rows.innerHTML = '<tr><td colspan="8" style="text-align:center;color:#64748b;">No rows</td></tr>';
+        return;
+      }
+      rows.innerHTML = j.rows.map(r => `
+        <tr>
+          <td>${r.awb}</td>
+          <td>${r.reference_code || '-'}</td>
+          <td>${r.current_status || '-'}</td>
+          <td>${pillFor(r.computed_status)}</td>
+          <td>${r.label_printed_at ? new Date(r.label_printed_at).toLocaleString() : '-'}</td>
+          <td>${r.dispatched_at ? new Date(r.dispatched_at).toLocaleString() : '-'}</td>
+          <td>${r.s3_key ? '<a href="#" data-key="' + r.s3_key + '" class="vmsr-play">▶ play</a>' : '-'}</td>
+          <td>${r.packer_name || '-'}</td>
+        </tr>`).join('');
+      rows.querySelectorAll('.vmsr-play').forEach(a => {
+        a.addEventListener('click', async (e) => {
+          e.preventDefault();
+          const r = await fetch('/vms/api/playback-url?key=' + encodeURIComponent(a.dataset.key), { credentials: 'same-origin' });
+          const j = await r.json();
+          if (j.ok && j.url) window.open(j.url, '_blank');
+        });
+      });
+    } catch (err) {
+      rows.innerHTML = '<tr><td colspan="8" style="color:#dc2626;">' + err.message + '</td></tr>';
+    }
+  }
+
+  cards.forEach(c => c.addEventListener('click', () => {
+    currentStatus = c.dataset.status || '';
+    load(currentStatus);
+  }));
+  daysSel.addEventListener('change', () => {
+    exportLink.href = '/vms-report/export.xlsx?days=' + daysSel.value;
+    location.search = '?days=' + daysSel.value;
+  });
+})();
+</script>


### PR DESCRIPTION
PR#3 - VMS status report
- /vms-report dashboard joins ee_shipments with vms_videos and computes status on the fly (video_created / video_pending / video_missing / awb_not_ready) — no flag to keep in sync
- Filter by lookback days, click-through rows, Excel export
- Inline playback via existing /vms/api/playback-url presigned GET

PR#4 - Mail auto-reply cron (9 AM, 9 PM IST)
- New utils/mailAutoReplyJob.js: scans Zoho inbox, extracts Order ID, resolves AWB via order_awb_mapping → ee_orders.reference_code (the Ajio customer order number), checks S3, sends Zoho reply with video link, marks mail_replies as 'replied'
- Records 'initial' state for emails it can't yet match (no order id / no AWB / no video) so the next run picks them back up
- /admin/mail-auto-reply/{run,stats} for manual trigger + visibility
- Skips our own outbound (anti-loop) and already-replied messages
- Configurable: MAIL_REPLY_CRON, MAIL_REPLY_LOOKBACK_DAYS, MAIL_REPLY_MAX_PER_RUN, OUR_SENDER_EMAIL