### PR TITLE
fix(ajio-recon): use nextUrl for V2 pagination, drop duplicate status…

### DIFF
--- a/utils/ajioShipmentSync.js
+++ b/utils/ajioShipmentSync.js
@@ -26,7 +26,10 @@ const WAREHOUSES = [
   },
 ];
 
-const STATUS_FILTERS = ['Printed', 'Shipped']; // statuses that can carry an AWB
+// EasyEcom currently ignores the order_status filter and returns all orders
+// in the date window, so we send one pass per chunk and rely on
+// `awb_number != null` (handled in extractAwb) to keep only relevant rows.
+const STATUS_FILTERS = ['Printed'];
 const LOOKBACK_DAYS = parseInt(process.env.AJIO_RECON_LOOKBACK_DAYS || '7', 10);
 
 // Token cache per warehouse (mirrors easyecomReturnsClient pattern)
@@ -59,24 +62,26 @@ function fmtDate(d) {
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
 }
 
-// EasyEcom V2 list endpoint. EasyEcom enforces a max 7-day window per call
-// and returns errors in the body shape { code, message, data }.
-async function fetchOrdersPage(token, { status, fromDate, toDate, cursor }) {
-  const url = `${EASYECOM_API_BASE}/orders/V2/getAllOrders`;
-  const params = {
-    order_status: status,
-    start_date: fmtDate(fromDate),
-    end_date: fmtDate(toDate),
-  };
-  if (cursor) params.cursor = cursor;
+// EasyEcom V2 list endpoint. EasyEcom enforces a max 7-day window per call,
+// returns errors in the body shape { code, message, data }, and paginates
+// via a `nextUrl` field (a fully-formed URL) — not a cursor.
+async function fetchOrdersPage(token, { status, fromDate, toDate, nextUrl }) {
+  const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' };
 
-  const { data } = await axios.get(url, {
-    params,
-    headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
-    timeout: 60000,
-  });
+  let resp;
+  if (nextUrl) {
+    resp = await axios.get(nextUrl, { headers, timeout: 60000 });
+  } else {
+    const url = `${EASYECOM_API_BASE}/orders/V2/getAllOrders`;
+    const params = {
+      order_status: status,
+      start_date: fmtDate(fromDate),
+      end_date: fmtDate(toDate),
+    };
+    resp = await axios.get(url, { params, headers, timeout: 60000 });
+  }
+  const data = resp.data;
 
-  // EasyEcom signals errors via body.code rather than HTTP status.
   if (data && typeof data.code === 'number' && data.code >= 400) {
     throw new Error(`EasyEcom ${data.code}: ${data.message}`);
   }
@@ -85,10 +90,10 @@ async function fetchOrdersPage(token, { status, fromDate, toDate, cursor }) {
   const orders = Array.isArray(payload)
     ? payload
     : (payload.orders || payload.data || payload.results || []);
-  const nextCursor = (payload && !Array.isArray(payload))
-    ? (payload.next_cursor || payload.cursor || payload.nextCursor || null)
+  const nextUrlOut = (payload && !Array.isArray(payload))
+    ? (payload.nextUrl || payload.next_url || null)
     : null;
-  return { orders: Array.isArray(orders) ? orders : [], nextCursor };
+  return { orders: Array.isArray(orders) ? orders : [], nextUrl: nextUrlOut };
 }
 
 // Build ≤7-day chunks counting backwards from `to`. Last chunk may be shorter.
@@ -219,7 +224,7 @@ async function syncWarehouse(wh, { lookbackDays = LOOKBACK_DAYS, onProgress } = 
         fromDate: fmtDate(from), toDate: fmtDate(to),
         step: stepIdx, totalSteps,
       });
-      let cursor = null;
+      let nextUrl = null;
       let pages = 0;
       let chunkOrders = 0;
       let chunkAjio = 0;
@@ -227,7 +232,7 @@ async function syncWarehouse(wh, { lookbackDays = LOOKBACK_DAYS, onProgress } = 
       do {
         let page;
         try {
-          page = await fetchOrdersPage(token, { status, fromDate: from, toDate: to, cursor });
+          page = await fetchOrdersPage(token, { status, fromDate: from, toDate: to, nextUrl });
         } catch (err) {
           const msg = err.response?.data || err.message;
           console.error(`[ajioRecon] ${wh.key} ${status} ${fmtDate(from)}..${fmtDate(to)} error:`, msg);
@@ -247,10 +252,14 @@ async function syncWarehouse(wh, { lookbackDays = LOOKBACK_DAYS, onProgress } = 
             rowsToUpsert.push(row);
           }
         }
-        cursor = page.nextCursor;
+        nextUrl = page.nextUrl;
         pages++;
-        if (pages > 200) break; // safety cap
-      } while (cursor);
+        // Emit per-page progress so long chunks stay visible
+        if (pages > 1 && pages % 5 === 0) {
+          emit({ kind: 'chunk_progress', warehouse: wh.key, status, pages, chunkOrders, chunkAwb });
+        }
+        if (pages > 500) break; // safety cap (~25k orders)
+      } while (nextUrl);
       emit({
         kind: 'chunk_done', warehouse: wh.key, status,
         orders: chunkOrders, ajio: chunkAjio, withAwb: chunkAwb,

--- a/views/ajioRecon.ejs
+++ b/views/ajioRecon.ejs
@@ -71,6 +71,32 @@
   </div>
 
   <div class="ar-section">
+    <h3>Debug — peek at raw EasyEcom order</h3>
+    <div class="ar-toolbar" style="padding:12px;">
+      <select id="arDbgWh" class="form-select form-select-sm" style="width:140px;">
+        <option value="faridabad">faridabad</option>
+        <option value="delhi" selected>delhi</option>
+      </select>
+      <select id="arDbgStatus" class="form-select form-select-sm" style="width:140px;">
+        <option value="Printed" selected>Printed</option>
+        <option value="Shipped">Shipped</option>
+        <option value="Open">Open</option>
+        <option value="Confirmed">Confirmed</option>
+        <option value="Ready to dispatch">Ready to dispatch</option>
+      </select>
+      <select id="arDbgDays" class="form-select form-select-sm" style="width:140px;">
+        <option value="3">last 3 days</option>
+        <option value="7" selected>last 7 days</option>
+      </select>
+      <label style="font-size:0.85rem;"><input type="checkbox" id="arDbgAjio" checked> Ajio only</label>
+      <button id="arDbgRun" class="btn btn-secondary btn-sm">🔍 Inspect one order</button>
+      <span id="arDbgInfo" style="font-size:0.85rem; color:#475569;"></span>
+    </div>
+    <div id="arDbgKeys" style="margin:6px 0; font-size:0.85rem; color:#0f172a;"></div>
+    <pre id="arDbgSample" class="ar-log" style="max-height:40vh;"></pre>
+  </div>
+
+  <div class="ar-section">
     <h3>Most recent shipments</h3>
     <div style="overflow-x:auto;">
       <table class="ar-table">
@@ -232,6 +258,42 @@
   });
 
   els.refreshRecent.addEventListener('click', refreshRecent);
+
+  // Debug panel
+  const dbg = {
+    wh: $('arDbgWh'), status: $('arDbgStatus'), days: $('arDbgDays'), ajio: $('arDbgAjio'),
+    run: $('arDbgRun'), info: $('arDbgInfo'), keys: $('arDbgKeys'), sample: $('arDbgSample'),
+  };
+  dbg.run.addEventListener('click', async () => {
+    dbg.info.textContent = 'fetching…';
+    dbg.sample.textContent = '';
+    dbg.keys.textContent = '';
+    try {
+      const r = await fetch('/admin/ajio-recon/debug', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          warehouse: dbg.wh.value,
+          status: dbg.status.value,
+          lookbackDays: parseInt(dbg.days.value, 10),
+          ajioOnly: dbg.ajio.checked,
+        }),
+      });
+      const j = await r.json();
+      const a = (j.attempts || []).find((x) => x.status === 200) || (j.attempts || [])[0];
+      if (!a) { dbg.info.textContent = 'no response'; return; }
+      dbg.info.textContent = `URL=${a.url} | orders=${a.ordersCount} | ajio=${a.ajioCount} | bodyCode=${a.bodyCode || 'ok'}`;
+      dbg.keys.textContent = a.firstOrderKeys
+        ? 'Top-level keys: ' + a.firstOrderKeys.join(', ')
+        : (a.bodyMessage || 'no first order');
+      dbg.sample.textContent = a.firstOrderSample
+        ? JSON.stringify(JSON.parse(a.firstOrderSample), null, 2)
+        : JSON.stringify(j, null, 2);
+    } catch (err) {
+      dbg.info.textContent = 'error: ' + err.message;
+    }
+  });
 
   // Resume any in-flight job on page load
   poll();


### PR DESCRIPTION
… pass

Findings from /debug:
- V2 returns { code, message, data: { orders, nextUrl } }
- Pagination is via nextUrl (full URL), not next_cursor
- The order_status query param appears to be ignored — Printed query returned an Open order. So we get all orders in the window regardless.

Fixes:
- fetchOrdersPage now follows nextUrl directly
- syncWarehouse paginates until nextUrl is null (cap 500 pages)
- Status loop reduced to one pass per chunk; awb_number != null is the real filter for relevance
- Per-page progress events emitted every 5 pages so long chunks stay visible in the UI
- Added in-page debug panel to /admin/ajio-recon (no console needed)