### PR TITLE
debug(ajio-recon): add /admin/ajio-recon/debug endpoint

### DIFF
--- a/routes/ajioReconRoutes.js
+++ b/routes/ajioReconRoutes.js
@@ -5,7 +5,7 @@ const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/db');
 const { isAuthenticated, isAdmin } = require('../middlewares/auth');
-const { syncAjioShipments } = require('../utils/ajioShipmentSync');
+const { syncAjioShipments, debugFetchOnce } = require('../utils/ajioShipmentSync');
 
 router.post('/run', isAuthenticated, isAdmin, async (req, res) => {
   try {
@@ -33,6 +33,17 @@ router.get('/stats', isAuthenticated, isAdmin, async (req, res) => {
       WHERE marketplace LIKE '%ajio%'
     `);
     res.json({ ok: true, stats: counts });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// Debug: hit EasyEcom once with several candidate URLs and dump the raw
+// response shape. Use this to figure out the right endpoint for the tenant.
+router.post('/debug', isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    const out = await debugFetchOnce(req.body || {});
+    res.json({ ok: true, ...out });
   } catch (err) {
     res.status(500).json({ ok: false, error: err.message });
   }

--- a/utils/ajioShipmentSync.js
+++ b/utils/ajioShipmentSync.js
@@ -234,4 +234,63 @@ async function syncAjioShipments(opts = {}) {
   return { tookMs, results };
 }
 
-module.exports = { syncAjioShipments, syncWarehouse };
+// Debug helper: hit EasyEcom once for one warehouse + status, return the
+// raw response so we can see the actual response shape.
+async function debugFetchOnce({ warehouse = 'faridabad', status = 'Printed', lookbackDays = 30, urlOverride, method = 'GET' } = {}) {
+  const wh = WAREHOUSES.find((w) => w.key === warehouse);
+  if (!wh) throw new Error(`unknown warehouse: ${warehouse}`);
+  const token = await getToken(wh);
+  if (!token) return { error: 'no_token', warehouse };
+
+  const toDate = new Date();
+  const fromDate = new Date(Date.now() - lookbackDays * 24 * 60 * 60 * 1000);
+  const candidates = urlOverride
+    ? [urlOverride]
+    : [
+        `${EASYECOM_API_BASE}/orders/V2/getAllOrders`,
+        `${EASYECOM_API_BASE}/Orders/V2/getAllOrders`,
+        `${EASYECOM_API_BASE}/orders/getAllOrders`,
+        `${EASYECOM_API_BASE}/orders`,
+      ];
+
+  const params = {
+    order_status: status,
+    status,
+    start_date: fmtDate(fromDate),
+    end_date: fmtDate(toDate),
+    from_date: fmtDate(fromDate),
+    to_date: fmtDate(toDate),
+  };
+
+  const attempts = [];
+  for (const url of candidates) {
+    try {
+      const config = {
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        timeout: 30000,
+      };
+      const resp = method === 'POST'
+        ? await axios.post(url, params, config)
+        : await axios.get(url, { ...config, params });
+      attempts.push({
+        url,
+        method,
+        status: resp.status,
+        sentParams: method === 'POST' ? params : params,
+        responseKeys: Object.keys(resp.data || {}),
+        sample: JSON.stringify(resp.data).slice(0, 4000),
+      });
+    } catch (err) {
+      attempts.push({
+        url,
+        method,
+        error: err.message,
+        responseStatus: err.response?.status,
+        responseData: err.response?.data ? JSON.stringify(err.response.data).slice(0, 1500) : null,
+      });
+    }
+  }
+  return { warehouse, status, fromDate: fmtDate(fromDate), toDate: fmtDate(toDate), attempts };
+}
+
+module.exports = { syncAjioShipments, syncWarehouse, debugFetchOnce };


### PR DESCRIPTION
Tries several candidate EasyEcom V2 URLs and returns each attempt's status + response keys + a sample of the body, so we can see which endpoint shape this tenant actually exposes. fetched=0 across both warehouses suggests the path or params we picked are wrong.