### PR TITLE
feat(vms-operator): manual AWB upload + mail/video dashboards

### DIFF
--- a/app.js
+++ b/app.js
@@ -273,6 +273,10 @@ app.use('/vms-report', vmsReportRoutes);
 const mailAutoReplyRoutes = require('./routes/mailAutoReplyRoutes');
 app.use('/admin/mail-auto-reply', mailAutoReplyRoutes);
 
+// VMS Operator (AWB upload + mail/video dashboards)
+const vmsOperatorRoutes = require('./routes/vmsOperatorRoutes');
+app.use('/vms-operator', vmsOperatorRoutes);
+
 // Home Route
 app.get('/', (req, res) => {
     res.redirect('/login');

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -191,12 +191,30 @@ function isVideoCreator(req, res, next) {
   }
   const username = (user.username || '').toLowerCase();
   const role = user.roleName;
-  if (role === 'videocreator' || role === 'videofinder' || username === 'mohitoperator') {
+  if (role === 'videocreator' || role === 'videofinder' || role === 'vmsoperator' || username === 'mohitoperator') {
     return next();
   }
   const wantsJson = req.headers.accept?.includes('application/json') || req.xhr;
   if (wantsJson) return res.status(403).json({ error: 'Permission denied' });
   req.flash('error', 'You do not have permission to access the VMS recorder.');
+  return res.redirect('/');
+}
+
+// vmsOperator: uploads AWBs, sees mail/video dashboards.
+function isVmsOperator(req, res, next) {
+  const user = req.session?.user;
+  if (!user) {
+    req.flash('error', 'Please login first.');
+    return res.redirect('/login');
+  }
+  const username = (user.username || '').toLowerCase();
+  const role = user.roleName;
+  if (role === 'vmsoperator' || username === 'mohitoperator') {
+    return next();
+  }
+  const wantsJson = req.headers.accept?.includes('application/json') || req.xhr;
+  if (wantsJson) return res.status(403).json({ error: 'Permission denied' });
+  req.flash('error', 'You do not have permission to access the VMS Operator page.');
   return res.redirect('/');
 }
 
@@ -280,6 +298,7 @@ module.exports = {
     isVendorFiles,
     isVideoFinder,
     isVideoCreator,
+    isVmsOperator,
     isProductViewer,
     allowUserIds,
     allowRoles,

--- a/routes/vmsOperatorRoutes.js
+++ b/routes/vmsOperatorRoutes.js
@@ -1,0 +1,344 @@
+// vmsOperator dashboard
+// - Upload AWB list (Excel/CSV) into vms_awb_uploads
+// - Browse mails (replied / unreplied / closed) from mail_replies
+// - Browse video uploads
+// - Per-packer counts
+// - Each list exportable to Excel
+
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const xlsx = require('xlsx');
+const ExcelJS = require('exceljs');
+const { pool } = require('../config/db');
+const { isAuthenticated, isVmsOperator } = require('../middlewares/auth');
+const { generatePresignedUrl } = require('../utils/s3Client');
+
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 20 * 1024 * 1024 } });
+
+// ---------- helpers ----------
+function findColIndex(headerRow, names) {
+  const lc = headerRow.map((h) => String(h || '').trim().toLowerCase());
+  for (const n of names) {
+    const idx = lc.indexOf(n.toLowerCase());
+    if (idx !== -1) return idx;
+  }
+  return -1;
+}
+
+function parseSheet(buffer) {
+  const wb = xlsx.read(buffer, { type: 'buffer' });
+  const ws = wb.Sheets[wb.SheetNames[0]];
+  const rows = xlsx.utils.sheet_to_json(ws, { header: 1, defval: '' });
+  if (!rows.length) return { rows: [] };
+  const header = rows[0];
+  const awbIdx = findColIndex(header, ['awb', 'awb number', 'awb_number', 'tracking', 'tracking number']);
+  const orderIdx = findColIndex(header, ['customer order id', 'customer_order_id', 'order id', 'order_id', 'ajio order', 'ajio order number']);
+  const mktIdx = findColIndex(header, ['marketplace', 'channel', 'platform']);
+  const noteIdx = findColIndex(header, ['notes', 'note', 'remarks']);
+  if (awbIdx === -1) return { rows: [], error: 'No AWB column found' };
+  const out = [];
+  for (let i = 1; i < rows.length; i++) {
+    const r = rows[i];
+    const awb = String(r[awbIdx] || '').trim();
+    if (!awb) continue;
+    out.push({
+      awb,
+      customer_order_id: orderIdx !== -1 ? String(r[orderIdx] || '').trim() || null : null,
+      marketplace: mktIdx !== -1 ? String(r[mktIdx] || '').trim() || null : null,
+      notes: noteIdx !== -1 ? String(r[noteIdx] || '').trim() || null : null,
+    });
+  }
+  return { rows: out };
+}
+
+async function exportRowsAsXlsx(res, name, columns, rows) {
+  const wb = new ExcelJS.Workbook();
+  const ws = wb.addWorksheet(name.slice(0, 30));
+  ws.columns = columns;
+  for (const r of rows) ws.addRow(r);
+  res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+  res.setHeader('Content-Disposition', `attachment; filename="${name}_${Date.now()}.xlsx"`);
+  await wb.xlsx.write(res);
+  res.end();
+}
+
+// ---------- page ----------
+router.get('/', isAuthenticated, isVmsOperator, async (req, res) => {
+  try {
+    const [[counts]] = await pool.query(`
+      SELECT
+        (SELECT COUNT(*) FROM vms_awb_uploads) AS uploaded_awbs,
+        (SELECT COUNT(*) FROM vms_videos)     AS total_videos,
+        (SELECT COUNT(*) FROM mail_replies WHERE status='replied')                       AS mails_replied,
+        (SELECT COUNT(*) FROM mail_replies WHERE status IN ('initial','proceeding'))     AS mails_unreplied,
+        (SELECT COUNT(*) FROM mail_replies WHERE status='closed')                        AS mails_closed
+    `);
+    res.render('vmsOperator', { user: req.session.user, counts });
+  } catch (err) {
+    console.error('vmsOperator dashboard error:', err);
+    res.status(500).send('Failed: ' + err.message);
+  }
+});
+
+// ---------- upload AWB sheet ----------
+router.post('/api/upload', isAuthenticated, isVmsOperator, upload.single('awbFile'), async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ ok: false, error: 'No file uploaded' });
+    const { rows, error } = parseSheet(req.file.buffer);
+    if (error) return res.status(400).json({ ok: false, error });
+    if (!rows.length) return res.status(400).json({ ok: false, error: 'No AWBs found in file' });
+
+    const userId = req.session.user?.id || null;
+    const sourceFile = (req.file.originalname || 'upload').slice(0, 255);
+
+    const values = rows.map((r) => [r.awb, r.customer_order_id, r.marketplace, r.notes, userId, sourceFile]);
+    await pool.query(
+      `INSERT INTO vms_awb_uploads (awb, customer_order_id, marketplace, notes, uploaded_by, source_file)
+       VALUES ?
+       ON DUPLICATE KEY UPDATE
+         customer_order_id = COALESCE(VALUES(customer_order_id), customer_order_id),
+         marketplace       = COALESCE(VALUES(marketplace), marketplace),
+         notes             = COALESCE(VALUES(notes), notes),
+         uploaded_by       = COALESCE(VALUES(uploaded_by), uploaded_by),
+         source_file       = COALESCE(VALUES(source_file), source_file)`,
+      [values]
+    );
+    res.json({ ok: true, received: rows.length });
+  } catch (err) {
+    console.error('vmsOperator upload error:', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// ---------- AWB uploads list ----------
+router.get('/api/awbs', isAuthenticated, isVmsOperator, async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit || '500', 10), 5000);
+    const [rows] = await pool.query(`
+      SELECT u.awb, u.customer_order_id, u.marketplace, u.notes,
+             u.created_at, u.source_file,
+             usr.username AS uploaded_by_name,
+             v.id IS NOT NULL AS has_video,
+             v.created_at AS video_at, v.packer_name
+      FROM vms_awb_uploads u
+      LEFT JOIN users usr ON usr.id = u.uploaded_by
+      LEFT JOIN vms_videos v ON v.awb = u.awb
+      ORDER BY u.created_at DESC
+      LIMIT ?`, [limit]);
+    res.json({ ok: true, rows });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/awbs/export.xlsx', isAuthenticated, isVmsOperator, async (req, res) => {
+  try {
+    const [rows] = await pool.query(`
+      SELECT u.awb, u.customer_order_id, u.marketplace, u.notes,
+             u.created_at, u.source_file,
+             usr.username AS uploaded_by_name,
+             v.id IS NOT NULL AS has_video, v.created_at AS video_at, v.packer_name
+      FROM vms_awb_uploads u
+      LEFT JOIN users usr ON usr.id = u.uploaded_by
+      LEFT JOIN vms_videos v ON v.awb = u.awb
+      ORDER BY u.created_at DESC LIMIT 50000`);
+    await exportRowsAsXlsx(res, 'vms_awbs', [
+      { header: 'AWB', key: 'awb', width: 22 },
+      { header: 'Customer Order ID', key: 'customer_order_id', width: 22 },
+      { header: 'Marketplace', key: 'marketplace', width: 14 },
+      { header: 'Has Video', key: 'has_video', width: 10 },
+      { header: 'Video At', key: 'video_at', width: 20 },
+      { header: 'Packer', key: 'packer_name', width: 16 },
+      { header: 'Uploaded By', key: 'uploaded_by_name', width: 16 },
+      { header: 'Source File', key: 'source_file', width: 30 },
+      { header: 'Uploaded At', key: 'created_at', width: 20 },
+      { header: 'Notes', key: 'notes', width: 30 },
+    ], rows);
+  } catch (err) { res.status(500).send(err.message); }
+});
+
+// ---------- mails ----------
+const MAIL_BUCKETS = {
+  replied:    `status='replied'`,
+  unreplied:  `status IN ('initial','proceeding')`,
+  closed:     `status='closed'`,
+};
+
+router.get('/api/mails/:bucket', isAuthenticated, isVmsOperator, async (req, res) => {
+  try {
+    const where = MAIL_BUCKETS[req.params.bucket];
+    if (!where) return res.status(400).json({ ok: false, error: 'unknown bucket' });
+    const limit = Math.min(parseInt(req.query.limit || '500', 10), 5000);
+    const [rows] = await pool.query(`
+      SELECT id, message_id, thread_id, from_address, to_address, subject,
+             order_id, awb, video_url, status, classification,
+             replied_at, created_at
+      FROM mail_replies
+      WHERE ${where}
+      ORDER BY created_at DESC
+      LIMIT ?`, [limit]);
+    res.json({ ok: true, rows });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/mails/:bucket/export.xlsx', isAuthenticated, isVmsOperator, async (req, res) => {
+  try {
+    const where = MAIL_BUCKETS[req.params.bucket];
+    if (!where) return res.status(400).send('unknown bucket');
+    const [rows] = await pool.query(`
+      SELECT id, message_id, from_address, to_address, subject,
+             order_id, awb, video_url, status, classification,
+             replied_at, created_at
+      FROM mail_replies WHERE ${where}
+      ORDER BY created_at DESC LIMIT 50000`);
+    await exportRowsAsXlsx(res, `mails_${req.params.bucket}`, [
+      { header: 'Created', key: 'created_at', width: 20 },
+      { header: 'From', key: 'from_address', width: 28 },
+      { header: 'Subject', key: 'subject', width: 50 },
+      { header: 'Order ID', key: 'order_id', width: 18 },
+      { header: 'AWB', key: 'awb', width: 22 },
+      { header: 'Status', key: 'status', width: 12 },
+      { header: 'Classification', key: 'classification', width: 18 },
+      { header: 'Replied At', key: 'replied_at', width: 20 },
+      { header: 'Video URL', key: 'video_url', width: 60 },
+      { header: 'Message ID', key: 'message_id', width: 36 },
+    ], rows);
+  } catch (err) { res.status(500).send(err.message); }
+});
+
+// ---------- videos ----------
+router.get('/api/videos', isAuthenticated, isVmsOperator, async (req, res) => {
+  try {
+    const limit = Math.min(parseInt(req.query.limit || '500', 10), 5000);
+    const fromDate = req.query.from || null;
+    const toDate = req.query.to || null;
+    const args = [];
+    let dateClause = '';
+    if (fromDate) { dateClause += ' AND v.created_at >= ?'; args.push(fromDate); }
+    if (toDate)   { dateClause += ' AND v.created_at < ?';  args.push(toDate); }
+
+    const [rows] = await pool.query(`
+      SELECT v.id, v.awb, v.marketplace, v.packer_name, v.s3_bucket, v.s3_key,
+             v.size_bytes, v.duration_ms, v.created_at, u.username AS packer_username
+      FROM vms_videos v
+      LEFT JOIN users u ON u.id = v.packer_id
+      WHERE 1=1 ${dateClause}
+      ORDER BY v.created_at DESC
+      LIMIT ?`, [...args, limit]);
+    res.json({ ok: true, rows });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/videos/export.xlsx', isAuthenticated, isVmsOperator, async (req, res) => {
+  try {
+    const fromDate = req.query.from || null;
+    const toDate = req.query.to || null;
+    const includeUrls = req.query.includeUrls === '1';
+    const args = [];
+    let dateClause = '';
+    if (fromDate) { dateClause += ' AND v.created_at >= ?'; args.push(fromDate); }
+    if (toDate)   { dateClause += ' AND v.created_at < ?';  args.push(toDate); }
+
+    const [rows] = await pool.query(`
+      SELECT v.awb, v.marketplace, v.packer_name, u.username AS packer_username,
+             v.s3_bucket, v.s3_key, v.size_bytes, v.duration_ms, v.created_at
+      FROM vms_videos v
+      LEFT JOIN users u ON u.id = v.packer_id
+      WHERE 1=1 ${dateClause}
+      ORDER BY v.created_at DESC LIMIT 50000`, args);
+
+    if (includeUrls) {
+      // Generate fresh presigned URLs for each row. Slow on huge exports;
+      // capped at 5000 to avoid timing out.
+      const cap = Math.min(rows.length, 5000);
+      for (let i = 0; i < cap; i++) {
+        try { rows[i].video_url = await generatePresignedUrl(rows[i].s3_key); }
+        catch (e) { rows[i].video_url = ''; }
+      }
+    }
+
+    const cols = [
+      { header: 'Created', key: 'created_at', width: 20 },
+      { header: 'AWB', key: 'awb', width: 22 },
+      { header: 'Marketplace', key: 'marketplace', width: 14 },
+      { header: 'Packer', key: 'packer_name', width: 16 },
+      { header: 'Packer (user)', key: 'packer_username', width: 16 },
+      { header: 'Size', key: 'size_bytes', width: 12 },
+      { header: 'Duration (ms)', key: 'duration_ms', width: 14 },
+      { header: 'S3 Key', key: 's3_key', width: 60 },
+    ];
+    if (includeUrls) cols.push({ header: 'Video URL (15-min)', key: 'video_url', width: 100 });
+    await exportRowsAsXlsx(res, 'vms_videos', cols, rows);
+  } catch (err) { res.status(500).send(err.message); }
+});
+
+// ---------- per-packer counts ----------
+router.get('/api/packer-counts', isAuthenticated, isVmsOperator, async (req, res) => {
+  try {
+    const fromDate = req.query.from || null;
+    const toDate = req.query.to || null;
+    const args = [];
+    let dateClause = '';
+    if (fromDate) { dateClause += ' AND v.created_at >= ?'; args.push(fromDate); }
+    if (toDate)   { dateClause += ' AND v.created_at < ?';  args.push(toDate); }
+    const [rows] = await pool.query(`
+      SELECT COALESCE(u.username, v.packer_name, 'unknown') AS packer,
+             COUNT(*) AS video_count,
+             MIN(v.created_at) AS first_at,
+             MAX(v.created_at) AS last_at
+      FROM vms_videos v
+      LEFT JOIN users u ON u.id = v.packer_id
+      WHERE 1=1 ${dateClause}
+      GROUP BY packer
+      ORDER BY video_count DESC`, args);
+    res.json({ ok: true, rows });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/packer-counts/export.xlsx', isAuthenticated, isVmsOperator, async (req, res) => {
+  try {
+    const fromDate = req.query.from || null;
+    const toDate = req.query.to || null;
+    const args = [];
+    let dateClause = '';
+    if (fromDate) { dateClause += ' AND v.created_at >= ?'; args.push(fromDate); }
+    if (toDate)   { dateClause += ' AND v.created_at < ?';  args.push(toDate); }
+    const [rows] = await pool.query(`
+      SELECT COALESCE(u.username, v.packer_name, 'unknown') AS packer,
+             COUNT(*) AS video_count,
+             MIN(v.created_at) AS first_at,
+             MAX(v.created_at) AS last_at
+      FROM vms_videos v
+      LEFT JOIN users u ON u.id = v.packer_id
+      WHERE 1=1 ${dateClause}
+      GROUP BY packer
+      ORDER BY video_count DESC`, args);
+    await exportRowsAsXlsx(res, 'vms_packer_counts', [
+      { header: 'Packer', key: 'packer', width: 22 },
+      { header: 'Videos', key: 'video_count', width: 10 },
+      { header: 'First', key: 'first_at', width: 20 },
+      { header: 'Last', key: 'last_at', width: 20 },
+    ], rows);
+  } catch (err) { res.status(500).send(err.message); }
+});
+
+// ---------- single playback URL (used by table buttons) ----------
+router.get('/api/playback-url', isAuthenticated, isVmsOperator, async (req, res) => {
+  try {
+    const key = String(req.query.key || '');
+    if (!key) return res.status(400).json({ ok: false, error: 'key required' });
+    const url = await generatePresignedUrl(key);
+    res.json({ ok: true, url });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+module.exports = router;

--- a/routes/vmsRoutes.js
+++ b/routes/vmsRoutes.js
@@ -60,20 +60,21 @@ router.get('/api/server-time', isAuthenticated, isVideoCreator, (req, res) => {
 });
 
 // ---------- AWB list ----------
-// Pending = printed-label Ajio AWBs without a video, last N days.
+// Pending = AWBs uploaded by vmsOperator that don't yet have a video.
 router.get('/api/awbs', isAuthenticated, isVideoCreator, async (req, res) => {
   try {
-    const days = Math.min(parseInt(req.query.days || '7', 10), 30);
+    const days = Math.min(parseInt(req.query.days || '30', 10), 365);
     const [rows] = await pool.query(
-      `SELECT s.awb, s.marketplace, s.reference_code, s.warehouse_id,
-              s.label_printed_at, s.current_status,
+      `SELECT u.awb,
+              u.marketplace,
+              u.customer_order_id  AS reference_code,
+              u.created_at         AS label_printed_at,
+              CASE WHEN v.id IS NULL THEN 'Pending' ELSE 'Recorded' END AS current_status,
               v.id IS NOT NULL AS has_video
-         FROM ee_shipments s
-         LEFT JOIN vms_videos v ON v.awb = s.awb
-        WHERE s.marketplace LIKE '%ajio%'
-          AND s.label_printed_at IS NOT NULL
-          AND s.label_printed_at >= NOW() - INTERVAL ? DAY
-        ORDER BY s.label_printed_at DESC
+         FROM vms_awb_uploads u
+         LEFT JOIN vms_videos v ON v.awb = u.awb
+        WHERE u.created_at >= NOW() - INTERVAL ? DAY
+        ORDER BY u.created_at DESC
         LIMIT 5000`,
       [days]
     );
@@ -89,23 +90,24 @@ router.get('/api/awbs', isAuthenticated, isVideoCreator, async (req, res) => {
   }
 });
 
-// Lookup a single AWB so we can warn the operator if the AWB isn't
-// in the printed-Ajio set (still allow recording — we don't want to
-// block them — but flag it on the UI).
+// Lookup a single AWB. Used by the recorder to warn if the AWB hasn't
+// been uploaded by vmsOperator yet (still allow recording — won't block
+// the packer — but flag it on the UI).
 router.get('/api/awb/:awb', isAuthenticated, isVideoCreator, async (req, res) => {
   try {
     const awb = String(req.params.awb || '').trim();
     if (!awb) return res.status(400).json({ ok: false, error: 'awb required' });
-    const [[shipment]] = await pool.query(
-      `SELECT awb, marketplace, current_status, reference_code, label_printed_at
-         FROM ee_shipments WHERE awb = ? LIMIT 1`,
+    const [[uploaded]] = await pool.query(
+      `SELECT awb, customer_order_id AS reference_code, marketplace, created_at AS label_printed_at,
+              'Pending' AS current_status
+         FROM vms_awb_uploads WHERE awb = ? LIMIT 1`,
       [awb]
     );
     const [[video]] = await pool.query(
       `SELECT id, s3_key, created_at FROM vms_videos WHERE awb = ? LIMIT 1`,
       [awb]
     );
-    res.json({ ok: true, awb, shipment: shipment || null, video: video || null });
+    res.json({ ok: true, awb, shipment: uploaded || null, video: video || null });
   } catch (err) {
     res.status(500).json({ ok: false, error: err.message });
   }

--- a/sql/vms_awb_uploads.sql
+++ b/sql/vms_awb_uploads.sql
@@ -1,0 +1,16 @@
+-- vmsOperator manually uploads the AWBs we need to record videos for.
+-- Replaces the EasyEcom-recon path for the VMS pending list.
+
+CREATE TABLE IF NOT EXISTS vms_awb_uploads (
+  awb VARCHAR(64) NOT NULL PRIMARY KEY,
+  customer_order_id VARCHAR(100) NULL,
+  marketplace VARCHAR(120) NULL,
+  notes VARCHAR(255) NULL,
+  uploaded_by INT NULL,
+  source_file VARCHAR(255) NULL,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_vms_uploads_customer_order (customer_order_id),
+  INDEX idx_vms_uploads_created_at (created_at),
+  CONSTRAINT fk_vms_uploads_uploader FOREIGN KEY (uploaded_by) REFERENCES users(id) ON DELETE SET NULL
+);

--- a/utils/mailAutoReplyJob.js
+++ b/utils/mailAutoReplyJob.js
@@ -26,25 +26,21 @@ async function isAlreadyReplied(messageId) {
 async function lookupAwbForOrder(orderId) {
   if (!orderId) return null;
 
-  // (1) order_awb_mapping (manual Excel upload)
+  // (1) vmsOperator AWB upload sheet (primary source)
+  const [[upload]] = await pool.query(
+    `SELECT awb FROM vms_awb_uploads
+      WHERE UPPER(customer_order_id) = UPPER(?)
+      ORDER BY created_at DESC LIMIT 1`,
+    [orderId]
+  );
+  if (upload?.awb) return { awb: upload.awb, source: 'vms_uploads' };
+
+  // (2) order_awb_mapping (legacy manual Excel via Mail Manager)
   const [[mapped]] = await pool.query(
     `SELECT awb FROM order_awb_mapping WHERE order_id = ? LIMIT 1`,
     [orderId.toUpperCase()]
   );
   if (mapped?.awb) return { awb: mapped.awb, source: 'mapping' };
-
-  // (2) ee_orders.reference_code (the Ajio customer order number) → ee_shipments
-  const [[ref]] = await pool.query(
-    `SELECT s.awb
-       FROM ee_orders o
-       JOIN ee_shipments s ON s.order_id = o.order_id
-      WHERE UPPER(o.reference_code) = UPPER(?)
-        AND o.marketplace LIKE '%ajio%'
-      ORDER BY s.updated_at DESC
-      LIMIT 1`,
-    [orderId]
-  );
-  if (ref?.awb) return { awb: ref.awb, source: 'ee_shipments' };
 
   return null;
 }

--- a/utils/scheduler.js
+++ b/utils/scheduler.js
@@ -20,21 +20,24 @@ function startCronJobs() {
     return;
   }
 
-  // Ajio shipment reconciliation: every 30 min.
-  // Pulls Printed/Shipped Ajio orders and upserts AWBs into ee_shipments.
-  cron.schedule(
-    process.env.AJIO_RECON_CRON || '*/30 * * * *',
-    async () => {
-      try {
-        await syncAjioShipments();
-      } catch (err) {
-        console.error('[cron] ajio recon failed:', err);
-      }
-    },
-    { timezone: TZ }
-  );
-
-  console.log(`[cron] scheduled ajio shipment recon (every 30 min, TZ=${TZ})`);
+  // Ajio shipment reconciliation cron — opt-in only. Default OFF because
+  // AWBs now come from the vmsOperator manual upload sheet.
+  if (process.env.AJIO_RECON_ENABLED === '1' || process.env.AJIO_RECON_ENABLED === 'true') {
+    cron.schedule(
+      process.env.AJIO_RECON_CRON || '*/30 * * * *',
+      async () => {
+        try {
+          await syncAjioShipments();
+        } catch (err) {
+          console.error('[cron] ajio recon failed:', err);
+        }
+      },
+      { timezone: TZ }
+    );
+    console.log(`[cron] scheduled ajio shipment recon (every 30 min, TZ=${TZ})`);
+  } else {
+    console.log('[cron] ajio shipment recon DISABLED (set AJIO_RECON_ENABLED=1 to re-enable)');
+  }
 
   // Mail auto-reply: 9 AM and 9 PM IST.
   // Scans inbox, resolves AWB via order_awb_mapping → ee_orders.reference_code,

--- a/views/vmsOperator.ejs
+++ b/views/vmsOperator.ejs
@@ -1,0 +1,261 @@
+<%- include('partials/header', { pageTitle: 'VMS Operator' }) %>
+<%- include('partials/navbar', { user: user }) %>
+
+<style>
+  .vo-content { margin-top: var(--navbar-height); padding: 22px; }
+  .vo-cards { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; margin-bottom: 16px; }
+  .vo-card  { background:#fff; padding:14px; border-radius:10px; box-shadow:0 1px 3px rgba(0,0,0,.06); }
+  .vo-card .label { font-size:0.8rem; color:#64748b; }
+  .vo-card .value { font-size:1.5rem; font-weight:700; margin-top:4px; }
+  .vo-card.green  .value { color:#16a34a; }
+  .vo-card.amber  .value { color:#ca8a04; }
+  .vo-card.red    .value { color:#dc2626; }
+  .vo-card.blue   .value { color:#2563eb; }
+  .vo-section { background:#fff; border-radius:10px; box-shadow:0 1px 3px rgba(0,0,0,.06); margin-bottom:16px; padding:14px; }
+  .vo-section h3 { margin:0 0 10px; font-size:1rem; }
+  .vo-toolbar { display:flex; gap:8px; align-items:center; flex-wrap:wrap; margin-bottom:10px; }
+  .vo-tabs { display:flex; gap:4px; border-bottom:1px solid #e2e8f0; margin-bottom:10px; }
+  .vo-tab { padding:8px 14px; cursor:pointer; border-bottom:2px solid transparent; font-size:0.9rem; color:#64748b; }
+  .vo-tab.active { border-bottom-color:#2563eb; color:#0f172a; font-weight:600; }
+  .vo-table { width:100%; border-collapse:collapse; font-size:0.86rem; }
+  .vo-table th, .vo-table td { padding:6px 9px; border-bottom:1px solid #eee; text-align:left; vertical-align:top; }
+  .vo-table th { background:#f8fafc; font-weight:600; }
+  .pill { display:inline-block; padding:2px 8px; border-radius:999px; font-size:0.74rem; }
+  .pill.green { background:#dcfce7; color:#166534; }
+  .pill.amber { background:#fef9c3; color:#854d0e; }
+  .pill.red   { background:#fee2e2; color:#991b1b; }
+  .pill.blue  { background:#dbeafe; color:#1d4ed8; }
+  .pill.gray  { background:#f1f5f9; color:#475569; }
+  .vo-uploadbox { border:2px dashed #cbd5e1; padding:14px; border-radius:8px; }
+</style>
+
+<div class="vo-content">
+  <h2 style="margin-top:0;">🎛️ VMS Operator</h2>
+
+  <div class="vo-cards">
+    <div class="vo-card blue"><div class="label">Uploaded AWBs</div><div class="value" id="cUploaded"><%= counts.uploaded_awbs || 0 %></div></div>
+    <div class="vo-card green"><div class="label">Videos recorded</div><div class="value" id="cVideos"><%= counts.total_videos || 0 %></div></div>
+    <div class="vo-card green"><div class="label">Mails replied</div><div class="value" id="cReplied"><%= counts.mails_replied || 0 %></div></div>
+    <div class="vo-card amber"><div class="label">Mails unreplied</div><div class="value" id="cUnreplied"><%= counts.mails_unreplied || 0 %></div></div>
+    <div class="vo-card gray"><div class="label">Mails closed</div><div class="value" id="cClosed"><%= counts.mails_closed || 0 %></div></div>
+  </div>
+
+  <!-- Upload -->
+  <div class="vo-section">
+    <h3>📤 Upload AWB list</h3>
+    <div class="vo-uploadbox">
+      <div style="margin-bottom:6px; color:#475569; font-size:0.88rem;">
+        Excel/CSV with columns: <strong>AWB</strong> (required), <em>Customer Order ID</em>, <em>Marketplace</em>, <em>Notes</em>.
+        Re-uploading the same AWB updates its row.
+      </div>
+      <form id="voUploadForm" style="display:flex; gap:8px; align-items:center;">
+        <input type="file" id="voFile" accept=".csv,.xls,.xlsx" required>
+        <button id="voUploadBtn" class="btn btn-primary btn-sm" type="submit">Upload</button>
+        <span id="voUploadMsg" style="font-size:0.86rem; color:#475569;"></span>
+      </form>
+    </div>
+  </div>
+
+  <!-- Tabs -->
+  <div class="vo-section">
+    <div class="vo-tabs">
+      <div class="vo-tab active" data-tab="awbs">📦 AWB Uploads</div>
+      <div class="vo-tab" data-tab="replied">✉️ Replied</div>
+      <div class="vo-tab" data-tab="unreplied">⏳ Unreplied</div>
+      <div class="vo-tab" data-tab="closed">🔒 Closed</div>
+      <div class="vo-tab" data-tab="videos">🎥 Videos</div>
+      <div class="vo-tab" data-tab="packers">👥 Packer counts</div>
+    </div>
+
+    <div class="vo-toolbar">
+      <input type="date" id="voFrom" class="form-control form-control-sm" style="width:160px;">
+      <input type="date" id="voTo" class="form-control form-control-sm" style="width:160px;">
+      <button id="voApply" class="btn btn-secondary btn-sm">Apply dates</button>
+      <span style="flex:1;"></span>
+      <label style="font-size:0.85rem;"><input type="checkbox" id="voIncludeUrls"> Include video URLs in export (slow)</label>
+      <a id="voExport" class="btn btn-outline-success btn-sm" href="#">⬇ Export Excel</a>
+    </div>
+
+    <div style="overflow-x:auto;">
+      <table class="vo-table">
+        <thead id="voThead"></thead>
+        <tbody id="voTbody"><tr><td style="text-align:center;color:#64748b;">Loading…</td></tr></tbody>
+      </table>
+    </div>
+  </div>
+</div>
+
+<script>
+(() => {
+  const $ = (id) => document.getElementById(id);
+  const tbody = $('voTbody'), thead = $('voThead');
+  const exportLink = $('voExport');
+  const includeUrls = $('voIncludeUrls');
+  const tabs = document.querySelectorAll('.vo-tab');
+  let activeTab = 'awbs';
+
+  const HEADERS = {
+    awbs:      ['AWB','Customer Order ID','Marketplace','Has Video','Video At','Packer','Uploaded By','Uploaded At','Notes'],
+    replied:   ['Created','From','Subject','Order ID','AWB','Status','Replied At','Video'],
+    unreplied: ['Created','From','Subject','Order ID','AWB','Status','Classification'],
+    closed:    ['Created','From','Subject','Order ID','AWB','Status'],
+    videos:    ['Created','AWB','Packer','Marketplace','Size','S3 Key','Action'],
+    packers:   ['Packer','Videos','First','Last'],
+  };
+
+  function pillForStatus(s) {
+    if (s === 'replied') return '<span class="pill green">replied</span>';
+    if (s === 'closed')  return '<span class="pill gray">closed</span>';
+    if (s === 'initial') return '<span class="pill amber">initial</span>';
+    if (s === 'proceeding') return '<span class="pill blue">proceeding</span>';
+    if (s === 'error') return '<span class="pill red">error</span>';
+    return '<span class="pill gray">' + (s || '-') + '</span>';
+  }
+  function fmtDate(d) { return d ? new Date(d).toLocaleString() : '-'; }
+  function fmtBytes(n) {
+    if (!n) return '-'; const u = ['B','KB','MB','GB']; let i = 0;
+    while (n > 1024 && i < u.length - 1) { n /= 1024; i++; }
+    return n.toFixed(1) + ' ' + u[i];
+  }
+
+  function setHeader(tab) {
+    thead.innerHTML = '<tr>' + HEADERS[tab].map(h => `<th>${h}</th>`).join('') + '</tr>';
+  }
+
+  function dateParams() {
+    const p = new URLSearchParams();
+    if ($('voFrom').value) p.set('from', $('voFrom').value);
+    if ($('voTo').value)   p.set('to', $('voTo').value);
+    return p.toString();
+  }
+
+  async function loadAwbs() {
+    const r = await fetch('/vms-operator/api/awbs?limit=500', { credentials: 'same-origin' }).then(r => r.json());
+    if (!r.ok) throw new Error(r.error);
+    tbody.innerHTML = r.rows.length ? r.rows.map(x => `<tr>
+      <td>${x.awb}</td>
+      <td>${x.customer_order_id || '-'}</td>
+      <td>${x.marketplace || '-'}</td>
+      <td>${x.has_video ? '<span class="pill green">yes</span>' : '<span class="pill amber">no</span>'}</td>
+      <td>${fmtDate(x.video_at)}</td>
+      <td>${x.packer_name || '-'}</td>
+      <td>${x.uploaded_by_name || '-'}</td>
+      <td>${fmtDate(x.created_at)}</td>
+      <td>${x.notes || '-'}</td>
+    </tr>`).join('') : `<tr><td colspan="9" style="text-align:center;color:#64748b;">No uploads yet.</td></tr>`;
+  }
+
+  async function loadMails(bucket) {
+    const r = await fetch('/vms-operator/api/mails/' + bucket + '?limit=500', { credentials: 'same-origin' }).then(r => r.json());
+    if (!r.ok) throw new Error(r.error);
+    if (!r.rows.length) {
+      tbody.innerHTML = `<tr><td colspan="${HEADERS[bucket].length}" style="text-align:center;color:#64748b;">No mails.</td></tr>`;
+      return;
+    }
+    tbody.innerHTML = r.rows.map(x => {
+      if (bucket === 'replied') return `<tr>
+        <td>${fmtDate(x.created_at)}</td><td>${x.from_address || '-'}</td><td>${x.subject || '-'}</td>
+        <td>${x.order_id || '-'}</td><td>${x.awb || '-'}</td><td>${pillForStatus(x.status)}</td>
+        <td>${fmtDate(x.replied_at)}</td>
+        <td>${x.video_url ? `<a href="${x.video_url}" target="_blank">link</a>` : '-'}</td>
+      </tr>`;
+      if (bucket === 'unreplied') return `<tr>
+        <td>${fmtDate(x.created_at)}</td><td>${x.from_address || '-'}</td><td>${x.subject || '-'}</td>
+        <td>${x.order_id || '-'}</td><td>${x.awb || '-'}</td><td>${pillForStatus(x.status)}</td>
+        <td>${x.classification || '-'}</td>
+      </tr>`;
+      // closed
+      return `<tr>
+        <td>${fmtDate(x.created_at)}</td><td>${x.from_address || '-'}</td><td>${x.subject || '-'}</td>
+        <td>${x.order_id || '-'}</td><td>${x.awb || '-'}</td><td>${pillForStatus(x.status)}</td>
+      </tr>`;
+    }).join('');
+  }
+
+  async function loadVideos() {
+    const qs = dateParams();
+    const r = await fetch('/vms-operator/api/videos?limit=500' + (qs ? '&' + qs : ''), { credentials: 'same-origin' }).then(r => r.json());
+    if (!r.ok) throw new Error(r.error);
+    tbody.innerHTML = r.rows.length ? r.rows.map(x => `<tr>
+      <td>${fmtDate(x.created_at)}</td>
+      <td>${x.awb}</td>
+      <td>${x.packer_username || x.packer_name || '-'}</td>
+      <td>${x.marketplace || '-'}</td>
+      <td>${fmtBytes(x.size_bytes)}</td>
+      <td style="font-family:ui-monospace,monospace; font-size:0.78rem;">${x.s3_key}</td>
+      <td><a href="#" data-key="${x.s3_key}" class="vo-play">▶ play</a></td>
+    </tr>`).join('') : `<tr><td colspan="7" style="text-align:center;color:#64748b;">No videos.</td></tr>`;
+    tbody.querySelectorAll('.vo-play').forEach(a => a.addEventListener('click', async (e) => {
+      e.preventDefault();
+      const r = await fetch('/vms-operator/api/playback-url?key=' + encodeURIComponent(a.dataset.key), { credentials: 'same-origin' }).then(r => r.json());
+      if (r.ok && r.url) window.open(r.url, '_blank');
+    }));
+  }
+
+  async function loadPackers() {
+    const qs = dateParams();
+    const r = await fetch('/vms-operator/api/packer-counts' + (qs ? '?' + qs : ''), { credentials: 'same-origin' }).then(r => r.json());
+    if (!r.ok) throw new Error(r.error);
+    tbody.innerHTML = r.rows.length ? r.rows.map(x => `<tr>
+      <td>${x.packer}</td><td>${x.video_count}</td>
+      <td>${fmtDate(x.first_at)}</td><td>${fmtDate(x.last_at)}</td>
+    </tr>`).join('') : `<tr><td colspan="4" style="text-align:center;color:#64748b;">No data.</td></tr>`;
+  }
+
+  function exportHref() {
+    const qs = dateParams();
+    const urlsFlag = (activeTab === 'videos' && includeUrls.checked) ? (qs ? '&' : '?') + 'includeUrls=1' : '';
+    if (activeTab === 'awbs')    return '/vms-operator/awbs/export.xlsx';
+    if (['replied','unreplied','closed'].includes(activeTab)) return `/vms-operator/mails/${activeTab}/export.xlsx`;
+    if (activeTab === 'videos')  return '/vms-operator/videos/export.xlsx' + (qs ? '?' + qs : '') + urlsFlag;
+    if (activeTab === 'packers') return '/vms-operator/packer-counts/export.xlsx' + (qs ? '?' + qs : '');
+    return '#';
+  }
+
+  async function loadActive() {
+    setHeader(activeTab);
+    tbody.innerHTML = `<tr><td colspan="${HEADERS[activeTab].length}" style="text-align:center;color:#64748b;">Loading…</td></tr>`;
+    exportLink.href = exportHref();
+    try {
+      if (activeTab === 'awbs') await loadAwbs();
+      else if (['replied','unreplied','closed'].includes(activeTab)) await loadMails(activeTab);
+      else if (activeTab === 'videos') await loadVideos();
+      else if (activeTab === 'packers') await loadPackers();
+    } catch (err) {
+      tbody.innerHTML = `<tr><td colspan="${HEADERS[activeTab].length}" style="color:#dc2626;">${err.message}</td></tr>`;
+    }
+  }
+
+  tabs.forEach(t => t.addEventListener('click', () => {
+    tabs.forEach(x => x.classList.toggle('active', x === t));
+    activeTab = t.dataset.tab;
+    loadActive();
+  }));
+
+  $('voApply').addEventListener('click', loadActive);
+  includeUrls.addEventListener('change', () => { exportLink.href = exportHref(); });
+
+  $('voUploadForm').addEventListener('submit', async (e) => {
+    e.preventDefault();
+    const file = $('voFile').files[0];
+    if (!file) return;
+    $('voUploadMsg').textContent = 'Uploading…';
+    const fd = new FormData();
+    fd.append('awbFile', file);
+    try {
+      const r = await fetch('/vms-operator/api/upload', { method: 'POST', credentials: 'same-origin', body: fd });
+      const j = await r.json();
+      if (!r.ok || !j.ok) throw new Error(j.error || 'failed');
+      $('voUploadMsg').textContent = `✅ Loaded ${j.received} AWBs`;
+      $('voFile').value = '';
+      activeTab = 'awbs';
+      tabs.forEach(x => x.classList.toggle('active', x.dataset.tab === 'awbs'));
+      loadActive();
+    } catch (err) {
+      $('voUploadMsg').textContent = '❌ ' + err.message;
+    }
+  });
+
+  loadActive();
+})();
+</script>


### PR DESCRIPTION
Pivots AWB ingestion from EasyEcom auto-pull to vmsOperator manual Excel upload — simpler, no API guessing, no slow recon.

- New table vms_awb_uploads (awb PK, customer_order_id, marketplace, notes, uploaded_by, source_file)
- New role vmsoperator + middleware isVmsOperator
- New /vms-operator dashboard:
  * 5 cards (uploaded AWBs, videos, mails replied/unreplied/closed)
  * Upload box (Excel/CSV, columns AWB/Customer Order ID/Marketplace/Notes)
  * Tabs: AWB Uploads | Replied | Unreplied | Closed | Videos | Packer counts
  * ⬇ Excel export per tab; videos export can include presigned URLs
  * Date filter for videos + packer counts
- /vms pending list now reads from vms_awb_uploads (was ee_shipments)
- Mail auto-reply lookup chain switched to vms_awb_uploads.customer_order_id → order_awb_mapping fallback (ee_orders dependency dropped)
- Ajio recon cron disabled by default; set AJIO_RECON_ENABLED=1 to re-enable