### PR TITLE
fix(ajio-recon): resolve relative nextUrl, default lookback to 30 days

### DIFF
--- a/utils/ajioShipmentSync.js
+++ b/utils/ajioShipmentSync.js
@@ -70,7 +70,14 @@ async function fetchOrdersPage(token, { status, fromDate, toDate, nextUrl }) {
 
   let resp;
   if (nextUrl) {
-    resp = await axios.get(nextUrl, { headers, timeout: 60000 });
+    // EasyEcom may return nextUrl as a relative path; resolve against the API base.
+    let fullUrl;
+    try {
+      fullUrl = new URL(nextUrl, EASYECOM_API_BASE).toString();
+    } catch (e) {
+      throw new Error(`Bad nextUrl from EasyEcom: ${String(nextUrl).slice(0, 200)}`);
+    }
+    resp = await axios.get(fullUrl, { headers, timeout: 60000 });
   } else {
     const url = `${EASYECOM_API_BASE}/orders/V2/getAllOrders`;
     const params = {

--- a/views/ajioRecon.ejs
+++ b/views/ajioRecon.ejs
@@ -52,8 +52,8 @@
   <div class="ar-toolbar">
     <strong>Run reconciliation:</strong>
     <select id="arDays" class="form-select form-select-sm" style="width:160px;">
-      <% [3,7,14,21,30].forEach(d => { %>
-        <option value="<%= d %>" <%= d === 7 ? 'selected' : '' %>>last <%= d %> days</option>
+      <% [3,7,14,21,30,60,90].forEach(d => { %>
+        <option value="<%= d %>" <%= d === 30 ? 'selected' : '' %>>last <%= d %> days</option>
       <% }) %>
     </select>
     <button id="arRun" class="btn btn-primary btn-sm">▶ Run</button>


### PR DESCRIPTION
- Wrap nextUrl in URL() with EASYECOM_API_BASE so relative paths (which EasyEcom returns) don't crash axios with 'Invalid URL'
- 7d window has no printed Ajio AWBs in this tenant; default to 30d in the dashboard selector, also expose 60/90d for backfills