### PR TITLE
fix(pm): orders 7-day chunking + mini-sales params + debug endpoint

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -460,4 +460,85 @@ router.post('/pull-now', async (req, res) => {
   }
 });
 
+// ─── Temp debug: run a single EasyEcom call and return the raw response ──
+// Admin-only. Lets us see what EasyEcom actually returns without trawling
+// through Cloud Run logs. Examples:
+//   GET /pm/debug-ee?what=snapshot&warehouse=faridabad&days=30
+//   GET /pm/debug-ee?what=mini-sales&warehouse=faridabad&days=7
+//   GET /pm/debug-ee?what=orders&warehouse=faridabad&days=7
+// Remove after debugging.
+router.get('/debug-ee', async (req, res) => {
+  if (req.session.user.roleName !== 'admin') {
+    return res.status(403).json({ ok: false, error: 'admin role required.' });
+  }
+  const { what = 'snapshot', warehouse = 'faridabad', days = '7' } = req.query;
+  const client = require('../utils/easyecomReturnsClient');
+  const axios = require('axios');
+  const days_n = Math.min(Math.max(parseInt(days, 10) || 7, 1), 90);
+  const end = new Date();
+  const start = new Date(end.getTime() - days_n * 24 * 60 * 60 * 1000);
+  const fmt = (d) => {
+    const p = (n) => String(n).padStart(2, '0');
+    return `${d.getFullYear()}-${p(d.getMonth()+1)}-${p(d.getDate())} ${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+  };
+  const fmtDay = (d) => `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+
+  try {
+    if (what === 'snapshot') {
+      const files = await client.listInventorySnapshots(
+        { startDate: fmt(start), endDate: fmt(end) }, warehouse
+      );
+      return res.json({ ok: true, what, warehouse, params: { startDate: fmt(start), endDate: fmt(end) }, count: files.length, sample: files.slice(0, 3), files });
+    }
+    if (what === 'mini-sales') {
+      // Queue + poll inline so we see the exact error if 400.
+      const token = await client.authenticateWithCredentials(warehouse);
+      const api = axios.create({
+        baseURL: process.env.EASYECOM_API_BASE || 'https://api.easyecom.io',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        timeout: 60000, validateStatus: () => true,
+      });
+      const body = {
+        reportType: 'MINI_SALES_REPORT',
+        params: { invoiceType: 'ALL', dateType: 'ORDER_DATE', startDate: fmtDay(start), endDate: fmtDay(end) },
+      };
+      const resp = await api.post('/reports/queue', body);
+      return res.json({ ok: resp.status < 300, what, status: resp.status, requestBody: body, response: resp.data });
+    }
+    if (what === 'orders') {
+      const token = await client.authenticateWithCredentials(warehouse);
+      const api = axios.create({
+        baseURL: process.env.EASYECOM_API_BASE || 'https://api.easyecom.io',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        timeout: 60000, validateStatus: () => true,
+      });
+      const params = { start_date: fmt(start), end_date: fmt(end) };
+      const resp = await api.get('/orders/V2/getAllOrders', { params });
+      const data = resp.data?.data || {};
+      const ordersArr = data.orders || data.invoices || [];
+      return res.json({
+        ok: resp.status < 300, what, status: resp.status, params,
+        responseShape: { code: resp.data?.code, message: resp.data?.message, hasOrdersField: !!data.orders, hasInvoicesField: !!data.invoices, count: ordersArr.length, nextUrl: data.nextUrl || null },
+        sampleFirst: ordersArr[0] || null,
+      });
+    }
+    if (what === 'locations') {
+      const token = await client.authenticateWithCredentials(warehouse);
+      const api = axios.create({
+        baseURL: process.env.EASYECOM_API_BASE || 'https://api.easyecom.io',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+        timeout: 60000, validateStatus: () => true,
+      });
+      const resp = await api.get('/getAllLocation');
+      return res.json({ ok: resp.status < 300, what, status: resp.status, response: resp.data });
+    }
+    return res.status(400).json({ ok: false, error: `unknown what=${what}. Try snapshot|mini-sales|orders|locations` });
+  } catch (err) {
+    return res.status(500).json({
+      ok: false, error: err.message,
+      eeStatus: err.response?.status, eeBody: err.response?.data,
+    });
+  }
+});
+
 module.exports = router;

--- a/utils/easyecomPullWorker.js
+++ b/utils/easyecomPullWorker.js
@@ -190,29 +190,44 @@ async function pullSnapshotsForWarehouse(pool, warehouseId, runStartedAt, window
 // Step 2 — Orders (getAllOrders)
 // ────────────────────────────────────────────────────────────────────
 
+// EasyEcom enforces a max 7-day window per call to /orders/V2/getAllOrders.
+// We chunk the requested window into 7-day pieces and concatenate results.
 async function pullOrders(pool, runStartedAt, bootstrapMode) {
   const stepStart = Date.now();
   const windowDays = bootstrapMode ? 30 : 3;
-  const end = new Date();
-  const start = new Date(end.getTime() - windowDays * 24 * 60 * 60 * 1000);
-  const startStr = `${ymd(start)} 00:00:00`;
-  const endStr = `${ymd(end)} 23:59:59`;
+  const CHUNK_DAYS = 7;
+  const now = new Date();
+
+  // Build a list of [chunkStart, chunkEnd] covering windowDays back from now.
+  const chunks = [];
+  let cursor = new Date(now.getTime() - windowDays * 24 * 60 * 60 * 1000);
+  while (cursor < now) {
+    const chunkEnd = new Date(Math.min(cursor.getTime() + CHUNK_DAYS * 24 * 60 * 60 * 1000, now.getTime()));
+    chunks.push([
+      `${ymd(cursor)} 00:00:00`,
+      `${ymd(new Date(chunkEnd.getTime() - 1))} 23:59:59`,
+    ]);
+    cursor = new Date(chunkEnd.getTime());
+  }
 
   let totalOrders = 0;
   let totalSubs = 0;
 
   for (const [warehouseIdStr, warehouseKey] of Object.entries(WAREHOUSE_KEY_BY_ID)) {
-    try {
-      const counts = await pullOrdersForWarehouse(pool, warehouseKey, Number(warehouseIdStr), startStr, endStr);
-      totalOrders += counts.orders;
-      totalSubs += counts.subs;
-    } catch (err) {
-      console.error(`[pullWorker] orders pull failed for ${warehouseKey}:`, err.message);
-      await logStep(pool, runStartedAt, `orders:${warehouseKey}`, 'error', err.message, Date.now() - stepStart);
+    for (const [startStr, endStr] of chunks) {
+      try {
+        const counts = await pullOrdersForWarehouse(pool, warehouseKey, Number(warehouseIdStr), startStr, endStr);
+        totalOrders += counts.orders;
+        totalSubs += counts.subs;
+      } catch (err) {
+        console.error(`[pullWorker] orders pull failed for ${warehouseKey} ${startStr}..${endStr}:`, err.message);
+        await logStep(pool, runStartedAt, `orders:${warehouseKey}`, 'error',
+          `${startStr}..${endStr}: ${err.message}`, Date.now() - stepStart);
+      }
     }
   }
   await logStep(pool, runStartedAt, 'orders', 'ok',
-    `mode=${bootstrapMode ? 'bootstrap' : 'steady'} window=${windowDays}d orders=${totalOrders} subs=${totalSubs}`,
+    `mode=${bootstrapMode ? 'bootstrap' : 'steady'} window=${windowDays}d chunks=${chunks.length} orders=${totalOrders} subs=${totalSubs}`,
     Date.now() - stepStart);
 }
 

--- a/utils/easyecomReturnsClient.js
+++ b/utils/easyecomReturnsClient.js
@@ -889,10 +889,12 @@ async function waitForAndDownloadReport(reportId, warehouse = 'faridabad', { pol
 }
 
 // Convenience wrappers — queue + poll + download for the reports we care about.
-async function fetchMiniSalesReport({ startDate, endDate, warehouseIds = '', invoiceType = 'ALL', dateType = 'ORDER_DATE' }, warehouse = 'faridabad') {
-  const reportId = await queueReport('MINI_SALES_REPORT', {
-    invoiceType, warehouseIds, dateType, startDate, endDate,
-  }, warehouse);
+async function fetchMiniSalesReport({ startDate, endDate, warehouseIds, invoiceType = 'ALL', dateType = 'ORDER_DATE' }, warehouse = 'faridabad') {
+  // EasyEcom rejects empty/missing warehouseIds with a 400 — only pass the
+  // param when caller supplied a non-empty location-key list.
+  const params = { invoiceType, dateType, startDate, endDate };
+  if (warehouseIds && String(warehouseIds).trim()) params.warehouseIds = warehouseIds;
+  const reportId = await queueReport('MINI_SALES_REPORT', params, warehouse);
   return waitForAndDownloadReport(reportId, warehouse);
 }
 


### PR DESCRIPTION
- Orders: EasyEcom caps getAllOrders at a 7-day window; chunk the 30-day bootstrap into 5 chunks instead of one (was returning 0).
- MINI_SALES_REPORT: 400 was caused by sending warehouseIds=''. Skip the param entirely when not supplied so EasyEcom uses the auth-scoped warehouse.
- New /pm/debug-ee admin endpoint surfaces the raw EasyEcom response for snapshot / mini-sales / orders / locations so we can diagnose without trawling Cloud Run logs.