### PR TITLE
feat(washingin): match reference design — hero CTA + all splits visible

### DIFF
--- a/views/washingInDashboard.ejs
+++ b/views/washingInDashboard.ejs
@@ -7,20 +7,40 @@
 
 <style>
   /* =========================================================
-     Washing-In Dashboard — Industrial entry surface
-     Goals: factory-floor mobile, common case is 1 tap.
-     Tokens from kotty-theme.css:
-       --font-body (Outfit), --font-display (DM Serif), --font-mono (JetBrains)
-       --terracotta, --success #2d8a5f, --warning #c4873a, --danger #c23b22
+     Washing-In Dashboard — clear, always-visible splits.
+     Goal: happy path = 1 tap, exceptions = visible by default,
+     bidirectional steppers (RW+ pulls from TAKE automatically).
      ========================================================= */
   * { box-sizing: border-box; }
-  body { background: #FAF7F2; font-family: var(--font-body, 'Outfit', sans-serif); color: var(--text-primary, #1a1a1a); font-size: 16px; }
+  body {
+    background: #F4F5F9;
+    font-family: var(--font-body, 'Outfit', sans-serif);
+    color: #1a1a1a;
+    font-size: 16px;
+  }
 
-  /* ---- Shared shell ---- */
-  .wi-shell { max-width: 560px; margin: 0 auto; padding: 76px 0 0; }
+  :root {
+    --wi-indigo: #5b5bf5;
+    --wi-indigo-dark: #4f46e5;
+    --wi-indigo-bg: #EEF0FE;
+    --wi-amber: #c4873a;
+    --wi-amber-bg: #FEF6E5;
+    --wi-amber-chip: #FFE9B8;
+    --wi-red: #c23b22;
+    --wi-red-bg: #FCEDEA;
+    --wi-red-chip: #FAD3CD;
+    --wi-green: #2d8a5f;
+    --wi-ink: #1a1a1a;
+    --wi-muted: #6b7280;
+    --wi-line: rgba(0,0,0,.08);
+    --wi-bg: #F4F5F9;
+    --wi-card: #ffffff;
+  }
+
+  .wi-shell { max-width: 760px; margin: 0 auto; padding: 76px 0 0; }
   .wi-pad   { padding: 0 16px; }
 
-  /* ---- Toasts ---- */
+  /* Toasts */
   .toast-container { position: fixed; top: 80px; left: 50%; transform: translateX(-50%); z-index: 9999; width: calc(100% - 32px); max-width: 400px; }
   .toast { padding: 14px 18px; border-radius: 12px; font-weight: 500; display: flex; align-items: center; gap: 10px; box-shadow: 0 4px 12px rgba(0,0,0,0.15); animation: toastIn .25s ease-out; margin-bottom: 8px; }
   @keyframes toastIn { from { opacity: 0; transform: translateY(-12px); } to { opacity: 1; transform: translateY(0); } }
@@ -29,332 +49,391 @@
   .toast-warning { background: #92400e; color: white; }
   .toast-info    { background: #1e40af; color: white; }
 
-  /* ---- Page header ---- */
+  /* Page header */
   .wi-pageHeader { display: flex; justify-content: space-between; align-items: baseline; padding: 8px 16px 16px; }
   .wi-pageHeader h1 { font-family: var(--font-display, 'DM Serif Display', serif); font-size: 1.75rem; margin: 0; letter-spacing: -0.01em; }
-  .wi-pageHeader .wi-payLink { font-size: .85rem; color: var(--terracotta, #c45c3a); text-decoration: none; font-weight: 500; display: inline-flex; align-items: center; gap: 6px; }
+  .wi-pageHeader .wi-payLink { font-size: .85rem; color: var(--wi-indigo); text-decoration: none; font-weight: 600; display: inline-flex; align-items: center; gap: 6px; }
 
-  /* ---- Stats strip ---- */
+  /* Stats strip */
   .wi-stats { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin: 0 16px 16px; }
-  .wi-stat  { background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; padding: 14px 16px; }
-  .wi-stat__n { font-family: var(--font-mono, 'JetBrains Mono', monospace); font-size: 1.65rem; font-weight: 600; color: #111; line-height: 1; }
-  .wi-stat__l { font-size: .75rem; color: #6b6b6b; text-transform: uppercase; letter-spacing: .08em; margin-top: 6px; }
+  .wi-stat  { background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 14px; padding: 14px 16px; }
+  .wi-stat__n { font-family: var(--font-mono, 'JetBrains Mono', monospace); font-size: 1.6rem; font-weight: 600; color: #111; line-height: 1; }
+  .wi-stat__l { font-size: .72rem; color: var(--wi-muted); text-transform: uppercase; letter-spacing: .08em; margin-top: 6px; font-weight: 600; }
 
-  /* ---- Tabs ---- */
-  .wi-tabs { display: flex; background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; padding: 4px; margin: 0 16px 16px; }
-  .wi-tab  { flex: 1; padding: 11px 8px; border: none; background: transparent; border-radius: 10px; font-weight: 600; font-size: .85rem; color: #6b6b6b; cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 6px; }
+  /* Tabs */
+  .wi-tabs { display: flex; background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 14px; padding: 4px; margin: 0 16px 16px; }
+  .wi-tab  { flex: 1; padding: 11px 8px; border: none; background: transparent; border-radius: 10px; font-weight: 600; font-size: .85rem; color: var(--wi-muted); cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 6px; }
   .wi-tab.active { background: #111; color: white; }
 
   .tab-content { display: none; }
   .tab-content.active { display: block; }
 
-  /* ============================================================
-     SUBMIT TAB — the redesigned data-entry surface
-     ============================================================ */
-
-  /* Search */
-  .wi-search { background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; padding: 18px; margin: 0 16px 16px; }
-  .wi-search label { display: block; font-size: .8rem; font-weight: 600; color: #6b6b6b; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 10px; }
-  .wi-search input { width: 100%; padding: 14px 16px; border: 1.5px solid #e4e1da; border-radius: 12px; font-size: 1.05rem; font-family: var(--font-mono, monospace); text-transform: uppercase; letter-spacing: .04em; }
-  .wi-search input:focus { outline: none; border-color: #111; box-shadow: 0 0 0 3px rgba(0,0,0,.08); }
-  .wi-search input.input-error { border-color: var(--danger, #c23b22); animation: shake .3s; }
+  /* =================== Search =================== */
+  .wi-search { background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 14px; padding: 18px; margin: 0 16px 16px; }
+  .wi-search label { display: block; font-size: .72rem; font-weight: 700; color: var(--wi-muted); text-transform: uppercase; letter-spacing: .1em; margin-bottom: 10px; }
+  .wi-search input { width: 100%; padding: 14px 16px; border: 1.5px solid #e4e4ea; border-radius: 12px; font-size: 1.05rem; font-family: var(--font-mono, monospace); text-transform: uppercase; letter-spacing: .04em; }
+  .wi-search input:focus { outline: none; border-color: var(--wi-indigo); box-shadow: 0 0 0 3px var(--wi-indigo-bg); }
+  .wi-search input.input-error { border-color: var(--wi-red); animation: shake .3s; }
   @keyframes shake { 0%, 100% { transform: translateX(0); } 25% { transform: translateX(-4px); } 75% { transform: translateX(4px); } }
   .wi-search button { width: 100%; padding: 14px; background: #111; color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 10px; display: flex; align-items: center; justify-content: center; gap: 8px; }
 
-  /* Lot picker (multi-match) */
-  .wi-pickHeader { font-size: .75rem; font-weight: 600; color: #6b6b6b; text-transform: uppercase; letter-spacing: .08em; padding: 0 4px 8px; }
+  /* Multi-match picker */
+  .wi-pickHeader { font-size: .72rem; font-weight: 700; color: var(--wi-muted); text-transform: uppercase; letter-spacing: .1em; padding: 0 4px 8px; }
   .wi-pickList { display: flex; flex-direction: column; gap: 8px; padding: 0 16px 16px; }
-  .wi-pickItem { background: white; border: 1px solid rgba(0,0,0,.08); border-radius: 12px; padding: 14px 16px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; gap: 12px; }
-  .wi-pickItem:hover { border-color: #111; }
+  .wi-pickItem { background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 12px; padding: 14px 16px; cursor: pointer; display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+  .wi-pickItem:hover { border-color: var(--wi-indigo); background: var(--wi-indigo-bg); }
   .wi-pickItem__no { font-family: var(--font-mono, monospace); font-weight: 600; font-size: 1rem; text-transform: uppercase; letter-spacing: .03em; }
-  .wi-pickItem__meta { font-size: .78rem; color: #6b6b6b; margin-top: 2px; }
-  .wi-pickItem__remark { font-size: .78rem; color: var(--terracotta, #c45c3a); font-weight: 500; margin-top: 4px; }
-  .wi-pickItem__avail { font-family: var(--font-mono, monospace); font-weight: 600; color: var(--success, #2d8a5f); white-space: nowrap; }
+  .wi-pickItem__meta { font-size: .78rem; color: var(--wi-muted); margin-top: 2px; }
+  .wi-pickItem__remark { font-size: .78rem; color: var(--wi-amber); font-weight: 500; margin-top: 4px; }
+  .wi-pickItem__avail { font-family: var(--font-mono, monospace); font-weight: 600; color: var(--wi-green); white-space: nowrap; }
 
-  /* ----- Sticky lot header ----- */
+  /* =================== Sticky lot header =================== */
   .wi-lotHeader {
     position: sticky; top: 56px; z-index: 50;
-    background: #FAF7F2;
+    background: var(--wi-bg);
     padding: 12px 16px 10px;
-    border-bottom: 1px solid rgba(0,0,0,.06);
-    margin-bottom: 14px;
+    border-bottom: 1px solid var(--wi-line);
+    margin-bottom: 16px;
   }
-  .wi-lotHeader__top { display: flex; align-items: baseline; gap: 12px; }
+  .wi-lotHeader__top { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
   .wi-lotHeader__no { font-family: var(--font-mono, monospace); font-size: 1.4rem; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
   .wi-lotHeader__badge { display: inline-block; padding: 2px 8px; border-radius: 999px; background: #111; color: white; font-size: .65rem; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; }
-  .wi-lotHeader__total { margin-left: auto; font-family: var(--font-mono, monospace); font-size: 1.1rem; font-weight: 600; }
-  .wi-lotHeader__total small { font-size: .65rem; color: #6b6b6b; text-transform: uppercase; font-family: var(--font-body, sans-serif); font-weight: 500; letter-spacing: .08em; margin-left: 4px; }
-  .wi-lotHeader__meta { font-size: .82rem; color: #4a4a4a; margin-top: 4px; }
-  .wi-lotHeader__meta strong { font-weight: 600; color: #111; }
+  .wi-lotHeader__close { margin-left: auto; background: transparent; border: 1px solid var(--wi-line); border-radius: 999px; width: 32px; height: 32px; cursor: pointer; color: var(--wi-muted); display: inline-flex; align-items: center; justify-content: center; }
+  .wi-lotHeader__close:hover { background: white; color: var(--wi-ink); }
+  .wi-lotHeader__meta { font-size: .82rem; color: var(--wi-muted); margin-top: 4px; }
+  .wi-lotHeader__meta strong { font-weight: 600; color: var(--wi-ink); }
   .wi-cuttingRemark {
     display: flex; align-items: flex-start; gap: 8px;
     background: #FFF7E5; border: 1px solid #F0DDB8; border-radius: 10px;
     padding: 8px 12px; margin-top: 10px;
     font-size: .82rem; color: #6b4a16;
   }
-  .wi-cuttingRemark i { color: #c4873a; margin-top: 2px; }
+  .wi-cuttingRemark i { color: var(--wi-amber); margin-top: 2px; }
   .wi-cuttingRemark strong { color: #6b4a16; font-weight: 600; }
 
-  /* ----- Size rows ----- */
-  .wi-sizesHeader {
-    display: flex; justify-content: space-between; align-items: baseline;
-    padding: 4px 16px 10px;
-    font-size: .72rem; font-weight: 600; color: #6b6b6b;
-    text-transform: uppercase; letter-spacing: .08em;
-  }
-  .wi-sizes { display: flex; flex-direction: column; padding: 0 16px; gap: 8px; padding-bottom: 140px; /* room for sticky footer */ }
-
-  .wi-row {
-    background: white;
-    border: 1px solid rgba(0,0,0,.06);
-    border-radius: 14px;
-    overflow: hidden;
-    position: relative;
-    transition: border-color .15s ease, box-shadow .15s ease;
-  }
-  .wi-row.has-exception { border-color: rgba(196,135,58,.5); box-shadow: 0 1px 0 rgba(196,135,58,.1); }
-  .wi-row.is-disabled { opacity: .45; pointer-events: none; }
-
-  .wi-row__rail {
-    position: absolute; left: 0; top: 0; bottom: 0; width: 4px;
-    background: var(--success, #2d8a5f);
-  }
-  .wi-row.has-rw .wi-row__rail { background: linear-gradient(180deg, var(--success, #2d8a5f) 0%, var(--success, #2d8a5f) 50%, var(--warning, #c4873a) 50%, var(--warning, #c4873a) 100%); }
-  .wi-row.has-rj .wi-row__rail { background: linear-gradient(180deg, var(--success, #2d8a5f) 0%, var(--success, #2d8a5f) 50%, var(--danger, #c23b22) 50%, var(--danger, #c23b22) 100%); }
-  .wi-row.has-rw.has-rj .wi-row__rail { background: linear-gradient(180deg, var(--success, #2d8a5f) 0%, var(--success, #2d8a5f) 34%, var(--warning, #c4873a) 34%, var(--warning, #c4873a) 67%, var(--danger, #c23b22) 67%, var(--danger, #c23b22) 100%); }
-  .wi-row.is-zero .wi-row__rail { background: #d0d0d0; }
-
-  .wi-row__summary {
-    display: flex; align-items: center; gap: 14px;
-    padding: 14px 16px 14px 20px;
-    cursor: pointer;
-    -webkit-tap-highlight-color: transparent;
-  }
-  .wi-row__size {
-    font-family: var(--font-mono, monospace);
-    font-weight: 700;
-    font-size: 1.15rem;
-    min-width: 42px;
-    color: #111;
-  }
-  .wi-row__breakdown { flex: 1; display: flex; flex-wrap: wrap; gap: 6px 10px; align-items: center; }
-  .wi-chip {
-    font-family: var(--font-mono, monospace);
-    font-size: .9rem; font-weight: 600;
-    display: inline-flex; align-items: baseline; gap: 4px;
-  }
-  .wi-chip small { font-family: var(--font-body, sans-serif); font-size: .65rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: #6b6b6b; }
-  .wi-chip.ok    { color: var(--success, #2d8a5f); }
-  .wi-chip.ok small { color: var(--success, #2d8a5f); opacity: .8; }
-  .wi-chip.rw    { color: var(--warning, #c4873a); }
-  .wi-chip.rw small { color: var(--warning, #c4873a); opacity: .8; }
-  .wi-chip.rj    { color: var(--danger, #c23b22); }
-  .wi-chip.rj small { color: var(--danger, #c23b22); opacity: .8; }
-  .wi-chip.dim   { color: #9a9a9a; }
-  .wi-row__caret { color: #b8b8b8; transition: transform .15s ease; font-size: 1.1rem; }
-  .wi-row.is-open .wi-row__caret { transform: rotate(90deg); color: #111; }
-
-  /* ----- Expanded editor for a row ----- */
-  .wi-row__edit { display: none; padding: 4px 16px 16px 20px; }
-  .wi-row.is-open .wi-row__edit { display: block; }
-  .wi-row.is-open { border-color: #111; box-shadow: 0 4px 18px rgba(0,0,0,.06); }
-
-  .wi-row__visual {
-    height: 8px; border-radius: 99px; overflow: hidden; display: flex;
-    background: #e9e6df; margin-bottom: 16px;
-  }
-  .wi-row__visual .seg { height: 100%; transition: width .15s ease; }
-  .wi-row__visual .seg.ok { background: var(--success, #2d8a5f); }
-  .wi-row__visual .seg.rw { background: var(--warning, #c4873a); }
-  .wi-row__visual .seg.rj { background: var(--danger, #c23b22); }
-
-  .wi-bucket { display: flex; align-items: center; gap: 12px; padding: 10px 0; }
-  .wi-bucket + .wi-bucket { border-top: 1px dashed rgba(0,0,0,.08); }
-  .wi-bucket__lbl { flex: 1; min-width: 0; }
-  .wi-bucket__name { font-size: .9rem; font-weight: 600; color: #111; display: flex; align-items: center; gap: 6px; }
-  .wi-bucket__name.ok { color: var(--success, #2d8a5f); }
-  .wi-bucket__name.rw { color: var(--warning, #c4873a); }
-  .wi-bucket__name.rj { color: var(--danger, #c23b22); }
-  .wi-bucket__hint { font-size: .72rem; color: #888; margin-top: 2px; }
-  .wi-stepper { display: flex; align-items: stretch; gap: 0; border: 1.5px solid #e4e1da; border-radius: 12px; overflow: hidden; background: #fafaf8; }
-  .wi-stepper button {
-    width: 42px; height: 42px;
-    border: none; background: transparent;
-    font-size: 1.3rem; font-weight: 600; color: #111;
-    cursor: pointer; display: flex; align-items: center; justify-content: center;
-    -webkit-tap-highlight-color: transparent;
-  }
-  .wi-stepper button:disabled { color: #c8c8c8; cursor: not-allowed; }
-  .wi-stepper button:active { background: rgba(0,0,0,.06); }
-  .wi-stepper input {
-    width: 58px; height: 42px;
-    border: none; border-left: 1.5px solid #e4e1da; border-right: 1.5px solid #e4e1da;
-    text-align: center;
-    font-family: var(--font-mono, monospace);
-    font-size: 1.05rem; font-weight: 600;
-    background: white; color: #111;
-    -moz-appearance: textfield;
-  }
-  .wi-stepper input::-webkit-outer-spin-button,
-  .wi-stepper input::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
-  .wi-stepper input:focus { outline: none; background: #fff8ee; }
-  .wi-stepper.rw input:focus { background: #fef6e8; }
-  .wi-stepper.rj input:focus { background: #fdf2f0; }
-
-  .wi-bucket.ok .wi-bucket__readonly {
-    font-family: var(--font-mono, monospace);
-    font-size: 1.25rem; font-weight: 700;
-    color: var(--success, #2d8a5f);
-    min-width: 110px; text-align: right;
+  /* =================== "What you can do" section =================== */
+  .wi-sectionLabel {
+    font-size: .72rem; font-weight: 700; color: var(--wi-muted);
+    text-transform: uppercase; letter-spacing: .12em;
+    padding: 0 18px 10px;
   }
 
-  .wi-rowError { display: none; padding: 8px 12px; margin-top: 8px; background: var(--danger-light, #fdf2f0); color: var(--danger, #c23b22); border-radius: 10px; font-size: .82rem; font-weight: 500; }
-  .wi-row.has-error .wi-rowError { display: block; }
-
-  .wi-rowActions { display: flex; gap: 8px; margin-top: 14px; }
-  .wi-btnGhost, .wi-btnDone {
-    flex: 1; padding: 11px; border-radius: 11px; font-weight: 600; font-size: .9rem;
-    cursor: pointer; border: 1.5px solid transparent;
-    display: flex; align-items: center; justify-content: center; gap: 6px;
+  /* Primary CTA card */
+  .wi-primaryCard {
+    background: var(--wi-card);
+    border: 1px solid var(--wi-line);
+    border-radius: 16px;
+    padding: 22px 22px 24px;
+    margin: 0 16px 18px;
+    box-shadow: 0 1px 0 rgba(0,0,0,.02);
   }
-  .wi-btnGhost { background: transparent; border-color: #e4e1da; color: #4a4a4a; }
-  .wi-btnDone  { background: #111; color: white; }
-
-  /* ----- Sticky submit footer ----- */
-  .wi-stickyFooter {
-    position: fixed; left: 0; right: 0; bottom: 0; z-index: 80;
-    background: rgba(250,247,242,.96);
-    backdrop-filter: blur(10px);
-    -webkit-backdrop-filter: blur(10px);
-    border-top: 1px solid rgba(0,0,0,.08);
-    padding: 12px 16px calc(env(safe-area-inset-bottom, 8px) + 12px);
+  .wi-primaryCard__row {
+    display: flex; gap: 16px; align-items: flex-start;
+    margin-bottom: 18px;
   }
-  .wi-stickyFooter__inner { max-width: 560px; margin: 0 auto; }
-  .wi-stickyFooter__totals {
-    display: flex; gap: 16px; align-items: baseline;
-    font-family: var(--font-mono, monospace);
-    font-size: .95rem; font-weight: 600;
-    margin-bottom: 10px;
+  .wi-primaryCard__icon {
+    width: 44px; height: 44px; flex: 0 0 44px;
+    border-radius: 12px;
+    background: var(--wi-indigo-bg); color: var(--wi-indigo);
+    display: flex; align-items: center; justify-content: center;
+    font-size: 1.3rem;
   }
-  .wi-stickyFooter__totals .pill { display: inline-flex; align-items: baseline; gap: 4px; }
-  .wi-stickyFooter__totals small { font-family: var(--font-body, sans-serif); font-size: .65rem; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: #6b6b6b; }
-  .wi-stickyFooter__totals .pill.ok { color: var(--success, #2d8a5f); }
-  .wi-stickyFooter__totals .pill.rw { color: var(--warning, #c4873a); }
-  .wi-stickyFooter__totals .pill.rj { color: var(--danger, #c23b22); }
-  .wi-debit { margin-left: auto; font-size: .78rem; color: #6b6b6b; font-family: var(--font-body, sans-serif); font-weight: 500; }
-  .wi-debit b { color: var(--warning, #c4873a); }
+  .wi-primaryCard__title {
+    font-size: 1.2rem; font-weight: 700; color: var(--wi-ink);
+    line-height: 1.3;
+  }
+  .wi-primaryCard__title em {
+    color: var(--wi-indigo); font-style: normal; font-weight: 800;
+    font-family: var(--font-mono, monospace); letter-spacing: -0.01em;
+  }
+  .wi-primaryCard__desc {
+    margin-top: 6px; font-size: .92rem; color: var(--wi-muted); line-height: 1.5;
+  }
 
-  .wi-submit {
-    width: 100%; padding: 16px;
-    background: #111; color: white;
-    border: none; border-radius: 13px;
-    font-family: var(--font-body, sans-serif); font-size: 1.02rem; font-weight: 600;
+  .wi-primaryBtn {
+    width: 100%; padding: 16px 20px;
+    background: var(--wi-indigo); color: white;
+    border: none; border-radius: 14px;
+    font-size: 1.05rem; font-weight: 700;
     cursor: pointer;
     display: flex; align-items: center; justify-content: center; gap: 10px;
-    letter-spacing: .01em;
+    box-shadow: 0 6px 18px rgba(91,91,245,.25);
+    transition: transform .08s ease, box-shadow .15s ease, background .15s ease;
   }
-  .wi-submit:disabled { background: #c8c8c8; cursor: not-allowed; }
-  .wi-submit .wi-submit__count { font-family: var(--font-mono, monospace); font-weight: 700; }
+  .wi-primaryBtn:hover { background: var(--wi-indigo-dark); box-shadow: 0 8px 22px rgba(91,91,245,.32); }
+  .wi-primaryBtn:active { transform: translateY(1px); }
+  .wi-primaryBtn:disabled { background: #c5c8d4; box-shadow: none; cursor: not-allowed; }
+  .wi-primaryBtn .check {
+    width: 26px; height: 26px; border-radius: 999px;
+    background: rgba(255,255,255,.22);
+    display: inline-flex; align-items: center; justify-content: center;
+    font-size: .95rem;
+  }
+  .wi-primaryBtn .num { font-family: var(--font-mono, monospace); font-weight: 800; }
 
-  /* ----- Empty / today list ----- */
-  .wi-empty { text-align: center; padding: 40px 16px; color: #888; }
+  /* Or split each size divider */
+  .wi-orSplit {
+    text-align: center;
+    padding: 6px 16px 14px;
+    font-weight: 600; color: var(--wi-muted);
+    font-size: .92rem;
+  }
+  .wi-helperText {
+    padding: 0 22px 16px; margin: 0;
+    font-size: .88rem; color: var(--wi-muted); line-height: 1.5;
+  }
+  .wi-helperText .rwk { color: var(--wi-amber); font-weight: 600; }
+  .wi-helperText .rjk { color: var(--wi-red); font-weight: 600; }
+
+  /* =================== Size rows (ALWAYS VISIBLE) =================== */
+  .wi-sizesList { padding: 0 16px 160px; display: flex; flex-direction: column; gap: 10px; }
+
+  .wi-sizeRow {
+    background: var(--wi-card);
+    border: 1px solid var(--wi-line);
+    border-radius: 14px;
+    padding: 16px 18px;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+    transition: border-color .15s ease, box-shadow .15s ease;
+  }
+  .wi-sizeRow.has-rw { border-color: rgba(196,135,58,.45); }
+  .wi-sizeRow.has-rj { border-color: rgba(194,59,34,.45); }
+  .wi-sizeRow.has-rw.has-rj { border-color: rgba(120,60,30,.45); }
+  .wi-sizeRow.is-disabled { opacity: .45; pointer-events: none; }
+  .wi-sizeRow.has-error { border-color: var(--wi-red); box-shadow: 0 0 0 3px var(--wi-red-bg); }
+
+  .wi-sizeRow__head {
+    display: flex; justify-content: space-between; align-items: baseline;
+  }
+  .wi-sizeRow__num {
+    font-family: var(--font-mono, monospace);
+    font-size: 1.6rem; font-weight: 800;
+    color: var(--wi-ink);
+  }
+  .wi-sizeRow__avail {
+    font-family: var(--font-mono, monospace);
+    font-size: 1rem; font-weight: 700; color: var(--wi-ink);
+  }
+  .wi-sizeRow__avail small {
+    font-family: var(--font-body, sans-serif);
+    font-size: .72rem; font-weight: 500; color: var(--wi-muted);
+    margin-left: 4px;
+  }
+
+  /* Stepper rows */
+  .wi-stepperRow {
+    display: flex; align-items: center; gap: 6px;
+    flex-wrap: nowrap;
+  }
+  .wi-stepperRow .chip {
+    flex: 0 0 auto;
+    min-width: 78px;
+    padding: 8px 10px;
+    border-radius: 10px;
+    font-size: .72rem; font-weight: 800;
+    text-transform: uppercase; letter-spacing: .08em;
+    text-align: center;
+  }
+  .wi-stepperRow.take .chip   { background: var(--wi-indigo-bg); color: var(--wi-indigo); }
+  .wi-stepperRow.rewash .chip { background: var(--wi-amber-chip); color: #92400e; }
+  .wi-stepperRow.reject .chip { background: var(--wi-red-chip); color: #7f1d1d; }
+
+  .wi-stepperRow .grow { flex: 1; }
+
+  .wi-btn {
+    width: 40px; height: 40px;
+    border: 1px solid #e4e4ea;
+    background: var(--wi-card);
+    border-radius: 10px;
+    font-size: 1.1rem; font-weight: 600;
+    color: var(--wi-ink);
+    cursor: pointer;
+    display: inline-flex; align-items: center; justify-content: center;
+    -webkit-tap-highlight-color: transparent;
+    flex: 0 0 40px;
+  }
+  .wi-btn.tiny {
+    width: auto; flex: 0 0 auto; min-width: 44px;
+    font-size: .78rem; font-weight: 700; padding: 0 8px;
+    color: var(--wi-muted);
+  }
+  .wi-btn:active { background: #f3f4f6; }
+  .wi-btn:disabled { color: #c8c8d0; cursor: not-allowed; }
+  .wi-stepperRow.take .wi-btn:focus-visible   { outline: 2px solid var(--wi-indigo); outline-offset: 1px; }
+  .wi-stepperRow.rewash .wi-btn:focus-visible { outline: 2px solid var(--wi-amber); outline-offset: 1px; }
+  .wi-stepperRow.reject .wi-btn:focus-visible { outline: 2px solid var(--wi-red); outline-offset: 1px; }
+
+  .wi-numInput {
+    flex: 1 1 70px;
+    min-width: 60px;
+    height: 40px;
+    border: 1px solid #e4e4ea;
+    border-radius: 10px;
+    text-align: center;
+    font-family: var(--font-mono, monospace);
+    font-size: 1.05rem; font-weight: 700;
+    color: var(--wi-ink);
+    background: var(--wi-card);
+    -moz-appearance: textfield;
+  }
+  .wi-numInput::-webkit-outer-spin-button,
+  .wi-numInput::-webkit-inner-spin-button { -webkit-appearance: none; margin: 0; }
+  .wi-numInput:focus { outline: none; border-color: var(--wi-indigo); box-shadow: 0 0 0 3px var(--wi-indigo-bg); }
+  .wi-stepperRow.rewash .wi-numInput { background: var(--wi-amber-bg); }
+  .wi-stepperRow.rewash .wi-numInput:focus { border-color: var(--wi-amber); box-shadow: 0 0 0 3px rgba(196,135,58,.18); }
+  .wi-stepperRow.reject .wi-numInput { background: var(--wi-red-bg); }
+  .wi-stepperRow.reject .wi-numInput:focus { border-color: var(--wi-red); box-shadow: 0 0 0 3px rgba(194,59,34,.18); }
+
+  /* Rewash + Reject side-by-side when width allows */
+  .wi-rwRjRow { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
+  @media (max-width: 540px) {
+    .wi-rwRjRow { grid-template-columns: 1fr; gap: 10px; }
+    .wi-stepperRow .chip { min-width: 64px; padding: 8px 8px; font-size: .68rem; }
+    .wi-btn { width: 36px; flex-basis: 36px; height: 38px; }
+    .wi-numInput { height: 38px; font-size: 1rem; }
+    .wi-btn.tiny { min-width: 38px; padding: 0 6px; height: 38px; }
+  }
+  @media (max-width: 360px) {
+    .wi-btn.tiny { display: none; } /* drop ±10 on smallest phones */
+  }
+
+  .wi-rowError { display: none; color: var(--wi-red); font-size: .8rem; font-weight: 500; padding: 4px 4px 0; }
+  .wi-sizeRow.has-error .wi-rowError { display: block; }
+
+  /* =================== Sticky footer =================== */
+  .wi-stickyFooter {
+    position: fixed; left: 0; right: 0; bottom: 0; z-index: 80;
+    background: rgba(244,245,249,.96);
+    backdrop-filter: blur(10px);
+    -webkit-backdrop-filter: blur(10px);
+    border-top: 1px solid var(--wi-line);
+    padding: 12px 16px calc(env(safe-area-inset-bottom, 8px) + 12px);
+  }
+  .wi-stickyFooter__inner { max-width: 760px; margin: 0 auto; }
+  .wi-stickyFooter__row {
+    display: flex; gap: 10px; align-items: center; margin-bottom: 10px;
+    flex-wrap: wrap;
+  }
+  .wi-stickyFooter__pill {
+    font-family: var(--font-mono, monospace);
+    font-size: .9rem; font-weight: 700;
+    padding: 6px 10px; border-radius: 999px;
+    display: inline-flex; align-items: baseline; gap: 4px;
+  }
+  .wi-stickyFooter__pill small {
+    font-family: var(--font-body, sans-serif);
+    font-size: .62rem; font-weight: 700; text-transform: uppercase; letter-spacing: .08em;
+    opacity: .8;
+  }
+  .wi-stickyFooter__pill.take   { background: var(--wi-indigo-bg); color: var(--wi-indigo); }
+  .wi-stickyFooter__pill.rewash { background: var(--wi-amber-chip); color: #92400e; }
+  .wi-stickyFooter__pill.reject { background: var(--wi-red-chip); color: #7f1d1d; }
+  .wi-stickyFooter__debit {
+    margin-left: auto;
+    font-size: .78rem; color: var(--wi-muted); font-weight: 500;
+  }
+  .wi-stickyFooter__debit b { color: var(--wi-amber); font-weight: 700; }
+
+  .wi-submitMirror {
+    width: 100%; padding: 14px;
+    background: #111; color: white;
+    border: none; border-radius: 12px;
+    font-size: .98rem; font-weight: 700;
+    cursor: pointer;
+    display: flex; align-items: center; justify-content: center; gap: 10px;
+  }
+  .wi-submitMirror:disabled { background: #c5c8d4; cursor: not-allowed; }
+
+  /* Empty / today */
+  .wi-empty { text-align: center; padding: 40px 16px; color: var(--wi-muted); }
   .wi-empty i { font-size: 2.4rem; opacity: .3; display: block; margin-bottom: 10px; }
   .wi-empty p { margin: 0; font-weight: 500; color: #4a4a4a; }
   .wi-empty span { font-size: .85rem; }
 
-  .wi-today { background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; margin: 24px 16px 0; overflow: hidden; }
-  .wi-today__head { display: flex; justify-content: space-between; align-items: center; padding: 14px 18px; background: #f5f1ea; border-bottom: 1px solid rgba(0,0,0,.06); font-weight: 600; font-size: .9rem; }
-  .wi-today__head .total { font-family: var(--font-mono, monospace); color: var(--success, #2d8a5f); }
+  .wi-today { background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 14px; margin: 24px 16px 0; overflow: hidden; }
+  .wi-today__head { display: flex; justify-content: space-between; align-items: center; padding: 14px 18px; background: #f5f5f9; border-bottom: 1px solid var(--wi-line); font-weight: 600; font-size: .9rem; }
+  .wi-today__head .total { font-family: var(--font-mono, monospace); color: var(--wi-green); }
   .wi-today__list { list-style: none; padding: 0; margin: 0; max-height: 280px; overflow-y: auto; }
   .wi-today__item { display: flex; justify-content: space-between; align-items: center; padding: 12px 18px; border-bottom: 1px solid rgba(0,0,0,.05); }
   .wi-today__item:last-child { border-bottom: none; }
   .wi-today__lot { font-family: var(--font-mono, monospace); font-weight: 600; font-size: .95rem; text-transform: uppercase; }
-  .wi-today__sku { font-size: .78rem; color: #888; margin-top: 2px; }
-  .wi-today__qty { font-family: var(--font-mono, monospace); font-weight: 600; color: var(--success, #2d8a5f); }
+  .wi-today__sku { font-size: .78rem; color: var(--wi-muted); margin-top: 2px; }
+  .wi-today__qty { font-family: var(--font-mono, monospace); font-weight: 600; color: var(--wi-green); }
 
-  /* ============================================================
-     History + Indent tab styles (mostly retained — tightened)
-     ============================================================ */
-  .history-search { background: white; border-radius: 14px; padding: 16px; margin: 0 16px 16px; border: 1px solid rgba(0,0,0,.06); }
-  .history-input  { width: 100%; padding: 12px 14px; border: 1px solid #e4e1da; border-radius: 10px; }
+  /* History */
+  .history-search { background: var(--wi-card); border-radius: 14px; padding: 16px; margin: 0 16px 16px; border: 1px solid var(--wi-line); }
+  .history-input  { width: 100%; padding: 12px 14px; border: 1px solid #e4e4ea; border-radius: 10px; }
   .history-filters { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
-  .history-filters input[type="date"] { flex: 1; min-width: 120px; padding: 10px 12px; border: 1px solid #e4e1da; border-radius: 10px; font-size: .875rem; }
+  .history-filters input[type="date"] { flex: 1; min-width: 120px; padding: 10px 12px; border: 1px solid #e4e4ea; border-radius: 10px; font-size: .875rem; }
   .btn-filter, .btn-download { padding: 10px 14px; border: none; border-radius: 10px; font-size: .85rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; gap: 6px; }
   .btn-filter   { background: #111; color: white; }
-  .btn-download { background: var(--success, #2d8a5f); color: white; }
-  .history-list { background: white; border-radius: 14px; margin: 0 16px 16px; border: 1px solid rgba(0,0,0,.06); overflow: hidden; }
+  .btn-download { background: var(--wi-green); color: white; }
+  .history-list { background: var(--wi-card); border-radius: 14px; margin: 0 16px 16px; border: 1px solid var(--wi-line); overflow: hidden; }
   .history-item { display: flex; justify-content: space-between; align-items: center; padding: 14px 18px; border-bottom: 1px solid rgba(0,0,0,.05); }
   .history-item:last-child { border-bottom: none; }
   .history-item.clickable { cursor: pointer; }
-  .history-item.clickable:hover { background: #f9f6f0; }
+  .history-item.clickable:hover { background: #f5f5f9; }
   .today-lot { font-family: var(--font-mono, monospace); font-weight: 600; font-size: .95rem; text-transform: uppercase; }
-  .today-sku { font-size: .78rem; color: #888; margin-top: 2px; }
-  .today-qty { font-family: var(--font-mono, monospace); font-weight: 600; color: var(--success, #2d8a5f); }
-  .history-remark { display: block; font-size: .72rem; color: var(--terracotta, #c45c3a); margin-top: 4px; }
+  .today-sku { font-size: .78rem; color: var(--wi-muted); margin-top: 2px; }
+  .today-qty { font-family: var(--font-mono, monospace); font-weight: 600; color: var(--wi-green); }
+  .history-remark { display: block; font-size: .72rem; color: var(--wi-amber); margin-top: 4px; }
 
   /* Modal */
   .modal-overlay { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: 10000; display: flex; align-items: center; justify-content: center; padding: 16px; }
   .modal-content { background: white; border-radius: 16px; width: 100%; max-width: 500px; max-height: 85vh; overflow: hidden; display: flex; flex-direction: column; }
-  .modal-header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; border-bottom: 1px solid rgba(0,0,0,.06); background: #f5f1ea; }
+  .modal-header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; border-bottom: 1px solid var(--wi-line); background: #f5f5f9; }
   .modal-title { font-size: 1.05rem; font-weight: 700; font-family: var(--font-mono, monospace); text-transform: uppercase; }
-  .modal-close { background: none; border: none; font-size: 1.5rem; cursor: pointer; color: #888; line-height: 1; }
+  .modal-close { background: none; border: none; font-size: 1.5rem; cursor: pointer; color: var(--wi-muted); line-height: 1; }
   .modal-body { padding: 20px; overflow-y: auto; flex: 1; }
   .detail-section { margin-bottom: 18px; }
-  .detail-section-title { font-size: .7rem; font-weight: 700; color: #6b6b6b; text-transform: uppercase; letter-spacing: .08em; margin-bottom: 10px; }
+  .detail-section-title { font-size: .7rem; font-weight: 700; color: var(--wi-muted); text-transform: uppercase; letter-spacing: .08em; margin-bottom: 10px; }
   .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; }
-  .detail-item { background: #f9f6f0; padding: 12px; border-radius: 10px; }
-  .detail-label { font-size: .72rem; color: #888; margin-bottom: 4px; }
+  .detail-item { background: #f5f5f9; padding: 12px; border-radius: 10px; }
+  .detail-label { font-size: .72rem; color: var(--wi-muted); margin-bottom: 4px; }
   .detail-value { font-family: var(--font-mono, monospace); font-size: .95rem; font-weight: 600; }
-  .detail-value.highlight { color: var(--terracotta, #c45c3a); }
-  .detail-value.success { color: var(--success, #2d8a5f); }
-  .detail-value.warning { color: var(--warning, #c4873a); }
+  .detail-value.highlight { color: var(--wi-indigo); }
+  .detail-value.success   { color: var(--wi-green); }
+  .detail-value.warning   { color: var(--wi-amber); }
   .detail-remark { background: #FFF7E5; padding: 12px; border-radius: 10px; margin-top: 12px; }
   .detail-remark-label { font-size: .72rem; color: #9a3412; margin-bottom: 4px; }
   .detail-remark-text  { font-size: .9rem; color: #6b4a16; }
 
-  /* Indent (left mostly untouched) */
-  .indent-card { background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; padding: 18px; margin: 0 16px 16px; }
+  /* Indent */
+  .indent-card { background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 14px; padding: 18px; margin: 0 16px 16px; }
   .indent-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 14px; }
   .indent-title { font-size: 1rem; font-weight: 700; }
-  .btn-add-item { padding: 8px 14px; background: #111; color: white; border: none; border-radius: 8px; font-size: .85rem; font-weight: 600; cursor: pointer; }
+  .btn-add-item { padding: 8px 14px; background: var(--wi-indigo); color: white; border: none; border-radius: 8px; font-size: .85rem; font-weight: 600; cursor: pointer; }
   .indent-items { display: flex; flex-direction: column; gap: 14px; }
-  .indent-item { background: #f9f6f0; border: 1px solid rgba(0,0,0,.06); border-radius: 12px; padding: 14px; }
+  .indent-item { background: #f5f5f9; border: 1px solid var(--wi-line); border-radius: 12px; padding: 14px; }
   .indent-item-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 10px; }
-  .indent-item-num { font-size: .78rem; font-weight: 600; color: #888; }
-  .btn-remove-item { padding: 4px 8px; background: transparent; color: var(--danger, #c23b22); border: 1px solid var(--danger, #c23b22); border-radius: 6px; font-size: .72rem; cursor: pointer; }
+  .indent-item-num { font-size: .78rem; font-weight: 600; color: var(--wi-muted); }
+  .btn-remove-item { padding: 4px 8px; background: transparent; color: var(--wi-red); border: 1px solid var(--wi-red); border-radius: 6px; font-size: .72rem; cursor: pointer; }
   .indent-row { display: grid; grid-template-columns: 1fr 80px; gap: 10px; margin-bottom: 10px; }
   .indent-row.single { grid-template-columns: 1fr; }
   .indent-label { font-size: .78rem; font-weight: 600; margin-bottom: 6px; display: block; }
-  .indent-select, .indent-input { width: 100%; padding: 11px; font-size: .92rem; border: 1.5px solid #e4e1da; border-radius: 10px; }
-  .btn-submit-indent { width: 100%; padding: 14px; background: var(--success, #2d8a5f); color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 16px; }
-  .indent-requests-card { background: white; border: 1px solid rgba(0,0,0,.06); border-radius: 14px; margin: 0 16px 16px; overflow: hidden; }
-  .indent-requests-header { padding: 12px 18px; background: #f5f1ea; border-bottom: 1px solid rgba(0,0,0,.06); font-weight: 700; }
+  .indent-select, .indent-input { width: 100%; padding: 11px; font-size: .92rem; border: 1.5px solid #e4e4ea; border-radius: 10px; }
+  .btn-submit-indent { width: 100%; padding: 14px; background: var(--wi-green); color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 16px; }
+  .indent-requests-card { background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 14px; margin: 0 16px 16px; overflow: hidden; }
+  .indent-requests-header { padding: 12px 18px; background: #f5f5f9; border-bottom: 1px solid var(--wi-line); font-weight: 700; }
   .indent-request-item { padding: 14px 18px; border-bottom: 1px solid rgba(0,0,0,.05); display: flex; justify-content: space-between; align-items: flex-start; gap: 12px; }
   .indent-request-item:last-child { border-bottom: none; }
   .indent-request-main { flex: 1; min-width: 0; }
   .indent-request-desc { font-size: .92rem; font-weight: 500; margin-bottom: 4px; word-break: break-word; }
-  .indent-request-meta { font-size: .78rem; color: #888; }
-  .indent-request-lot { color: var(--terracotta, #c45c3a); font-weight: 500; }
+  .indent-request-meta { font-size: .78rem; color: var(--wi-muted); }
+  .indent-request-lot { color: var(--wi-indigo); font-weight: 500; }
   .indent-request-status { padding: 4px 10px; border-radius: 999px; font-size: .68rem; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
   .indent-request-status.open { background: #FEE9C8; color: #92400e; }
   .indent-request-status.proceeding { background: #cffafe; color: #155e75; }
-  .indent-request-status.arrived { background: var(--success-light, #e8f5ee); color: var(--success, #2d8a5f); }
-  .indent-empty { padding: 28px 18px; text-align: center; color: #888; }
-  .select2-container--default .select2-selection--single { height: auto; padding: 8px 12px; border: 1.5px solid #e4e1da; border-radius: 10px; }
+  .indent-request-status.arrived { background: #e8f5ee; color: var(--wi-green); }
+  .indent-empty { padding: 28px 18px; text-align: center; color: var(--wi-muted); }
+  .select2-container--default .select2-selection--single { height: auto; padding: 8px 12px; border: 1.5px solid #e4e4ea; border-radius: 10px; }
 
   /* Spinner */
   .spinner { width: 18px; height: 18px; border: 2px solid rgba(255,255,255,.3); border-top-color: white; border-radius: 50%; animation: spin .8s linear infinite; }
   .spinner.dark { border: 2px solid rgba(0,0,0,.2); border-top-color: #111; }
   @keyframes spin { to { transform: rotate(360deg); } }
-
-  /* Narrow phones */
-  @media (max-width: 380px) {
-    .wi-lotHeader__no { font-size: 1.2rem; }
-    .wi-lotHeader__total { font-size: 1rem; }
-    .wi-row__summary { gap: 10px; padding-left: 16px; }
-    .wi-stepper button { width: 38px; height: 40px; }
-    .wi-stepper input { width: 50px; height: 40px; }
-  }
 </style>
 
 <div class="toast-container" id="toastContainer"></div>
@@ -397,12 +476,13 @@
 
     <!-- Lot work area -->
     <div id="lotResult" style="display: none;">
+
       <!-- Sticky lot context -->
       <div class="wi-lotHeader">
         <div class="wi-lotHeader__top">
           <span class="wi-lotHeader__no" id="lotNo">—</span>
           <span class="wi-lotHeader__badge">DENIM</span>
-          <span class="wi-lotHeader__total"><span id="lotTotalAvail">0</span><small>avail</small></span>
+          <button type="button" class="wi-lotHeader__close" onclick="resetLotView()" title="Close lot"><i class="bi bi-x-lg"></i></button>
         </div>
         <div class="wi-lotHeader__meta"><span id="lotSku">—</span> &middot; from <strong id="lotMaster">—</strong></div>
         <div class="wi-cuttingRemark" id="cuttingRemarkNote" style="display: none;">
@@ -411,11 +491,33 @@
         </div>
       </div>
 
-      <div class="wi-sizesHeader">
-        <span>Sizes</span>
-        <span id="sizesHint">Tap a row to flag rewash or reject</span>
+      <!-- "What you can do" -->
+      <div class="wi-sectionLabel">What you can do</div>
+
+      <!-- PRIMARY CTA -->
+      <div class="wi-primaryCard">
+        <div class="wi-primaryCard__row">
+          <div class="wi-primaryCard__icon"><i class="bi bi-arrow-down-right"></i></div>
+          <div>
+            <div class="wi-primaryCard__title">Take <em id="primaryTakeNum">0</em> pieces into washing in</div>
+            <div class="wi-primaryCard__desc">Inspect what came in: take the good ones, send wet/improper back for rewash, reject anything torn or unusable.</div>
+          </div>
+        </div>
+        <button type="button" class="wi-primaryBtn" id="btnPrimary" onclick="submitWashingIn()" disabled>
+          <span class="check"><i class="bi bi-check-lg"></i></span>
+          <span class="btn-text" id="primaryBtnLabel">Yes, take all <span class="num" id="primaryBtnNum">0</span> pieces</span>
+        </button>
       </div>
-      <div class="wi-sizes" id="sizesList"></div>
+
+      <!-- Divider -->
+      <div class="wi-orSplit">↑ Or split each size: take / rewash / reject</div>
+      <p class="wi-helperText">
+        Pre-filled with the full available qty under <strong>Take</strong>.
+        Move pieces into <span class="rwk">Rewash</span> or <span class="rjk">Reject</span> for sizes that need attention.
+      </p>
+
+      <!-- Size rows (always visible) -->
+      <div class="wi-sizesList" id="sizesList"></div>
     </div>
 
     <div id="noResult" class="wi-empty" style="display: none;">
@@ -424,10 +526,10 @@
       <span>Check the lot number and try again.</span>
     </div>
 
-    <!-- Today's work (shown only when no lot is loaded, to stay focused) -->
+    <!-- Today's work (shown only when no lot is loaded) -->
     <div class="wi-today" id="todayCard">
       <div class="wi-today__head"><span><i class="bi bi-check2-all"></i> Today's work</span><span class="total" id="todayTotal">0 pcs</span></div>
-      <ul class="wi-today__list" id="todayList"><li class="wi-today__item" style="justify-content: center; color: #888;">Loading…</li></ul>
+      <ul class="wi-today__list" id="todayList"><li class="wi-today__item" style="justify-content: center; color: var(--wi-muted);">Loading…</li></ul>
     </div>
   </div>
 
@@ -442,7 +544,7 @@
         <button type="button" class="btn-download" onclick="downloadHistory()"><i class="bi bi-download"></i> Excel</button>
       </div>
     </div>
-    <div class="history-list" id="historyList"><div class="history-item" style="justify-content: center; color: #888;">Loading…</div></div>
+    <div class="history-list" id="historyList"><div class="history-item" style="justify-content: center; color: var(--wi-muted);">Loading…</div></div>
   </div>
 
   <!-- =================== INDENT TAB =================== -->
@@ -462,20 +564,17 @@
   </div>
 </div>
 
-<!-- =================== STICKY FOOTER (visible only when lot loaded) =================== -->
+<!-- Sticky submit mirror (in case operator is scrolled deep into size rows) -->
 <div class="wi-stickyFooter" id="stickyFooter" style="display: none;">
   <div class="wi-stickyFooter__inner">
-    <div class="wi-stickyFooter__totals">
-      <span class="pill ok"><span id="footOk">0</span><small>OK</small></span>
-      <span class="pill rw" id="footRwPill" style="display:none;"><span id="footRw">0</span><small>RW</small></span>
-      <span class="pill rj" id="footRjPill" style="display:none;"><span id="footRj">0</span><small>RJ</small></span>
-      <span class="wi-debit" id="footDebit" style="display:none;">Debit <b>₹<span id="footDebitAmt">0</span></b></span>
+    <div class="wi-stickyFooter__row">
+      <span class="wi-stickyFooter__pill take"><span id="footTake">0</span><small>Take</small></span>
+      <span class="wi-stickyFooter__pill rewash" id="footRwPill" style="display:none;"><span id="footRw">0</span><small>Rewash</small></span>
+      <span class="wi-stickyFooter__pill reject" id="footRjPill" style="display:none;"><span id="footRj">0</span><small>Reject</small></span>
+      <span class="wi-stickyFooter__debit" id="footDebit" style="display:none;">Debit <b>₹<span id="footDebitAmt">0</span></b></span>
     </div>
-    <button type="button" class="wi-submit" id="btnSubmit" onclick="submitWashingIn()" disabled>
-      <span class="btn-text">
-        <i class="bi bi-check-circle"></i>
-        Submit <span class="wi-submit__count" id="footSubmitCount">0</span> pcs
-      </span>
+    <button type="button" class="wi-submitMirror" id="btnSubmitMirror" onclick="submitWashingIn()" disabled>
+      <i class="bi bi-check-circle"></i> <span id="footSubmitLabel">Submit</span>
     </button>
   </div>
 </div>
@@ -507,8 +606,10 @@ function showToast(msg, type, duration) {
 function setSearchLoading(loading) {
   var btn = document.getElementById('btnSearch');
   var span = btn.querySelector('.btn-text');
-  if (loading) { btn.disabled = true; span.textContent = ''; var s = document.createElement('div'); s.className = 'spinner'; span.appendChild(s); }
-  else {
+  if (loading) {
+    btn.disabled = true; span.textContent = '';
+    var s = document.createElement('div'); s.className = 'spinner'; span.appendChild(s);
+  } else {
     btn.disabled = false; span.textContent = '';
     var i = document.createElement('i'); i.className = 'bi bi-search';
     span.appendChild(i); span.appendChild(document.createTextNode(' Find lot'));
@@ -571,7 +672,7 @@ async function selectLotFromList(i) {
 }
 
 /* ============================================================
-   Render lot: sticky header + size rows
+   Render lot
    ============================================================ */
 async function renderLot() {
   document.getElementById('searchCard').style.display = 'none';
@@ -594,259 +695,268 @@ async function renderLot() {
   var sizes = await res.json();
   currentLot.sizes = sizes;
 
-  // Total available
-  var totAvail = sizes.reduce(function(s, x){ return s + (parseInt(x.remain) || 0); }, 0);
-  document.getElementById('lotTotalAvail').textContent = totAvail;
-
   // Build rows
   var list = document.getElementById('sizesList');
   list.textContent = '';
-  sizes.forEach(function(size) { list.appendChild(buildRow(size)); });
+  sizes.forEach(function(size) { list.appendChild(buildSizeRow(size)); });
 
-  updateFooter();
-  showToast('Loaded ' + currentLot.lot_no.toUpperCase(), 'success', 1800);
+  updateAll();
+  showToast('Loaded ' + currentLot.lot_no.toUpperCase(), 'success', 1500);
 }
 
-function buildRow(size) {
-  var row = document.createElement('div');
-  row.className = 'wi-row';
+/* Each size row holds three steppers. We keep state on the row's dataset:
+   row.dataset.max = available
+   row.dataset.take, row.dataset.rw, row.dataset.rj */
+function buildSizeRow(size) {
+  var max = parseInt(size.remain) || 0;
+  var row = document.createElement('div'); row.className = 'wi-sizeRow';
   row.dataset.sizeId = size.id;
-  row.dataset.max = size.remain;
-  row.dataset.label = size.size_label;
-  row.dataset.rw = '0';
-  row.dataset.rj = '0';
-  if (size.remain <= 0) { row.classList.add('is-disabled', 'is-zero'); row.dataset.max = '0'; }
+  row.dataset.max = max;
+  row.dataset.take = max;  // default: take everything
+  row.dataset.rw = 0;
+  row.dataset.rj = 0;
+  if (max <= 0) row.classList.add('is-disabled');
 
-  // Rail
-  var rail = document.createElement('div'); rail.className = 'wi-row__rail'; row.appendChild(rail);
+  // Head
+  var head = document.createElement('div'); head.className = 'wi-sizeRow__head';
+  var num = document.createElement('div'); num.className = 'wi-sizeRow__num'; num.textContent = size.size_label;
+  var av = document.createElement('div'); av.className = 'wi-sizeRow__avail';
+  var avN = document.createElement('span'); avN.textContent = max;
+  var avL = document.createElement('small'); avL.textContent = 'available';
+  av.appendChild(avN); av.appendChild(avL);
+  head.appendChild(num); head.appendChild(av);
+  row.appendChild(head);
 
-  // Summary
-  var sum = document.createElement('div'); sum.className = 'wi-row__summary'; sum.onclick = function(){ toggleRow(row); };
-  var sz = document.createElement('div'); sz.className = 'wi-row__size'; sz.textContent = size.size_label;
-  var bd = document.createElement('div'); bd.className = 'wi-row__breakdown';
-  bd.appendChild(makeChip(size.remain, 'OK', 'ok'));
-  var caret = document.createElement('i'); caret.className = 'wi-row__caret bi bi-chevron-right';
-  sum.appendChild(sz); sum.appendChild(bd); sum.appendChild(caret);
-  row.appendChild(sum);
+  // TAKE row (with ±10)
+  row.appendChild(buildStepper(row, 'take', max, max, true));
 
-  // Editor
-  var ed = document.createElement('div'); ed.className = 'wi-row__edit';
+  // REWASH + REJECT side-by-side
+  var pair = document.createElement('div'); pair.className = 'wi-rwRjRow';
+  pair.appendChild(buildStepper(row, 'rewash', 0, max, false));
+  pair.appendChild(buildStepper(row, 'reject', 0, max, false));
+  row.appendChild(pair);
 
-  // Visual bar
-  var vis = document.createElement('div'); vis.className = 'wi-row__visual';
-  vis.innerHTML = '<div class="seg ok" style="width:100%"></div><div class="seg rw" style="width:0"></div><div class="seg rj" style="width:0"></div>';
-  ed.appendChild(vis);
+  // Error message
+  var err = document.createElement('div'); err.className = 'wi-rowError';
+  err.textContent = 'Take + Rewash + Reject cannot exceed ' + max;
+  row.appendChild(err);
 
-  // OK readout
-  var okBucket = document.createElement('div'); okBucket.className = 'wi-bucket ok';
-  var okLbl = document.createElement('div'); okLbl.className = 'wi-bucket__lbl';
-  okLbl.innerHTML = '<div class="wi-bucket__name ok"><i class="bi bi-check2"></i> OK — taken in</div><div class="wi-bucket__hint">Auto-calculated. Max ' + size.remain + '.</div>';
-  var okRO = document.createElement('div'); okRO.className = 'wi-bucket__readonly'; okRO.textContent = size.remain;
-  okBucket.appendChild(okLbl); okBucket.appendChild(okRO);
-  ed.appendChild(okBucket);
-
-  // RW stepper
-  ed.appendChild(buildBucket('rw', '↩ Rewash', 'Send back to washer · ₹200/pc debit', size.remain, row));
-  // RJ stepper
-  ed.appendChild(buildBucket('rj', '✗ Reject', 'Damaged · permanent', size.remain, row));
-
-  // Error
-  var err = document.createElement('div'); err.className = 'wi-rowError'; err.textContent = 'Total exceeds ' + size.remain + ' available'; ed.appendChild(err);
-
-  // Done
-  var act = document.createElement('div'); act.className = 'wi-rowActions';
-  var done = document.createElement('button'); done.type = 'button'; done.className = 'wi-btnDone';
-  done.innerHTML = '<i class="bi bi-check2"></i> Done';
-  done.onclick = function(){ toggleRow(row, false); };
-  act.appendChild(done);
-  ed.appendChild(act);
-
-  row.appendChild(ed);
   return row;
 }
 
-function buildBucket(kind, name, hint, max, row) {
-  var b = document.createElement('div'); b.className = 'wi-bucket ' + kind;
-  var lbl = document.createElement('div'); lbl.className = 'wi-bucket__lbl';
-  lbl.innerHTML = '<div class="wi-bucket__name ' + kind + '">' + name + '</div><div class="wi-bucket__hint">' + hint + '</div>';
-  var st = document.createElement('div'); st.className = 'wi-stepper ' + kind;
-  var dec = document.createElement('button'); dec.type = 'button'; dec.textContent = '−';
-  var inp = document.createElement('input'); inp.type = 'number'; inp.value = '0'; inp.min = '0'; inp.max = max; inp.inputMode = 'numeric'; inp.dataset.kind = kind;
-  var inc = document.createElement('button'); inc.type = 'button'; inc.textContent = '+';
+function buildStepper(row, kind, value, max, withTen) {
+  var sr = document.createElement('div'); sr.className = 'wi-stepperRow ' + kind;
+  var chip = document.createElement('span'); chip.className = 'chip';
+  chip.textContent = kind.toUpperCase();
+  sr.appendChild(chip);
 
-  function bump(delta) {
-    var cur = parseInt(inp.value) || 0;
-    var other = kind === 'rw' ? (parseInt(row.dataset.rj) || 0) : (parseInt(row.dataset.rw) || 0);
-    var headroom = Math.max(0, max - other);
-    var next = Math.min(headroom, Math.max(0, cur + delta));
-    inp.value = next;
-    applyChange(row, kind, next);
+  var spacer = document.createElement('span'); spacer.className = 'grow'; sr.appendChild(spacer);
+
+  if (withTen) {
+    var dec10 = document.createElement('button'); dec10.type = 'button'; dec10.className = 'wi-btn tiny';
+    dec10.textContent = '−10';
+    dec10.onclick = function() { bump(row, kind, -10); };
+    sr.appendChild(dec10);
   }
-  dec.onclick = function(){ bump(-1); };
-  inc.onclick = function(){ bump(+1); };
+
+  var dec = document.createElement('button'); dec.type = 'button'; dec.className = 'wi-btn';
+  dec.textContent = '−';
+  dec.onclick = function() { bump(row, kind, -1); };
+  sr.appendChild(dec);
+
+  var inp = document.createElement('input');
+  inp.type = 'number'; inp.className = 'wi-numInput';
+  inp.value = value; inp.min = '0'; inp.max = max; inp.inputMode = 'numeric';
+  inp.dataset.kind = kind;
   inp.addEventListener('focus', function(){ inp.select(); });
   inp.addEventListener('input', function() {
-    var v = Math.max(0, Math.min(max, parseInt(inp.value) || 0));
-    applyChange(row, kind, v);
+    var v = Math.max(0, parseInt(inp.value) || 0);
+    setKind(row, kind, v, /* fromInput */ true);
   });
-  inp.addEventListener('keydown', function(e) {
-    if (e.key === 'Enter') { e.preventDefault(); toggleRow(row, false); focusNextOpenable(row); }
-    else if (e.key === 'Escape') { e.preventDefault(); toggleRow(row, false); }
+  inp.addEventListener('blur', function() {
+    // Re-sync from canonical dataset so we never show out-of-bounds
+    inp.value = row.dataset[kind];
   });
-  st.appendChild(dec); st.appendChild(inp); st.appendChild(inc);
-  b.appendChild(lbl); b.appendChild(st);
-  return b;
+  sr.appendChild(inp);
+
+  var inc = document.createElement('button'); inc.type = 'button'; inc.className = 'wi-btn';
+  inc.textContent = '+';
+  inc.onclick = function() { bump(row, kind, +1); };
+  sr.appendChild(inc);
+
+  if (withTen) {
+    var inc10 = document.createElement('button'); inc10.type = 'button'; inc10.className = 'wi-btn tiny';
+    inc10.textContent = '+10';
+    inc10.onclick = function() { bump(row, kind, +10); };
+    sr.appendChild(inc10);
+  }
+
+  return sr;
 }
 
 /* ============================================================
-   State updates
+   Bidirectional logic: when REWASH or REJECT changes, TAKE
+   auto-adjusts (decrements). When TAKE changes directly,
+   REWASH/REJECT stay put; TAKE is capped so total ≤ max.
    ============================================================ */
-function applyChange(row, kind, value) {
+function bump(row, kind, delta) {
+  var cur = parseInt(row.dataset[kind]) || 0;
+  setKind(row, kind, Math.max(0, cur + delta), false);
+}
+
+function setKind(row, kind, value, fromInput) {
   var max = parseInt(row.dataset.max) || 0;
-  row.dataset[kind] = value;
-  var rw = parseInt(row.dataset.rw) || 0;
-  var rj = parseInt(row.dataset.rj) || 0;
-  var ok = Math.max(0, max - rw - rj);
-  var over = rw + rj > max;
+  var take = parseInt(row.dataset.take) || 0;
+  var rw   = parseInt(row.dataset.rw)   || 0;
+  var rj   = parseInt(row.dataset.rj)   || 0;
 
-  // OK readout
-  var okRO = row.querySelector('.wi-bucket__readonly');
-  if (okRO) okRO.textContent = ok;
-
-  // Visual bar
-  var vis = row.querySelectorAll('.wi-row__visual .seg');
-  if (vis.length === 3 && max > 0) {
-    vis[0].style.width = (ok / max * 100) + '%';
-    vis[1].style.width = (rw / max * 100) + '%';
-    vis[2].style.width = (rj / max * 100) + '%';
+  if (kind === 'rewash' || kind === 'rj' || kind === 'reject') {
+    var k = (kind === 'reject') ? 'rj' : (kind === 'rewash' ? 'rw' : kind);
+    // Headroom = max - (the other exception)
+    var other = (k === 'rw') ? rj : rw;
+    var headroom = Math.max(0, max - other);
+    var newVal = Math.min(headroom, Math.max(0, value));
+    row.dataset[k] = newVal;
+    // Auto-adjust TAKE = max - rw - rj
+    if (k === 'rw') row.dataset.take = Math.max(0, max - newVal - rj);
+    else            row.dataset.take = Math.max(0, max - rw - newVal);
+  } else if (kind === 'take') {
+    // Cap TAKE at max - rw - rj
+    var ceil = Math.max(0, max - rw - rj);
+    row.dataset.take = Math.min(ceil, Math.max(0, value));
   }
 
-  // Row state
+  applyRow(row);
+  updateAll();
+}
+
+function applyRow(row) {
+  var max = parseInt(row.dataset.max) || 0;
+  var take = parseInt(row.dataset.take) || 0;
+  var rw   = parseInt(row.dataset.rw)   || 0;
+  var rj   = parseInt(row.dataset.rj)   || 0;
+
+  // Reflect into inputs (skip the input the user is typing in to avoid caret jump)
+  row.querySelectorAll('.wi-numInput').forEach(function(inp) {
+    var k = inp.dataset.kind;
+    var canon = (k === 'rewash') ? rw : (k === 'reject' ? rj : take);
+    if (document.activeElement !== inp) inp.value = canon;
+  });
+
+  // Disable +/- buttons at extremes (TAKE +/-, RW +/-, RJ +/-)
+  var sumOthers = rw + rj;
+  var takeCeil = Math.max(0, max - sumOthers);
+  toggleStepperBtns(row, 'take',   take, takeCeil);
+  toggleStepperBtns(row, 'rewash', rw,   Math.max(0, max - rj));
+  toggleStepperBtns(row, 'reject', rj,   Math.max(0, max - rw));
+
+  // Row state classes
   row.classList.toggle('has-rw', rw > 0);
   row.classList.toggle('has-rj', rj > 0);
-  row.classList.toggle('has-exception', rw > 0 || rj > 0);
-  row.classList.toggle('has-error', over);
-
-  // Re-render breakdown chips
-  var bd = row.querySelector('.wi-row__breakdown');
-  bd.textContent = '';
-  if (max === 0) {
-    bd.appendChild(makeChip(0, 'OK', 'dim'));
-  } else {
-    bd.appendChild(makeChip(ok, 'OK', 'ok'));
-    if (rw > 0) bd.appendChild(makeChip(rw, 'RW', 'rw'));
-    if (rj > 0) bd.appendChild(makeChip(rj, 'RJ', 'rj'));
-  }
-
-  updateFooter();
+  row.classList.toggle('has-error', take + rw + rj > max);
 }
 
-function makeChip(n, label, cls) {
-  var c = document.createElement('span'); c.className = 'wi-chip ' + cls;
-  var v = document.createElement('span'); v.textContent = n;
-  var s = document.createElement('small'); s.textContent = label;
-  c.appendChild(v); c.appendChild(s);
-  return c;
-}
-
-function toggleRow(row, force) {
-  if (row.classList.contains('is-disabled')) return;
-  var willOpen = (typeof force === 'boolean') ? force : !row.classList.contains('is-open');
-  // Close all others (one editor at a time keeps the screen calm)
-  document.querySelectorAll('.wi-row.is-open').forEach(function(r) { if (r !== row) r.classList.remove('is-open'); });
-  row.classList.toggle('is-open', willOpen);
-  if (willOpen) {
-    // Focus the RW stepper input first — most exceptions are rewashes
-    var inp = row.querySelector('.wi-stepper.rw input');
-    if (inp) setTimeout(function(){ inp.focus(); inp.select(); }, 60);
-    // Scroll the row into view comfortably under the sticky lot header
-    setTimeout(function(){
-      var top = row.getBoundingClientRect().top;
-      if (top < 140 || top > window.innerHeight - 220) {
-        row.scrollIntoView({ block: 'center', behavior: 'smooth' });
-      }
-    }, 80);
-  }
-}
-
-function focusNextOpenable(currentRow) {
-  // After Enter in a stepper, look for the next size row that has an exception flagged
-  // (so the operator can continue typing exceptions). Else just close.
-  var rows = Array.prototype.slice.call(document.querySelectorAll('.wi-row'));
-  var idx = rows.indexOf(currentRow);
-  for (var i = idx + 1; i < rows.length; i++) {
-    var r = rows[i];
-    if (r.classList.contains('has-exception')) { toggleRow(r, true); return; }
-  }
+function toggleStepperBtns(row, kind, cur, ceil) {
+  var sr = row.querySelector('.wi-stepperRow.' + kind);
+  if (!sr) return;
+  var btns = sr.querySelectorAll('.wi-btn');
+  btns.forEach(function(b) {
+    var t = b.textContent;
+    if (t === '−')       b.disabled = (cur <= 0);
+    else if (t === '−10') b.disabled = (cur <= 0);
+    else if (t === '+')   b.disabled = (cur >= ceil);
+    else if (t === '+10') b.disabled = (cur >= ceil);
+  });
 }
 
 /* ============================================================
-   Footer totals + submit
+   Totals + submit
    ============================================================ */
 function readTotals() {
-  var rows = document.querySelectorAll('.wi-row');
-  var ok = 0, rw = 0, rj = 0, anyError = false, anyAvail = false;
+  var rows = document.querySelectorAll('.wi-sizeRow');
+  var take = 0, rw = 0, rj = 0, anyError = false, anyAvail = false;
   rows.forEach(function(r) {
     var max = parseInt(r.dataset.max) || 0;
     if (max === 0) return;
     anyAvail = true;
-    var rwV = parseInt(r.dataset.rw) || 0;
-    var rjV = parseInt(r.dataset.rj) || 0;
-    if (rwV + rjV > max) anyError = true;
-    ok += Math.max(0, max - rwV - rjV);
-    rw += rwV;
-    rj += rjV;
+    var t = parseInt(r.dataset.take) || 0;
+    var w = parseInt(r.dataset.rw)   || 0;
+    var j = parseInt(r.dataset.rj)   || 0;
+    if (t + w + j > max) anyError = true;
+    take += t; rw += w; rj += j;
   });
-  return { ok: ok, rw: rw, rj: rj, error: anyError, hasAvail: anyAvail };
+  return { take: take, rw: rw, rj: rj, error: anyError, hasAvail: anyAvail };
 }
 
-function updateFooter() {
+function updateAll() {
   var t = readTotals();
-  document.getElementById('footOk').textContent = t.ok;
-  document.getElementById('footRw').textContent = t.rw;
-  document.getElementById('footRj').textContent = t.rj;
+  var totalAvail = 0;
+  document.querySelectorAll('.wi-sizeRow').forEach(function(r){ totalAvail += parseInt(r.dataset.max) || 0; });
+
+  // Primary card numbers
+  document.getElementById('primaryTakeNum').textContent = formatNum(totalAvail);
+  // Primary button label changes based on whether any exception is set
+  var primaryBtn = document.getElementById('btnPrimary');
+  var primaryLabel = document.getElementById('primaryBtnLabel');
+  if (t.rw === 0 && t.rj === 0) {
+    primaryLabel.innerHTML = 'Yes, take all <span class="num">' + formatNum(t.take) + '</span> pieces';
+  } else {
+    var parts = ['Submit <span class="num">' + formatNum(t.take) + '</span> take'];
+    if (t.rw > 0) parts.push('<span class="num">' + formatNum(t.rw) + '</span> rewash');
+    if (t.rj > 0) parts.push('<span class="num">' + formatNum(t.rj) + '</span> reject');
+    primaryLabel.innerHTML = parts.join(' · ');
+  }
+  primaryBtn.disabled = t.error || !t.hasAvail || (t.take + t.rw + t.rj === 0);
+
+  // Sticky footer
+  document.getElementById('footTake').textContent = formatNum(t.take);
+  document.getElementById('footRw').textContent   = formatNum(t.rw);
+  document.getElementById('footRj').textContent   = formatNum(t.rj);
   document.getElementById('footRwPill').style.display = t.rw > 0 ? '' : 'none';
   document.getElementById('footRjPill').style.display = t.rj > 0 ? '' : 'none';
   var debit = t.rw * 200;
   document.getElementById('footDebit').style.display = debit > 0 ? '' : 'none';
-  document.getElementById('footDebitAmt').textContent = debit;
+  document.getElementById('footDebitAmt').textContent = formatNum(debit);
 
-  var total = t.ok + t.rw + t.rj;
-  document.getElementById('footSubmitCount').textContent = total;
-  var btn = document.getElementById('btnSubmit');
-  btn.disabled = t.error || !t.hasAvail;
+  var mirror = document.getElementById('btnSubmitMirror');
+  mirror.disabled = primaryBtn.disabled;
+  document.getElementById('footSubmitLabel').textContent =
+    'Submit ' + formatNum(t.take + t.rw + t.rj) + ' pcs';
+}
+
+function formatNum(n) {
+  return (n || 0).toLocaleString('en-IN');
 }
 
 async function submitWashingIn() {
   if (!currentLot) return;
   var t = readTotals();
-  if (t.error) { showToast('Fix sizes that exceed available', 'error'); return; }
-  if (t.ok + t.rw + t.rj === 0) { showToast('Nothing to submit', 'warning'); return; }
+  if (t.error) { showToast('Some sizes exceed the available qty', 'error'); return; }
+  if (t.take + t.rw + t.rj === 0) { showToast('Nothing to submit', 'warning'); return; }
 
-  // Build payload
+  // Build payload (sizes = take, rewash, reject — keyed by sizeId)
   var sizes = {}, rewash = {}, reject = {};
-  document.querySelectorAll('.wi-row').forEach(function(r) {
+  document.querySelectorAll('.wi-sizeRow').forEach(function(r) {
     var max = parseInt(r.dataset.max) || 0;
     if (max === 0) return;
     var sid = r.dataset.sizeId;
-    var rwV = parseInt(r.dataset.rw) || 0;
-    var rjV = parseInt(r.dataset.rj) || 0;
-    var okV = Math.max(0, max - rwV - rjV);
-    if (okV > 0) sizes[sid] = okV;
-    if (rwV > 0) rewash[sid] = rwV;
-    if (rjV > 0) reject[sid] = rjV;
+    var tv = parseInt(r.dataset.take) || 0;
+    var wv = parseInt(r.dataset.rw)   || 0;
+    var jv = parseInt(r.dataset.rj)   || 0;
+    if (tv > 0) sizes[sid] = tv;
+    if (wv > 0) rewash[sid] = wv;
+    if (jv > 0) reject[sid] = jv;
   });
 
-  var msg = 'Submit ' + t.ok + ' OK';
-  if (t.rw > 0) msg += ', ' + t.rw + ' rewash (₹' + (t.rw * 200) + ' debit)';
-  if (t.rj > 0) msg += ', ' + t.rj + ' reject';
+  var msg = 'Submit ' + formatNum(t.take) + ' take';
+  if (t.rw > 0) msg += ', ' + formatNum(t.rw) + ' rewash (₹' + formatNum(t.rw * 200) + ' debit)';
+  if (t.rj > 0) msg += ', ' + formatNum(t.rj) + ' reject';
   msg += '?';
   if (!confirm(msg)) return;
 
-  var btn = document.getElementById('btnSubmit');
-  btn.disabled = true;
-  var span = btn.querySelector('.btn-text');
-  span.textContent = ''; var sp = document.createElement('div'); sp.className = 'spinner'; span.appendChild(sp);
+  var primaryBtn = document.getElementById('btnPrimary');
+  var mirror = document.getElementById('btnSubmitMirror');
+  primaryBtn.disabled = true; mirror.disabled = true;
 
   try {
     var res = await fetch('/washingin/submit', {
@@ -856,27 +966,19 @@ async function submitWashingIn() {
     });
     var data = await res.json();
     if (data.success) {
-      var m = 'Submitted ' + t.ok + ' OK';
-      if (t.rw > 0) m += ', ' + t.rw + ' rewash';
-      if (t.rj > 0) m += ', ' + t.rj + ' reject';
+      var m = 'Submitted ' + formatNum(t.take) + ' take';
+      if (t.rw > 0) m += ', ' + formatNum(t.rw) + ' rewash';
+      if (t.rj > 0) m += ', ' + formatNum(t.rj) + ' reject';
       showToast(m, 'success', 3500);
       resetLotView();
       loadToday();
     } else {
       showToast(data.error || 'Failed', 'error');
-      btn.disabled = false; span.textContent = '';
-      var i = document.createElement('i'); i.className = 'bi bi-check-circle';
-      span.appendChild(i); span.appendChild(document.createTextNode(' Submit '));
-      var cs = document.createElement('span'); cs.className = 'wi-submit__count'; cs.id = 'footSubmitCount'; cs.textContent = (t.ok + t.rw + t.rj);
-      span.appendChild(cs); span.appendChild(document.createTextNode(' pcs'));
+      updateAll(); // re-enable
     }
   } catch (e) {
     showToast('Error: ' + e.message, 'error');
-    btn.disabled = false; span.textContent = '';
-    var i = document.createElement('i'); i.className = 'bi bi-check-circle';
-    span.appendChild(i); span.appendChild(document.createTextNode(' Submit '));
-    var cs = document.createElement('span'); cs.className = 'wi-submit__count'; cs.id = 'footSubmitCount'; cs.textContent = (t.ok + t.rw + t.rj);
-    span.appendChild(cs); span.appendChild(document.createTextNode(' pcs'));
+    updateAll();
   }
 }
 
@@ -890,7 +992,7 @@ function resetLotView() {
 }
 
 /* ============================================================
-   Today / History / Modal — unchanged behavior, refreshed selectors
+   Today / History / Modal — unchanged behavior
    ============================================================ */
 async function loadToday() {
   try {
@@ -902,7 +1004,8 @@ async function loadToday() {
     var list = document.getElementById('todayList'); list.textContent = '';
     if (!data.entries || !data.entries.length) {
       var li = document.createElement('li'); li.className = 'wi-today__item';
-      li.style.justifyContent = 'center'; li.style.color = '#888'; li.textContent = 'No entries yet today';
+      li.style.justifyContent = 'center'; li.style.color = 'var(--wi-muted)';
+      li.textContent = 'No entries yet today';
       list.appendChild(li); return;
     }
     data.entries.forEach(function(e) {
@@ -932,7 +1035,7 @@ async function loadHistory(reset) {
     var list = document.getElementById('historyList');
     if (reset) list.textContent = '';
     if (!data.entries || !data.entries.length) {
-      if (reset) { var d = document.createElement('div'); d.className = 'history-item'; d.style.justifyContent = 'center'; d.style.color = '#888'; d.textContent = 'No entries'; list.appendChild(d); }
+      if (reset) { var d = document.createElement('div'); d.className = 'history-item'; d.style.justifyContent = 'center'; d.style.color = 'var(--wi-muted)'; d.textContent = 'No entries'; list.appendChild(d); }
       return;
     }
     data.entries.forEach(function(e) {


### PR DESCRIPTION
Previous redesign hid the per-size split behind a tap-to-expand row, which operators found just as bad. Operators also had to manually deduct from Take before they could add to Rewash/Reject.

This rewrite mirrors the reference UI: a large indigo "Yes, take all X pieces" CTA up top (one tap for the happy path), then every size row is always visible with three steppers — Take, Rewash, Reject. Steppers are bidirectional: incrementing Rewash or Reject auto-decrements Take, so the operator never has to do the math themselves. Take also has ±10 shortcuts for fast bulk adjustments. Sticky footer mirrors the totals and submit so operators don't have to scroll back to the top after edits.

Wire format to /washingin/submit is unchanged.