### PR TITLE
fix(auth): map vmsoperator + videocreator roles to their dashboards

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -49,6 +49,8 @@ function getDashboardForRole(roleName) {
     'productviewer': '/product-links',
     'wishlinkops': '/webhook/logs',
     'videofinder': '/video-finder',
+    'videocreator': '/vms',
+    'vmsoperator': '/vms-operator',
     'return_grn': '/return-grn/scan',
     'returns_operator': '/return-grn/dashboard',
   };


### PR DESCRIPTION
Without an entry, getDashboardForRole falls back to /operator/dashboard which is gated by isOperator and doesn't allow vmsoperator — login → operator dashboard → bounce → login again → infinite redirect.

- vmsoperator → /vms-operator
- videocreator → /vms