### PR TITLE
feat: migrate all read-side dashboards/reports to *_events truth source

### DIFF
--- a/public/js/lot-size-expand.js
+++ b/public/js/lot-size-expand.js
@@ -1,0 +1,228 @@
+/* lot-size-expand.js
+ *
+ * Shared progressive-enhancement script: turns any <tr data-lot-no="..."> in
+ * any dashboard table into an expandable row that loads per-size data
+ * on-demand from GET /operator/api/lot-sizes?lot_no=<lotNo>.
+ *
+ * Markup contract (add to each view, in the row's first <td>):
+ *   <td>
+ *     <button type="button"
+ *             class="lse-toggle btn btn-link btn-sm p-0"
+ *             aria-expanded="false"
+ *             aria-label="Show size breakdown">
+ *       <span class="lse-chevron">&#9654;</span>
+ *     </button>
+ *   </td>
+ * Then add `data-lot-no="..."` on the <tr>. The script auto-wires every row.
+ *
+ * The cache is per-row (kept on the row element), so re-expanding never
+ * re-fetches.
+ */
+(function () {
+  'use strict';
+
+  var ENDPOINT = '/operator/api/lot-sizes';
+
+  // Inject minimal CSS once.
+  function injectStyles() {
+    if (document.getElementById('lse-styles')) return;
+    var css = ''
+      + '.lse-toggle{background:none;border:none;cursor:pointer;color:inherit;}'
+      + '.lse-toggle:focus{outline:2px solid #d4826a;outline-offset:2px;}'
+      + '.lse-chevron{display:inline-block;transition:transform .15s ease;font-size:.85em;}'
+      + '.lse-toggle[aria-expanded="true"] .lse-chevron{transform:rotate(90deg);}'
+      + '.lse-detail-row > td{background:#faf7f2;padding:12px 18px;border-top:0;}'
+      + '.lse-detail-wrap{margin:0;}'
+      + '.lse-detail-head{font-size:12px;font-weight:600;color:#5a4a3a;margin-bottom:6px;letter-spacing:.02em;}'
+      + '.lse-detail-table{width:auto;min-width:60%;border-collapse:collapse;font-size:12px;background:#fff;border:1px solid #e6dfd2;border-radius:6px;overflow:hidden;}'
+      + '.lse-detail-table th,.lse-detail-table td{padding:6px 10px;text-align:right;border-bottom:1px solid #f0e9da;}'
+      + '.lse-detail-table th:first-child,.lse-detail-table td:first-child{text-align:left;font-weight:600;}'
+      + '.lse-detail-table thead th{background:#f3ece0;color:#3d2f20;font-weight:600;text-transform:uppercase;font-size:10.5px;letter-spacing:.04em;border-bottom:1px solid #e6dfd2;}'
+      + '.lse-detail-table tbody tr:last-child td{border-bottom:0;}'
+      + '.lse-detail-table tbody tr:hover td{background:#fdfaf3;}'
+      + '.lse-empty{font-size:12px;color:#8a7860;font-style:italic;}'
+      + '.lse-spinner{display:inline-block;width:14px;height:14px;border:2px solid #d4826a33;border-top-color:#d4826a;border-radius:50%;animation:lse-spin .7s linear infinite;vertical-align:middle;margin-right:6px;}'
+      + '@keyframes lse-spin{to{transform:rotate(360deg);}}';
+    var style = document.createElement('style');
+    style.id = 'lse-styles';
+    style.textContent = css;
+    document.head.appendChild(style);
+  }
+
+  function fmt(n) {
+    n = Number(n) || 0;
+    return n.toLocaleString();
+  }
+
+  function renderDetail(data) {
+    var wrap = document.createElement('div');
+    wrap.className = 'lse-detail-wrap';
+
+    if (!data || !data.sizes || !data.sizes.length) {
+      var p = document.createElement('div');
+      p.className = 'lse-empty';
+      p.textContent = 'No size detail available.';
+      wrap.appendChild(p);
+      return wrap;
+    }
+
+    var head = document.createElement('div');
+    head.className = 'lse-detail-head';
+    head.textContent = 'Per-size breakdown · ' + (data.lot_no || '')
+      + (data.totalCut ? ' · total cut ' + fmt(data.totalCut) : '');
+    wrap.appendChild(head);
+
+    var table = document.createElement('table');
+    table.className = 'lse-detail-table';
+    table.innerHTML =
+      '<thead><tr>'
+      + '<th>Size</th>'
+      + '<th>Cut</th>'
+      + '<th>Stitched</th>'
+      + '<th>Assembled</th>'
+      + '<th>Washed</th>'
+      + '<th>Wash-In</th>'
+      + '<th>Finished</th>'
+      + '<th>Dispatched</th>'
+      + '</tr></thead>';
+    var tbody = document.createElement('tbody');
+    data.sizes.forEach(function (s) {
+      var tr = document.createElement('tr');
+      tr.innerHTML =
+        '<td>' + (s.size_label || '') + '</td>'
+        + '<td>' + fmt(s.cut) + '</td>'
+        + '<td>' + fmt(s.stitched) + '</td>'
+        + '<td>' + fmt(s.assembled) + '</td>'
+        + '<td>' + fmt(s.washed) + '</td>'
+        + '<td>' + fmt(s.washing_in) + '</td>'
+        + '<td>' + fmt(s.finished) + '</td>'
+        + '<td>' + fmt(s.dispatched) + '</td>';
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    wrap.appendChild(table);
+    return wrap;
+  }
+
+  function countCols(tr) {
+    var cells = tr.children;
+    var n = 0;
+    for (var i = 0; i < cells.length; i++) {
+      var cs = parseInt(cells[i].getAttribute('colspan') || '1', 10);
+      n += isNaN(cs) ? 1 : cs;
+    }
+    return n || 1;
+  }
+
+  function getOrCreateDetailRow(tr) {
+    if (tr._lseDetailRow && tr._lseDetailRow.parentNode === tr.parentNode) {
+      return tr._lseDetailRow;
+    }
+    var detail = document.createElement('tr');
+    detail.className = 'lse-detail-row';
+    detail.style.display = 'none';
+    var td = document.createElement('td');
+    td.colSpan = countCols(tr);
+    detail.appendChild(td);
+    tr.parentNode.insertBefore(detail, tr.nextSibling);
+    tr._lseDetailRow = detail;
+    return detail;
+  }
+
+  function setLoading(td) {
+    td.innerHTML = '';
+    var spin = document.createElement('span');
+    spin.className = 'lse-spinner';
+    var txt = document.createElement('span');
+    txt.textContent = 'Loading size detail…';
+    td.appendChild(spin);
+    td.appendChild(txt);
+  }
+
+  function setError(td, msg) {
+    td.innerHTML = '';
+    var p = document.createElement('div');
+    p.className = 'lse-empty';
+    p.textContent = msg || 'Failed to load size detail.';
+    td.appendChild(p);
+  }
+
+  function toggleRow(tr, btn) {
+    var lotNo = tr.getAttribute('data-lot-no');
+    if (!lotNo) return;
+
+    var detail = getOrCreateDetailRow(tr);
+    var td = detail.firstChild;
+    td.colSpan = countCols(tr);
+    var expanded = btn.getAttribute('aria-expanded') === 'true';
+
+    if (expanded) {
+      detail.style.display = 'none';
+      btn.setAttribute('aria-expanded', 'false');
+      btn.setAttribute('aria-label', 'Show size breakdown');
+      return;
+    }
+
+    btn.setAttribute('aria-expanded', 'true');
+    btn.setAttribute('aria-label', 'Hide size breakdown');
+    detail.style.display = '';
+
+    if (tr._lseCachedData !== undefined) {
+      // Cached — render instantly.
+      td.innerHTML = '';
+      td.appendChild(renderDetail(tr._lseCachedData));
+      return;
+    }
+
+    setLoading(td);
+    fetch(ENDPOINT + '?lot_no=' + encodeURIComponent(lotNo), {
+      credentials: 'same-origin',
+      headers: { 'Accept': 'application/json' }
+    })
+      .then(function (res) {
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+      })
+      .then(function (data) {
+        tr._lseCachedData = data;
+        td.innerHTML = '';
+        td.appendChild(renderDetail(data));
+      })
+      .catch(function (err) {
+        console.error('lot-size-expand fetch failed:', err);
+        setError(td, 'No size detail available.');
+      });
+  }
+
+  function onClick(e) {
+    var btn = e.target.closest && e.target.closest('.lse-toggle');
+    if (!btn) return;
+    var tr = btn.closest('tr[data-lot-no]');
+    if (!tr) return;
+    e.preventDefault();
+    e.stopPropagation();
+    toggleRow(tr, btn);
+  }
+
+  function onKeyDown(e) {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    var btn = e.target.closest && e.target.closest('.lse-toggle');
+    if (!btn) return;
+    var tr = btn.closest('tr[data-lot-no]');
+    if (!tr) return;
+    e.preventDefault();
+    toggleRow(tr, btn);
+  }
+
+  function init() {
+    injectStyles();
+    document.addEventListener('click', onClick, false);
+    document.addEventListener('keydown', onKeyDown, false);
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/routes/challanDashboardRoutes.js
+++ b/routes/challanDashboardRoutes.js
@@ -134,16 +134,23 @@ async function getNextChallanCounter (washerId) {
 
 // --------------------------------------------------------------------
 // HELPER: exclude lots already in a challan
+// Works against any id-bearing alias (legacy washing_assignments.id or
+// the offset event_id used by the events-sourced rows).
 // --------------------------------------------------------------------
-const EXCLUDE_USED_LOTS_CLAUSE = `
+const EXCLUDE_USED_LOTS_CLAUSE_FOR = (idExpr) => `
   NOT EXISTS (
     SELECT 1
       FROM challan ch
      WHERE JSON_SEARCH(
-             ch.items,'one',CAST(wa.id AS CHAR),NULL,'$[*].washing_id'
+             ch.items,'one',CAST(${idExpr} AS CHAR),NULL,'$[*].washing_id'
            ) IS NOT NULL
   )
 `;
+
+// Events-sourced rows surface to the UI with washing_id = EVENT_ID_OFFSET + event_id
+// so they cannot collide with legacy washing_assignments.id values (low thousands).
+// On create we decode back.
+const EVENT_ID_OFFSET = 100000000;
 
 // ====================================================================
 // GET /challandashboard  – dashboard
@@ -160,23 +167,50 @@ router.get('/', isAuthenticated, async (req,res)=>{
     const limit  = 50;
 
     const [assignments] = await pool.query(`
-      SELECT
-        wa.id        AS washing_id,
-        jd.lot_no, jd.sku, jd.total_pieces,
-        jd.remark    AS assembly_remark,
-        c.remark     AS cutting_remark,
-        wa.target_day, wa.assigned_on,
-        wa.is_approved, wa.assignment_remark,
-        u.username   AS washer_username,
-        m.username   AS master_username
-      FROM washing_assignments wa
-      JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
-      JOIN cutting_lots        c  ON jd.lot_no = c.lot_no
-      JOIN users               u  ON wa.user_id = u.id
-      JOIN users               m  ON wa.jeans_assembly_master_id = m.id
-      WHERE ${EXCLUDE_USED_LOTS_CLAUSE}
-        AND wa.is_approved = 1
-      ORDER BY wa.assigned_on DESC
+      ( SELECT
+          wa.id        AS washing_id,
+          jd.lot_no, jd.sku, jd.total_pieces,
+          jd.remark    AS assembly_remark,
+          c.remark     AS cutting_remark,
+          wa.target_day, wa.assigned_on,
+          wa.is_approved, wa.assignment_remark,
+          u.username   AS washer_username,
+          m.username   AS master_username
+        FROM washing_assignments wa
+        JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
+        JOIN cutting_lots        c  ON jd.lot_no = c.lot_no
+        JOIN users               u  ON wa.user_id = u.id
+        JOIN users               m  ON wa.jeans_assembly_master_id = m.id
+        WHERE ${EXCLUDE_USED_LOTS_CLAUSE_FOR('wa.id')}
+          AND wa.is_approved = 1 )
+      UNION ALL
+      ( SELECT
+          we.id + ${EVENT_ID_OFFSET}  AS washing_id,
+          c.lot_no, c.sku, c.total_pieces,
+          NULL          AS assembly_remark,
+          c.remark      AS cutting_remark,
+          NULL          AS target_day,
+          we.created_at AS assigned_on,
+          1             AS is_approved,
+          we.remark     AS assignment_remark,
+          u.username    AS washer_username,
+          COALESCE((SELECT u2.username
+                      FROM jeans_assembly_events je
+                      JOIN users u2 ON u2.id = je.operator_id
+                     WHERE je.cutting_lot_id = c.id AND je.event_type='complete'
+                     ORDER BY je.created_at DESC LIMIT 1), '') AS master_username
+        FROM washing_events we
+        JOIN cutting_lots c ON c.id = we.cutting_lot_id
+        JOIN users u        ON u.id = we.operator_id
+        WHERE we.event_type = 'approve'
+          -- Avoid double-listing if a legacy washing_assignments row exists for this lot.
+          AND NOT EXISTS (
+            SELECT 1 FROM washing_assignments wa
+              JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
+             WHERE jd.lot_no = c.lot_no AND wa.is_approved = 1
+          )
+          AND ${EXCLUDE_USED_LOTS_CLAUSE_FOR(`we.id + ${EVENT_ID_OFFSET}`)} )
+      ORDER BY assigned_on DESC
       LIMIT ? OFFSET ?`,
       [limit, offset]
     );
@@ -208,45 +242,81 @@ router.get('/search', isAuthenticated, async (req,res)=>{
     const offset  = parseInt(req.query.offset,10)||0;
     const limit   = 50;
 
-    let sql = `
-      SELECT
-        wa.id        AS washing_id,
-        jd.lot_no, jd.sku, jd.total_pieces,
-        jd.remark    AS assembly_remark,
-        c.remark     AS cutting_remark,
-        wa.target_day, wa.assigned_on,
-        wa.is_approved, wa.assignment_remark,
-        u.username   AS washer_username,
-        m.username   AS master_username
-      FROM washing_assignments wa
-      JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
-      JOIN cutting_lots        c  ON jd.lot_no = c.lot_no
-      JOIN users               u  ON wa.user_id = u.id
-      JOIN users               m  ON wa.jeans_assembly_master_id = m.id
-      WHERE ${EXCLUDE_USED_LOTS_CLAUSE}
-        AND wa.is_approved = 1`;
-    const params = [];
+    // Build the search predicate once; applied to both halves of the UNION.
+    let searchClauseLegacy = '';
+    let searchClauseEvent  = '';
+    const searchParams = [];
 
     if (search.includes(',')) {
       const terms = search.split(',').map(t=>t.trim()).filter(Boolean);
       if (!terms.length) return res.json({assignments:[]});
-      const conds = [];
+      const condsLegacy = [], condsEvent = [];
       for (const t of terms) {
         const like = `%${t}%`;
-        conds.push('(jd.sku LIKE ? OR jd.lot_no LIKE ? OR c.remark LIKE ?)');
-        params.push(like,like,like);
+        condsLegacy.push('(jd.sku LIKE ? OR jd.lot_no LIKE ? OR c.remark LIKE ?)');
+        condsEvent .push('(c.sku  LIKE ? OR c.lot_no  LIKE ? OR c.remark LIKE ?)');
+        searchParams.push(like,like,like);
       }
-      sql += ` AND (${conds.join(' OR ')})`;
+      searchClauseLegacy = ` AND (${condsLegacy.join(' OR ')})`;
+      searchClauseEvent  = ` AND (${condsEvent .join(' OR ')})`;
     } else if (search) {
       const like = `%${search}%`;
-      sql += ` AND (jd.sku LIKE ? OR jd.lot_no LIKE ? OR c.remark LIKE ?)`;
-      params.push(like,like,like);
+      searchClauseLegacy = ` AND (jd.sku LIKE ? OR jd.lot_no LIKE ? OR c.remark LIKE ?)`;
+      searchClauseEvent  = ` AND (c.sku  LIKE ? OR c.lot_no  LIKE ? OR c.remark LIKE ?)`;
+      searchParams.push(like,like,like);
     }
 
-    sql += ` ORDER BY wa.assigned_on DESC LIMIT ? OFFSET ?`;
-    params.push(limit,offset);
+    const sql = `
+      ( SELECT
+          wa.id        AS washing_id,
+          jd.lot_no, jd.sku, jd.total_pieces,
+          jd.remark    AS assembly_remark,
+          c.remark     AS cutting_remark,
+          wa.target_day, wa.assigned_on,
+          wa.is_approved, wa.assignment_remark,
+          u.username   AS washer_username,
+          m.username   AS master_username
+        FROM washing_assignments wa
+        JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
+        JOIN cutting_lots        c  ON jd.lot_no = c.lot_no
+        JOIN users               u  ON wa.user_id = u.id
+        JOIN users               m  ON wa.jeans_assembly_master_id = m.id
+        WHERE ${EXCLUDE_USED_LOTS_CLAUSE_FOR('wa.id')}
+          AND wa.is_approved = 1
+          ${searchClauseLegacy} )
+      UNION ALL
+      ( SELECT
+          we.id + ${EVENT_ID_OFFSET}  AS washing_id,
+          c.lot_no, c.sku, c.total_pieces,
+          NULL          AS assembly_remark,
+          c.remark      AS cutting_remark,
+          NULL          AS target_day,
+          we.created_at AS assigned_on,
+          1             AS is_approved,
+          we.remark     AS assignment_remark,
+          u.username    AS washer_username,
+          COALESCE((SELECT u2.username
+                      FROM jeans_assembly_events je
+                      JOIN users u2 ON u2.id = je.operator_id
+                     WHERE je.cutting_lot_id = c.id AND je.event_type='complete'
+                     ORDER BY je.created_at DESC LIMIT 1), '') AS master_username
+        FROM washing_events we
+        JOIN cutting_lots c ON c.id = we.cutting_lot_id
+        JOIN users u        ON u.id = we.operator_id
+        WHERE we.event_type = 'approve'
+          AND NOT EXISTS (
+            SELECT 1 FROM washing_assignments wa
+              JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
+             WHERE jd.lot_no = c.lot_no AND wa.is_approved = 1
+          )
+          AND ${EXCLUDE_USED_LOTS_CLAUSE_FOR(`we.id + ${EVENT_ID_OFFSET}`)}
+          ${searchClauseEvent} )
+      ORDER BY assigned_on DESC
+      LIMIT ? OFFSET ?
+    `;
+    const params = [...searchParams, ...searchParams, limit, offset];
 
-    const [assignments] = await pool.query(sql,params);
+    const [assignments] = await pool.query(sql, params);
     res.json({assignments});
   } catch (err) {
     console.error('[ERROR] GET /challandashboard/search:',err);
@@ -324,11 +394,29 @@ router.post('/create', isAuthenticated, async (req,res)=>{
       conn.release(); return res.redirect('/challandashboard');
     }
 
-    const [[{total:approvedCnt}]] = await conn.query(
-      `SELECT COUNT(*) AS total FROM washing_assignments
-        WHERE id IN (?) AND is_approved=1`,
-      [washingIds]
-    );
+    // Split into legacy washing_assignments ids vs offset-encoded
+    // washing_events.id (decoded via EVENT_ID_OFFSET).
+    const legacyIds = washingIds.filter(id => id < EVENT_ID_OFFSET);
+    const eventIds  = washingIds.filter(id => id >= EVENT_ID_OFFSET)
+                                .map(id => id - EVENT_ID_OFFSET);
+
+    let approvedCnt = 0;
+    if (legacyIds.length) {
+      const [[{total}]] = await conn.query(
+        `SELECT COUNT(*) AS total FROM washing_assignments
+          WHERE id IN (?) AND is_approved=1`,
+        [legacyIds]
+      );
+      approvedCnt += total;
+    }
+    if (eventIds.length) {
+      const [[{total}]] = await conn.query(
+        `SELECT COUNT(*) AS total FROM washing_events
+          WHERE id IN (?) AND event_type='approve'`,
+        [eventIds]
+      );
+      approvedCnt += total;
+    }
     if (approvedCnt !== washingIds.length) {
       req.flash('error','Some selected lots are not approved or missing');
       conn.release(); return res.redirect('/challandashboard');

--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -607,9 +607,12 @@ router.get('/assign-stitching/lots', isAuthenticated, isCuttingManager, async (r
         c.created_at
       FROM cutting_lots c
       WHERE c.user_id = ?
-        AND c.id NOT IN (
-          SELECT s.cutting_lot_id 
-          FROM stitching_assignments s
+        AND NOT EXISTS (
+          SELECT 1 FROM stitching_assignments s WHERE s.cutting_lot_id = c.id
+        )
+        AND NOT EXISTS (
+          SELECT 1 FROM stitching_events se
+           WHERE se.cutting_lot_id = c.id AND se.event_type='approve'
         )
       ORDER BY c.created_at DESC
     `,

--- a/routes/dashboardRoutes.js
+++ b/routes/dashboardRoutes.js
@@ -454,7 +454,13 @@ router.get('/rejected-lots', isAuthenticated, async (req, res) => {
     const params = [];
     const dateFilter = `AND approved_on >= DATE_SUB(NOW(), INTERVAL ? DAY)`;
 
-    // Stitching rejections (isApproved = 0)
+    // Rejections come from BOTH the legacy *_assignments tables (is_approved
+    // = 0, or 2 for finishing) AND the *_events tables (event_type='reject').
+    // The events feed is the truth source for newer activity; legacy still
+    // holds historical denials. Union them.
+    const eventDateFilter = `AND e.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)`;
+
+    // --- Stitching ---
     if (stage === 'all' || stage === 'stitching') {
       queries.push(`
         SELECT
@@ -476,9 +482,23 @@ router.get('/rejected-lots', isAuthenticated, async (req, res) => {
       `);
       params.push(daysAgo);
       if (search) { params.push(`%${search}%`, `%${search}%`); }
+
+      queries.push(`
+        SELECT 'Stitching' AS stage, cl.lot_no, cl.sku,
+               e.created_at AS rejected_on,
+               u.username AS assigned_to, NULL AS assigner,
+               e.remark AS rejection_reason, e.pieces AS total_pieces
+          FROM stitching_events e
+          JOIN cutting_lots cl ON cl.id = e.cutting_lot_id
+          JOIN users u ON u.id = e.operator_id
+         WHERE e.event_type='reject' ${eventDateFilter}
+         ${search ? 'AND (cl.lot_no LIKE ? OR cl.sku LIKE ?)' : ''}
+      `);
+      params.push(daysAgo);
+      if (search) { params.push(`%${search}%`, `%${search}%`); }
     }
 
-    // Assembly rejections
+    // --- Assembly ---
     if (stage === 'all' || stage === 'assembly') {
       queries.push(`
         SELECT
@@ -491,40 +511,70 @@ router.get('/rejected-lots', isAuthenticated, async (req, res) => {
           ja.assignment_remark AS rejection_reason,
           sd.total_pieces
         FROM jeans_assembly_assignments ja
-        JOIN stitching_data sd ON sd.id = ja.stitching_data_id
+        JOIN stitching_data sd ON sd.id = ja.stitching_assignment_id
         JOIN users u_assigned ON u_assigned.id = ja.user_id
-        LEFT JOIN users u_assigner ON u_assigner.id = ja.assigner_stitching_master
+        LEFT JOIN users u_assigner ON u_assigner.id = ja.stitching_master_id
         WHERE ja.is_approved = 0 ${dateFilter}
         ${search ? 'AND (sd.lot_no LIKE ? OR sd.sku LIKE ?)' : ''}
       `);
       params.push(daysAgo);
       if (search) { params.push(`%${search}%`, `%${search}%`); }
-    }
 
-    // Washing rejections
-    if (stage === 'all' || stage === 'washing') {
       queries.push(`
-        SELECT
-          'Washing' AS stage,
-          ad.lot_no,
-          ad.sku,
-          wa.approved_on AS rejected_on,
-          u_assigned.username AS assigned_to,
-          u_assigner.username AS assigner,
-          wa.assignment_remark AS rejection_reason,
-          ad.total_pieces
-        FROM washing_assignments wa
-        JOIN assembly_data ad ON ad.id = wa.assembly_data_id
-        JOIN users u_assigned ON u_assigned.id = wa.user_id
-        LEFT JOIN users u_assigner ON u_assigner.id = wa.assigner_assembly_master
-        WHERE wa.is_approved = 0 ${dateFilter}
-        ${search ? 'AND (ad.lot_no LIKE ? OR ad.sku LIKE ?)' : ''}
+        SELECT 'Assembly' AS stage, cl.lot_no, cl.sku,
+               e.created_at AS rejected_on,
+               u.username AS assigned_to, NULL AS assigner,
+               e.remark AS rejection_reason, e.pieces AS total_pieces
+          FROM jeans_assembly_events e
+          JOIN cutting_lots cl ON cl.id = e.cutting_lot_id
+          JOIN users u ON u.id = e.operator_id
+         WHERE e.event_type='reject' ${eventDateFilter}
+         ${search ? 'AND (cl.lot_no LIKE ? OR cl.sku LIKE ?)' : ''}
       `);
       params.push(daysAgo);
       if (search) { params.push(`%${search}%`, `%${search}%`); }
     }
 
-    // Washing-In rejections
+    // --- Washing ---
+    // (legacy query reference to non-existent assembly_data dropped; replaced
+    // with jeans_assembly_data, the actual upstream table.)
+    if (stage === 'all' || stage === 'washing') {
+      queries.push(`
+        SELECT
+          'Washing' AS stage,
+          jd.lot_no,
+          jd.sku,
+          wa.approved_on AS rejected_on,
+          u_assigned.username AS assigned_to,
+          u_assigner.username AS assigner,
+          wa.assignment_remark AS rejection_reason,
+          jd.total_pieces
+        FROM washing_assignments wa
+        JOIN jeans_assembly_data jd ON jd.id = wa.jeans_assembly_assignment_id
+        JOIN users u_assigned ON u_assigned.id = wa.user_id
+        LEFT JOIN users u_assigner ON u_assigner.id = wa.jeans_assembly_master_id
+        WHERE wa.is_approved = 0 ${dateFilter}
+        ${search ? 'AND (jd.lot_no LIKE ? OR jd.sku LIKE ?)' : ''}
+      `);
+      params.push(daysAgo);
+      if (search) { params.push(`%${search}%`, `%${search}%`); }
+
+      queries.push(`
+        SELECT 'Washing' AS stage, cl.lot_no, cl.sku,
+               e.created_at AS rejected_on,
+               u.username AS assigned_to, NULL AS assigner,
+               e.remark AS rejection_reason, e.pieces AS total_pieces
+          FROM washing_events e
+          JOIN cutting_lots cl ON cl.id = e.cutting_lot_id
+          JOIN users u ON u.id = e.operator_id
+         WHERE e.event_type='reject' ${eventDateFilter}
+         ${search ? 'AND (cl.lot_no LIKE ? OR cl.sku LIKE ?)' : ''}
+      `);
+      params.push(daysAgo);
+      if (search) { params.push(`%${search}%`, `%${search}%`); }
+    }
+
+    // --- Washing-In ---
     if (stage === 'all' || stage === 'washing_in') {
       queries.push(`
         SELECT
@@ -539,15 +589,29 @@ router.get('/rejected-lots', isAuthenticated, async (req, res) => {
         FROM washing_in_assignments wia
         JOIN washing_data wd ON wd.id = wia.washing_data_id
         JOIN users u_assigned ON u_assigned.id = wia.user_id
-        LEFT JOIN users u_assigner ON u_assigner.id = wia.assigner_washing_master
+        LEFT JOIN users u_assigner ON u_assigner.id = wia.washing_master_id
         WHERE wia.is_approved = 0 ${dateFilter}
         ${search ? 'AND (wd.lot_no LIKE ? OR wd.sku LIKE ?)' : ''}
       `);
       params.push(daysAgo);
       if (search) { params.push(`%${search}%`, `%${search}%`); }
+
+      queries.push(`
+        SELECT 'Washing-In' AS stage, cl.lot_no, cl.sku,
+               e.created_at AS rejected_on,
+               u.username AS assigned_to, NULL AS assigner,
+               e.remark AS rejection_reason, e.pieces AS total_pieces
+          FROM washing_in_events e
+          JOIN cutting_lots cl ON cl.id = e.cutting_lot_id
+          JOIN users u ON u.id = e.operator_id
+         WHERE e.event_type='reject' ${eventDateFilter}
+         ${search ? 'AND (cl.lot_no LIKE ? OR cl.sku LIKE ?)' : ''}
+      `);
+      params.push(daysAgo);
+      if (search) { params.push(`%${search}%`, `%${search}%`); }
     }
 
-    // Finishing rejections (is_approved = 2)
+    // --- Finishing ---
     if (stage === 'all' || stage === 'finishing') {
       queries.push(`
         SELECT
@@ -565,6 +629,20 @@ router.get('/rejected-lots', isAuthenticated, async (req, res) => {
         JOIN users u_assigned ON u_assigned.id = fa.user_id
         WHERE fa.is_approved = 2 ${dateFilter}
         ${search ? 'AND (COALESCE(wid.lot_no, sd.lot_no) LIKE ? OR COALESCE(wid.sku, sd.sku) LIKE ?)' : ''}
+      `);
+      params.push(daysAgo);
+      if (search) { params.push(`%${search}%`, `%${search}%`); }
+
+      queries.push(`
+        SELECT 'Finishing' AS stage, cl.lot_no, cl.sku,
+               e.created_at AS rejected_on,
+               u.username AS assigned_to, NULL AS assigner,
+               e.remark AS rejection_reason, e.pieces AS total_pieces
+          FROM finishing_events e
+          JOIN cutting_lots cl ON cl.id = e.cutting_lot_id
+          JOIN users u ON u.id = e.operator_id
+         WHERE e.event_type='reject' ${eventDateFilter}
+         ${search ? 'AND (cl.lot_no LIKE ? OR cl.sku LIKE ?)' : ''}
       `);
       params.push(daysAgo);
       if (search) { params.push(`%${search}%`, `%${search}%`); }

--- a/routes/indentRoutes.js
+++ b/routes/indentRoutes.js
@@ -719,14 +719,17 @@ router.get('/api/my-approved-lots', isAuthenticated, canCreateStageIndent, async
   try {
     let rows = [];
     if (userRole === 'stitching_master') {
-      // Lots assigned & approved to this stitching master, with cutting lot info
+      // Lots this stitching master has approved (taken in) — sourced from
+      // stitching_events. Distinct lots, ordered by most-recent approve.
       const [r] = await pool.query(
-        `SELECT c.lot_no, c.sku, c.total_pieces, c.lot_type, c.fabric_type
-           FROM stitching_assignments sa
-           JOIN cutting_lots c ON c.id = sa.cutting_lot_id
-          WHERE sa.user_id = ? AND sa.isApproved = 1
+        `SELECT c.lot_no, c.sku, c.total_pieces, c.lot_type, c.fabric_type,
+                MAX(se.created_at) AS approved_on
+           FROM stitching_events se
+           JOIN cutting_lots c ON c.id = se.cutting_lot_id
+          WHERE se.operator_id = ? AND se.event_type = 'approve'
             ${lotType ? 'AND c.lot_type = ?' : ''}
-          ORDER BY sa.approved_on DESC
+          GROUP BY c.id, c.lot_no, c.sku, c.total_pieces, c.lot_type, c.fabric_type
+          ORDER BY approved_on DESC
           LIMIT 200`,
         lotType ? [userId, lotType] : [userId]
       );

--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -80,22 +80,28 @@ async function computeAdvancedAnalytics(startDate, endDate) {
   return cache.fetchCached(cacheKey, async () => {
     const analytics = {};
 
+    // Sourced from *_events (truth source) — counts pieces that have been
+    // completed in each stage. Pending = lots whose finished total is below
+    // their cut total.
     const totalsQ = pool.query(`
     SELECT
-      (SELECT COALESCE(SUM(total_pieces),0) FROM cutting_lots)     AS totalCut,
-      (SELECT COALESCE(SUM(total_pieces),0) FROM stitching_data)   AS totalStitched,
-      (SELECT COALESCE(SUM(total_pieces),0) FROM washing_data)     AS totalWashed,
-      (SELECT COALESCE(SUM(total_pieces),0) FROM finishing_data)   AS totalFinished,
-      (SELECT COUNT(*) FROM cutting_lots)                          AS totalCount,
+      (SELECT COALESCE(SUM(total_pieces),0) FROM cutting_lots) AS totalCut,
+      (SELECT COALESCE(SUM(pieces),0)
+         FROM stitching_events WHERE event_type='complete')    AS totalStitched,
+      (SELECT COALESCE(SUM(pieces),0)
+         FROM washing_events   WHERE event_type='complete')    AS totalWashed,
+      (SELECT COALESCE(SUM(pieces),0)
+         FROM finishing_events WHERE event_type='complete')    AS totalFinished,
+      (SELECT COUNT(*) FROM cutting_lots)                      AS totalCount,
       (
         SELECT COUNT(*)
           FROM cutting_lots c
           LEFT JOIN (
-            SELECT lot_no, COALESCE(SUM(total_pieces),0) AS sumFinish
-              FROM finishing_data
-             GROUP BY lot_no
-          ) fd ON c.lot_no = fd.lot_no
-         WHERE fd.sumFinish < c.total_pieces
+            SELECT cutting_lot_id, COALESCE(SUM(pieces),0) AS sumFinish
+              FROM finishing_events WHERE event_type='complete'
+             GROUP BY cutting_lot_id
+          ) fd ON c.id = fd.cutting_lot_id
+         WHERE COALESCE(fd.sumFinish,0) < c.total_pieces
       ) AS pendingLots
     `);
 
@@ -111,23 +117,32 @@ async function computeAdvancedAnalytics(startDate, endDate) {
     const topQuery = skuQuery + 'GROUP BY sku ORDER BY total DESC LIMIT 10';
     const bottomQuery = skuQuery + 'GROUP BY sku ORDER BY total ASC LIMIT 10';
 
+    // Turnaround: lots whose finishing-complete events sum to >= cut total.
     const turnaroundQ = pool.query(`
-      SELECT c.lot_no, c.created_at AS cut_date, MAX(f.created_at) AS finish_date,
-             c.total_pieces, COALESCE(SUM(f.total_pieces),0) as sumFin
+      SELECT c.lot_no,
+             c.created_at AS cut_date,
+             MAX(f.created_at) AS finish_date,
+             c.total_pieces,
+             COALESCE(SUM(f.pieces),0) AS sumFin
         FROM cutting_lots c
-        LEFT JOIN finishing_data f ON c.lot_no = f.lot_no
-       GROUP BY c.lot_no
+        LEFT JOIN finishing_events f
+               ON f.cutting_lot_id = c.id
+              AND f.event_type='complete'
+       GROUP BY c.id, c.lot_no, c.created_at, c.total_pieces
        HAVING sumFin >= c.total_pieces
     `);
+    // Approval rates from events: per stage, approved-events / (approved + rejected events).
     const stitchRateQ = pool.query(`
-      SELECT COUNT(*) AS totalAssigned,
-             SUM(CASE WHEN isApproved=1 THEN 1 ELSE 0 END) AS approvedCount
-        FROM stitching_assignments
+      SELECT
+        SUM(CASE WHEN event_type IN ('approve','reject') THEN 1 ELSE 0 END) AS totalAssigned,
+        SUM(CASE WHEN event_type='approve' THEN 1 ELSE 0 END)               AS approvedCount
+        FROM stitching_events
     `);
     const washRateQ = pool.query(`
-      SELECT COUNT(*) AS totalAssigned,
-             SUM(CASE WHEN is_approved=1 THEN 1 ELSE 0 END) AS approvedCount
-        FROM washing_assignments
+      SELECT
+        SUM(CASE WHEN event_type IN ('approve','reject') THEN 1 ELSE 0 END) AS totalAssigned,
+        SUM(CASE WHEN event_type='approve' THEN 1 ELSE 0 END)               AS approvedCount
+        FROM washing_events
     `);
 
     const [
@@ -215,35 +230,34 @@ router.get("/dashboard/washer-activity", isAuthenticated, isOperator, async (req
       return res.status(400).json({ error: "startDate cannot be after endDate" });
     }
 
-    // Fixed: Optimized to filter users first before joining
+    // Events-sourced washer activity. A washer counts as "active" if they
+    // have any approve/complete event for washing in the window. Approved
+    // lots = distinct lots they took into washing (event_type='approve');
+    // completed lots = distinct lots they marked complete in washing.
     const [rows] = await pool.query(
-      `SELECT
-         u.id AS washer_id,
-         u.username,
-         COALESCE(ap.approvedLots, 0) AS approvedLots,
-         COALESCE(wc.completedLots, 0) AS completedLots
-       FROM (
-         SELECT DISTINCT user_id FROM washing_assignments WHERE DATE(approved_on) BETWEEN ? AND ?
-         UNION
-         SELECT DISTINCT user_id FROM washing_data WHERE DATE(created_at) BETWEEN ? AND ?
-       ) active_washers
-       JOIN users u ON u.id = active_washers.user_id
-       LEFT JOIN (
-         SELECT wa.user_id, COUNT(DISTINCT jd.lot_no) AS approvedLots
-           FROM washing_assignments wa
-           LEFT JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
-          WHERE wa.is_approved = 1
-            AND DATE(wa.approved_on) BETWEEN ? AND ?
-          GROUP BY wa.user_id
-       ) ap ON ap.user_id = u.id
-       LEFT JOIN (
-         SELECT wd.user_id, COUNT(DISTINCT wd.lot_no) AS completedLots
-           FROM washing_data wd
-          WHERE DATE(wd.created_at) BETWEEN ? AND ?
-          GROUP BY wd.user_id
-       ) wc ON wc.user_id = u.id
-      ORDER BY u.username ASC`,
-      [startDate, endDate, startDate, endDate, startDate, endDate, startDate, endDate]
+      `SELECT u.id AS washer_id,
+              u.username,
+              COALESCE(ap.approvedLots,  0) AS approvedLots,
+              COALESCE(wc.completedLots, 0) AS completedLots
+         FROM (
+           SELECT DISTINCT operator_id AS user_id FROM washing_events
+            WHERE DATE(created_at) BETWEEN ? AND ?
+         ) active_washers
+         JOIN users u ON u.id = active_washers.user_id
+         LEFT JOIN (
+           SELECT operator_id AS user_id, COUNT(DISTINCT cutting_lot_id) AS approvedLots
+             FROM washing_events
+            WHERE event_type='approve' AND DATE(created_at) BETWEEN ? AND ?
+            GROUP BY operator_id
+         ) ap ON ap.user_id = u.id
+         LEFT JOIN (
+           SELECT operator_id AS user_id, COUNT(DISTINCT cutting_lot_id) AS completedLots
+             FROM washing_events
+            WHERE event_type='complete' AND DATE(created_at) BETWEEN ? AND ?
+            GROUP BY operator_id
+         ) wc ON wc.user_id = u.id
+        ORDER BY u.username ASC`,
+      [startDate, endDate, startDate, endDate, startDate, endDate]
     );
 
     return res.json({ data: rows });
@@ -312,12 +326,15 @@ router.get("/dashboard", isAuthenticated, isOperator, async (req, res) => {
 
     const [[totals]] = await pool.query(`
       SELECT
-        (SELECT COUNT(*) FROM cutting_lots)                                  AS lotCount,
-        (SELECT COALESCE(SUM(total_pieces),0) FROM cutting_lots)             AS totalPieces,
-        (SELECT COALESCE(SUM(total_pieces),0) FROM stitching_data)           AS totalStitched,
-        (SELECT COALESCE(SUM(total_pieces),0) FROM washing_data)             AS totalWashed,
-        (SELECT COALESCE(SUM(total_pieces),0) FROM finishing_data)           AS totalFinished,
-        (SELECT COUNT(*) FROM users)                                        AS userCount
+        (SELECT COUNT(*) FROM cutting_lots)                          AS lotCount,
+        (SELECT COALESCE(SUM(total_pieces),0) FROM cutting_lots)     AS totalPieces,
+        (SELECT COALESCE(SUM(pieces),0) FROM stitching_events
+           WHERE event_type='complete')                              AS totalStitched,
+        (SELECT COALESCE(SUM(pieces),0) FROM washing_events
+           WHERE event_type='complete')                              AS totalWashed,
+        (SELECT COALESCE(SUM(pieces),0) FROM finishing_events
+           WHERE event_type='complete')                              AS totalFinished,
+        (SELECT COUNT(*) FROM users)                                 AS userCount
     `);
 
     const lotCount = totals.lotCount;
@@ -539,42 +556,27 @@ router.get("/dashboard/employees/download", isAuthenticated, isOperator, async (
 
 router.get("/dashboard/lot-departments/download", isAuthenticated, isOperator, async (req, res) => {
   try {
-    const rows = await cache.fetchCached("lotDeptCounts", async () => {
+    // Events-sourced per-stage completion counts. Each "complete" event
+    // counts once (so a lot with multiple partial completions per stage
+    // shows the higher number, matching prior behaviour).
+    const rows = await cache.fetchCached("lotDeptCounts-ev", async () => {
       const [data] = await pool.query(`
         SELECT cl.lot_no,
                cl.sku,
                cl.total_pieces AS pieces,
-               counts.cutting,
-               counts.stitching,
-               counts.washing,
-               counts.washing_in,
-               counts.finishing,
-               counts.assembly
-        FROM (
-          SELECT lot_no,
-                 SUM(stage='cutting')    AS cutting,
-                 SUM(stage='stitching')  AS stitching,
-                 SUM(stage='washing')    AS washing,
-                 SUM(stage='washing_in') AS washing_in,
-                 SUM(stage='finishing')  AS finishing,
-                 SUM(stage='assembly')   AS assembly
-          FROM (
-            SELECT lot_no, 'cutting'    AS stage FROM cutting_lots
-            UNION ALL
-            SELECT lot_no, 'stitching'  AS stage FROM stitching_data
-            UNION ALL
-            SELECT lot_no, 'washing'    AS stage FROM washing_data
-            UNION ALL
-            SELECT lot_no, 'washing_in' AS stage FROM washing_in_data
-            UNION ALL
-            SELECT lot_no, 'finishing'  AS stage FROM finishing_data
-            UNION ALL
-            SELECT lot_no, 'assembly'   AS stage FROM jeans_assembly_data
-          ) AS t1
-          GROUP BY lot_no
-        ) AS counts
-        JOIN cutting_lots cl ON counts.lot_no = cl.lot_no
-        ORDER BY cl.lot_no
+               1                                                            AS cutting,
+               (SELECT COUNT(*) FROM stitching_events e
+                 WHERE e.cutting_lot_id = cl.id AND e.event_type='complete') AS stitching,
+               (SELECT COUNT(*) FROM washing_events e
+                 WHERE e.cutting_lot_id = cl.id AND e.event_type='complete') AS washing,
+               (SELECT COUNT(*) FROM washing_in_events e
+                 WHERE e.cutting_lot_id = cl.id AND e.event_type='complete') AS washing_in,
+               (SELECT COUNT(*) FROM finishing_events e
+                 WHERE e.cutting_lot_id = cl.id AND e.event_type='complete') AS finishing,
+               (SELECT COUNT(*) FROM jeans_assembly_events e
+                 WHERE e.cutting_lot_id = cl.id AND e.event_type='complete') AS assembly
+          FROM cutting_lots cl
+         ORDER BY cl.lot_no
       `);
       return data;
     });
@@ -617,11 +619,16 @@ router.get("/debug/lot-journey", async (req, res) => {
         cl.remark,
         DATE_FORMAT(cl.created_at, '%Y-%m-%d') as created_date,
         u.username as cutting_master,
-        COALESCE((SELECT SUM(total_pieces) FROM stitching_data WHERE lot_no = cl.lot_no), 0) as stitched,
-        COALESCE((SELECT SUM(total_pieces) FROM jeans_assembly_data WHERE lot_no = cl.lot_no), 0) as assembled,
-        COALESCE((SELECT SUM(total_pieces) FROM washing_data WHERE lot_no = cl.lot_no), 0) as washed,
-        COALESCE((SELECT SUM(total_pieces) FROM washing_in_data WHERE lot_no = cl.lot_no), 0) as wash_in,
-        COALESCE((SELECT SUM(total_pieces) FROM finishing_data WHERE lot_no = cl.lot_no), 0) as finished
+        COALESCE((SELECT SUM(pieces) FROM stitching_events
+          WHERE cutting_lot_id = cl.id AND event_type='complete'), 0) as stitched,
+        COALESCE((SELECT SUM(pieces) FROM jeans_assembly_events
+          WHERE cutting_lot_id = cl.id AND event_type='complete'), 0) as assembled,
+        COALESCE((SELECT SUM(pieces) FROM washing_events
+          WHERE cutting_lot_id = cl.id AND event_type='complete'), 0) as washed,
+        COALESCE((SELECT SUM(pieces) FROM washing_in_events
+          WHERE cutting_lot_id = cl.id AND event_type='complete'), 0) as wash_in,
+        COALESCE((SELECT SUM(pieces) FROM finishing_events
+          WHERE cutting_lot_id = cl.id AND event_type='complete'), 0) as finished
       FROM cutting_lots cl
       LEFT JOIN users u ON cl.user_id = u.id
     `;
@@ -692,28 +699,30 @@ router.get("/debug/lot-journey", async (req, res) => {
 });
 
 async function buildWasherMonthlySummary(prefix) {
-  // Cache the summary for 5 minutes to avoid repeated heavy queries
-  return cache.fetchCached(`washerSummary-${prefix}`, async () => {
+  // Sourced from washing_events (truth source). One approve event = an
+  // assignment of `pieces` to this washer in that month; one complete event
+  // = pieces completed by this washer in that month.
+  return cache.fetchCached(`washerSummary-ev-${prefix}`, async () => {
   const [assignRows] = await pool.query(
-    `SELECT wa.user_id, u.username,
-            DATE_FORMAT(wa.assigned_on,'%Y-%m') AS month,
-            wa.sizes_json, jd.lot_no,
+    `SELECT we.operator_id AS user_id, u.username,
+            DATE_FORMAT(we.created_at,'%Y-%m') AS month,
+            we.pieces, cl.lot_no,
             cl.total_pieces AS cutting_pieces,
             cl.remark
-       FROM washing_assignments wa
-       JOIN users u ON wa.user_id = u.id
-       JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
-       LEFT JOIN cutting_lots cl ON jd.lot_no = cl.lot_no
-      WHERE jd.lot_no LIKE ?`,
+       FROM washing_events we
+       JOIN users u        ON u.id = we.operator_id
+       JOIN cutting_lots cl ON cl.id = we.cutting_lot_id
+      WHERE we.event_type = 'approve' AND cl.lot_no LIKE ?`,
     [prefix]
   );
   const [compRows] = await pool.query(
-    `SELECT user_id,
-            DATE_FORMAT(created_at,'%Y-%m') AS month,
-            SUM(total_pieces) AS completed
-       FROM washing_data
-      WHERE lot_no LIKE ?
-      GROUP BY user_id, month`,
+    `SELECT we.operator_id AS user_id,
+            DATE_FORMAT(we.created_at,'%Y-%m') AS month,
+            SUM(we.pieces) AS completed
+       FROM washing_events we
+       JOIN cutting_lots cl ON cl.id = we.cutting_lot_id
+      WHERE we.event_type = 'complete' AND cl.lot_no LIKE ?
+      GROUP BY we.operator_id, month`,
     [prefix]
   );
 
@@ -727,13 +736,8 @@ async function buildWasherMonthlySummary(prefix) {
   }
 
   assignRows.forEach(r => {
-    let pcs = 0;
-    try {
-      const arr = JSON.parse(r.sizes_json || '[]');
-      if (Array.isArray(arr)) for (const s of arr) pcs += parseInt(s.pieces, 10) || 0;
-    } catch { pcs = 0; }
     const entry = ensure(r.user_id, r.month, r.username);
-    entry.assigned += pcs;
+    entry.assigned += parseFloat(r.pieces) || 0;
     if (!entry._lots.has(r.lot_no)) {
       entry._lots.add(r.lot_no);
       if (!r.remark || !r.remark.toLowerCase().includes('date')) {
@@ -1277,185 +1281,6 @@ const PIC_REPORT_V2_COLUMNS = [
   { header: 'Finishing Reject Reasons', key: 'finishingRejectReasons', width: 28 },
   { header: 'Total Rejects',          key: 'totalRejectQty',          width: 11 }
 ];
-
-// Aggregates and last-assignment data for multiple lots in one go
-async function fetchLotAggregates(lotNos = []) {
-  if (!lotNos.length) {
-    return {
-      lotSumsMap: {},
-      stitchMap: {},
-      asmMap: {},
-      washMap: {},
-      winMap: {},
-      finMap: {}
-    };
-  }
-
-  // Use count + first/last lot as cache key instead of joining all 7000+ lot numbers
-  const sorted = lotNos.slice().sort();
-  const cacheKey = `lotAgg-${sorted.length}-${sorted[0]}-${sorted[sorted.length - 1]}`;
-  return cache.fetchCached(cacheKey, async () => {
-    const sumsQ = pool.query(`
-      SELECT 'stitched' AS sumType, lot_no, COALESCE(SUM(total_pieces),0) AS sumVal
-        FROM stitching_data
-       WHERE lot_no IN (?)
-       GROUP BY lot_no
-
-      UNION ALL
-
-      SELECT 'assembled' AS sumType, lot_no, COALESCE(SUM(total_pieces),0) AS sumVal
-        FROM jeans_assembly_data
-       WHERE lot_no IN (?)
-       GROUP BY lot_no
-
-      UNION ALL
-
-      SELECT 'washed' AS sumType, lot_no, COALESCE(SUM(total_pieces),0) AS sumVal
-        FROM washing_data
-       WHERE lot_no IN (?)
-       GROUP BY lot_no
-
-      UNION ALL
-
-      SELECT 'washing_in' AS sumType, lot_no, COALESCE(SUM(total_pieces),0) AS sumVal
-        FROM washing_in_data
-       WHERE lot_no IN (?)
-       GROUP BY lot_no
-
-      UNION ALL
-
-      SELECT 'finished' AS sumType, lot_no, COALESCE(SUM(total_pieces),0) AS sumVal
-        FROM finishing_data
-       WHERE lot_no IN (?)
-       GROUP BY lot_no
-    `, [lotNos, lotNos, lotNos, lotNos, lotNos]);
-
-    const stQ = pool.query(`
-      SELECT c.lot_no, sa.id, sa.isApproved AS is_approved,
-             sa.assigned_on, sa.approved_on, sa.user_id,
-             u.username AS opName
-        FROM stitching_assignments sa
-        JOIN cutting_lots c ON sa.cutting_lot_id = c.id
-        LEFT JOIN users u ON sa.user_id = u.id
-        LEFT JOIN stitching_assignments sa2
-               ON sa2.cutting_lot_id = sa.cutting_lot_id
-              AND sa2.assigned_on > sa.assigned_on
-       WHERE sa2.id IS NULL
-         AND c.lot_no IN (?)
-    `, [lotNos]);
-
-    const asmQ = pool.query(`
-      SELECT sd.lot_no, ja.id, ja.is_approved,
-             ja.assigned_on, ja.approved_on, ja.user_id,
-             u.username AS opName
-        FROM jeans_assembly_assignments ja
-        JOIN stitching_data sd ON ja.stitching_assignment_id = sd.id
-        LEFT JOIN users u ON ja.user_id = u.id
-        LEFT JOIN jeans_assembly_assignments ja2
-               ON ja2.stitching_assignment_id = ja.stitching_assignment_id
-              AND ja2.assigned_on > ja.assigned_on
-       WHERE ja2.id IS NULL
-         AND sd.lot_no IN (?)
-    `, [lotNos]);
-
-    const washQ = pool.query(`
-      SELECT jd.lot_no, wa.id, wa.is_approved,
-             wa.assigned_on, wa.approved_on, wa.user_id,
-             u.username AS opName
-        FROM washing_assignments wa
-        JOIN jeans_assembly_data jd ON wa.jeans_assembly_assignment_id = jd.id
-        LEFT JOIN users u ON wa.user_id = u.id
-        LEFT JOIN washing_assignments wa2
-               ON wa2.jeans_assembly_assignment_id = wa.jeans_assembly_assignment_id
-              AND wa2.assigned_on > wa.assigned_on
-       WHERE wa2.id IS NULL
-         AND jd.lot_no IN (?)
-    `, [lotNos]);
-
-    const winQ = pool.query(`
-      SELECT wd.lot_no, wia.id, wia.is_approved,
-             wia.assigned_on, wia.approved_on, wia.user_id,
-             u.username AS opName
-        FROM washing_in_assignments wia
-        JOIN washing_data wd ON wia.washing_data_id = wd.id
-        LEFT JOIN users u ON wia.user_id = u.id
-        LEFT JOIN washing_in_assignments wia2
-               ON wia2.washing_data_id = wia.washing_data_id
-              AND wia2.assigned_on > wia.assigned_on
-       WHERE wia2.id IS NULL
-         AND wd.lot_no IN (?)
-    `, [lotNos]);
-
-    const finQ = pool.query(`
-      SELECT
-        CASE
-          WHEN fa.washing_in_data_id IS NOT NULL THEN wid.lot_no
-          WHEN fa.stitching_assignment_id IS NOT NULL THEN sd.lot_no
-        END AS lot_no,
-        fa.id, fa.is_approved, fa.assigned_on, fa.approved_on, fa.user_id,
-        u.username AS opName
-      FROM finishing_assignments fa
-      LEFT JOIN washing_in_data wid ON fa.washing_in_data_id = wid.id
-      LEFT JOIN stitching_data sd ON fa.stitching_assignment_id = sd.id
-      LEFT JOIN users u         ON fa.user_id = u.id
-      LEFT JOIN finishing_assignments fa2
-             ON (
-                  fa.washing_in_data_id IS NOT NULL
-                  AND fa.washing_in_data_id = fa2.washing_in_data_id
-                  AND fa2.assigned_on > fa.assigned_on
-                )
-                OR (
-                  fa.stitching_assignment_id IS NOT NULL
-                  AND fa.stitching_assignment_id = fa2.stitching_assignment_id
-                  AND fa2.assigned_on > fa.assigned_on
-                )
-      WHERE fa2.id IS NULL
-        AND (
-             (wid.lot_no IN (?) AND wid.lot_no IS NOT NULL)
-             OR
-             (sd.lot_no IN (?) AND sd.lot_no IS NOT NULL)
-            )
-    `, [lotNos, lotNos]);
-
-    const [
-      [sumRows],
-      [stRows],
-      [asmRows],
-      [washRows],
-      [winRows],
-      [finRows]
-    ] = await Promise.all([sumsQ, stQ, asmQ, washQ, winQ, finQ]);
-
-    const lotSumsMap = {};
-    lotNos.forEach(ln => {
-      lotSumsMap[ln] = { stitchedQty:0, assembledQty:0, washedQty:0, washingInQty:0, finishedQty:0 };
-    });
-    for (const row of sumRows) {
-      const m = lotSumsMap[row.lot_no];
-      if (!m) continue;
-      switch (row.sumType) {
-        case 'stitched':   m.stitchedQty   = parseFloat(row.sumVal) || 0; break;
-        case 'assembled':  m.assembledQty  = parseFloat(row.sumVal) || 0; break;
-        case 'washed':     m.washedQty     = parseFloat(row.sumVal) || 0; break;
-        case 'washing_in': m.washingInQty  = parseFloat(row.sumVal) || 0; break;
-        case 'finished':   m.finishedQty   = parseFloat(row.sumVal) || 0; break;
-      }
-    }
-
-    const stitchMap = {};
-    stRows.forEach(r => { stitchMap[r.lot_no] = r; });
-    const asmMap = {};
-    asmRows.forEach(r => { asmMap[r.lot_no] = r; });
-    const washMap = {};
-    washRows.forEach(r => { washMap[r.lot_no] = r; });
-    const winMap = {};
-    winRows.forEach(r => { winMap[r.lot_no] = r; });
-    const finMap = {};
-    finRows.forEach(r => { if (r.lot_no) finMap[r.lot_no] = r; });
-
-    return { lotSumsMap, stitchMap, asmMap, washMap, winMap, finMap };
-  });
-}
 
 // ---------------------------------------------------------------------------
 // Event-sourced aggregates (truth source for PIC reports).
@@ -2692,80 +2517,54 @@ router.get("/dashboard/pic-size-report", isAuthenticated, isOperator, async (req
 router.get("/stitching-tat", isAuthenticated, isOperator, async (req, res) => {
   try {
     const { download = "0" } = req.query;
-    const masterCards = await cache.fetchCached(`tat-summary-${download}`, async () => {
-      // 1) Identify all users (Stitching Masters) who have either
-      //    pending or in-line lots
-      const [masters] = await pool.query(`
-        SELECT DISTINCT u.id, u.username
-          FROM users u
-          JOIN stitching_assignments sa ON sa.user_id = u.id
-          JOIN cutting_lots cl ON sa.cutting_lot_id = cl.id
-          JOIN users cu ON cl.user_id = cu.id
-         WHERE (
-                sa.isApproved IS NULL
-                OR
-                (
-                  sa.isApproved = 1
-                  AND (
-                    (
-                      (cl.flow_type = 'denim' OR (cl.flow_type IS NULL AND cu.is_denim_cutter = 1) OR (cl.flow_type IS NULL AND cu.is_denim_cutter IS NULL AND (cl.lot_no LIKE 'AK%' OR cl.lot_no LIKE 'UM%')))
-                      AND NOT EXISTS (
-                        SELECT 1
-                          FROM jeans_assembly_assignments ja
-                          JOIN stitching_data sd ON ja.stitching_assignment_id = sd.id
-                         WHERE sd.lot_no = cl.lot_no
-                           AND ja.is_approved IS NOT NULL
-                      )
-                    )
-                    OR
-                    (
-                      (cl.flow_type = 'hosiery' OR (cl.flow_type IS NULL AND cu.is_denim_cutter = 0) OR (cl.flow_type IS NULL AND cu.is_denim_cutter IS NULL AND cl.lot_no NOT LIKE 'AK%' AND cl.lot_no NOT LIKE 'UM%'))
-                      AND NOT EXISTS (
-                        SELECT 1
-                          FROM finishing_assignments fa
-                          JOIN stitching_data sd ON fa.stitching_assignment_id = sd.id
-                         WHERE sd.lot_no = cl.lot_no
-                           AND fa.is_approved IS NOT NULL
-                      )
-                    )
-                  )
-                )
-              )
-      `);
-
+    const masterCards = await cache.fetchCached(`tat-summary-ev-${download}`, async () => {
+      // Sourced from stitching_events (truth source).
+      //
+      //   inLinePieces    = approved - completed - rejected
+      //                     (currently being stitched by this master)
+      //   pendingApproval = completed by master, but downstream (assembly for
+      //                     denim / finishing for hosiery) hasn't taken
+      //                     delivery yet
+      //
+      // For hosiery-era / pre-events lots, downstream may live only in the
+      // legacy *_data tables — those are treated as "handed off" so a lot
+      // that's been long-since cleared doesn't sit forever in pendingApproval.
       const [summary] = await pool.query(`
-        SELECT sa.user_id,
-               u.username,
-               SUM(CASE WHEN sa.isApproved IS NULL THEN cl.total_pieces ELSE 0 END) AS pendingApproval,
-               SUM(CASE WHEN sa.isApproved = 1 AND (
-                     ((cl.flow_type = 'denim' OR (cl.flow_type IS NULL AND cu.is_denim_cutter = 1) OR (cl.flow_type IS NULL AND cu.is_denim_cutter IS NULL AND (cl.lot_no LIKE 'AK%' OR cl.lot_no LIKE 'UM%'))) AND NOT EXISTS (
-                          SELECT 1 FROM jeans_assembly_assignments ja
-                           JOIN stitching_data sd ON ja.stitching_assignment_id = sd.id
-                          WHERE sd.lot_no = cl.lot_no AND ja.is_approved IS NOT NULL
-                     ))
-                     OR
-                     ((cl.flow_type = 'hosiery' OR (cl.flow_type IS NULL AND cu.is_denim_cutter = 0) OR (cl.flow_type IS NULL AND cu.is_denim_cutter IS NULL AND cl.lot_no NOT LIKE 'AK%' AND cl.lot_no NOT LIKE 'UM%')) AND NOT EXISTS (
-                          SELECT 1 FROM finishing_assignments fa
-                           JOIN stitching_data sd ON fa.stitching_assignment_id = sd.id
-                          WHERE sd.lot_no = cl.lot_no AND fa.is_approved IS NOT NULL
-                     ))
-                 ) THEN cl.total_pieces ELSE 0 END) AS inLinePieces
-          FROM stitching_assignments sa
-          JOIN cutting_lots cl ON sa.cutting_lot_id = cl.id
-          JOIN users u ON sa.user_id = u.id
-          JOIN users cu ON cl.user_id = cu.id
-         GROUP BY sa.user_id, u.username
-         HAVING pendingApproval > 0 OR inLinePieces > 0
+        SELECT t.user_id, u.username,
+               SUM(t.inLinePcs)      AS inLinePieces,
+               SUM(t.unhandedOffPcs) AS pendingApproval
+          FROM (
+            SELECT se.operator_id AS user_id,
+                   cl.id          AS cutting_lot_id,
+                   GREATEST(0,
+                     SUM(CASE WHEN se.event_type='approve'  THEN se.pieces ELSE 0 END)
+                     - SUM(CASE WHEN se.event_type='complete' THEN se.pieces ELSE 0 END)
+                     - SUM(CASE WHEN se.event_type='reject'   THEN se.pieces ELSE 0 END)
+                   ) AS inLinePcs,
+                   CASE
+                     WHEN SUM(CASE WHEN se.event_type='complete' THEN se.pieces ELSE 0 END) > 0
+                      AND NOT EXISTS (SELECT 1 FROM jeans_assembly_events ae WHERE ae.cutting_lot_id=cl.id AND ae.event_type='approve')
+                      AND NOT EXISTS (SELECT 1 FROM finishing_events fe      WHERE fe.cutting_lot_id=cl.id AND fe.event_type='approve')
+                      AND NOT EXISTS (SELECT 1 FROM jeans_assembly_data jd   WHERE jd.lot_no=cl.lot_no)
+                      AND NOT EXISTS (SELECT 1 FROM finishing_data fd        WHERE fd.lot_no=cl.lot_no)
+                     THEN SUM(CASE WHEN se.event_type='complete' THEN se.pieces ELSE 0 END)
+                     ELSE 0
+                   END AS unhandedOffPcs
+              FROM stitching_events se
+              JOIN cutting_lots cl ON cl.id = se.cutting_lot_id
+             GROUP BY se.operator_id, cl.id
+          ) t
+          JOIN users u ON u.id = t.user_id
+         GROUP BY t.user_id, u.username
+         HAVING inLinePieces > 0 OR pendingApproval > 0
       `);
 
-      const cards = summary.map(r => ({
+      return summary.map(r => ({
         masterId: r.user_id,
         username: r.username,
         pendingApproval: parseFloat(r.pendingApproval) || 0,
-        inLinePieces: parseFloat(r.inLinePieces) || 0
+        inLinePieces:    parseFloat(r.inLinePieces) || 0
       }));
-
-      return cards;
     });
 
     // 3) If ?download=1 => produce Excel summary
@@ -2820,99 +2619,66 @@ router.get("/stitching-tat/:masterId", isAuthenticated, isOperator, async (req, 
       return res.status(400).send("Invalid Master ID");
     }
     const { download = "0" } = req.query;
-    const data = await cache.fetchCached(`tat-detail-${masterId}`, async () => {
+    const data = await cache.fetchCached(`tat-detail-ev-${masterId}`, async () => {
       const [[masterUser]] = await pool.query(
         `SELECT id, username FROM users WHERE id = ?`,
         [masterId]
       );
       if (!masterUser) return null;
 
-      const [assignments] = await pool.query(`
-        SELECT sa.id AS stitching_assignment_id,
-               sa.isApproved AS stitchIsApproved,
-               sa.assigned_on AS stitchAssignedOn,
-               cl.lot_no,
+      // Events-sourced: per (master, lot) get totals + timestamps. Surface
+      // only lots still in line or completed but not handed off downstream.
+      const [rows] = await pool.query(`
+        SELECT cl.lot_no,
                cl.sku,
                cl.total_pieces,
                cl.remark AS cutting_remark,
-               cl.flow_type,
-               u.is_denim_cutter,
-               asm.next_on AS asm_next_on,
-               fin.next_on AS fin_next_on
-          FROM stitching_assignments sa
-          JOIN cutting_lots cl ON sa.cutting_lot_id = cl.id
-          JOIN users u ON cl.user_id = u.id
-          LEFT JOIN (
-                SELECT sd.lot_no, MIN(ja.assigned_on) AS next_on
-                  FROM jeans_assembly_assignments ja
-                  JOIN stitching_data sd ON ja.stitching_assignment_id = sd.id
-                 WHERE ja.is_approved IS NOT NULL
-                 GROUP BY sd.lot_no
-          ) asm ON asm.lot_no = cl.lot_no
-          LEFT JOIN (
-                SELECT sd.lot_no, MIN(fa.assigned_on) AS next_on
-                  FROM finishing_assignments fa
-                  JOIN stitching_data sd ON fa.stitching_assignment_id = sd.id
-                 WHERE fa.is_approved IS NOT NULL
-                 GROUP BY sd.lot_no
-          ) fin ON fin.lot_no = cl.lot_no
-         WHERE sa.user_id = ?
-           AND (
-                sa.isApproved IS NULL
-                OR (
-                     sa.isApproved = 1
-                     AND (
-                       ( (cl.flow_type = 'denim' OR (cl.flow_type IS NULL AND u.is_denim_cutter = 1) OR (cl.flow_type IS NULL AND u.is_denim_cutter IS NULL AND (cl.lot_no LIKE 'AK%' OR cl.lot_no LIKE 'UM%')))
-                         AND asm.next_on IS NULL )
-                       OR
-                       ( (cl.flow_type = 'hosiery' OR (cl.flow_type IS NULL AND u.is_denim_cutter = 0) OR (cl.flow_type IS NULL AND u.is_denim_cutter IS NULL AND cl.lot_no NOT LIKE 'AK%' AND cl.lot_no NOT LIKE 'UM%'))
-                         AND fin.next_on IS NULL )
-                     )
-                   )
-              )
-         ORDER BY sa.assigned_on DESC
+               MIN(CASE WHEN se.event_type='approve'  THEN se.created_at END) AS firstApproveAt,
+               MAX(CASE WHEN se.event_type='complete' THEN se.created_at END) AS lastCompleteAt,
+               SUM(CASE WHEN se.event_type='approve'  THEN se.pieces ELSE 0 END) AS approvedPcs,
+               SUM(CASE WHEN se.event_type='complete' THEN se.pieces ELSE 0 END) AS completedPcs,
+               SUM(CASE WHEN se.event_type='reject'   THEN se.pieces ELSE 0 END) AS rejectedPcs,
+               (SELECT MIN(ae.created_at) FROM jeans_assembly_events ae
+                 WHERE ae.cutting_lot_id = cl.id AND ae.event_type='approve') AS asmFirstApproveAt,
+               (SELECT MIN(fe.created_at) FROM finishing_events fe
+                 WHERE fe.cutting_lot_id = cl.id AND fe.event_type='approve') AS finFirstApproveAt,
+               -- legacy downstream presence (older lots may have no events)
+               (SELECT 1 FROM jeans_assembly_data jd WHERE jd.lot_no = cl.lot_no LIMIT 1) AS asmLegacyExists,
+               (SELECT 1 FROM finishing_data fd      WHERE fd.lot_no = cl.lot_no LIMIT 1) AS finLegacyExists
+          FROM stitching_events se
+          JOIN cutting_lots cl ON cl.id = se.cutting_lot_id
+         WHERE se.operator_id = ?
+         GROUP BY cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark
+         ORDER BY firstApproveAt DESC
       `, [masterId]);
 
       const detailRows = [];
-      const currentDate = new Date();
-      for (const a of assignments) {
-        const {
-          lot_no,
-          sku,
-          total_pieces,
-          cutting_remark,
-          flow_type,
-          is_denim_cutter,
-          stitchAssignedOn,
-          stitchIsApproved,
-          asm_next_on,
-          fin_next_on
-        } = a;
+      const now = new Date();
+      for (const r of rows) {
+        const inLinePcs = Math.max(0,
+          (Number(r.approvedPcs) || 0) - (Number(r.completedPcs) || 0) - (Number(r.rejectedPcs) || 0)
+        );
+        const nextOn = r.asmFirstApproveAt || r.finFirstApproveAt || null;
+        const handedOff = !!nextOn || !!r.asmLegacyExists || !!r.finLegacyExists;
 
-        let nextAssignedOn = null;
-        const isDenim = isDenimLot(lot_no, is_denim_cutter, flow_type);
-        if (stitchIsApproved === 1) {
-          nextAssignedOn = isDenim ? asm_next_on : fin_next_on;
-        }
+        let status = null;
+        if (inLinePcs > 0) status = "In Line";
+        else if ((Number(r.completedPcs) || 0) > 0 && !handedOff) status = "Awaiting Handoff";
+        if (!status) continue; // already handed off
 
-        let tatDays = 0;
-        if (stitchAssignedOn) {
-          const startMs = new Date(stitchAssignedOn).getTime();
-          const endMs = nextAssignedOn
-            ? new Date(nextAssignedOn).getTime()
-            : currentDate.getTime();
-          tatDays = Math.floor((endMs - startMs) / (1000 * 60 * 60 * 24));
-        }
+        const startMs = r.firstApproveAt ? new Date(r.firstApproveAt).getTime() : null;
+        const endMs   = nextOn ? new Date(nextOn).getTime() : now.getTime();
+        const tatDays = startMs ? Math.floor((endMs - startMs) / (1000 * 60 * 60 * 24)) : 0;
 
         detailRows.push({
-          lotNo: lot_no,
-          sku,
-          totalPieces: total_pieces,
-          cuttingRemark: cutting_remark || "",
-          assignedOn: stitchAssignedOn,
-          nextDeptAssignedOn: nextAssignedOn,
+          lotNo: r.lot_no,
+          sku: r.sku,
+          totalPieces: r.total_pieces,
+          cuttingRemark: r.cutting_remark || "",
+          assignedOn: r.firstApproveAt,
+          nextDeptAssignedOn: nextOn,
           tatDays,
-          status: stitchIsApproved === null ? "Pending Approval" : "In Line"
+          status
         });
       }
       return { masterUser, detailRows };
@@ -3144,18 +2910,35 @@ router.route("/urgent-tat")
         return res.end(noMapHtml);
       }
 
-      const [rows] = await cache.fetchCached(`urgent-${userIds.join('-')}`, async () =>
+      // Earliest stitching-approve event per (operator, lot). A lot still
+      // 'urgent' for the operator when it isn't yet completed, isn't handed
+      // off downstream, and was approved more than 20 days ago.
+      const [rows] = await cache.fetchCached(`urgent-ev-${userIds.join('-')}`, async () =>
         pool.query(
-          `SELECT sa.user_id, u.username,
-                  cl.lot_no, cl.remark,
-                  sa.assigned_on
-             FROM stitching_assignments sa
-             JOIN cutting_lots cl ON sa.cutting_lot_id = cl.id
-             JOIN users u         ON sa.user_id = u.id
-            WHERE sa.assigned_on IS NOT NULL
-              AND DATEDIFF(NOW(), sa.assigned_on) > 20
-              AND sa.user_id IN (?)
-            ORDER BY sa.user_id, sa.assigned_on`,
+          `SELECT t.user_id, u.username, cl.lot_no, cl.remark, t.assigned_on
+             FROM (
+               SELECT se.operator_id AS user_id, se.cutting_lot_id,
+                      MIN(se.created_at) AS assigned_on,
+                      SUM(CASE WHEN se.event_type='approve'  THEN se.pieces ELSE 0 END) AS approvedPcs,
+                      SUM(CASE WHEN se.event_type='complete' THEN se.pieces ELSE 0 END) AS completedPcs
+                 FROM stitching_events se
+                WHERE se.operator_id IN (?)
+                GROUP BY se.operator_id, se.cutting_lot_id
+             ) t
+             JOIN cutting_lots cl ON cl.id = t.cutting_lot_id
+             JOIN users u         ON u.id = t.user_id
+            WHERE t.assigned_on IS NOT NULL
+              AND DATEDIFF(NOW(), t.assigned_on) > 20
+              AND t.approvedPcs > t.completedPcs
+              AND NOT EXISTS (
+                SELECT 1 FROM jeans_assembly_events ae
+                 WHERE ae.cutting_lot_id = cl.id AND ae.event_type='approve'
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM finishing_events fe
+                 WHERE fe.cutting_lot_id = cl.id AND fe.event_type='approve'
+              )
+            ORDER BY t.user_id, t.assigned_on`,
           [userIds]
         )
       );
@@ -3893,6 +3676,104 @@ router.delete('/api/sku-categories/:id', isAuthenticated, isOperator, async (req
   } catch (error) {
     console.error('Error deleting SKU category:', error);
     return res.status(500).json({ error: 'Failed to delete category' });
+  }
+});
+
+/**
+ * GET /operator/api/lot-sizes?lot_no=<lotNo>
+ * Shared endpoint used by the "expand-on-click" pattern in every dashboard
+ * that lists lots. Returns per-size pieces for every stage of the lot,
+ * sourced from the *_event_sizes tables (truth source) plus
+ * finishing_dispatches for dispatched qty.
+ */
+router.get('/api/lot-sizes', isAuthenticated, async (req, res) => {
+  try {
+    const lotNoRaw = (req.query.lot_no || '').trim();
+    if (!lotNoRaw) {
+      return res.status(400).json({ error: 'lot_no query param required' });
+    }
+    // Look up cutting_lot by lot_no (case-insensitive — DB collation usually
+    // handles this, but trim and pass as-is).
+    const [lotRows] = await pool.query(
+      `SELECT id, lot_no, sku FROM cutting_lots WHERE lot_no = ? LIMIT 1`,
+      [lotNoRaw]
+    );
+    if (!lotRows.length) {
+      return res.json({ lot_no: lotNoRaw, sku: null, totalCut: 0, sizes: [] });
+    }
+    const lot = lotRows[0];
+
+    // Per-size cut baseline from cutting_lot_sizes.
+    const [cutRows] = await pool.query(
+      `SELECT size_label, COALESCE(total_pieces,0) AS pieces
+         FROM cutting_lot_sizes
+        WHERE cutting_lot_id = ?`,
+      [lot.id]
+    );
+
+    // Per-size event sums (stitched / assembled / washed / washing_in / finished).
+    const sizeEventSums = await fetchLotSizeEventSums([lot.lot_no]);
+
+    // Per-size dispatched from finishing_dispatches.
+    const [dispRows] = await pool.query(
+      `SELECT size_label, COALESCE(SUM(quantity),0) AS dispatched
+         FROM finishing_dispatches
+        WHERE lot_no = ?
+        GROUP BY size_label`,
+      [lot.lot_no]
+    );
+    const dispMap = {};
+    for (const r of dispRows) dispMap[r.size_label] = parseFloat(r.dispatched) || 0;
+
+    // Build the union of size labels found anywhere (cut / events / dispatch).
+    const labelSet = new Set();
+    cutRows.forEach(r => labelSet.add(r.size_label));
+    Object.keys(sizeEventSums).forEach(k => {
+      const [ln, sz] = k.split('|');
+      if (ln === lot.lot_no) labelSet.add(sz);
+    });
+    Object.keys(dispMap).forEach(sz => labelSet.add(sz));
+
+    const cutMap = {};
+    cutRows.forEach(r => { cutMap[r.size_label] = parseFloat(r.pieces) || 0; });
+
+    // Numeric-aware sort: pure numbers first (ascending), then strings A→Z.
+    const labels = Array.from(labelSet).sort((a, b) => {
+      const na = parseFloat(a);
+      const nb = parseFloat(b);
+      const aNum = !isNaN(na) && /^\d+(\.\d+)?$/.test(String(a).trim());
+      const bNum = !isNaN(nb) && /^\d+(\.\d+)?$/.test(String(b).trim());
+      if (aNum && bNum) return na - nb;
+      if (aNum) return -1;
+      if (bNum) return 1;
+      return String(a).localeCompare(String(b));
+    });
+
+    const sizes = labels.map(sz => {
+      const ev = sizeEventSums[`${lot.lot_no}|${sz}`] || {};
+      return {
+        size_label: sz,
+        cut:        cutMap[sz] || 0,
+        stitched:   ev.stitchedQty   || 0,
+        assembled:  ev.assembledQty  || 0,
+        washed:     ev.washedQty     || 0,
+        washing_in: ev.washingInQty  || 0,
+        finished:   ev.finishedQty   || 0,
+        dispatched: dispMap[sz]      || 0,
+      };
+    });
+
+    const totalCut = sizes.reduce((s, r) => s + (r.cut || 0), 0);
+
+    return res.json({
+      lot_no: lot.lot_no,
+      sku: lot.sku,
+      totalCut,
+      sizes,
+    });
+  } catch (err) {
+    console.error('GET /operator/api/lot-sizes error:', err);
+    return res.status(500).json({ error: 'Failed to fetch lot sizes' });
   }
 });
 

--- a/routes/stagePaymentRoutes.js
+++ b/routes/stagePaymentRoutes.js
@@ -309,116 +309,55 @@ router.get('/api/eligible-lots', isAuthenticated, isOperator, async (req, res) =
     const params = [];
     const searchLike = `%${search}%`;
 
-    // Different queries based on stage - getting approved qty from next department
-    if (stage === 'stitching') {
-      // Stitching eligible when jeans_assembly_assignments.is_approved = 1
-      query = `
-        SELECT
-          sd.id AS source_id,
-          sd.lot_no,
-          sd.sku,
-          sd.total_pieces AS qty,
-          sd.user_id,
-          u.username,
-          sd.created_at
-        FROM stitching_data sd
-        JOIN users u ON sd.user_id = u.id
-        JOIN jeans_assembly_assignments ja ON ja.stitching_assignment_id = sd.id
-        WHERE ja.is_approved = 1
-          AND (sd.lot_no LIKE ? OR sd.sku LIKE ?)
-          AND NOT EXISTS (
-            SELECT 1 FROM stage_payments sp
-            WHERE sp.lot_no = sd.lot_no
-              AND sp.stage = 'stitching'
-              AND sp.user_id = sd.user_id
-              AND sp.status != 'cancelled'
-          )
-        ORDER BY sd.created_at DESC
-        LIMIT 100
-      `;
-      params.push(searchLike, searchLike);
-    } else if (stage === 'assembly') {
-      // Assembly eligible when washing_assignments.is_approved = 1
-      query = `
-        SELECT
-          jd.id AS source_id,
-          jd.lot_no,
-          jd.sku,
-          jd.total_pieces AS qty,
-          jd.user_id,
-          u.username,
-          jd.created_at
-        FROM jeans_assembly_data jd
-        JOIN users u ON jd.user_id = u.id
-        JOIN washing_assignments wa ON wa.jeans_assembly_assignment_id = jd.id
-        WHERE wa.is_approved = 1
-          AND (jd.lot_no LIKE ? OR jd.sku LIKE ?)
-          AND NOT EXISTS (
-            SELECT 1 FROM stage_payments sp
-            WHERE sp.lot_no = jd.lot_no
-              AND sp.stage = 'assembly'
-              AND sp.user_id = jd.user_id
-              AND sp.status != 'cancelled'
-          )
-        ORDER BY jd.created_at DESC
-        LIMIT 100
-      `;
-      params.push(searchLike, searchLike);
-    } else if (stage === 'washing') {
-      // Washing eligible when washing_in_assignments.is_approved = 1
-      query = `
-        SELECT
-          wd.id AS source_id,
-          wd.lot_no,
-          wd.sku,
-          wd.total_pieces AS qty,
-          wd.user_id,
-          u.username,
-          wd.created_at
-        FROM washing_data wd
-        JOIN users u ON wd.user_id = u.id
-        JOIN washing_in_assignments wia ON wia.washing_data_id = wd.id
-        WHERE wia.is_approved = 1
-          AND (wd.lot_no LIKE ? OR wd.sku LIKE ?)
-          AND NOT EXISTS (
-            SELECT 1 FROM stage_payments sp
-            WHERE sp.lot_no = wd.lot_no
-              AND sp.stage = 'washing'
-              AND sp.user_id = wd.user_id
-              AND sp.status != 'cancelled'
-          )
-        ORDER BY wd.created_at DESC
-        LIMIT 100
-      `;
-      params.push(searchLike, searchLike);
-    } else if (stage === 'finishing') {
-      // Finishing - just needs to exist in finishing_data
-      query = `
-        SELECT
-          fd.id AS source_id,
-          fd.lot_no,
-          fd.sku,
-          fd.total_pieces AS qty,
-          fd.user_id,
-          u.username,
-          fd.created_at
-        FROM finishing_data fd
-        JOIN users u ON fd.user_id = u.id
-        WHERE (fd.lot_no LIKE ? OR fd.sku LIKE ?)
-          AND NOT EXISTS (
-            SELECT 1 FROM stage_payments sp
-            WHERE sp.lot_no = fd.lot_no
-              AND sp.stage = 'finishing'
-              AND sp.user_id = fd.user_id
-              AND sp.status != 'cancelled'
-          )
-        ORDER BY fd.created_at DESC
-        LIMIT 100
-      `;
-      params.push(searchLike, searchLike);
-    } else {
+    // Eligibility is sourced from the *_events tables (truth source).
+    // Per-(lot, operator) a row is eligible when the operator has a
+    // 'complete' event in their stage AND the downstream stage has any
+    // 'approve' event (i.e. taken delivery), AND no non-cancelled payment
+    // exists yet. Finishing has no downstream — completion alone qualifies.
+    const stageConfig = {
+      stitching: { eventsTbl: 'stitching_events',      downstream: ['jeans_assembly_events', 'finishing_events'] },
+      assembly:  { eventsTbl: 'jeans_assembly_events', downstream: ['washing_events'] },
+      washing:   { eventsTbl: 'washing_events',        downstream: ['washing_in_events'] },
+      finishing: { eventsTbl: 'finishing_events',      downstream: [] },
+    }[stage];
+
+    if (!stageConfig) {
       return res.json({ lots: [], message: 'Stage not configured' });
     }
+
+    const downstreamClause = stageConfig.downstream.length
+      ? `AND (${stageConfig.downstream.map(t =>
+          `EXISTS (SELECT 1 FROM ${t} d WHERE d.cutting_lot_id = cl.id AND d.event_type='approve')`
+        ).join(' OR ')})`
+      : '';
+
+    query = `
+      SELECT
+        MIN(e.id)            AS source_id,
+        cl.lot_no            AS lot_no,
+        cl.sku               AS sku,
+        SUM(e.pieces)        AS qty,
+        e.operator_id        AS user_id,
+        u.username           AS username,
+        MIN(e.created_at)    AS created_at
+      FROM ${stageConfig.eventsTbl} e
+      JOIN cutting_lots cl ON cl.id = e.cutting_lot_id
+      JOIN users u         ON u.id = e.operator_id
+      WHERE e.event_type = 'complete'
+        ${downstreamClause}
+        AND (cl.lot_no LIKE ? OR cl.sku LIKE ?)
+        AND NOT EXISTS (
+          SELECT 1 FROM stage_payments sp
+          WHERE sp.lot_no  = cl.lot_no
+            AND sp.stage   = ?
+            AND sp.user_id = e.operator_id
+            AND sp.status != 'cancelled'
+        )
+      GROUP BY cl.id, e.operator_id, cl.lot_no, cl.sku, u.username
+      ORDER BY MIN(e.created_at) DESC
+      LIMIT 100
+    `;
+    params.push(searchLike, searchLike, stage);
 
     const [lots] = await pool.query(query, params);
 

--- a/views/challanDashboard.ejs
+++ b/views/challanDashboard.ejs
@@ -86,6 +86,7 @@
         <table class="table mb-0" id="assignmentsTable">
           <thead>
             <tr>
+              <th style="width: 28px;"></th>
               <th style="width: 50px;">
                 <input type="checkbox" id="selectAllCheckbox" class="form-check-input" style="margin: 0; cursor: pointer;">
               </th>
@@ -106,7 +107,8 @@
           <tbody>
             <% if (assignments && assignments.length) { %>
               <% assignments.forEach(a => { %>
-                <tr data-id="<%= a.washing_id %>">
+                <tr data-id="<%= a.washing_id %>" data-lot-no="<%= a.lot_no %>">
+                  <td><button type="button" class="lse-toggle" aria-expanded="false" aria-label="Show size breakdown"><span class="lse-chevron">&#9654;</span></button></td>
                   <td>
                     <input type="checkbox" class="rowCheckbox form-check-input" style="cursor: pointer;">
                   </td>
@@ -134,7 +136,7 @@
               <% }); %>
             <% } else { %>
               <tr id="noRecordsRow">
-                <td colspan="13" class="text-center py-5">
+                <td colspan="14" class="text-center py-5">
                   <div class="empty-state">
                     <i class="bi bi-inbox empty-state-icon" style="font-size: 48px;"></i>
                     <h4 class="empty-state-title mt-3">No Records Found</h4>
@@ -484,6 +486,21 @@
       assignments.forEach(a => {
         const tr = document.createElement('tr');
         tr.setAttribute('data-id', a.washing_id);
+        if (a.lot_no) tr.setAttribute('data-lot-no', a.lot_no);
+
+        // Expand chevron cell
+        const tdToggle = document.createElement('td');
+        const btnToggle = document.createElement('button');
+        btnToggle.type = 'button';
+        btnToggle.className = 'lse-toggle';
+        btnToggle.setAttribute('aria-expanded', 'false');
+        btnToggle.setAttribute('aria-label', 'Show size breakdown');
+        const chevSpan = document.createElement('span');
+        chevSpan.className = 'lse-chevron';
+        chevSpan.innerHTML = '&#9654;';
+        btnToggle.appendChild(chevSpan);
+        tdToggle.appendChild(btnToggle);
+        tr.appendChild(tdToggle);
 
         // Checkbox cell
         const tdCheckbox = document.createElement('td');
@@ -673,10 +690,10 @@
             tr.classList.add('selected');
             selectedRows.push({
               washing_id: tr.getAttribute('data-id'),
-              lot_no: tr.children[2].textContent,
-              sku: tr.children[3].textContent,
-              total_pieces: tr.children[4].textContent,
-              cutting_remark: tr.children[6].textContent
+              lot_no: tr.children[3].textContent,
+              sku: tr.children[4].textContent,
+              total_pieces: tr.children[5].textContent,
+              cutting_remark: tr.children[7].textContent
             });
           } else {
             tr.classList.remove('selected');
@@ -783,5 +800,6 @@
   // Ensure handlers are attached after the DOM loads.
   document.addEventListener('DOMContentLoaded', attachCheckboxHandlers);
 </script>
+<script src="/public/js/lot-size-expand.js"></script>
 
 <%- include('partials/footer') %>

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -328,6 +328,7 @@
               <table class="kotty-table">
                 <thead>
                   <tr>
+                    <th style="width:28px;"></th>
                     <th data-i18n="idLabel">ID</th>
                     <th data-i18n="lotNumberLabel">Lot Number</th>
                     <th data-i18n="skuLabel">SKU</th>
@@ -344,10 +345,11 @@
                 </thead>
                 <tbody>
                   <% if (cuttingLots.length === 0) { %>
-                    <tr><td colspan="12" class="text-center" style="padding: 40px;" data-i18n="noCuttingLotsAvailable">No cutting lots available.</td></tr>
+                    <tr><td colspan="13" class="text-center" style="padding: 40px;" data-i18n="noCuttingLotsAvailable">No cutting lots available.</td></tr>
                   <% } else { %>
                     <% cuttingLots.forEach(lot => { %>
-                      <tr>
+                      <tr data-lot-no="<%= lot.lot_no %>">
+                        <td><button type="button" class="lse-toggle" aria-expanded="false" aria-label="Show size breakdown"><span class="lse-chevron">&#9654;</span></button></td>
                         <td><%= lot.id %></td>
                         <td><strong><%= lot.lot_no %></strong></td>
                         <td><%= lot.sku %></td>
@@ -1151,5 +1153,6 @@ document.getElementById('lotForm').addEventListener('submit', function(e) {
 
 loadSkuCategories();
 </script>
+<script src="/public/js/lot-size-expand.js"></script>
 
 <%- include('partials/footer') %>

--- a/views/lotCompletionDashboard.ejs
+++ b/views/lotCompletionDashboard.ejs
@@ -434,6 +434,7 @@
       <table class="kotty-table">
         <thead>
           <tr>
+            <th style="width:28px;"></th>
             <th>Lot No</th>
             <th>SKU</th>
             <th>Fabric</th>
@@ -447,11 +448,12 @@
         <tbody>
           <% if (lots.length === 0) { %>
           <tr>
-            <td colspan="8" class="text-center text-muted py-4">No lots found</td>
+            <td colspan="9" class="text-center text-muted py-4">No lots found</td>
           </tr>
           <% } else { %>
           <% lots.forEach(lot => { %>
-          <tr>
+          <tr data-lot-no="<%= lot.lot_no %>">
+            <td><button type="button" class="lse-toggle" aria-expanded="false" aria-label="Show size breakdown"><span class="lse-chevron">&#9654;</span></button></td>
             <td><span class="lot-no"><%= lot.lot_no %></span></td>
             <td><span class="sku"><%= lot.sku || '-' %></span></td>
             <td><%= lot.fabric_type || '-' %></td>
@@ -530,5 +532,7 @@
     <% } %>
   </div>
 </div>
+
+<script src="/public/js/lot-size-expand.js"></script>
 
 <%- include('partials/footer') %>

--- a/views/operatorAssemblyPendencyReport.ejs
+++ b/views/operatorAssemblyPendencyReport.ejs
@@ -130,6 +130,7 @@
                 <table class="table mb-0">
                   <thead>
                     <tr>
+                      <th style="width:28px;"></th>
                       <th>Lot No</th>
                       <th>Total Pieces</th>
                       <th>Assembled</th>
@@ -140,7 +141,8 @@
                   </thead>
                   <tbody>
                     <% detailedAssignments.forEach(function(asg) { %>
-                      <tr>
+                      <tr data-lot-no="<%= asg.lot_no %>">
+                        <td><button type="button" class="lse-toggle" aria-expanded="false" aria-label="Show size breakdown"><span class="lse-chevron">&#9654;</span></button></td>
                         <td>
                           <span class="fw-medium text-terracotta"><%= asg.lot_no %></span>
                         </td>
@@ -237,5 +239,7 @@
     }
   }
 </style>
+
+<script src="/public/js/lot-size-expand.js"></script>
 
 <%- include('partials/footer') %>

--- a/views/operatorFinishingPendencyReport.ejs
+++ b/views/operatorFinishingPendencyReport.ejs
@@ -134,6 +134,7 @@
                 <table class="table mb-0">
                   <thead>
                     <tr>
+                      <th style="width:28px;"></th>
                       <th>Lot No</th>
                       <th>Total Pieces</th>
                       <th>Finished</th>
@@ -143,7 +144,8 @@
                   </thead>
                   <tbody>
                     <% detailedAssignments.forEach(function(asg) { %>
-                      <tr>
+                      <tr data-lot-no="<%= asg.lot_no %>">
+                        <td><button type="button" class="lse-toggle" aria-expanded="false" aria-label="Show size breakdown"><span class="lse-chevron">&#9654;</span></button></td>
                         <td>
                           <span style="font-weight: 500; color: var(--terracotta);"><%= asg.lot_no %></span>
                         </td>
@@ -186,5 +188,7 @@
 
   </div>
 </main>
+
+<script src="/public/js/lot-size-expand.js"></script>
 
 <%- include('partials/footer') %>

--- a/views/operatorPICReport.ejs
+++ b/views/operatorPICReport.ejs
@@ -124,6 +124,7 @@
             <table class="table table-sm mb-0" style="font-size: var(--text-xs);">
               <thead>
                 <tr>
+                  <th style="width:28px;"></th>
                   <th>Lot No</th>
                   <th>Ext Lot</th>
                   <th>Sort</th>
@@ -146,7 +147,8 @@
               </thead>
               <tbody>
                 <% rows.slice(0, 50).forEach(row => { %>
-                <tr>
+                <tr data-lot-no="<%= row.lotNo %>">
+                  <td><button type="button" class="lse-toggle" aria-expanded="false" aria-label="Show size breakdown"><span class="lse-chevron">&#9654;</span></button></td>
                   <td><strong style="color: var(--terracotta);"><%= row.lotNo %></strong></td>
                   <td><%= row.externalLotNo || '—' %></td>
                   <td><%= row.sortNo || '—' %></td>
@@ -394,5 +396,6 @@
     }
   }
 </script>
+<script src="/public/js/lot-size-expand.js"></script>
 
 <%- include('partials/footer') %>

--- a/views/operatorStitchingPendencyReport.ejs
+++ b/views/operatorStitchingPendencyReport.ejs
@@ -129,6 +129,7 @@
                 <table class="table mb-0">
                   <thead>
                     <tr>
+                      <th style="width:28px;"></th>
                       <th>Lot No</th>
                       <th>Total Pieces</th>
                       <th>Stitched</th>
@@ -139,7 +140,8 @@
                   </thead>
                   <tbody>
                     <% detailedAssignments.forEach(function(asg) { %>
-                      <tr>
+                      <tr data-lot-no="<%= asg.lot_no %>">
+                        <td><button type="button" class="lse-toggle" aria-expanded="false" aria-label="Show size breakdown"><span class="lse-chevron">&#9654;</span></button></td>
                         <td>
                           <span class="fw-medium" style="color: var(--terracotta);"><%= asg.lot_no %></span>
                         </td>
@@ -210,5 +212,7 @@
     margin-left: 0 !important;
   }
 </style>
+
+<script src="/public/js/lot-size-expand.js"></script>
 
 <%- include('partials/footer') %>

--- a/views/operatorStitchingTatDetail.ejs
+++ b/views/operatorStitchingTatDetail.ejs
@@ -39,6 +39,7 @@
           <table class="table mb-0">
             <thead>
               <tr>
+                <th style="width:28px;"></th>
                 <th>Lot No</th>
                 <th>SKU</th>
                 <th>Status</th>
@@ -58,7 +59,8 @@
                  // Extra label in the TAT cell => e.g. "4 (TAT Crossed)" or "2 (Within TAT)"
                  const tatLabel = isDelayed ? "TAT Crossed" : "Within TAT";
               %>
-                <tr class="<%= rowClass %>">
+                <tr class="<%= rowClass %>" data-lot-no="<%= row.lotNo %>">
+                  <td><button type="button" class="lse-toggle" aria-expanded="false" aria-label="Show size breakdown"><span class="lse-chevron">&#9654;</span></button></td>
                   <td>
                     <span class="fw-medium" style="color: var(--terracotta);"><%= row.lotNo %></span>
                   </td>
@@ -148,5 +150,7 @@
     margin-left: 0 !important;
   }
 </style>
+
+<script src="/public/js/lot-size-expand.js"></script>
 
 <%- include('partials/footer') %>


### PR DESCRIPTION
## Summary
- Migrates read-side dashboards and reports to source from `*_events` tables as the truth source (cdb1c4d).

## Test plan
- [ ] Spot-check dashboards that read from migrated tables for correct counts
- [ ] Verify PIC reports still match (follow-up to 805b42c)
- [ ] Deploy to Cloud Run and smoke-test prod read paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)