### PR TITLE
feat(washingin): redesign data-entry surface for one-tap common case

### DIFF
--- a/views/washingInDashboard.ejs
+++ b/views/washingInDashboard.ejs
@@ -6,240 +6,435 @@
 <%- include('partials/navbar', { user: user, dashboardUrl: '/washingin' }) %>
 
 <style>
+  /* =========================================================
+     Washing-In Dashboard — Industrial entry surface
+     Goals: factory-floor mobile, common case is 1 tap.
+     Tokens from kotty-theme.css:
+       --font-body (Outfit), --font-display (DM Serif), --font-mono (JetBrains)
+       --terracotta, --success #2d8a5f, --warning #c4873a, --danger #c23b22
+     ========================================================= */
   * { box-sizing: border-box; }
-  :root {
-    --primary: #2563eb;
-    --success: #16a34a;
-    --success-light: #dcfce7;
-    --danger: #dc2626;
-    --danger-light: #fee2e2;
-    --warning: #f59e0b;
-    --bg: #f8fafc;
-    --card: #ffffff;
-    --text: #1e293b;
-    --text-light: #64748b;
-    --border: #e2e8f0;
-    --shadow: 0 1px 3px rgba(0,0,0,0.1);
-  }
-  body { background: var(--bg); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; font-size: 16px; color: var(--text); }
-  .container { max-width: 600px; margin: 0 auto; padding: 16px; padding-top: 76px; }
+  body { background: #FAF7F2; font-family: var(--font-body, 'Outfit', sans-serif); color: var(--text-primary, #1a1a1a); font-size: 16px; }
+
+  /* ---- Shared shell ---- */
+  .wi-shell { max-width: 560px; margin: 0 auto; padding: 76px 0 0; }
+  .wi-pad   { padding: 0 16px; }
+
+  /* ---- Toasts ---- */
   .toast-container { position: fixed; top: 80px; left: 50%; transform: translateX(-50%); z-index: 9999; width: calc(100% - 32px); max-width: 400px; }
-  .toast { padding: 14px 18px; border-radius: 12px; font-weight: 500; display: flex; align-items: center; gap: 10px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); animation: toastIn 0.3s ease-out; margin-bottom: 8px; }
-  @keyframes toastIn { from { opacity: 0; transform: translateY(-20px); } to { opacity: 1; transform: translateY(0); } }
+  .toast { padding: 14px 18px; border-radius: 12px; font-weight: 500; display: flex; align-items: center; gap: 10px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); animation: toastIn .25s ease-out; margin-bottom: 8px; }
+  @keyframes toastIn { from { opacity: 0; transform: translateY(-12px); } to { opacity: 1; transform: translateY(0); } }
   .toast-success { background: #166534; color: white; }
-  .toast-error { background: #991b1b; color: white; }
+  .toast-error   { background: #991b1b; color: white; }
   .toast-warning { background: #92400e; color: white; }
-  .page-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 20px; }
-  .page-title { font-size: 1.5rem; font-weight: 700; margin: 0; }
-  .btn-payments { display: inline-flex; align-items: center; gap: 6px; padding: 10px 16px; background: var(--card); border: 1px solid var(--border); border-radius: 10px; color: var(--text); font-weight: 500; text-decoration: none; font-size: 0.875rem; }
-  .stats-row { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin-bottom: 20px; }
-  .stat-box { background: var(--card); border-radius: 12px; padding: 16px; text-align: center; box-shadow: var(--shadow); }
-  .stat-number { font-size: 1.75rem; font-weight: 700; color: var(--primary); }
-  .stat-label { font-size: 0.8125rem; color: var(--text-light); margin-top: 4px; }
-  .tabs { display: flex; background: var(--card); border-radius: 12px; padding: 4px; margin-bottom: 20px; box-shadow: var(--shadow); }
-  .tab-btn { flex: 1; padding: 12px; border: none; background: transparent; border-radius: 10px; font-weight: 600; font-size: 0.875rem; color: var(--text-light); cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 8px; }
-  .tab-btn.active { background: var(--primary); color: white; }
+  .toast-info    { background: #1e40af; color: white; }
+
+  /* ---- Page header ---- */
+  .wi-pageHeader { display: flex; justify-content: space-between; align-items: baseline; padding: 8px 16px 16px; }
+  .wi-pageHeader h1 { font-family: var(--font-display, 'DM Serif Display', serif); font-size: 1.75rem; margin: 0; letter-spacing: -0.01em; }
+  .wi-pageHeader .wi-payLink { font-size: .85rem; color: var(--terracotta, #c45c3a); text-decoration: none; font-weight: 500; display: inline-flex; align-items: center; gap: 6px; }
+
+  /* ---- Stats strip ---- */
+  .wi-stats { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin: 0 16px 16px; }
+  .wi-stat  { background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; padding: 14px 16px; }
+  .wi-stat__n { font-family: var(--font-mono, 'JetBrains Mono', monospace); font-size: 1.65rem; font-weight: 600; color: #111; line-height: 1; }
+  .wi-stat__l { font-size: .75rem; color: #6b6b6b; text-transform: uppercase; letter-spacing: .08em; margin-top: 6px; }
+
+  /* ---- Tabs ---- */
+  .wi-tabs { display: flex; background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; padding: 4px; margin: 0 16px 16px; }
+  .wi-tab  { flex: 1; padding: 11px 8px; border: none; background: transparent; border-radius: 10px; font-weight: 600; font-size: .85rem; color: #6b6b6b; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  .wi-tab.active { background: #111; color: white; }
+
   .tab-content { display: none; }
   .tab-content.active { display: block; }
-  .search-card { background: var(--card); border-radius: 16px; padding: 20px; box-shadow: var(--shadow); margin-bottom: 16px; }
-  .search-label { display: block; font-weight: 600; margin-bottom: 12px; }
-  .search-input { width: 100%; padding: 14px 16px; border: 2px solid var(--border); border-radius: 12px; font-size: 1rem; margin-bottom: 12px; }
-  .search-input:focus { outline: none; border-color: var(--primary); }
-  .search-input.input-error { border-color: var(--danger); animation: shake 0.3s; }
-  @keyframes shake { 0%, 100% { transform: translateX(0); } 25% { transform: translateX(-4px); } 75% { transform: translateX(4px); } }
-  .btn-search { width: 100%; padding: 14px; background: var(--primary); color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 8px; }
-  .lot-card { background: var(--card); border-radius: 16px; padding: 20px; box-shadow: var(--shadow); margin-bottom: 16px; }
-  .lot-header { margin-bottom: 20px; padding-bottom: 16px; border-bottom: 1px solid var(--border); }
-  .lot-title { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; }
-  .lot-number { font-size: 1.25rem; font-weight: 700; }
-  .lot-badge { padding: 4px 10px; border-radius: 20px; font-size: 0.75rem; font-weight: 600; background: #dbeafe; color: #1e40af; }
-  .lot-meta { font-size: 0.875rem; color: var(--text-light); }
-  .sizes-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(80px, 1fr)); gap: 8px; margin-bottom: 16px; }
-  .size-card { background: #f8fafc; border: 2px solid var(--border); border-radius: 10px; padding: 8px 6px; text-align: center; }
-  .size-card.has-qty { border-color: var(--success); background: var(--success-light); }
-  .size-card.disabled { opacity: 0.5; }
-  .size-card.input-error { border-color: var(--danger); background: var(--danger-light); }
-  .size-name { font-weight: 700; font-size: 0.8rem; margin-bottom: 2px; }
-  .size-avail { font-size: 0.65rem; color: var(--text-light); margin-bottom: 4px; }
-  .size-avail .green { color: var(--success); font-weight: 600; }
-  .size-input { width: 100%; padding: 8px 4px; border: 1px solid var(--border); border-radius: 8px; font-size: 1rem; font-weight: 600; text-align: center; }
-  .size-error { font-size: 0.6875rem; color: var(--danger); margin-top: 4px; display: none; }
-  .size-card.input-error .size-error { display: block; }
-  /* Rewash/Reject compact row */
-  .rw-rj-row { display: flex; gap: 4px; margin-top: 6px; }
-  .rw-rj-item { flex: 1; display: flex; flex-direction: column; align-items: center; }
-  .rw-rj-label { font-size: 0.55rem; font-weight: 600; margin-bottom: 2px; text-transform: uppercase; }
-  .rw-rj-label.rw { color: #d97706; }
-  .rw-rj-label.rj { color: #dc2626; }
-  .rw-rj-input { width: 100%; padding: 4px 2px; border: 1px solid var(--border); border-radius: 4px; font-size: 0.8rem; font-weight: 600; text-align: center; }
-  .rw-rj-input.rewash { border-color: #fbbf24; background: #fef9c3; }
-  .rw-rj-input.reject { border-color: #f87171; background: #fee2e2; }
-  .rw-rj-input::placeholder { font-weight: 400; color: #9ca3af; font-size: 0.65rem; }
-  .rw-rj-input:focus { outline: none; }
-  .submit-section { padding-top: 16px; border-top: 1px solid var(--border); }
-  .total-row { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
-  .total-label { font-weight: 600; }
-  .total-value { font-size: 1.25rem; font-weight: 700; color: var(--primary); }
-  .btn-submit { width: 100%; padding: 16px; background: var(--success); color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 8px; }
-  .btn-submit:disabled { opacity: 0.5; cursor: not-allowed; }
-  .empty-state { text-align: center; padding: 48px 20px; color: var(--text-light); }
-  .empty-state i { font-size: 3rem; opacity: 0.3; margin-bottom: 16px; }
-  .today-card { background: var(--card); border-radius: 16px; box-shadow: var(--shadow); overflow: hidden; }
-  .today-header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; background: #f8fafc; border-bottom: 1px solid var(--border); }
-  .today-title { font-weight: 600; display: flex; align-items: center; gap: 8px; }
-  .today-total { font-weight: 700; color: var(--primary); }
-  .today-list { list-style: none; margin: 0; padding: 0; max-height: 300px; overflow-y: auto; }
-  .today-item { display: flex; justify-content: space-between; align-items: center; padding: 14px 20px; border-bottom: 1px solid var(--border); }
-  .today-item:last-child { border-bottom: none; }
-  .today-lot { font-weight: 600; text-transform: uppercase; }
-  .today-sku { font-size: 0.8125rem; color: var(--text-light); }
-  .today-qty { font-weight: 700; color: var(--success); }
-  .history-search { background: var(--card); border-radius: 12px; padding: 16px; margin-bottom: 16px; box-shadow: var(--shadow); }
-  .history-input { width: 100%; padding: 12px 16px; border: 1px solid var(--border); border-radius: 10px; }
-  .history-list { background: var(--card); border-radius: 12px; box-shadow: var(--shadow); overflow: hidden; }
-  .history-item { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; border-bottom: 1px solid var(--border); }
-  .history-item:last-child { border-bottom: none; }
-  .spinner { width: 20px; height: 20px; border: 2px solid rgba(255,255,255,0.3); border-top-color: white; border-radius: 50%; animation: spin 0.8s linear infinite; }
-  @keyframes spin { to { transform: rotate(360deg); } }
-  .lot-selection-header { font-size: 14px; font-weight: 600; color: #6b7280; margin-bottom: 12px; }
-  .lot-options { display: flex; flex-direction: column; gap: 8px; max-height: 300px; overflow-y: auto; }
-  .lot-option { background: white; border: 1px solid #e5e7eb; border-radius: 8px; padding: 12px 16px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; }
-  .lot-option:hover { border-color: #3b82f6; background: #eff6ff; }
-  .lot-option-main { display: flex; flex-direction: column; gap: 2px; }
-  .lot-option-no { font-weight: 600; font-size: 15px; text-transform: uppercase; }
-  .lot-option-meta { font-size: 12px; color: #6b7280; }
-  .lot-option-remark { font-size: 12px; color: #3b82f6; font-weight: 500; word-break: break-word; }
-  .lot-option-avail { font-size: 13px; font-weight: 600; color: #22c55e; }
 
-  /* History filters & download */
-  .history-filters { display: flex; flex-wrap: wrap; gap: 10px; margin-top: 12px; }
-  .history-filters input[type="date"] { flex: 1; min-width: 120px; padding: 10px 12px; border: 1px solid var(--border); border-radius: 10px; font-size: 0.875rem; }
-  .btn-filter, .btn-download { padding: 10px 14px; border: none; border-radius: 10px; font-size: 0.875rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; gap: 6px; }
-  .btn-filter { background: var(--primary); color: white; }
-  .btn-download { background: #059669; color: white; }
-  .history-item.clickable { cursor: pointer; transition: background 0.15s; }
-  .history-item.clickable:hover { background: #f1f5f9; }
-  .history-remark { font-size: 0.75rem; color: var(--primary); display: block; }
+  /* ============================================================
+     SUBMIT TAB — the redesigned data-entry surface
+     ============================================================ */
+
+  /* Search */
+  .wi-search { background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; padding: 18px; margin: 0 16px 16px; }
+  .wi-search label { display: block; font-size: .8rem; font-weight: 600; color: #6b6b6b; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 10px; }
+  .wi-search input { width: 100%; padding: 14px 16px; border: 1.5px solid #e4e1da; border-radius: 12px; font-size: 1.05rem; font-family: var(--font-mono, monospace); text-transform: uppercase; letter-spacing: .04em; }
+  .wi-search input:focus { outline: none; border-color: #111; box-shadow: 0 0 0 3px rgba(0,0,0,.08); }
+  .wi-search input.input-error { border-color: var(--danger, #c23b22); animation: shake .3s; }
+  @keyframes shake { 0%, 100% { transform: translateX(0); } 25% { transform: translateX(-4px); } 75% { transform: translateX(4px); } }
+  .wi-search button { width: 100%; padding: 14px; background: #111; color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 10px; display: flex; align-items: center; justify-content: center; gap: 8px; }
+
+  /* Lot picker (multi-match) */
+  .wi-pickHeader { font-size: .75rem; font-weight: 600; color: #6b6b6b; text-transform: uppercase; letter-spacing: .08em; padding: 0 4px 8px; }
+  .wi-pickList { display: flex; flex-direction: column; gap: 8px; padding: 0 16px 16px; }
+  .wi-pickItem { background: white; border: 1px solid rgba(0,0,0,.08); border-radius: 12px; padding: 14px 16px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+  .wi-pickItem:hover { border-color: #111; }
+  .wi-pickItem__no { font-family: var(--font-mono, monospace); font-weight: 600; font-size: 1rem; text-transform: uppercase; letter-spacing: .03em; }
+  .wi-pickItem__meta { font-size: .78rem; color: #6b6b6b; margin-top: 2px; }
+  .wi-pickItem__remark { font-size: .78rem; color: var(--terracotta, #c45c3a); font-weight: 500; margin-top: 4px; }
+  .wi-pickItem__avail { font-family: var(--font-mono, monospace); font-weight: 600; color: var(--success, #2d8a5f); white-space: nowrap; }
+
+  /* ----- Sticky lot header ----- */
+  .wi-lotHeader {
+    position: sticky; top: 56px; z-index: 50;
+    background: #FAF7F2;
+    padding: 12px 16px 10px;
+    border-bottom: 1px solid rgba(0,0,0,.06);
+    margin-bottom: 14px;
+  }
+  .wi-lotHeader__top { display: flex; align-items: baseline; gap: 12px; }
+  .wi-lotHeader__no { font-family: var(--font-mono, monospace); font-size: 1.4rem; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
+  .wi-lotHeader__badge { display: inline-block; padding: 2px 8px; border-radius: 999px; background: #111; color: white; font-size: .65rem; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; }
+  .wi-lotHeader__total { margin-left: auto; font-family: var(--font-mono, monospace); font-size: 1.1rem; font-weight: 600; }
+  .wi-lotHeader__total small { font-size: .65rem; color: #6b6b6b; text-transform: uppercase; font-family: var(--font-body, sans-serif); font-weight: 500; letter-spacing: .08em; margin-left: 4px; }
+  .wi-lotHeader__meta { font-size: .82rem; color: #4a4a4a; margin-top: 4px; }
+  .wi-lotHeader__meta strong { font-weight: 600; color: #111; }
+  .wi-cuttingRemark {
+    display: flex; align-items: flex-start; gap: 8px;
+    background: #FFF7E5; border: 1px solid #F0DDB8; border-radius: 10px;
+    padding: 8px 12px; margin-top: 10px;
+    font-size: .82rem; color: #6b4a16;
+  }
+  .wi-cuttingRemark i { color: #c4873a; margin-top: 2px; }
+  .wi-cuttingRemark strong { color: #6b4a16; font-weight: 600; }
+
+  /* ----- Size rows ----- */
+  .wi-sizesHeader {
+    display: flex; justify-content: space-between; align-items: baseline;
+    padding: 4px 16px 10px;
+    font-size: .72rem; font-weight: 600; color: #6b6b6b;
+    text-transform: uppercase; letter-spacing: .08em;
+  }
+  .wi-sizes { display: flex; flex-direction: column; padding: 0 16px; gap: 8px; padding-bottom: 140px; /* room for sticky footer */ }
+
+  .wi-row {
+    background: white;
+    border: 1px solid rgba(0,0,0,.06);
+    border-radius: 14px;
+    overflow: hidden;
+    position: relative;
+    transition: border-color .15s ease, box-shadow .15s ease;
+  }
+  .wi-row.has-exception { border-color: rgba(196,135,58,.5); box-shadow: 0 1px 0 rgba(196,135,58,.1); }
+  .wi-row.is-disabled { opacity: .45; pointer-events: none; }
+
+  .wi-row__rail {
+    position: absolute; left: 0; top: 0; bottom: 0; width: 4px;
+    background: var(--success, #2d8a5f);
+  }
+  .wi-row.has-rw .wi-row__rail { background: linear-gradient(180deg, var(--success, #2d8a5f) 0%, var(--success, #2d8a5f) 50%, var(--warning, #c4873a) 50%, var(--warning, #c4873a) 100%); }
+  .wi-row.has-rj .wi-row__rail { background: linear-gradient(180deg, var(--success, #2d8a5f) 0%, var(--success, #2d8a5f) 50%, var(--danger, #c23b22) 50%, var(--danger, #c23b22) 100%); }
+  .wi-row.has-rw.has-rj .wi-row__rail { background: linear-gradient(180deg, var(--success, #2d8a5f) 0%, var(--success, #2d8a5f) 34%, var(--warning, #c4873a) 34%, var(--warning, #c4873a) 67%, var(--danger, #c23b22) 67%, var(--danger, #c23b22) 100%); }
+  .wi-row.is-zero .wi-row__rail { background: #d0d0d0; }
+
+  .wi-row__summary {
+    display: flex; align-items: center; gap: 14px;
+    padding: 14px 16px 14px 20px;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .wi-row__size {
+    font-family: var(--font-mono, monospace);
+    font-weight: 700;
+    font-size: 1.15rem;
+    min-width: 42px;
+    color: #111;
+  }
+  .wi-row__breakdown { flex: 1; display: flex; flex-wrap: wrap; gap: 6px 10px; align-items: center; }
+  .wi-chip {
+    font-family: var(--font-mono, monospace);
+    font-size: .9rem; font-weight: 600;
+    display: inline-flex; align-items: baseline; gap: 4px;
+  }
+  .wi-chip small { font-family: var(--font-body, sans-serif); font-size: .65rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: #6b6b6b; }
+  .wi-chip.ok    { color: var(--success, #2d8a5f); }
+  .wi-chip.ok small { color: var(--success, #2d8a5f); opacity: .8; }
+  .wi-chip.rw    { color: var(--warning, #c4873a); }
+  .wi-chip.rw small { color: var(--warning, #c4873a); opacity: .8; }
+  .wi-chip.rj    { color: var(--danger, #c23b22); }
+  .wi-chip.rj small { color: var(--danger, #c23b22); opacity: .8; }
+  .wi-chip.dim   { color: #9a9a9a; }
+  .wi-row__caret { color: #b8b8b8; transition: transform .15s ease; font-size: 1.1rem; }
+  .wi-row.is-open .wi-row__caret { transform: rotate(90deg); color: #111; }
+
+  /* ----- Expanded editor for a row ----- */
+  .wi-row__edit { display: none; padding: 4px 16px 16px 20px; }
+  .wi-row.is-open .wi-row__edit { display: block; }
+  .wi-row.is-open { border-color: #111; box-shadow: 0 4px 18px rgba(0,0,0,.06); }
+
+  .wi-row__visual {
+    height: 8px; border-radius: 99px; overflow: hidden; display: flex;
+    background: #e9e6df; margin-bottom: 16px;
+  }
+  .wi-row__visual .seg { height: 100%; transition: width .15s ease; }
+  .wi-row__visual .seg.ok { background: var(--success, #2d8a5f); }
+  .wi-row__visual .seg.rw { background: var(--warning, #c4873a); }
+  .wi-row__visual .seg.rj { background: var(--danger, #c23b22); }
+
+  .wi-bucket { display: flex; align-items: center; gap: 12px; padding: 10px 0; }
+  .wi-bucket + .wi-bucket { border-top: 1px dashed rgba(0,0,0,.08); }
+  .wi-bucket__lbl { flex: 1; min-width: 0; }
+  .wi-bucket__name { font-size: .9rem; font-weight: 600; color: #111; display: flex; align-items: center; gap: 6px; }
+  .wi-bucket__name.ok { color: var(--success, #2d8a5f); }
+  .wi-bucket__name.rw { color: var(--warning, #c4873a); }
+  .wi-bucket__name.rj { color: var(--danger, #c23b22); }
+  .wi-bucket__hint { font-size: .72rem; color: #888; margin-top: 2px; }
+  .wi-stepper { display: flex; align-items: stretch; gap: 0; border: 1.5px solid #e4e1da; border-radius: 12px; overflow: hidden; background: #fafaf8; }
+  .wi-stepper button {
+    width: 42px; height: 42px;
+    border: none; background: transparent;
+    font-size: 1.3rem; font-weight: 600; color: #111;
+    cursor: pointer; display: flex; align-items: center; justify-content: center;
+    -webkit-tap-highlight-color: transparent;
+  }
+  .wi-stepper button:disabled { color: #c8c8c8; cursor: not-allowed; }
+  .wi-stepper button:active { background: rgba(0,0,0,.06); }
+  .wi-stepper input {
+    width: 58px; height: 42px;
+    border: none; border-left: 1.5px solid #e4e1da; border-right: 1.5px solid #e4e1da;
+    text-align: center;
+    font-family: var(--font-mono, monospace);
+    font-size: 1.05rem; font-weight: 600;
+    background: white; color: #111;
+    -moz-appearance: textfield;
+  }
+  .wi-stepper input::-webkit-outer-spin-button,
+  .wi-stepper input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+  .wi-stepper input:focus { outline: none; background: #fff8ee; }
+  .wi-stepper.rw input:focus { background: #fef6e8; }
+  .wi-stepper.rj input:focus { background: #fdf2f0; }
+
+  .wi-bucket.ok .wi-bucket__readonly {
+    font-family: var(--font-mono, monospace);
+    font-size: 1.25rem; font-weight: 700;
+    color: var(--success, #2d8a5f);
+    min-width: 110px; text-align: right;
+  }
+
+  .wi-rowError { display: none; padding: 8px 12px; margin-top: 8px; background: var(--danger-light, #fdf2f0); color: var(--danger, #c23b22); border-radius: 10px; font-size: .82rem; font-weight: 500; }
+  .wi-row.has-error .wi-rowError { display: block; }
+
+  .wi-rowActions { display: flex; gap: 8px; margin-top: 14px; }
+  .wi-btnGhost, .wi-btnDone {
+    flex: 1; padding: 11px; border-radius: 11px; font-weight: 600; font-size: .9rem;
+    cursor: pointer; border: 1.5px solid transparent;
+    display: flex; align-items: center; justify-content: center; gap: 6px;
+  }
+  .wi-btnGhost { background: transparent; border-color: #e4e1da; color: #4a4a4a; }
+  .wi-btnDone  { background: #111; color: white; }
+
+  /* ----- Sticky submit footer ----- */
+  .wi-stickyFooter {
+    position: fixed; left: 0; right: 0; bottom: 0; z-index: 80;
+    background: rgba(250,247,242,.96);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-top: 1px solid rgba(0,0,0,.08);
+    padding: 12px 16px calc(env(safe-area-inset-bottom, 8px) + 12px);
+  }
+  .wi-stickyFooter__inner { max-width: 560px; margin: 0 auto; }
+  .wi-stickyFooter__totals {
+    display: flex; gap: 16px; align-items: baseline;
+    font-family: var(--font-mono, monospace);
+    font-size: .95rem; font-weight: 600;
+    margin-bottom: 10px;
+  }
+  .wi-stickyFooter__totals .pill { display: inline-flex; align-items: baseline; gap: 4px; }
+  .wi-stickyFooter__totals small { font-family: var(--font-body, sans-serif); font-size: .65rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: #6b6b6b; }
+  .wi-stickyFooter__totals .pill.ok { color: var(--success, #2d8a5f); }
+  .wi-stickyFooter__totals .pill.rw { color: var(--warning, #c4873a); }
+  .wi-stickyFooter__totals .pill.rj { color: var(--danger, #c23b22); }
+  .wi-debit { margin-left: auto; font-size: .78rem; color: #6b6b6b; font-family: var(--font-body, sans-serif); font-weight: 500; }
+  .wi-debit b { color: var(--warning, #c4873a); }
+
+  .wi-submit {
+    width: 100%; padding: 16px;
+    background: #111; color: white;
+    border: none; border-radius: 13px;
+    font-family: var(--font-body, sans-serif); font-size: 1.02rem; font-weight: 600;
+    cursor: pointer;
+    display: flex; align-items: center; justify-content: center; gap: 10px;
+    letter-spacing: .01em;
+  }
+  .wi-submit:disabled { background: #c8c8c8; cursor: not-allowed; }
+  .wi-submit .wi-submit__count { font-family: var(--font-mono, monospace); font-weight: 700; }
+
+  /* ----- Empty / today list ----- */
+  .wi-empty { text-align: center; padding: 40px 16px; color: #888; }
+  .wi-empty i { font-size: 2.4rem; opacity: .3; display: block; margin-bottom: 10px; }
+  .wi-empty p { margin: 0; font-weight: 500; color: #4a4a4a; }
+  .wi-empty span { font-size: .85rem; }
+
+  .wi-today { background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; margin: 24px 16px 0; overflow: hidden; }
+  .wi-today__head { display: flex; justify-content: space-between; align-items: center; padding: 14px 18px; background: #f5f1ea; border-bottom: 1px solid rgba(0,0,0,.06); font-weight: 600; font-size: .9rem; }
+  .wi-today__head .total { font-family: var(--font-mono, monospace); color: var(--success, #2d8a5f); }
+  .wi-today__list { list-style: none; padding: 0; margin: 0; max-height: 280px; overflow-y: auto; }
+  .wi-today__item { display: flex; justify-content: space-between; align-items: center; padding: 12px 18px; border-bottom: 1px solid rgba(0,0,0,.05); }
+  .wi-today__item:last-child { border-bottom: none; }
+  .wi-today__lot { font-family: var(--font-mono, monospace); font-weight: 600; font-size: .95rem; text-transform: uppercase; }
+  .wi-today__sku { font-size: .78rem; color: #888; margin-top: 2px; }
+  .wi-today__qty { font-family: var(--font-mono, monospace); font-weight: 600; color: var(--success, #2d8a5f); }
+
+  /* ============================================================
+     History + Indent tab styles (mostly retained — tightened)
+     ============================================================ */
+  .history-search { background: white; border-radius: 14px; padding: 16px; margin: 0 16px 16px; border: 1px solid rgba(0,0,0,.06); }
+  .history-input  { width: 100%; padding: 12px 14px; border: 1px solid #e4e1da; border-radius: 10px; }
+  .history-filters { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+  .history-filters input[type="date"] { flex: 1; min-width: 120px; padding: 10px 12px; border: 1px solid #e4e1da; border-radius: 10px; font-size: .875rem; }
+  .btn-filter, .btn-download { padding: 10px 14px; border: none; border-radius: 10px; font-size: .85rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; gap: 6px; }
+  .btn-filter   { background: #111; color: white; }
+  .btn-download { background: var(--success, #2d8a5f); color: white; }
+  .history-list { background: white; border-radius: 14px; margin: 0 16px 16px; border: 1px solid rgba(0,0,0,.06); overflow: hidden; }
+  .history-item { display: flex; justify-content: space-between; align-items: center; padding: 14px 18px; border-bottom: 1px solid rgba(0,0,0,.05); }
+  .history-item:last-child { border-bottom: none; }
+  .history-item.clickable { cursor: pointer; }
+  .history-item.clickable:hover { background: #f9f6f0; }
+  .today-lot { font-family: var(--font-mono, monospace); font-weight: 600; font-size: .95rem; text-transform: uppercase; }
+  .today-sku { font-size: .78rem; color: #888; margin-top: 2px; }
+  .today-qty { font-family: var(--font-mono, monospace); font-weight: 600; color: var(--success, #2d8a5f); }
+  .history-remark { display: block; font-size: .72rem; color: var(--terracotta, #c45c3a); margin-top: 4px; }
 
   /* Modal */
-  .modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 10000; display: flex; align-items: center; justify-content: center; padding: 16px; }
+  .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 10000; display: flex; align-items: center; justify-content: center; padding: 16px; }
   .modal-content { background: white; border-radius: 16px; width: 100%; max-width: 500px; max-height: 85vh; overflow: hidden; display: flex; flex-direction: column; }
-  .modal-header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; border-bottom: 1px solid var(--border); background: #f8fafc; }
-  .modal-title { font-size: 1.125rem; font-weight: 700; }
-  .modal-close { background: none; border: none; font-size: 1.5rem; cursor: pointer; color: var(--text-light); line-height: 1; }
+  .modal-header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; border-bottom: 1px solid rgba(0,0,0,.06); background: #f5f1ea; }
+  .modal-title { font-size: 1.05rem; font-weight: 700; font-family: var(--font-mono, monospace); text-transform: uppercase; }
+  .modal-close { background: none; border: none; font-size: 1.5rem; cursor: pointer; color: #888; line-height: 1; }
   .modal-body { padding: 20px; overflow-y: auto; flex: 1; }
-  .detail-section { margin-bottom: 20px; }
-  .detail-section-title { font-size: 0.8rem; font-weight: 600; color: var(--text-light); text-transform: uppercase; margin-bottom: 10px; }
-  .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-  .detail-item { background: #f8fafc; padding: 12px; border-radius: 10px; }
-  .detail-label { font-size: 0.75rem; color: var(--text-light); margin-bottom: 4px; }
-  .detail-value { font-size: 0.9375rem; font-weight: 600; }
-  .detail-value.highlight { color: var(--primary); }
-  .detail-value.success { color: var(--success); }
-  .detail-value.warning { color: var(--warning); }
-  .detail-remark { background: #fef3c7; padding: 12px; border-radius: 10px; margin-top: 12px; }
-  .detail-remark-label { font-size: 0.75rem; color: #9a3412; margin-bottom: 4px; }
-  .detail-remark-text { font-size: 0.9375rem; color: #92400e; }
+  .detail-section { margin-bottom: 18px; }
+  .detail-section-title { font-size: .7rem; font-weight: 700; color: #6b6b6b; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 10px; }
+  .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  .detail-item { background: #f9f6f0; padding: 12px; border-radius: 10px; }
+  .detail-label { font-size: .72rem; color: #888; margin-bottom: 4px; }
+  .detail-value { font-family: var(--font-mono, monospace); font-size: .95rem; font-weight: 600; }
+  .detail-value.highlight { color: var(--terracotta, #c45c3a); }
+  .detail-value.success { color: var(--success, #2d8a5f); }
+  .detail-value.warning { color: var(--warning, #c4873a); }
+  .detail-remark { background: #FFF7E5; padding: 12px; border-radius: 10px; margin-top: 12px; }
+  .detail-remark-label { font-size: .72rem; color: #9a3412; margin-bottom: 4px; }
+  .detail-remark-text  { font-size: .9rem; color: #6b4a16; }
 
-  /* Indent Tab */
-  .indent-card { background: var(--card); border: 1px solid var(--border); border-radius: 16px; padding: 20px; margin-bottom: 20px; }
-  .indent-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px; }
+  /* Indent (left mostly untouched) */
+  .indent-card { background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; padding: 18px; margin: 0 16px 16px; }
+  .indent-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; }
   .indent-title { font-size: 1rem; font-weight: 700; }
-  .btn-add-item { padding: 8px 14px; background: var(--primary); color: white; border: none; border-radius: 8px; font-size: 0.875rem; font-weight: 600; cursor: pointer; }
-  .indent-items { display: flex; flex-direction: column; gap: 16px; }
-  .indent-item { background: #f8fafc; border: 1px solid var(--border); border-radius: 12px; padding: 16px; }
-  .indent-item-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
-  .indent-item-num { font-size: 0.8rem; font-weight: 600; color: var(--text-light); }
-  .btn-remove-item { padding: 4px 8px; background: transparent; color: var(--danger); border: 1px solid var(--danger); border-radius: 6px; font-size: 0.75rem; cursor: pointer; }
+  .btn-add-item { padding: 8px 14px; background: #111; color: white; border: none; border-radius: 8px; font-size: .85rem; font-weight: 600; cursor: pointer; }
+  .indent-items { display: flex; flex-direction: column; gap: 14px; }
+  .indent-item { background: #f9f6f0; border: 1px solid rgba(0,0,0,.06); border-radius: 12px; padding: 14px; }
+  .indent-item-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
+  .indent-item-num { font-size: .78rem; font-weight: 600; color: #888; }
+  .btn-remove-item { padding: 4px 8px; background: transparent; color: var(--danger, #c23b22); border: 1px solid var(--danger, #c23b22); border-radius: 6px; font-size: .72rem; cursor: pointer; }
   .indent-row { display: grid; grid-template-columns: 1fr 80px; gap: 10px; margin-bottom: 10px; }
   .indent-row.single { grid-template-columns: 1fr; }
-  .indent-label { font-size: 0.8rem; font-weight: 600; margin-bottom: 6px; display: block; }
-  .indent-select, .indent-input { width: 100%; padding: 12px; font-size: 0.9375rem; border: 2px solid var(--border); border-radius: 10px; }
-  .btn-submit-indent { width: 100%; padding: 16px; background: var(--success); color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 20px; }
-  .btn-submit-indent:disabled { opacity: 0.7; cursor: not-allowed; }
-  .indent-requests-card { background: var(--card); border: 1px solid var(--border); border-radius: 16px; overflow: hidden; }
-  .indent-requests-header { padding: 14px 20px; background: #f1f5f9; border-bottom: 1px solid var(--border); font-weight: 700; }
-  .indent-request-item { padding: 14px 20px; border-bottom: 1px solid var(--border); display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
+  .indent-label { font-size: .78rem; font-weight: 600; margin-bottom: 6px; display: block; }
+  .indent-select, .indent-input { width: 100%; padding: 11px; font-size: .92rem; border: 1.5px solid #e4e1da; border-radius: 10px; }
+  .btn-submit-indent { width: 100%; padding: 14px; background: var(--success, #2d8a5f); color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 16px; }
+  .indent-requests-card { background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; margin: 0 16px 16px; overflow: hidden; }
+  .indent-requests-header { padding: 12px 18px; background: #f5f1ea; border-bottom: 1px solid rgba(0,0,0,.06); font-weight: 700; }
+  .indent-request-item { padding: 14px 18px; border-bottom: 1px solid rgba(0,0,0,.05); display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
   .indent-request-item:last-child { border-bottom: none; }
   .indent-request-main { flex: 1; min-width: 0; }
-  .indent-request-desc { font-size: 0.9375rem; font-weight: 500; margin-bottom: 4px; word-break: break-word; }
-  .indent-request-meta { font-size: 0.8rem; color: var(--text-light); }
-  .indent-request-lot { color: var(--primary); font-weight: 500; }
-  .indent-request-status { padding: 4px 10px; border-radius: 20px; font-size: 0.7rem; font-weight: 600; text-transform: uppercase; }
-  .indent-request-status.open { background: #fef3c7; color: #9a3412; }
+  .indent-request-desc { font-size: .92rem; font-weight: 500; margin-bottom: 4px; word-break: break-word; }
+  .indent-request-meta { font-size: .78rem; color: #888; }
+  .indent-request-lot { color: var(--terracotta, #c45c3a); font-weight: 500; }
+  .indent-request-status { padding: 4px 10px; border-radius: 999px; font-size: .68rem; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
+  .indent-request-status.open { background: #FEE9C8; color: #92400e; }
   .indent-request-status.proceeding { background: #cffafe; color: #155e75; }
-  .indent-request-status.arrived { background: #d1fae5; color: #065f46; }
-  .indent-empty { padding: 32px 20px; text-align: center; color: var(--text-light); }
-  .select2-container--default .select2-selection--single { height: auto; padding: 8px 12px; border: 2px solid var(--border); border-radius: 10px; }
+  .indent-request-status.arrived { background: var(--success-light, #e8f5ee); color: var(--success, #2d8a5f); }
+  .indent-empty { padding: 28px 18px; text-align: center; color: #888; }
+  .select2-container--default .select2-selection--single { height: auto; padding: 8px 12px; border: 1.5px solid #e4e1da; border-radius: 10px; }
+
+  /* Spinner */
+  .spinner { width: 18px; height: 18px; border: 2px solid rgba(255,255,255,.3); border-top-color: white; border-radius: 50%; animation: spin .8s linear infinite; }
+  .spinner.dark { border: 2px solid rgba(0,0,0,.2); border-top-color: #111; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* Narrow phones */
+  @media (max-width: 380px) {
+    .wi-lotHeader__no { font-size: 1.2rem; }
+    .wi-lotHeader__total { font-size: 1rem; }
+    .wi-row__summary { gap: 10px; padding-left: 16px; }
+    .wi-stepper button { width: 38px; height: 40px; }
+    .wi-stepper input { width: 50px; height: 40px; }
+  }
 </style>
 
 <div class="toast-container" id="toastContainer"></div>
 
-<div class="container">
-  <div class="page-header">
-    <h1 class="page-title">Washing In</h1>
-    <a href="/payments/my-payments" class="btn-payments"><i class="bi bi-wallet2"></i> Payments</a>
+<div class="wi-shell">
+
+  <div class="wi-pageHeader">
+    <h1>Washing&nbsp;In</h1>
+    <a href="/payments/my-payments" class="wi-payLink"><i class="bi bi-wallet2"></i> Payments</a>
   </div>
 
-  <div class="stats-row">
-    <div class="stat-box"><div class="stat-number" id="todayPieces">0</div><div class="stat-label">Pieces Today</div></div>
-    <div class="stat-box"><div class="stat-number" id="todayEntries">0</div><div class="stat-label">Entries</div></div>
+  <div class="wi-stats">
+    <div class="wi-stat"><div class="wi-stat__n" id="todayPieces">0</div><div class="wi-stat__l">Pieces Today</div></div>
+    <div class="wi-stat"><div class="wi-stat__n" id="todayEntries">0</div><div class="wi-stat__l">Entries</div></div>
   </div>
 
-  <div class="tabs">
-    <button class="tab-btn active" data-tab="submit"><i class="bi bi-plus-circle"></i> Submit</button>
-    <button class="tab-btn" data-tab="history"><i class="bi bi-clock-history"></i> History</button>
-    <button class="tab-btn" data-tab="indent"><i class="bi bi-box-seam"></i> Indent</button>
+  <div class="wi-tabs">
+    <button class="wi-tab active" data-tab="submit"><i class="bi bi-plus-circle"></i> Submit</button>
+    <button class="wi-tab" data-tab="history"><i class="bi bi-clock-history"></i> History</button>
+    <button class="wi-tab" data-tab="indent"><i class="bi bi-box-seam"></i> Indent</button>
   </div>
 
+  <!-- =================== SUBMIT TAB =================== -->
   <div class="tab-content active" id="submitTab">
-    <div class="search-card">
-      <label class="search-label">Enter Lot Number</label>
-      <input type="text" id="searchInput" class="search-input" placeholder="e.g. ak5128" autocomplete="off" autofocus>
-      <button type="button" class="btn-search" id="btnSearch" onclick="searchLot()">
-        <span class="btn-text"><i class="bi bi-search"></i> Search Lot</span>
+
+    <!-- Search (hidden once a lot is selected) -->
+    <div class="wi-search" id="searchCard">
+      <label>Lot Number</label>
+      <input type="text" id="searchInput" placeholder="e.g. AK5128" autocomplete="off" autofocus>
+      <button type="button" id="btnSearch" onclick="searchLot()">
+        <span class="btn-text"><i class="bi bi-search"></i> Find lot</span>
       </button>
     </div>
 
+    <!-- Multi-match picker -->
     <div id="lotSelectionList" style="display: none;">
-      <div class="lot-selection-header"><i class="bi bi-list-ul"></i> Multiple lots found - Select one:</div>
-      <div id="lotOptions" class="lot-options"></div>
+      <div class="wi-pickHeader wi-pad"><i class="bi bi-list-ul"></i> Multiple lots — pick one</div>
+      <div id="lotOptions" class="wi-pickList"></div>
     </div>
 
+    <!-- Lot work area -->
     <div id="lotResult" style="display: none;">
-      <div class="lot-card">
-        <div class="lot-header">
-          <div class="lot-title"><span class="lot-number" id="lotNo">-</span><span class="lot-badge">DENIM</span></div>
-          <div class="lot-meta"><span id="lotSku">-</span> &bull; Washed by <span id="lotMaster">-</span></div>
+      <!-- Sticky lot context -->
+      <div class="wi-lotHeader">
+        <div class="wi-lotHeader__top">
+          <span class="wi-lotHeader__no" id="lotNo">—</span>
+          <span class="wi-lotHeader__badge">DENIM</span>
+          <span class="wi-lotHeader__total"><span id="lotTotalAvail">0</span><small>avail</small></span>
         </div>
-        <div class="cutting-remark-note" id="cuttingRemarkNote" style="display: none;">
-          <span class="cutting-remark-note__label">From Cutting</span>
-          <span class="cutting-remark-note__text" id="cuttingRemarkText"></span>
-        </div>
-        <div class="sizes-grid" id="sizesGrid"></div>
-        <div class="submit-section">
-          <div class="total-row"><span class="total-label">Total</span><span class="total-value"><span id="totalQty">0</span> pcs</span></div>
-          <div style="font-size: 0.75rem; color: var(--text-light); margin-bottom: 12px; text-align: center;">
-            OK = normal payment • <span style="color:#f59e0b">Rewash = ₹200/pc debit</span> • <span style="color:#dc2626">Reject = permanent</span>
-          </div>
-          <button type="button" class="btn-submit" id="btnSubmit" onclick="submitWashingIn()" disabled>
-            <span class="btn-text"><i class="bi bi-check-circle"></i> Submit Washing In</span>
-          </button>
+        <div class="wi-lotHeader__meta"><span id="lotSku">—</span> &middot; from <strong id="lotMaster">—</strong></div>
+        <div class="wi-cuttingRemark" id="cuttingRemarkNote" style="display: none;">
+          <i class="bi bi-info-circle-fill"></i>
+          <div><strong>From cutting:</strong> <span id="cuttingRemarkText"></span></div>
         </div>
       </div>
+
+      <div class="wi-sizesHeader">
+        <span>Sizes</span>
+        <span id="sizesHint">Tap a row to flag rewash or reject</span>
+      </div>
+      <div class="wi-sizes" id="sizesList"></div>
     </div>
 
-    <div id="noResult" class="empty-state" style="display: none;"><i class="bi bi-search"></i><p>No lot found</p><span>Check the lot number and try again</span></div>
+    <div id="noResult" class="wi-empty" style="display: none;">
+      <i class="bi bi-search"></i>
+      <p>No lot found</p>
+      <span>Check the lot number and try again.</span>
+    </div>
 
-    <div class="today-card" style="margin-top: 24px;">
-      <div class="today-header"><span class="today-title"><i class="bi bi-check2-all"></i> Today's Work</span><span class="today-total" id="todayTotal">0 pcs</span></div>
-      <ul class="today-list" id="todayList"><li class="today-item" style="justify-content: center; color: var(--text-light);">Loading...</li></ul>
+    <!-- Today's work (shown only when no lot is loaded, to stay focused) -->
+    <div class="wi-today" id="todayCard">
+      <div class="wi-today__head"><span><i class="bi bi-check2-all"></i> Today's work</span><span class="total" id="todayTotal">0 pcs</span></div>
+      <ul class="wi-today__list" id="todayList"><li class="wi-today__item" style="justify-content: center; color: #888;">Loading…</li></ul>
     </div>
   </div>
 
+  <!-- =================== HISTORY TAB =================== -->
   <div class="tab-content" id="historyTab">
     <div class="history-search">
-      <input type="text" id="historySearch" class="history-input" placeholder="Search by lot or SKU...">
+      <input type="text" id="historySearch" class="history-input" placeholder="Search by lot or SKU…">
       <div class="history-filters">
         <input type="date" id="historyStartDate">
         <input type="date" id="historyEndDate">
@@ -247,33 +442,56 @@
         <button type="button" class="btn-download" onclick="downloadHistory()"><i class="bi bi-download"></i> Excel</button>
       </div>
     </div>
-    <div class="history-list" id="historyList"><div class="today-item" style="justify-content: center; color: var(--text-light);">Loading...</div></div>
+    <div class="history-list" id="historyList"><div class="history-item" style="justify-content: center; color: #888;">Loading…</div></div>
   </div>
 
-  <!-- INDENT TAB (lot-aware wrapper) -->
+  <!-- =================== INDENT TAB =================== -->
   <div class="tab-content" id="indentTab">
     <%- include('partials/indentWrapper', { user: user, stage: 'Washing In' }) %>
   </div>
 
-  <!-- Lot Details Modal -->
+  <!-- Lot details modal -->
   <div class="modal-overlay" id="lotModal" style="display: none;" onclick="if(event.target===this)closeLotModal()">
     <div class="modal-content">
       <div class="modal-header">
         <span class="modal-title" id="modalLotNo">Lot Details</span>
         <button type="button" class="modal-close" onclick="closeLotModal()">&times;</button>
       </div>
-      <div class="modal-body" id="modalBody"><div style="text-align:center; padding:20px;"><div class="spinner"></div></div></div>
+      <div class="modal-body" id="modalBody"><div style="text-align:center; padding:20px;"><div class="spinner dark"></div></div></div>
     </div>
   </div>
 </div>
 
+<!-- =================== STICKY FOOTER (visible only when lot loaded) =================== -->
+<div class="wi-stickyFooter" id="stickyFooter" style="display: none;">
+  <div class="wi-stickyFooter__inner">
+    <div class="wi-stickyFooter__totals">
+      <span class="pill ok"><span id="footOk">0</span><small>OK</small></span>
+      <span class="pill rw" id="footRwPill" style="display:none;"><span id="footRw">0</span><small>RW</small></span>
+      <span class="pill rj" id="footRjPill" style="display:none;"><span id="footRj">0</span><small>RJ</small></span>
+      <span class="wi-debit" id="footDebit" style="display:none;">Debit <b>₹<span id="footDebitAmt">0</span></b></span>
+    </div>
+    <button type="button" class="wi-submit" id="btnSubmit" onclick="submitWashingIn()" disabled>
+      <span class="btn-text">
+        <i class="bi bi-check-circle"></i>
+        Submit <span class="wi-submit__count" id="footSubmitCount">0</span> pcs
+      </span>
+    </button>
+  </div>
+</div>
+
 <script>
-document.querySelectorAll('.tab-btn').forEach(function(btn) {
+/* ============================================================
+   Tabs
+   ============================================================ */
+document.querySelectorAll('.wi-tab').forEach(function(btn) {
   btn.addEventListener('click', function() {
-    document.querySelectorAll('.tab-btn').forEach(function(b) { b.classList.remove('active'); });
+    document.querySelectorAll('.wi-tab').forEach(function(b) { b.classList.remove('active'); });
     document.querySelectorAll('.tab-content').forEach(function(c) { c.classList.remove('active'); });
     btn.classList.add('active');
     document.getElementById(btn.dataset.tab + 'Tab').classList.add('active');
+    document.getElementById('stickyFooter').style.display =
+      (btn.dataset.tab === 'submit' && currentLot) ? 'block' : 'none';
   });
 });
 
@@ -286,292 +504,349 @@ function showToast(msg, type, duration) {
   setTimeout(function() { toast.remove(); }, duration || 3000);
 }
 
-function setButtonLoading(btn, loading) {
+function setSearchLoading(loading) {
+  var btn = document.getElementById('btnSearch');
   var span = btn.querySelector('.btn-text');
-  if (loading) {
-    btn.disabled = true;
-    span.textContent = '';
-    var spinner = document.createElement('div');
-    spinner.className = 'spinner';
-    span.appendChild(spinner);
-  } else {
-    btn.disabled = false;
-    span.textContent = '';
-    var i = document.createElement('i');
-    i.className = btn.id === 'btnSearch' ? 'bi bi-search' : 'bi bi-check-circle';
-    span.appendChild(i);
-    span.appendChild(document.createTextNode(btn.id === 'btnSearch' ? ' Search Lot' : ' Submit Washing In'));
+  if (loading) { btn.disabled = true; span.textContent = ''; var s = document.createElement('div'); s.className = 'spinner'; span.appendChild(s); }
+  else {
+    btn.disabled = false; span.textContent = '';
+    var i = document.createElement('i'); i.className = 'bi bi-search';
+    span.appendChild(i); span.appendChild(document.createTextNode(' Find lot'));
   }
 }
 
+/* ============================================================
+   Lot search + picker
+   ============================================================ */
 var currentLot = null;
 var availableLots = [];
 
+async function searchLot() {
+  var input = document.getElementById('searchInput');
+  var v = input.value.trim();
+  if (!v) {
+    input.classList.add('input-error');
+    showToast('Enter a lot number', 'warning');
+    setTimeout(function(){ input.classList.remove('input-error'); }, 600);
+    return;
+  }
+  document.getElementById('lotResult').style.display = 'none';
+  document.getElementById('noResult').style.display = 'none';
+  document.getElementById('lotSelectionList').style.display = 'none';
+  setSearchLoading(true);
+  try {
+    var res = await fetch('/washingin/available-lots?search=' + encodeURIComponent(v));
+    var json = await res.json();
+    var lots = json.data || [];
+    if (!lots.length) { document.getElementById('noResult').style.display = 'block'; showToast('No lot found', 'warning'); return; }
+    if (lots.length > 1) { showLotSelectionList(lots); showToast('Found ' + lots.length + ' lots — pick one', 'info'); return; }
+    currentLot = lots[0];
+    await renderLot();
+  } catch (e) { showToast('Error: ' + e.message, 'error'); }
+  finally { setSearchLoading(false); }
+}
+
 function showLotSelectionList(lots) {
   availableLots = lots;
-  var container = document.getElementById('lotOptions');
-  container.textContent = '';
-  lots.forEach(function(lot, index) {
-    var div = document.createElement('div');
-    div.className = 'lot-option';
-    div.onclick = function() { selectLotFromList(index); };
-    var mainDiv = document.createElement('div');
-    mainDiv.className = 'lot-option-main';
-    var lotNo = document.createElement('span');
-    lotNo.className = 'lot-option-no';
-    lotNo.textContent = lot.lot_no;
-    mainDiv.appendChild(lotNo);
-    var meta = document.createElement('span');
-    meta.className = 'lot-option-meta';
-    meta.textContent = lot.sku + ' • ' + (lot.washing_master || '-');
-    mainDiv.appendChild(meta);
-    if (lot.cutting_remark) {
-      var remark = document.createElement('span');
-      remark.className = 'lot-option-remark';
-      remark.textContent = lot.cutting_remark;
-      mainDiv.appendChild(remark);
-    }
-    div.appendChild(mainDiv);
-    var avail = document.createElement('span');
-    avail.className = 'lot-option-avail';
-    avail.textContent = lot.remaining_pieces + ' pcs';
-    div.appendChild(avail);
-    container.appendChild(div);
+  var box = document.getElementById('lotOptions');
+  box.textContent = '';
+  lots.forEach(function(lot, i) {
+    var d = document.createElement('div'); d.className = 'wi-pickItem'; d.onclick = function(){ selectLotFromList(i); };
+    var main = document.createElement('div');
+    var no = document.createElement('div'); no.className = 'wi-pickItem__no'; no.textContent = lot.lot_no;
+    var meta = document.createElement('div'); meta.className = 'wi-pickItem__meta'; meta.textContent = lot.sku + ' • ' + (lot.washing_master || '-');
+    main.appendChild(no); main.appendChild(meta);
+    if (lot.cutting_remark) { var r = document.createElement('div'); r.className = 'wi-pickItem__remark'; r.textContent = lot.cutting_remark; main.appendChild(r); }
+    var av = document.createElement('div'); av.className = 'wi-pickItem__avail'; av.textContent = lot.remaining_pieces + ' pcs';
+    d.appendChild(main); d.appendChild(av);
+    box.appendChild(d);
   });
   document.getElementById('lotSelectionList').style.display = 'block';
 }
 
-async function selectLotFromList(index) {
+async function selectLotFromList(i) {
   document.getElementById('lotSelectionList').style.display = 'none';
-  currentLot = availableLots[index];
-  await displaySelectedLot();
+  currentLot = availableLots[i];
+  await renderLot();
 }
 
-async function displaySelectedLot() {
+/* ============================================================
+   Render lot: sticky header + size rows
+   ============================================================ */
+async function renderLot() {
+  document.getElementById('searchCard').style.display = 'none';
+  document.getElementById('todayCard').style.display = 'none';
+  document.getElementById('lotResult').style.display = 'block';
+  document.getElementById('stickyFooter').style.display = 'block';
+
   document.getElementById('lotNo').textContent = currentLot.lot_no.toUpperCase();
   document.getElementById('lotSku').textContent = currentLot.sku;
-  document.getElementById('lotMaster').textContent = currentLot.washing_master || '-';
+  document.getElementById('lotMaster').textContent = currentLot.washing_master || '—';
 
-  var remarkNote = document.getElementById('cuttingRemarkNote');
+  var rn = document.getElementById('cuttingRemarkNote');
   if (currentLot.cutting_remark) {
     document.getElementById('cuttingRemarkText').textContent = currentLot.cutting_remark;
-    remarkNote.style.display = 'flex';
-  } else {
-    remarkNote.style.display = 'none';
-  }
+    rn.style.display = 'flex';
+  } else { rn.style.display = 'none'; }
 
-  var sizeRes = await fetch('/washingin/available-lot-sizes/' + currentLot.id);
-  var sizes = await sizeRes.json();
+  // Fetch size availability
+  var res = await fetch('/washingin/available-lot-sizes/' + currentLot.id);
+  var sizes = await res.json();
   currentLot.sizes = sizes;
-  var grid = document.getElementById('sizesGrid');
-  grid.textContent = '';
-  sizes.forEach(function(size) {
-    var card = document.createElement('div');
-    card.className = 'size-card' + (size.remain <= 0 ? ' disabled' : '');
-    var nameDiv = document.createElement('div');
-    nameDiv.className = 'size-name';
-    nameDiv.textContent = size.size_label;
-    card.appendChild(nameDiv);
-    var availDiv = document.createElement('div');
-    availDiv.className = 'size-avail';
-    var greenSpan = document.createElement('span');
-    greenSpan.className = 'green';
-    greenSpan.textContent = size.remain;
-    availDiv.appendChild(greenSpan);
-    availDiv.appendChild(document.createTextNode(' / ' + size.pieces));
-    card.appendChild(availDiv);
-    // OK qty input
-    var input = document.createElement('input');
-    input.type = 'number';
-    input.className = 'size-input qty-input';
-    input.dataset.sizeId = size.id;
-    input.dataset.max = size.remain;
-    input.value = size.remain;
-    input.min = '0';
-    input.max = size.remain;
-    input.disabled = size.remain <= 0;
-    input.addEventListener('input', handleQtyInput);
-    input.addEventListener('focus', function() { this.select(); });
-    card.appendChild(input);
-    // Rewash + Reject compact row
-    var rwRjRow = document.createElement('div');
-    rwRjRow.className = 'rw-rj-row';
-    // Rewash item
-    var rwItem = document.createElement('div');
-    rwItem.className = 'rw-rj-item';
-    var rwLabel = document.createElement('div');
-    rwLabel.className = 'rw-rj-label rw';
-    rwLabel.textContent = 'RW';
-    rwItem.appendChild(rwLabel);
-    var rewashInput = document.createElement('input');
-    rewashInput.type = 'number';
-    rewashInput.className = 'rw-rj-input rewash rewash-input';
-    rewashInput.dataset.sizeId = size.id;
-    rewashInput.placeholder = '0';
-    rewashInput.min = '0';
-    rewashInput.disabled = size.remain <= 0;
-    rewashInput.addEventListener('input', handleQtyInput);
-    rewashInput.addEventListener('focus', function() { this.select(); });
-    rwItem.appendChild(rewashInput);
-    rwRjRow.appendChild(rwItem);
-    // Reject item
-    var rjItem = document.createElement('div');
-    rjItem.className = 'rw-rj-item';
-    var rjLabel = document.createElement('div');
-    rjLabel.className = 'rw-rj-label rj';
-    rjLabel.textContent = 'RJ';
-    rjItem.appendChild(rjLabel);
-    var rejectInput = document.createElement('input');
-    rejectInput.type = 'number';
-    rejectInput.className = 'rw-rj-input reject reject-input';
-    rejectInput.dataset.sizeId = size.id;
-    rejectInput.placeholder = '0';
-    rejectInput.min = '0';
-    rejectInput.disabled = size.remain <= 0;
-    rejectInput.addEventListener('input', handleQtyInput);
-    rejectInput.addEventListener('focus', function() { this.select(); });
-    rjItem.appendChild(rejectInput);
-    rwRjRow.appendChild(rjItem);
-    card.appendChild(rwRjRow);
-    var errorDiv = document.createElement('div');
-    errorDiv.className = 'size-error';
-    errorDiv.textContent = 'Max: ' + size.remain;
-    card.appendChild(errorDiv);
-    grid.appendChild(card);
+
+  // Total available
+  var totAvail = sizes.reduce(function(s, x){ return s + (parseInt(x.remain) || 0); }, 0);
+  document.getElementById('lotTotalAvail').textContent = totAvail;
+
+  // Build rows
+  var list = document.getElementById('sizesList');
+  list.textContent = '';
+  sizes.forEach(function(size) { list.appendChild(buildRow(size)); });
+
+  updateFooter();
+  showToast('Loaded ' + currentLot.lot_no.toUpperCase(), 'success', 1800);
+}
+
+function buildRow(size) {
+  var row = document.createElement('div');
+  row.className = 'wi-row';
+  row.dataset.sizeId = size.id;
+  row.dataset.max = size.remain;
+  row.dataset.label = size.size_label;
+  row.dataset.rw = '0';
+  row.dataset.rj = '0';
+  if (size.remain <= 0) { row.classList.add('is-disabled', 'is-zero'); row.dataset.max = '0'; }
+
+  // Rail
+  var rail = document.createElement('div'); rail.className = 'wi-row__rail'; row.appendChild(rail);
+
+  // Summary
+  var sum = document.createElement('div'); sum.className = 'wi-row__summary'; sum.onclick = function(){ toggleRow(row); };
+  var sz = document.createElement('div'); sz.className = 'wi-row__size'; sz.textContent = size.size_label;
+  var bd = document.createElement('div'); bd.className = 'wi-row__breakdown';
+  bd.appendChild(makeChip(size.remain, 'OK', 'ok'));
+  var caret = document.createElement('i'); caret.className = 'wi-row__caret bi bi-chevron-right';
+  sum.appendChild(sz); sum.appendChild(bd); sum.appendChild(caret);
+  row.appendChild(sum);
+
+  // Editor
+  var ed = document.createElement('div'); ed.className = 'wi-row__edit';
+
+  // Visual bar
+  var vis = document.createElement('div'); vis.className = 'wi-row__visual';
+  vis.innerHTML = '<div class="seg ok" style="width:100%"></div><div class="seg rw" style="width:0"></div><div class="seg rj" style="width:0"></div>';
+  ed.appendChild(vis);
+
+  // OK readout
+  var okBucket = document.createElement('div'); okBucket.className = 'wi-bucket ok';
+  var okLbl = document.createElement('div'); okLbl.className = 'wi-bucket__lbl';
+  okLbl.innerHTML = '<div class="wi-bucket__name ok"><i class="bi bi-check2"></i> OK — taken in</div><div class="wi-bucket__hint">Auto-calculated. Max ' + size.remain + '.</div>';
+  var okRO = document.createElement('div'); okRO.className = 'wi-bucket__readonly'; okRO.textContent = size.remain;
+  okBucket.appendChild(okLbl); okBucket.appendChild(okRO);
+  ed.appendChild(okBucket);
+
+  // RW stepper
+  ed.appendChild(buildBucket('rw', '↩ Rewash', 'Send back to washer · ₹200/pc debit', size.remain, row));
+  // RJ stepper
+  ed.appendChild(buildBucket('rj', '✗ Reject', 'Damaged · permanent', size.remain, row));
+
+  // Error
+  var err = document.createElement('div'); err.className = 'wi-rowError'; err.textContent = 'Total exceeds ' + size.remain + ' available'; ed.appendChild(err);
+
+  // Done
+  var act = document.createElement('div'); act.className = 'wi-rowActions';
+  var done = document.createElement('button'); done.type = 'button'; done.className = 'wi-btnDone';
+  done.innerHTML = '<i class="bi bi-check2"></i> Done';
+  done.onclick = function(){ toggleRow(row, false); };
+  act.appendChild(done);
+  ed.appendChild(act);
+
+  row.appendChild(ed);
+  return row;
+}
+
+function buildBucket(kind, name, hint, max, row) {
+  var b = document.createElement('div'); b.className = 'wi-bucket ' + kind;
+  var lbl = document.createElement('div'); lbl.className = 'wi-bucket__lbl';
+  lbl.innerHTML = '<div class="wi-bucket__name ' + kind + '">' + name + '</div><div class="wi-bucket__hint">' + hint + '</div>';
+  var st = document.createElement('div'); st.className = 'wi-stepper ' + kind;
+  var dec = document.createElement('button'); dec.type = 'button'; dec.textContent = '−';
+  var inp = document.createElement('input'); inp.type = 'number'; inp.value = '0'; inp.min = '0'; inp.max = max; inp.inputMode = 'numeric'; inp.dataset.kind = kind;
+  var inc = document.createElement('button'); inc.type = 'button'; inc.textContent = '+';
+
+  function bump(delta) {
+    var cur = parseInt(inp.value) || 0;
+    var other = kind === 'rw' ? (parseInt(row.dataset.rj) || 0) : (parseInt(row.dataset.rw) || 0);
+    var headroom = Math.max(0, max - other);
+    var next = Math.min(headroom, Math.max(0, cur + delta));
+    inp.value = next;
+    applyChange(row, kind, next);
+  }
+  dec.onclick = function(){ bump(-1); };
+  inc.onclick = function(){ bump(+1); };
+  inp.addEventListener('focus', function(){ inp.select(); });
+  inp.addEventListener('input', function() {
+    var v = Math.max(0, Math.min(max, parseInt(inp.value) || 0));
+    applyChange(row, kind, v);
   });
-  document.getElementById('lotResult').style.display = 'block';
-  updateTotal();
-  showToast('Selected: ' + currentLot.lot_no.toUpperCase(), 'success', 2000);
+  inp.addEventListener('keydown', function(e) {
+    if (e.key === 'Enter') { e.preventDefault(); toggleRow(row, false); focusNextOpenable(row); }
+    else if (e.key === 'Escape') { e.preventDefault(); toggleRow(row, false); }
+  });
+  st.appendChild(dec); st.appendChild(inp); st.appendChild(inc);
+  b.appendChild(lbl); b.appendChild(st);
+  return b;
 }
 
-async function searchLot() {
-  var searchInput = document.getElementById('searchInput');
-  var search = searchInput.value.trim();
-  var btn = document.getElementById('btnSearch');
+/* ============================================================
+   State updates
+   ============================================================ */
+function applyChange(row, kind, value) {
+  var max = parseInt(row.dataset.max) || 0;
+  row.dataset[kind] = value;
+  var rw = parseInt(row.dataset.rw) || 0;
+  var rj = parseInt(row.dataset.rj) || 0;
+  var ok = Math.max(0, max - rw - rj);
+  var over = rw + rj > max;
 
-  if (!search) {
-    searchInput.classList.add('input-error');
-    showToast('Please enter a lot number', 'warning');
-    setTimeout(function() { searchInput.classList.remove('input-error'); }, 600);
-    return;
+  // OK readout
+  var okRO = row.querySelector('.wi-bucket__readonly');
+  if (okRO) okRO.textContent = ok;
+
+  // Visual bar
+  var vis = row.querySelectorAll('.wi-row__visual .seg');
+  if (vis.length === 3 && max > 0) {
+    vis[0].style.width = (ok / max * 100) + '%';
+    vis[1].style.width = (rw / max * 100) + '%';
+    vis[2].style.width = (rj / max * 100) + '%';
   }
 
-  document.getElementById('lotResult').style.display = 'none';
-  document.getElementById('noResult').style.display = 'none';
-  document.getElementById('lotSelectionList').style.display = 'none';
-  setButtonLoading(btn, true);
+  // Row state
+  row.classList.toggle('has-rw', rw > 0);
+  row.classList.toggle('has-rj', rj > 0);
+  row.classList.toggle('has-exception', rw > 0 || rj > 0);
+  row.classList.toggle('has-error', over);
 
-  try {
-    var res = await fetch('/washingin/available-lots?search=' + encodeURIComponent(search));
-    var json = await res.json();
-    var lots = json.data || [];
-
-    if (lots.length === 0) {
-      document.getElementById('noResult').style.display = 'block';
-      showToast('No lot found', 'warning');
-      return;
-    }
-
-    if (lots.length > 1) {
-      showLotSelectionList(lots);
-      showToast('Found ' + lots.length + ' lots - select one', 'info');
-      return;
-    }
-
-    currentLot = lots[0];
-    await displaySelectedLot();
-  } catch (err) {
-    showToast('Error: ' + err.message, 'error');
-  } finally {
-    setButtonLoading(btn, false);
-  }
-}
-
-function handleQtyInput(e) {
-  var inp = e.target;
-  var card = inp.closest('.size-card');
-  var okInput = card.querySelector('.qty-input');
-  var rwInput = card.querySelector('.rewash-input');
-  var rjInput = card.querySelector('.reject-input');
-  var max = parseInt(okInput.dataset.max) || 0;
-  var rwVal = parseInt(rwInput.value) || 0;
-  var rjVal = parseInt(rjInput.value) || 0;
-
-  // Auto-adjust OK when RW/RJ changes (OK = max - RW - RJ)
-  if (inp === rwInput || inp === rjInput) {
-    var newOk = Math.max(0, max - rwVal - rjVal);
-    okInput.value = newOk;
-  }
-
-  var okVal = parseInt(okInput.value) || 0;
-  var total = okVal + rwVal + rjVal;
-  if (total > max) {
-    card.classList.add('input-error');
-    card.querySelector('.size-error').textContent = 'Total exceeds ' + max;
+  // Re-render breakdown chips
+  var bd = row.querySelector('.wi-row__breakdown');
+  bd.textContent = '';
+  if (max === 0) {
+    bd.appendChild(makeChip(0, 'OK', 'dim'));
   } else {
-    card.classList.remove('input-error');
-    card.classList.toggle('has-qty', total > 0);
+    bd.appendChild(makeChip(ok, 'OK', 'ok'));
+    if (rw > 0) bd.appendChild(makeChip(rw, 'RW', 'rw'));
+    if (rj > 0) bd.appendChild(makeChip(rj, 'RJ', 'rj'));
   }
-  updateTotal();
+
+  updateFooter();
 }
 
-function updateTotal() {
-  var cards = document.querySelectorAll('.size-card');
-  var totalOk = 0, totalRw = 0, totalRj = 0, hasError = false;
-  cards.forEach(function(card) {
-    var okInput = card.querySelector('.qty-input');
-    var rwInput = card.querySelector('.rewash-input');
-    var rjInput = card.querySelector('.reject-input');
-    if (!okInput) return;
-    var max = parseInt(okInput.dataset.max) || 0;
-    var okVal = parseInt(okInput.value) || 0;
-    var rwVal = parseInt(rwInput ? rwInput.value : 0) || 0;
-    var rjVal = parseInt(rjInput ? rjInput.value : 0) || 0;
-    if (okVal + rwVal + rjVal > max) hasError = true;
-    totalOk += okVal;
-    totalRw += rwVal;
-    totalRj += rjVal;
+function makeChip(n, label, cls) {
+  var c = document.createElement('span'); c.className = 'wi-chip ' + cls;
+  var v = document.createElement('span'); v.textContent = n;
+  var s = document.createElement('small'); s.textContent = label;
+  c.appendChild(v); c.appendChild(s);
+  return c;
+}
+
+function toggleRow(row, force) {
+  if (row.classList.contains('is-disabled')) return;
+  var willOpen = (typeof force === 'boolean') ? force : !row.classList.contains('is-open');
+  // Close all others (one editor at a time keeps the screen calm)
+  document.querySelectorAll('.wi-row.is-open').forEach(function(r) { if (r !== row) r.classList.remove('is-open'); });
+  row.classList.toggle('is-open', willOpen);
+  if (willOpen) {
+    // Focus the RW stepper input first — most exceptions are rewashes
+    var inp = row.querySelector('.wi-stepper.rw input');
+    if (inp) setTimeout(function(){ inp.focus(); inp.select(); }, 60);
+    // Scroll the row into view comfortably under the sticky lot header
+    setTimeout(function(){
+      var top = row.getBoundingClientRect().top;
+      if (top < 140 || top > window.innerHeight - 220) {
+        row.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
+    }, 80);
+  }
+}
+
+function focusNextOpenable(currentRow) {
+  // After Enter in a stepper, look for the next size row that has an exception flagged
+  // (so the operator can continue typing exceptions). Else just close.
+  var rows = Array.prototype.slice.call(document.querySelectorAll('.wi-row'));
+  var idx = rows.indexOf(currentRow);
+  for (var i = idx + 1; i < rows.length; i++) {
+    var r = rows[i];
+    if (r.classList.contains('has-exception')) { toggleRow(r, true); return; }
+  }
+}
+
+/* ============================================================
+   Footer totals + submit
+   ============================================================ */
+function readTotals() {
+  var rows = document.querySelectorAll('.wi-row');
+  var ok = 0, rw = 0, rj = 0, anyError = false, anyAvail = false;
+  rows.forEach(function(r) {
+    var max = parseInt(r.dataset.max) || 0;
+    if (max === 0) return;
+    anyAvail = true;
+    var rwV = parseInt(r.dataset.rw) || 0;
+    var rjV = parseInt(r.dataset.rj) || 0;
+    if (rwV + rjV > max) anyError = true;
+    ok += Math.max(0, max - rwV - rjV);
+    rw += rwV;
+    rj += rjV;
   });
-  var parts = [];
-  if (totalOk > 0) parts.push(totalOk + ' OK');
-  if (totalRw > 0) parts.push(totalRw + ' RW');
-  if (totalRj > 0) parts.push(totalRj + ' RJ');
-  var display = parts.length > 0 ? parts.join(', ') : '0';
-  document.getElementById('totalQty').textContent = display;
-  document.getElementById('btnSubmit').disabled = hasError || (totalOk + totalRw + totalRj) === 0;
+  return { ok: ok, rw: rw, rj: rj, error: anyError, hasAvail: anyAvail };
+}
+
+function updateFooter() {
+  var t = readTotals();
+  document.getElementById('footOk').textContent = t.ok;
+  document.getElementById('footRw').textContent = t.rw;
+  document.getElementById('footRj').textContent = t.rj;
+  document.getElementById('footRwPill').style.display = t.rw > 0 ? '' : 'none';
+  document.getElementById('footRjPill').style.display = t.rj > 0 ? '' : 'none';
+  var debit = t.rw * 200;
+  document.getElementById('footDebit').style.display = debit > 0 ? '' : 'none';
+  document.getElementById('footDebitAmt').textContent = debit;
+
+  var total = t.ok + t.rw + t.rj;
+  document.getElementById('footSubmitCount').textContent = total;
+  var btn = document.getElementById('btnSubmit');
+  btn.disabled = t.error || !t.hasAvail;
 }
 
 async function submitWashingIn() {
   if (!currentLot) return;
-  var cards = document.querySelectorAll('.size-card');
+  var t = readTotals();
+  if (t.error) { showToast('Fix sizes that exceed available', 'error'); return; }
+  if (t.ok + t.rw + t.rj === 0) { showToast('Nothing to submit', 'warning'); return; }
+
+  // Build payload
   var sizes = {}, rewash = {}, reject = {};
-  var totalOk = 0, totalRw = 0, totalRj = 0, hasError = false;
-  cards.forEach(function(card) {
-    var okInput = card.querySelector('.qty-input');
-    var rwInput = card.querySelector('.rewash-input');
-    var rjInput = card.querySelector('.reject-input');
-    if (!okInput) return;
-    var sizeId = okInput.dataset.sizeId;
-    var max = parseInt(okInput.dataset.max) || 0;
-    var okVal = parseInt(okInput.value) || 0;
-    var rwVal = parseInt(rwInput ? rwInput.value : 0) || 0;
-    var rjVal = parseInt(rjInput ? rjInput.value : 0) || 0;
-    if (okVal + rwVal + rjVal > max) hasError = true;
-    if (okVal > 0) { sizes[sizeId] = okVal; totalOk += okVal; }
-    if (rwVal > 0) { rewash[sizeId] = rwVal; totalRw += rwVal; }
-    if (rjVal > 0) { reject[sizeId] = rjVal; totalRj += rjVal; }
+  document.querySelectorAll('.wi-row').forEach(function(r) {
+    var max = parseInt(r.dataset.max) || 0;
+    if (max === 0) return;
+    var sid = r.dataset.sizeId;
+    var rwV = parseInt(r.dataset.rw) || 0;
+    var rjV = parseInt(r.dataset.rj) || 0;
+    var okV = Math.max(0, max - rwV - rjV);
+    if (okV > 0) sizes[sid] = okV;
+    if (rwV > 0) rewash[sid] = rwV;
+    if (rjV > 0) reject[sid] = rjV;
   });
-  if (hasError) { showToast('Fix errors first', 'error'); return; }
-  var grandTotal = totalOk + totalRw + totalRj;
-  if (grandTotal === 0) { showToast('Enter quantity', 'warning'); return; }
-  var confirmMsg = 'Submit ' + totalOk + ' OK pieces';
-  if (totalRw > 0) confirmMsg += ', ' + totalRw + ' REWASH (₹' + (totalRw * 200) + ' debit)';
-  if (totalRj > 0) confirmMsg += ', ' + totalRj + ' REJECT';
-  confirmMsg += '?';
-  if (!confirm(confirmMsg)) return;
+
+  var msg = 'Submit ' + t.ok + ' OK';
+  if (t.rw > 0) msg += ', ' + t.rw + ' rewash (₹' + (t.rw * 200) + ' debit)';
+  if (t.rj > 0) msg += ', ' + t.rj + ' reject';
+  msg += '?';
+  if (!confirm(msg)) return;
 
   var btn = document.getElementById('btnSubmit');
-  setButtonLoading(btn, true);
+  btn.disabled = true;
+  var span = btn.querySelector('.btn-text');
+  span.textContent = ''; var sp = document.createElement('div'); sp.className = 'spinner'; span.appendChild(sp);
 
   try {
     var res = await fetch('/washingin/submit', {
@@ -581,24 +856,42 @@ async function submitWashingIn() {
     });
     var data = await res.json();
     if (data.success) {
-      var msg = 'Submitted ' + totalOk + ' OK';
-      if (totalRw > 0) msg += ', ' + totalRw + ' rewash';
-      if (totalRj > 0) msg += ', ' + totalRj + ' reject';
-      showToast(msg, 'success', 4000);
-      document.getElementById('searchInput').value = '';
-      document.getElementById('lotResult').style.display = 'none';
-      currentLot = null;
+      var m = 'Submitted ' + t.ok + ' OK';
+      if (t.rw > 0) m += ', ' + t.rw + ' rewash';
+      if (t.rj > 0) m += ', ' + t.rj + ' reject';
+      showToast(m, 'success', 3500);
+      resetLotView();
       loadToday();
     } else {
       showToast(data.error || 'Failed', 'error');
+      btn.disabled = false; span.textContent = '';
+      var i = document.createElement('i'); i.className = 'bi bi-check-circle';
+      span.appendChild(i); span.appendChild(document.createTextNode(' Submit '));
+      var cs = document.createElement('span'); cs.className = 'wi-submit__count'; cs.id = 'footSubmitCount'; cs.textContent = (t.ok + t.rw + t.rj);
+      span.appendChild(cs); span.appendChild(document.createTextNode(' pcs'));
     }
-  } catch (err) {
-    showToast('Error: ' + err.message, 'error');
-  } finally {
-    setButtonLoading(btn, false);
+  } catch (e) {
+    showToast('Error: ' + e.message, 'error');
+    btn.disabled = false; span.textContent = '';
+    var i = document.createElement('i'); i.className = 'bi bi-check-circle';
+    span.appendChild(i); span.appendChild(document.createTextNode(' Submit '));
+    var cs = document.createElement('span'); cs.className = 'wi-submit__count'; cs.id = 'footSubmitCount'; cs.textContent = (t.ok + t.rw + t.rj);
+    span.appendChild(cs); span.appendChild(document.createTextNode(' pcs'));
   }
 }
 
+function resetLotView() {
+  currentLot = null;
+  document.getElementById('lotResult').style.display = 'none';
+  document.getElementById('stickyFooter').style.display = 'none';
+  document.getElementById('searchCard').style.display = 'block';
+  document.getElementById('todayCard').style.display = 'block';
+  var si = document.getElementById('searchInput'); si.value = ''; si.focus();
+}
+
+/* ============================================================
+   Today / History / Modal — unchanged behavior, refreshed selectors
+   ============================================================ */
 async function loadToday() {
   try {
     var res = await fetch('/washingin/my-today');
@@ -606,29 +899,22 @@ async function loadToday() {
     document.getElementById('todayPieces').textContent = data.total_pieces || 0;
     document.getElementById('todayEntries').textContent = data.count || 0;
     document.getElementById('todayTotal').textContent = (data.total_pieces || 0) + ' pcs';
-    var list = document.getElementById('todayList');
-    list.textContent = '';
-    if (!data.entries || data.entries.length === 0) {
-      var li = document.createElement('li');
-      li.className = 'today-item';
-      li.style.justifyContent = 'center';
-      li.style.color = 'var(--text-light)';
-      li.textContent = 'No entries today';
-      list.appendChild(li);
-      return;
+    var list = document.getElementById('todayList'); list.textContent = '';
+    if (!data.entries || !data.entries.length) {
+      var li = document.createElement('li'); li.className = 'wi-today__item';
+      li.style.justifyContent = 'center'; li.style.color = '#888'; li.textContent = 'No entries yet today';
+      list.appendChild(li); return;
     }
     data.entries.forEach(function(e) {
-      var li = document.createElement('li');
-      li.className = 'today-item';
+      var li = document.createElement('li'); li.className = 'wi-today__item';
       var left = document.createElement('div');
-      var lot = document.createElement('div'); lot.className = 'today-lot'; lot.textContent = e.lot_no;
-      var sku = document.createElement('div'); sku.className = 'today-sku'; sku.textContent = e.sku;
+      var lot = document.createElement('div'); lot.className = 'wi-today__lot'; lot.textContent = e.lot_no;
+      var sku = document.createElement('div'); sku.className = 'wi-today__sku'; sku.textContent = e.sku;
       left.appendChild(lot); left.appendChild(sku);
-      var qty = document.createElement('span'); qty.className = 'today-qty'; qty.textContent = e.total_pieces + ' pcs';
-      li.appendChild(left); li.appendChild(qty);
-      list.appendChild(li);
+      var qty = document.createElement('span'); qty.className = 'wi-today__qty'; qty.textContent = e.total_pieces + ' pcs';
+      li.appendChild(left); li.appendChild(qty); list.appendChild(li);
     });
-  } catch (err) { console.error(err); }
+  } catch (e) { console.error(e); }
 }
 
 var historyOffset = 0;
@@ -645,34 +931,24 @@ async function loadHistory(reset) {
     var data = await res.json();
     var list = document.getElementById('historyList');
     if (reset) list.textContent = '';
-    if (!data.entries || data.entries.length === 0) {
-      if (reset) { var d = document.createElement('div'); d.className = 'today-item'; d.style.justifyContent = 'center'; d.textContent = 'No entries'; list.appendChild(d); }
+    if (!data.entries || !data.entries.length) {
+      if (reset) { var d = document.createElement('div'); d.className = 'history-item'; d.style.justifyContent = 'center'; d.style.color = '#888'; d.textContent = 'No entries'; list.appendChild(d); }
       return;
     }
     data.entries.forEach(function(e) {
-      var div = document.createElement('div');
-      div.className = 'history-item clickable';
-      div.onclick = function() { showLotDetails(e.lot_no); };
+      var div = document.createElement('div'); div.className = 'history-item clickable'; div.onclick = function(){ showLotDetails(e.lot_no); };
       var left = document.createElement('div');
       var lot = document.createElement('div'); lot.className = 'today-lot'; lot.textContent = e.lot_no;
-      var sku = document.createElement('div'); sku.className = 'today-sku'; sku.textContent = e.sku + ' - ' + new Date(e.created_at).toLocaleDateString();
+      var sku = document.createElement('div'); sku.className = 'today-sku'; sku.textContent = e.sku + ' • ' + new Date(e.created_at).toLocaleDateString();
       left.appendChild(lot); left.appendChild(sku);
-      if (e.cutting_remark) {
-        var remark = document.createElement('span');
-        remark.className = 'history-remark';
-        remark.textContent = e.cutting_remark;
-        left.appendChild(remark);
-      }
+      if (e.cutting_remark) { var rk = document.createElement('span'); rk.className = 'history-remark'; rk.textContent = e.cutting_remark; left.appendChild(rk); }
       var qty = document.createElement('span'); qty.className = 'today-qty'; qty.textContent = e.total_pieces + ' pcs';
-      div.appendChild(left); div.appendChild(qty);
-      list.appendChild(div);
+      div.appendChild(left); div.appendChild(qty); list.appendChild(div);
     });
     historyOffset += data.entries.length;
-  } catch (err) { console.error(err); }
+  } catch (e) { console.error(e); }
 }
-
 function applyHistoryFilter() { loadHistory(true); }
-
 function downloadHistory() {
   var search = document.getElementById('historySearch').value;
   var startDate = document.getElementById('historyStartDate').value;
@@ -688,95 +964,55 @@ async function showLotDetails(lotNo) {
   document.getElementById('modalLotNo').textContent = lotNo.toUpperCase();
   var body = document.getElementById('modalBody');
   body.textContent = '';
-  var spinner = document.createElement('div');
-  spinner.className = 'spinner';
-  spinner.style.margin = '20px auto';
-  body.appendChild(spinner);
-
+  var spinner = document.createElement('div'); spinner.className = 'spinner dark'; spinner.style.margin = '20px auto'; body.appendChild(spinner);
   try {
     var res = await fetch('/washingin/lot-details/' + encodeURIComponent(lotNo));
     var data = await res.json();
     body.textContent = '';
     if (!data.success) { body.textContent = data.error || 'Failed to load'; return; }
     var lot = data.lot;
-
     var sec1 = createDetailSection('Lot Information');
-    var grid1 = createDetailGrid();
-    grid1.appendChild(createDetailItemDOM('SKU', lot.sku || '-'));
-    grid1.appendChild(createDetailItemDOM('Total Cut', lot.total_pieces || 0));
-    grid1.appendChild(createDetailItemDOM('Cutting Master', lot.cutting_master || '-'));
-    sec1.appendChild(grid1);
+    var g1 = createDetailGrid();
+    g1.appendChild(createDetailItemDOM('SKU', lot.sku || '-'));
+    g1.appendChild(createDetailItemDOM('Total Cut', lot.total_pieces || 0));
+    g1.appendChild(createDetailItemDOM('Cutting Master', lot.cutting_master || '-'));
+    sec1.appendChild(g1);
     if (lot.cutting_remark) {
-      var remarkDiv = document.createElement('div');
-      remarkDiv.className = 'detail-remark';
-      var remarkLabel = document.createElement('div');
-      remarkLabel.className = 'detail-remark-label';
-      remarkLabel.textContent = 'Cutting Remark';
-      var remarkText = document.createElement('div');
-      remarkText.className = 'detail-remark-text';
-      remarkText.textContent = lot.cutting_remark;
-      remarkDiv.appendChild(remarkLabel);
-      remarkDiv.appendChild(remarkText);
-      sec1.appendChild(remarkDiv);
+      var r = document.createElement('div'); r.className = 'detail-remark';
+      var l = document.createElement('div'); l.className = 'detail-remark-label'; l.textContent = 'Cutting Remark';
+      var t = document.createElement('div'); t.className = 'detail-remark-text'; t.textContent = lot.cutting_remark;
+      r.appendChild(l); r.appendChild(t); sec1.appendChild(r);
     }
     body.appendChild(sec1);
-
-    var sec2 = createDetailSection('Progress');
-    var grid2 = createDetailGrid();
-    grid2.appendChild(createDetailItemDOM('Stitched', lot.stitched_qty || 0, 'highlight'));
-    grid2.appendChild(createDetailItemDOM('Assembled', lot.assembly_qty || 0, 'highlight'));
-    grid2.appendChild(createDetailItemDOM('Washed Out', lot.washed_qty || 0, 'highlight'));
-    grid2.appendChild(createDetailItemDOM('Washed In', lot.washed_in_qty || 0, 'success'));
-    grid2.appendChild(createDetailItemDOM('Finished', lot.finished_qty || 0, 'highlight'));
-    sec2.appendChild(grid2);
-    body.appendChild(sec2);
-
-    var sec3 = createDetailSection('Payment (Washing In)');
-    var grid3 = createDetailGrid();
-    var payClass = lot.payment_status === 'paid' ? 'success' : lot.payment_status === 'pending' ? 'warning' : '';
-    grid3.appendChild(createDetailItemDOM('Status', (lot.payment_status || 'N/A').toUpperCase(), payClass));
-    grid3.appendChild(createDetailItemDOM('Amount Paid', '₹' + (lot.payment_amount || 0)));
-    sec3.appendChild(grid3);
-    body.appendChild(sec3);
+    var sec2 = createDetailSection('Progress'); var g2 = createDetailGrid();
+    g2.appendChild(createDetailItemDOM('Stitched',   lot.stitched_qty   || 0, 'highlight'));
+    g2.appendChild(createDetailItemDOM('Assembled',  lot.assembly_qty   || 0, 'highlight'));
+    g2.appendChild(createDetailItemDOM('Washed Out', lot.washed_qty     || 0, 'highlight'));
+    g2.appendChild(createDetailItemDOM('Washed In',  lot.washed_in_qty  || 0, 'success'));
+    g2.appendChild(createDetailItemDOM('Finished',   lot.finished_qty   || 0, 'highlight'));
+    sec2.appendChild(g2); body.appendChild(sec2);
+    var sec3 = createDetailSection('Payment (Washing In)'); var g3 = createDetailGrid();
+    var pc = lot.payment_status === 'paid' ? 'success' : lot.payment_status === 'pending' ? 'warning' : '';
+    g3.appendChild(createDetailItemDOM('Status', (lot.payment_status || 'N/A').toUpperCase(), pc));
+    g3.appendChild(createDetailItemDOM('Amount Paid', '₹' + (lot.payment_amount || 0)));
+    sec3.appendChild(g3); body.appendChild(sec3);
   } catch (e) { body.textContent = 'Error: ' + e.message; }
 }
-
 function closeLotModal() { document.getElementById('lotModal').style.display = 'none'; }
-
-function createDetailSection(title) {
-  var sec = document.createElement('div');
-  sec.className = 'detail-section';
-  var t = document.createElement('div');
-  t.className = 'detail-section-title';
-  t.textContent = title;
-  sec.appendChild(t);
-  return sec;
-}
-
-function createDetailGrid() {
-  var grid = document.createElement('div');
-  grid.className = 'detail-grid';
-  return grid;
-}
-
+function createDetailSection(title) { var s = document.createElement('div'); s.className = 'detail-section'; var t = document.createElement('div'); t.className = 'detail-section-title'; t.textContent = title; s.appendChild(t); return s; }
+function createDetailGrid() { var g = document.createElement('div'); g.className = 'detail-grid'; return g; }
 function createDetailItemDOM(label, value, cls) {
-  var item = document.createElement('div');
-  item.className = 'detail-item';
-  var lbl = document.createElement('div');
-  lbl.className = 'detail-label';
-  lbl.textContent = label;
-  var val = document.createElement('div');
-  val.className = 'detail-value' + (cls ? ' ' + cls : '');
-  val.textContent = String(value);
-  item.appendChild(lbl);
-  item.appendChild(val);
-  return item;
+  var i = document.createElement('div'); i.className = 'detail-item';
+  var l = document.createElement('div'); l.className = 'detail-label'; l.textContent = label;
+  var v = document.createElement('div'); v.className = 'detail-value' + (cls ? ' ' + cls : ''); v.textContent = String(value);
+  i.appendChild(l); i.appendChild(v); return i;
 }
-// INDENT TAB handled by views/partials/indentWrapper.ejs
 
-document.getElementById('searchInput').addEventListener('keypress', function(e) { if (e.key === 'Enter') searchLot(); });
-var ht; document.getElementById('historySearch').addEventListener('input', function() { clearTimeout(ht); ht = setTimeout(function() { loadHistory(true); }, 300); });
-loadToday(); loadHistory(true);
+document.getElementById('searchInput').addEventListener('keypress', function(e){ if (e.key === 'Enter') searchLot(); });
+var ht; document.getElementById('historySearch').addEventListener('input', function() { clearTimeout(ht); ht = setTimeout(function(){ loadHistory(true); }, 300); });
+
+loadToday();
+loadHistory(true);
 </script>
 
 <%- include('partials/footer') %>


### PR DESCRIPTION
Operators reported the size grid was painful to fill — 7 sizes × 3 tiny inputs forced them to read 21 fields per lot when 19 are usually zero.

Replaces the size-card grid with full-width size rows. Each row collapses to a single "X OK" chip; tap to open an inline editor with −/+ steppers for rewash/reject. OK is auto-derived and shown live. Sticky lot header keeps context on screen, sticky footer holds Submit + live totals + debit preview so the common case (no exceptions) is one tap.

API contract, History, Indent, and lot-details modal are untouched.