### PR TITLE
feat(my-lots): universal lot-trace page + orphan-assignment fix script

### DIFF
--- a/app.js
+++ b/app.js
@@ -202,6 +202,7 @@ const returnGrnRoutes = require('./routes/returnGrnRoutes');
 app.use('/health', healthRoutes);
 app.use('/', authRoutes);
 app.use('/', launcherRoutes);                       // /launcher + /switch-role
+app.use('/my-lots', require('./routes/myLotsRoutes'));
 app.use('/admin/user-roles', adminUserRolesRoutes); // mohitOperator-only
 app.use('/return-challan', returnChallanRoutes);    // returnchallan role
 app.use('/admin', adminRoutes);

--- a/routes/myLotsRoutes.js
+++ b/routes/myLotsRoutes.js
@@ -1,0 +1,309 @@
+/**
+ * My Lots — universal lot-trace dashboard.
+ *
+ * One page, accessible to any authenticated user. Shows every cutting
+ * lot the current user has touched (as cutter, stitching master,
+ * assembly master, washing master, wash-in master, or finishing
+ * master) with the full upstream + downstream chain of who handed it
+ * off and who has it next.
+ */
+
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated } = require('../middlewares/auth');
+
+router.get('/', isAuthenticated, async (req, res) => {
+  try {
+    return res.render('myLots', { user: req.session.user });
+  } catch (err) {
+    console.error('GET /my-lots error:', err);
+    return res.status(500).send('Failed to load My Lots');
+  }
+});
+
+router.get('/data', isAuthenticated, async (req, res) => {
+  const userId = req.session.user.id;
+  try {
+    // 1) Find every cutting_lot_id the current user touched.
+    const [lotIdRows] = await pool.query(
+      `
+      SELECT id AS lot_id FROM cutting_lots WHERE user_id = ?
+      UNION
+      SELECT cutting_lot_id FROM stitching_assignments WHERE user_id = ?
+      UNION
+      SELECT sa.cutting_lot_id
+        FROM jeans_assembly_assignments ja
+        JOIN stitching_assignments sa ON sa.id = ja.stitching_assignment_id
+       WHERE ja.user_id = ?
+      UNION
+      SELECT sa.cutting_lot_id
+        FROM washing_assignments wa
+        JOIN jeans_assembly_assignments ja ON ja.id = wa.jeans_assembly_assignment_id
+        JOIN stitching_assignments sa ON sa.id = ja.stitching_assignment_id
+       WHERE wa.user_id = ?
+      UNION
+      SELECT cl.id
+        FROM washing_in_assignments wia
+        JOIN washing_data wd ON wd.id = wia.washing_data_id
+        JOIN cutting_lots cl ON cl.lot_no = wd.lot_no
+       WHERE wia.user_id = ?
+      UNION
+      SELECT cl.id
+        FROM finishing_assignments fa
+        LEFT JOIN stitching_assignments sa2 ON sa2.id = fa.stitching_assignment_id
+        LEFT JOIN washing_in_assignments wia2 ON wia2.id = fa.washing_in_assignment_id
+        LEFT JOIN washing_data wd2 ON wd2.id = wia2.washing_data_id
+        LEFT JOIN washing_in_data wid2 ON wid2.id = fa.washing_in_data_id
+        JOIN cutting_lots cl ON cl.id = sa2.cutting_lot_id
+                             OR cl.lot_no = wd2.lot_no
+                             OR cl.lot_no = wid2.lot_no
+       WHERE fa.user_id = ?
+      `,
+      [userId, userId, userId, userId, userId, userId]
+    );
+
+    if (lotIdRows.length === 0) {
+      return res.json({ user: req.session.user, lots: [] });
+    }
+
+    const lotIds = lotIdRows.map(r => r.lot_id).filter(x => x);
+    if (lotIds.length === 0) {
+      return res.json({ user: req.session.user, lots: [] });
+    }
+
+    // 2) Load lot metadata.
+    const [lots] = await pool.query(
+      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.flow_type, cl.created_at,
+              cl.user_id AS cutter_id, cu.username AS cutter_name
+         FROM cutting_lots cl
+    LEFT JOIN users cu ON cu.id = cl.user_id
+        WHERE cl.id IN (?)
+     ORDER BY cl.created_at DESC
+        LIMIT 1000`,
+      [lotIds]
+    );
+
+    const lotById = {};
+    const lotNos = [];
+    for (const l of lots) {
+      lotById[l.id] = {
+        lot_id: l.id,
+        lot_no: l.lot_no,
+        sku: l.sku,
+        pieces: Number(l.total_pieces) || 0,
+        flow_type: l.flow_type || 'unknown',
+        created_at: l.created_at,
+        cutter: { user_id: l.cutter_id, name: l.cutter_name, is_me: l.cutter_id === userId },
+        stitching: null,
+        assembly: null,
+        washing: null,
+        washing_in: null,
+        finishing: null,
+        stitching_completed: false,
+        assembly_completed: false,
+        washing_completed: false,
+        washing_in_completed: false,
+        finishing_completed: false,
+        current_stage: 'Stitching',
+      };
+      lotNos.push(l.lot_no);
+    }
+
+    // 3) Stitching assignments.
+    const [saRows] = await pool.query(
+      `SELECT sa.id, sa.cutting_lot_id, sa.user_id, su.username,
+              sa.assigned_on, sa.isApproved AS is_approved, sa.approved_on
+         FROM stitching_assignments sa
+    LEFT JOIN users su ON su.id = sa.user_id
+        WHERE sa.cutting_lot_id IN (?)`,
+      [lotIds]
+    );
+    const saByLot = {};
+    for (const r of saRows) {
+      saByLot[r.cutting_lot_id] = r;
+      const lot = lotById[r.cutting_lot_id];
+      if (lot) {
+        lot.stitching = {
+          user_id: r.user_id, name: r.username, is_me: r.user_id === userId,
+          assigned_on: r.assigned_on, approved: r.is_approved === 1,
+          approved_on: r.approved_on,
+        };
+      }
+    }
+
+    // 4) Jeans assembly (denim only).
+    const saIds = saRows.map(r => r.id);
+    if (saIds.length) {
+      const [jaRows] = await pool.query(
+        `SELECT ja.id, ja.stitching_assignment_id, sa.cutting_lot_id, ja.user_id, ju.username,
+                ja.assigned_on, ja.is_approved, ja.approved_on
+           FROM jeans_assembly_assignments ja
+           JOIN stitching_assignments sa ON sa.id = ja.stitching_assignment_id
+      LEFT JOIN users ju ON ju.id = ja.user_id
+          WHERE ja.stitching_assignment_id IN (?)`,
+        [saIds]
+      );
+      const jaByLot = {};
+      for (const r of jaRows) {
+        jaByLot[r.cutting_lot_id] = r;
+        const lot = lotById[r.cutting_lot_id];
+        if (lot) {
+          lot.assembly = {
+            user_id: r.user_id, name: r.username, is_me: r.user_id === userId,
+            assigned_on: r.assigned_on, approved: r.is_approved === 1,
+            approved_on: r.approved_on,
+          };
+        }
+      }
+
+      // 5) Washing (denim only).
+      const jaIds = jaRows.map(r => r.id);
+      if (jaIds.length) {
+        const [waRows] = await pool.query(
+          `SELECT wa.id, wa.jeans_assembly_assignment_id, sa.cutting_lot_id,
+                  wa.user_id, wu.username,
+                  wa.assigned_on, wa.is_approved, wa.approved_on
+             FROM washing_assignments wa
+             JOIN jeans_assembly_assignments ja ON ja.id = wa.jeans_assembly_assignment_id
+             JOIN stitching_assignments sa ON sa.id = ja.stitching_assignment_id
+        LEFT JOIN users wu ON wu.id = wa.user_id
+            WHERE wa.jeans_assembly_assignment_id IN (?)`,
+          [jaIds]
+        );
+        for (const r of waRows) {
+          const lot = lotById[r.cutting_lot_id];
+          if (lot) {
+            lot.washing = {
+              user_id: r.user_id, name: r.username, is_me: r.user_id === userId,
+              assigned_on: r.assigned_on, approved: r.is_approved === 1,
+              approved_on: r.approved_on,
+            };
+          }
+        }
+      }
+    }
+
+    // 6) Washing-In (denim only) — chained via washing_data.lot_no.
+    if (lotNos.length) {
+      const [wiaRows] = await pool.query(
+        `SELECT wia.id, wd.lot_no, wia.user_id, wu.username,
+                wia.assigned_on, wia.is_approved, wia.approved_on
+           FROM washing_in_assignments wia
+           JOIN washing_data wd ON wd.id = wia.washing_data_id
+      LEFT JOIN users wu ON wu.id = wia.user_id
+          WHERE wd.lot_no IN (?)`,
+        [lotNos]
+      );
+      const wiaByLotNo = {};
+      for (const r of wiaRows) wiaByLotNo[r.lot_no] = r;
+      for (const lot of Object.values(lotById)) {
+        const r = wiaByLotNo[lot.lot_no];
+        if (r) {
+          lot.washing_in = {
+            user_id: r.user_id, name: r.username, is_me: r.user_id === userId,
+            assigned_on: r.assigned_on, approved: r.is_approved === 1,
+            approved_on: r.approved_on,
+          };
+        }
+      }
+    }
+
+    // 7) Finishing — can chain via stitching_assignment (hosiery), washing_in_data, or washing_in_assignment.
+    const [faRows] = await pool.query(
+      `SELECT fa.id, fa.user_id, fu.username,
+              fa.assigned_on, fa.is_approved, fa.approved_on,
+              sa.cutting_lot_id AS sa_lot_id,
+              wid.lot_no AS wid_lot_no,
+              wd2.lot_no AS wia_lot_no
+         FROM finishing_assignments fa
+    LEFT JOIN users fu ON fu.id = fa.user_id
+    LEFT JOIN stitching_assignments sa ON sa.id = fa.stitching_assignment_id
+    LEFT JOIN washing_in_data wid ON wid.id = fa.washing_in_data_id
+    LEFT JOIN washing_in_assignments wia ON wia.id = fa.washing_in_assignment_id
+    LEFT JOIN washing_data wd2 ON wd2.id = wia.washing_data_id
+        WHERE sa.cutting_lot_id IN (?)
+           OR wid.lot_no IN (?)
+           OR wd2.lot_no IN (?)`,
+      [lotIds.length ? lotIds : [0], lotNos.length ? lotNos : [''], lotNos.length ? lotNos : ['']]
+    );
+    for (const r of faRows) {
+      let lot = null;
+      if (r.sa_lot_id && lotById[r.sa_lot_id]) lot = lotById[r.sa_lot_id];
+      else if (r.wid_lot_no) {
+        for (const candidate of Object.values(lotById)) {
+          if (candidate.lot_no === r.wid_lot_no) { lot = candidate; break; }
+        }
+      }
+      else if (r.wia_lot_no) {
+        for (const candidate of Object.values(lotById)) {
+          if (candidate.lot_no === r.wia_lot_no) { lot = candidate; break; }
+        }
+      }
+      if (lot && !lot.finishing) {
+        lot.finishing = {
+          user_id: r.user_id, name: r.username, is_me: r.user_id === userId,
+          assigned_on: r.assigned_on, approved: r.is_approved === 1,
+          approved_on: r.approved_on,
+        };
+      }
+    }
+
+    // 8) Completion flags from *_events.
+    const stageEventTables = [
+      ['stitching_events',      'stitching_completed'],
+      ['jeans_assembly_events', 'assembly_completed'],
+      ['washing_events',        'washing_completed'],
+      ['washing_in_events',     'washing_in_completed'],
+      ['finishing_events',      'finishing_completed'],
+    ];
+    for (const [t, flag] of stageEventTables) {
+      const [rows] = await pool.query(
+        `SELECT cutting_lot_id FROM \`${t}\`
+          WHERE cutting_lot_id IN (?) AND event_type='complete'
+          GROUP BY cutting_lot_id`,
+        [lotIds]
+      );
+      for (const r of rows) {
+        const lot = lotById[r.cutting_lot_id];
+        if (lot) lot[flag] = true;
+      }
+    }
+
+    // 9) Compute current_stage for each lot.
+    for (const lot of Object.values(lotById)) {
+      const isDenim = lot.flow_type === 'denim';
+      const chain = isDenim
+        ? ['stitching', 'assembly', 'washing', 'washing_in', 'finishing']
+        : ['stitching', 'finishing'];
+      const completedFlag = {
+        stitching: 'stitching_completed',
+        assembly: 'assembly_completed',
+        washing: 'washing_completed',
+        washing_in: 'washing_in_completed',
+        finishing: 'finishing_completed',
+      };
+      let current = 'Done';
+      for (const stage of chain) {
+        if (lot[completedFlag[stage]]) continue;
+        current = stage;
+        break;
+      }
+      lot.current_stage = current;
+    }
+
+    // 10) Sort: newest first (already by created_at DESC from query).
+    const result = Object.values(lotById).sort((a, b) => {
+      const da = new Date(a.created_at).getTime();
+      const db = new Date(b.created_at).getTime();
+      return db - da;
+    });
+
+    return res.json({ user: req.session.user, lots: result });
+  } catch (err) {
+    console.error('GET /my-lots/data error:', err);
+    return res.status(500).json({ error: 'Failed to load my-lots data' });
+  }
+});
+
+module.exports = router;

--- a/scripts/fix-orphan-assignments.js
+++ b/scripts/fix-orphan-assignments.js
@@ -1,0 +1,386 @@
+#!/usr/bin/env node
+/**
+ * Fix orphan stage assignments.
+ *
+ * After the events-sourced migration (commit cdb1c4d), the legacy per-stage
+ * approve UI was removed. Any *_assignments row with is_approved IS NULL is
+ * now stuck: legacy dashboards gate on is_approved=1, and new reports read
+ * from *_events with event_type='approve'. Neither side sees it.
+ *
+ * This script:
+ *   1) inventories orphans across all 5 stages (dry-run by default),
+ *   2) with --apply, sets is_approved=1, approved_on=NOW() on the row AND
+ *      inserts a matching approve event (+ event_sizes from sizes_json).
+ *
+ * Usage:
+ *   node scripts/fix-orphan-assignments.js
+ *   node scripts/fix-orphan-assignments.js --lot AK5222
+ *   node scripts/fix-orphan-assignments.js --apply
+ *   node scripts/fix-orphan-assignments.js --apply --stage stitching
+ */
+
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+const { pool } = require('../config/db');
+
+// ─── Stage definitions ──────────────────────────────────────────────────
+// flag column differs (stitching uses camelCase isApproved); event tables
+// and size tables follow the *_events / *_event_sizes convention.
+const STAGES = [
+  {
+    key: 'stitching',
+    table: 'stitching_assignments',
+    flagCol: 'isApproved',
+    eventsTable: 'stitching_events',
+    sizesTable: 'stitching_event_sizes',
+  },
+  {
+    key: 'jeans_assembly',
+    table: 'jeans_assembly_assignments',
+    flagCol: 'is_approved',
+    eventsTable: 'jeans_assembly_events',
+    sizesTable: 'jeans_assembly_event_sizes',
+  },
+  {
+    key: 'washing',
+    table: 'washing_assignments',
+    flagCol: 'is_approved',
+    eventsTable: 'washing_events',
+    sizesTable: 'washing_event_sizes',
+  },
+  {
+    key: 'washing_in',
+    table: 'washing_in_assignments',
+    flagCol: 'is_approved',
+    eventsTable: 'washing_in_events',
+    sizesTable: 'washing_in_event_sizes',
+  },
+  {
+    key: 'finishing',
+    table: 'finishing_assignments',
+    flagCol: 'is_approved',
+    eventsTable: 'finishing_events',
+    sizesTable: 'finishing_event_sizes',
+  },
+];
+
+// ─── Arg parsing ────────────────────────────────────────────────────────
+function parseArgs(argv) {
+  const args = { apply: false, stage: null, lot: null };
+  for (let i = 2; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--apply') args.apply = true;
+    else if (a === '--stage') args.stage = argv[++i];
+    else if (a === '--lot') args.lot = argv[++i];
+    else if (a === '--help' || a === '-h') {
+      console.log(
+        'Usage:\n' +
+        '  node scripts/fix-orphan-assignments.js                  # dry-run\n' +
+        '  node scripts/fix-orphan-assignments.js --lot AK5222     # inspect one lot\n' +
+        '  node scripts/fix-orphan-assignments.js --apply          # fix all stages\n' +
+        '  node scripts/fix-orphan-assignments.js --apply --stage stitching\n'
+      );
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────
+function parseSizesJson(raw) {
+  if (raw === null || raw === undefined) return null;
+  let obj = raw;
+  if (typeof raw === 'string') {
+    try { obj = JSON.parse(raw); } catch { return null; }
+  }
+  if (!obj || typeof obj !== 'object') return null;
+  const out = [];
+  let total = 0;
+  for (const [label, val] of Object.entries(obj)) {
+    const n = Number(val);
+    if (!Number.isFinite(n) || n <= 0) continue;
+    out.push({ label, pieces: Math.round(n) });
+    total += Math.round(n);
+  }
+  if (out.length === 0) return null;
+  return { rows: out, total };
+}
+
+// Each stage chains to cutting_lots differently. Returns SQL fragments
+// resolving "cl.id" / "cl.lot_no" via the appropriate join chain.
+function joinChainToCuttingLots(stageKey) {
+  switch (stageKey) {
+    case 'stitching':
+      return { join: 'JOIN cutting_lots cl ON cl.id = a.cutting_lot_id', lotIdExpr: 'cl.id' };
+    case 'jeans_assembly':
+      return {
+        join: 'JOIN stitching_assignments sa ON sa.id = a.stitching_assignment_id ' +
+              'JOIN cutting_lots cl ON cl.id = sa.cutting_lot_id',
+        lotIdExpr: 'cl.id',
+      };
+    case 'washing':
+      return {
+        join: 'JOIN jeans_assembly_assignments ja ON ja.id = a.jeans_assembly_assignment_id ' +
+              'JOIN stitching_assignments sa ON sa.id = ja.stitching_assignment_id ' +
+              'JOIN cutting_lots cl ON cl.id = sa.cutting_lot_id',
+        lotIdExpr: 'cl.id',
+      };
+    case 'washing_in':
+      // washing_in_assignments → washing_data (by id) → cutting_lots (by lot_no)
+      return {
+        join: 'JOIN washing_data wd ON wd.id = a.washing_data_id ' +
+              'JOIN cutting_lots cl ON cl.lot_no = wd.lot_no',
+        lotIdExpr: 'cl.id',
+      };
+    case 'finishing':
+      // finishing_assignments can chain via 4 possible parents:
+      //   washing_in_data_id  → washing_in_data.lot_no
+      //   washing_in_assignment_id → washing_in_assignments.washing_data_id → washing_data.lot_no
+      //   washing_assignment_id → washing_assignments → jeans_assembly_assignments → stitching_assignments.cutting_lot_id
+      //   stitching_assignment_id → stitching_assignments.cutting_lot_id (hosiery)
+      return {
+        join:
+          'LEFT JOIN washing_in_data wid ON wid.id = a.washing_in_data_id ' +
+          'LEFT JOIN washing_in_assignments wia ON wia.id = a.washing_in_assignment_id ' +
+          'LEFT JOIN washing_data wd2 ON wd2.id = wia.washing_data_id ' +
+          'LEFT JOIN stitching_assignments sa2 ON sa2.id = a.stitching_assignment_id ' +
+          'JOIN cutting_lots cl ON cl.lot_no = COALESCE(wid.lot_no, wd2.lot_no) OR cl.id = sa2.cutting_lot_id',
+        lotIdExpr: 'cl.id',
+      };
+    default:
+      throw new Error(`Unknown stage: ${stageKey}`);
+  }
+}
+
+async function findOrphansForStage(conn, st, lotFilter) {
+  const chain = joinChainToCuttingLots(st.key);
+  let sql = `
+    SELECT a.*, cl.lot_no AS _lot_no, cl.id AS _cl_id, cl.total_pieces AS _cl_total_pieces
+      FROM \`${st.table}\` a
+      ${chain.join}
+     WHERE a.\`${st.flagCol}\` IS NULL`;
+  const params = [];
+  if (lotFilter) { sql += ' AND cl.lot_no = ?'; params.push(lotFilter); }
+  sql += ' ORDER BY a.id';
+  const [rows] = await conn.query(sql, params);
+  return rows;
+}
+
+async function existingApproveEvent(conn, st, cuttingLotId, operatorId, assignedOn) {
+  const [rows] = await conn.query(
+    `SELECT id FROM \`${st.eventsTable}\`
+      WHERE event_type='approve'
+        AND cutting_lot_id=?
+        AND operator_id=?
+        AND created_at <=> ?
+      LIMIT 1`,
+    [cuttingLotId, operatorId, assignedOn || null]
+  );
+  return rows.length ? rows[0].id : null;
+}
+
+// ─── Per-stage processing ───────────────────────────────────────────────
+async function processStage(st, { apply, lotFilter }) {
+  const summary = {
+    stage: st.key, orphans: 0, approved: 0, eventsInserted: 0,
+    sizeRows: 0, skippedDup: 0, errors: 0, sampleLots: [],
+  };
+
+  const conn = await pool.getConnection();
+  try {
+    const orphans = await findOrphansForStage(conn, st, lotFilter);
+    summary.orphans = orphans.length;
+    summary.sampleLots = orphans.slice(0, 5).map(r => r._lot_no);
+
+    if (!apply) return summary;
+    if (orphans.length === 0) return summary;
+
+    await conn.beginTransaction();
+
+    for (const row of orphans) {
+      try {
+        const aId        = row.id;
+        const lotId      = row.cutting_lot_id || row._cl_id;
+        const operatorId = row.user_id;
+        const assignedOn = row.assigned_on || null;
+        const sizes      = parseSizesJson(row.sizes_json);
+
+        let pieces;
+        if (sizes && sizes.total > 0) pieces = sizes.total;
+        else if (Number(row.total_pieces) > 0) pieces = Number(row.total_pieces);
+        else pieces = Number(row._cl_total_pieces) || 0;
+
+        // 1) Flip the assignment flag.
+        const [upd] = await conn.query(
+          `UPDATE \`${st.table}\`
+              SET \`${st.flagCol}\`=1, approved_on=COALESCE(approved_on, NOW())
+            WHERE id=? AND \`${st.flagCol}\` IS NULL`,
+          [aId]
+        );
+        if (upd.affectedRows === 1) summary.approved++;
+
+        // 2) Skip event if one already exists for this (lot, operator, assignedOn).
+        const existing = await existingApproveEvent(conn, st, lotId, operatorId, assignedOn);
+        if (existing) { summary.skippedDup++; continue; }
+
+        // 3) Insert approve event dated to assigned_on (so reports show
+        //    the historical day, not today).
+        const [ins] = await conn.query(
+          `INSERT INTO \`${st.eventsTable}\`
+             (cutting_lot_id, event_type, parent_event_id, pieces, operator_id, remark, created_at)
+           VALUES (?, 'approve', NULL, ?, ?, ?, COALESCE(?, NOW()))`,
+          [lotId, pieces, operatorId, `AUTO_APPROVE_ORPHAN:${st.table}#${aId}`, assignedOn]
+        );
+        const eventId = ins.insertId;
+        summary.eventsInserted++;
+
+        // 4) Insert size rows if we parsed sizes_json successfully.
+        if (sizes && sizes.rows.length) {
+          const values = sizes.rows.map(s => [eventId, s.label, s.pieces]);
+          await conn.query(
+            `INSERT IGNORE INTO \`${st.sizesTable}\` (event_id, size_label, pieces) VALUES ?`,
+            [values]
+          );
+          summary.sizeRows += sizes.rows.length;
+        }
+      } catch (e) {
+        summary.errors++;
+        console.error(`[${st.key}] row id=${row.id} lot=${row._lot_no} ERROR:`, e.message);
+      }
+    }
+
+    if (summary.errors > 0) {
+      await conn.rollback();
+      console.error(`[${st.key}] rolled back due to ${summary.errors} error(s).`);
+      summary.approved = 0; summary.eventsInserted = 0; summary.sizeRows = 0; summary.skippedDup = 0;
+    } else {
+      await conn.commit();
+    }
+  } catch (e) {
+    try { await conn.rollback(); } catch {}
+    summary.errors++;
+    console.error(`[${st.key}] FATAL:`, e.message);
+  } finally {
+    conn.release();
+  }
+  return summary;
+}
+
+// ─── --lot mode: per-stage diagnostic for a single lot ──────────────────
+async function diagnoseLot(lotNo) {
+  console.log(`\n=== Lot diagnosis: ${lotNo} ===`);
+  const conn = await pool.getConnection();
+  try {
+    const [lotRows] = await conn.query(
+      'SELECT id, lot_no, sku, total_pieces, flow_type, user_id, created_at FROM cutting_lots WHERE lot_no = ?',
+      [lotNo]
+    );
+    if (lotRows.length === 0) {
+      console.log(`Lot ${lotNo} not found in cutting_lots.`);
+      return;
+    }
+    const lot = lotRows[0];
+    console.log(`cutting_lots: id=${lot.id} sku=${lot.sku} pieces=${lot.total_pieces} flow=${lot.flow_type} cutter=${lot.user_id} created=${lot.created_at && lot.created_at.toISOString ? lot.created_at.toISOString() : lot.created_at}`);
+
+    for (const st of STAGES) {
+      const [aRows] = await conn.query(
+        `SELECT a.id, a.user_id, a.assigned_on, a.\`${st.flagCol}\` AS flag, a.approved_on, a.sizes_json
+           FROM \`${st.table}\` a
+          WHERE a.cutting_lot_id = ?`,
+        [lot.id]
+      );
+      const [eRows] = await conn.query(
+        `SELECT event_type, COUNT(*) AS c, SUM(pieces) AS pcs
+           FROM \`${st.eventsTable}\`
+          WHERE cutting_lot_id = ?
+          GROUP BY event_type`,
+        [lot.id]
+      );
+      const eMap = Object.fromEntries(eRows.map(r => [r.event_type, { c: r.c, pcs: r.pcs }]));
+      console.log(`--- ${st.key} ---`);
+      if (aRows.length === 0) {
+        console.log(`  assignment: (none)`);
+      } else {
+        for (const a of aRows) {
+          const sizes = parseSizesJson(a.sizes_json);
+          console.log(`  assignment id=${a.id} user=${a.user_id} assigned_on=${a.assigned_on} flag=${a.flag === null ? 'NULL (ORPHAN)' : a.flag} approved_on=${a.approved_on || '—'} sizes_total=${sizes ? sizes.total : 'n/a'}`);
+        }
+      }
+      const fmt = (k) => eMap[k] ? `${eMap[k].c} (${eMap[k].pcs} pcs)` : '0';
+      console.log(`  events: approve=${fmt('approve')}  complete=${fmt('complete')}  reject=${fmt('reject')}`);
+    }
+  } finally {
+    conn.release();
+  }
+}
+
+// ─── Reporting ──────────────────────────────────────────────────────────
+function printSummary(summaries, { apply }) {
+  if (!apply) {
+    console.log('\nORPHAN INVENTORY (dry-run — no writes)\n');
+    let total = 0;
+    for (const s of summaries) {
+      const sample = s.sampleLots.length ? ` (sample: ${s.sampleLots.join(', ')})` : '';
+      console.log(`  ${s.stage.padEnd(16)} — ${String(s.orphans).padStart(5)} orphans${sample}`);
+      total += s.orphans;
+    }
+    console.log('  ' + ' '.repeat(16) + '   ─────');
+    console.log('  ' + ' '.repeat(16) + `   ${String(total).padStart(5)} total\n`);
+    console.log('Re-run with --apply to fix.\n');
+    return;
+  }
+  console.log('\nAPPLY RESULTS\n');
+  console.log('  stage            orphans  approved  events  size_rows  skip(dup)  errors');
+  for (const s of summaries) {
+    console.log(
+      '  ' +
+      s.stage.padEnd(16) +
+      String(s.orphans).padStart(8) +
+      String(s.approved).padStart(10) +
+      String(s.eventsInserted).padStart(8) +
+      String(s.sizeRows).padStart(11) +
+      String(s.skippedDup).padStart(11) +
+      String(s.errors).padStart(8)
+    );
+  }
+  console.log('');
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────
+async function main() {
+  const args = parseArgs(process.argv);
+
+  if (args.lot && !args.apply) {
+    await diagnoseLot(args.lot);
+    return;
+  }
+
+  const stagesToRun = args.stage
+    ? STAGES.filter(s => s.key === args.stage)
+    : STAGES;
+  if (args.stage && stagesToRun.length === 0) {
+    console.error(`Unknown stage: ${args.stage}. Valid: ${STAGES.map(s => s.key).join(', ')}`);
+    process.exit(1);
+  }
+
+  if (args.apply) {
+    console.log(`Applying orphan fix to: ${stagesToRun.map(s => s.key).join(', ')}${args.lot ? ` (lot=${args.lot})` : ''}`);
+  } else {
+    console.log(`Dry-run on: ${stagesToRun.map(s => s.key).join(', ')}${args.lot ? ` (lot=${args.lot})` : ''}`);
+  }
+
+  const summaries = [];
+  for (const st of stagesToRun) {
+    const s = await processStage(st, { apply: args.apply, lotFilter: args.lot });
+    summaries.push(s);
+  }
+  printSummary(summaries, { apply: args.apply });
+
+  if (args.lot) {
+    await diagnoseLot(args.lot);
+  }
+}
+
+main()
+  .catch(err => { console.error('FATAL:', err); process.exitCode = 1; })
+  .finally(async () => { try { await pool.end(); } catch {} });

--- a/views/myLots.ejs
+++ b/views/myLots.ejs
@@ -1,0 +1,262 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>My Lots — Track your work</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+  <style>
+    body { background: #f6f7fb; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+    .page-head {
+      background: linear-gradient(135deg, #0f172a, #1e293b);
+      color: #fff; padding: 22px 24px; margin-bottom: 18px;
+      border-radius: 0 0 14px 14px;
+    }
+    .page-head h1 { font-size: 1.35rem; font-weight: 600; margin: 0; }
+    .page-head .sub { color: #94a3b8; font-size: 0.9rem; margin-top: 4px; }
+    .controls { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 14px; align-items: center; }
+    .controls input, .controls select {
+      background: #fff; border: 0; padding: 6px 10px; border-radius: 8px;
+      font-size: 0.88rem;
+    }
+    .counts { display: flex; gap: 14px; flex-wrap: wrap; margin-bottom: 14px; }
+    .count-pill {
+      background: #fff; border: 1px solid #e5e7eb; border-radius: 10px;
+      padding: 10px 14px; min-width: 130px;
+    }
+    .count-pill .num { font-size: 1.4rem; font-weight: 600; color: #111827; }
+    .count-pill .label { font-size: 0.75rem; color: #6b7280; text-transform: uppercase; letter-spacing: 0.3px; }
+    .lot-card {
+      background: #fff; border: 1px solid #e5e7eb; border-radius: 12px;
+      padding: 14px 16px; margin-bottom: 12px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.03);
+    }
+    .lot-head {
+      display: flex; justify-content: space-between; align-items: center; gap: 10px;
+      flex-wrap: wrap; margin-bottom: 12px;
+    }
+    .lot-no { font-weight: 600; font-size: 1.05rem; color: #111827; }
+    .lot-meta { font-size: 0.8rem; color: #6b7280; }
+    .dept-chip { font-size: 0.7rem; padding: 2px 8px; border-radius: 999px; }
+    .dept-chip.denim { background: #dbeafe; color: #1e40af; }
+    .dept-chip.hosiery { background: #fef3c7; color: #92400e; }
+    .dept-chip.unknown { background: #f3f4f6; color: #6b7280; }
+    .timeline {
+      display: flex; gap: 0; flex-wrap: nowrap; overflow-x: auto;
+      padding: 4px 0;
+    }
+    .step {
+      flex: 1; min-width: 130px; padding: 8px 10px;
+      border-left: 3px solid transparent;
+      position: relative;
+    }
+    .step + .step { border-left-color: #e5e7eb; }
+    .step .stage-name {
+      font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.3px;
+      color: #6b7280; margin-bottom: 4px; font-weight: 500;
+    }
+    .step .master {
+      font-weight: 500; font-size: 0.88rem; color: #111827;
+    }
+    .step .ts { font-size: 0.72rem; color: #9ca3af; margin-top: 2px; }
+    .step.completed { background: linear-gradient(to right, rgba(34,197,94,0.05), transparent); }
+    .step.completed .stage-name { color: #16a34a; }
+    .step.completed .stage-name::after { content: ' ✓'; }
+    .step.approved { background: linear-gradient(to right, rgba(59,130,246,0.06), transparent); }
+    .step.approved .stage-name { color: #2563eb; }
+    .step.assigned { background: linear-gradient(to right, rgba(251,191,36,0.08), transparent); }
+    .step.assigned .stage-name { color: #d97706; }
+    .step.empty .master { color: #9ca3af; font-style: italic; }
+    .step.me { box-shadow: inset 3px 0 0 #6366f1; background: linear-gradient(to right, rgba(99,102,241,0.08), transparent); }
+    .step.me::after {
+      content: 'YOU'; position: absolute; top: 4px; right: 6px;
+      background: #6366f1; color: #fff; font-size: 0.6rem;
+      padding: 1px 5px; border-radius: 3px; letter-spacing: 0.5px;
+    }
+    .step.current { box-shadow: inset 0 -2px 0 #f59e0b; }
+    .step.current .stage-name { color: #f59e0b; font-weight: 600; }
+    .step.na { opacity: 0.4; }
+    .step.na .master::before { content: '—'; }
+    .step.na .master { color: transparent; }
+    .empty-state {
+      background: #fff; border: 1px dashed #d1d5db; border-radius: 12px;
+      padding: 40px 20px; text-align: center; color: #6b7280;
+    }
+  </style>
+</head>
+<body>
+  <div class="page-head">
+    <h1><i class="bi bi-bag-check"></i> My Lots</h1>
+    <div class="sub">Every lot you've touched — and who has it next.</div>
+    <div class="controls">
+      <input type="text" id="search" placeholder="Filter by lot / SKU" style="width: 220px;">
+      <select id="stageFilter">
+        <option value="">All stages</option>
+        <option value="with_me">With me now</option>
+        <option value="Done">Completed</option>
+        <option value="stitching">In stitching</option>
+        <option value="assembly">In assembly</option>
+        <option value="washing">In washing</option>
+        <option value="washing_in">In wash-in</option>
+        <option value="finishing">In finishing</option>
+      </select>
+      <select id="flowFilter">
+        <option value="">All depts</option>
+        <option value="denim">Denim</option>
+        <option value="hosiery">Hosiery</option>
+      </select>
+    </div>
+  </div>
+
+  <div class="container-fluid" style="max-width: 1400px;">
+    <div class="counts" id="counts"></div>
+    <div id="list"></div>
+  </div>
+
+<script>
+  const $ = (id) => document.getElementById(id);
+  const ME = <%- JSON.stringify({ id: user.id, username: user.username, role: user.roleName }) %>;
+  let ALL = [];
+
+  function fmtDate(s) {
+    if (!s) return '';
+    const d = new Date(s);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleDateString('en-IN', { day: '2-digit', month: 'short', year: 'numeric', timeZone: 'Asia/Kolkata' });
+  }
+
+  function stepClass(stage, lot) {
+    const data = lot[stage];
+    const completedFlag = {
+      stitching: 'stitching_completed', assembly: 'assembly_completed',
+      washing: 'washing_completed', washing_in: 'washing_in_completed',
+      finishing: 'finishing_completed',
+    }[stage];
+    const classes = ['step'];
+
+    const isDenim = lot.flow_type === 'denim';
+    const naForHosiery = !isDenim && ['assembly','washing','washing_in'].includes(stage);
+    if (naForHosiery) { classes.push('na'); return classes.join(' '); }
+
+    if (lot[completedFlag]) classes.push('completed');
+    else if (data && data.approved) classes.push('approved');
+    else if (data) classes.push('assigned');
+    else classes.push('empty');
+
+    if (data && data.is_me) classes.push('me');
+    if (lot.current_stage === stage) classes.push('current');
+    return classes.join(' ');
+  }
+
+  function stepHtml(stageKey, stageLabel, lot) {
+    const data = lot[stageKey];
+    const classes = stepClass(stageKey, lot);
+    if (classes.includes('na')) {
+      return `<div class="${classes}">
+        <div class="stage-name">${stageLabel}</div>
+        <div class="master">—</div>
+      </div>`;
+    }
+    const name = data ? (data.name || `user#${data.user_id}`) : 'Not assigned';
+    const ts  = data ? (data.approved ? `Approved ${fmtDate(data.approved_on)}` : `Assigned ${fmtDate(data.assigned_on)}`) : '';
+    return `<div class="${classes}">
+      <div class="stage-name">${stageLabel}</div>
+      <div class="master">${name}</div>
+      <div class="ts">${ts}</div>
+    </div>`;
+  }
+
+  function lotCard(lot) {
+    const cutterName = lot.cutter.name || `user#${lot.cutter.user_id}`;
+    const cutterCls = (lot.cutter.is_me ? 'step me' : 'step') + ' approved';
+    const cuttingStep = `<div class="${cutterCls}">
+      <div class="stage-name">Cutting</div>
+      <div class="master">${cutterName}</div>
+      <div class="ts">Cut ${fmtDate(lot.created_at)}</div>
+    </div>`;
+
+    return `<div class="lot-card">
+      <div class="lot-head">
+        <div>
+          <span class="lot-no">${lot.lot_no}</span>
+          <span class="dept-chip ${lot.flow_type}">${lot.flow_type}</span>
+          <span class="lot-meta">· ${lot.sku} · ${lot.pieces.toLocaleString()} pcs</span>
+        </div>
+        <div class="lot-meta">Current stage: <strong>${lot.current_stage}</strong></div>
+      </div>
+      <div class="timeline">
+        ${cuttingStep}
+        ${stepHtml('stitching',  'Stitching',  lot)}
+        ${stepHtml('assembly',   'Assembly',   lot)}
+        ${stepHtml('washing',    'Washing',    lot)}
+        ${stepHtml('washing_in', 'Wash-In',    lot)}
+        ${stepHtml('finishing',  'Finishing',  lot)}
+      </div>
+    </div>`;
+  }
+
+  function isLotWithMe(lot) {
+    const stage = lot.current_stage;
+    if (stage === 'Done') return false;
+    const ref = lot[stage];
+    return !!(ref && ref.is_me);
+  }
+
+  function renderCounts(items) {
+    const total = items.length;
+    const withMe = items.filter(isLotWithMe).length;
+    const done = items.filter(l => l.current_stage === 'Done').length;
+    const denim = items.filter(l => l.flow_type === 'denim').length;
+    const hos   = items.filter(l => l.flow_type === 'hosiery').length;
+    $('counts').innerHTML = `
+      <div class="count-pill"><div class="num">${total}</div><div class="label">Total lots</div></div>
+      <div class="count-pill"><div class="num">${withMe}</div><div class="label">With me now</div></div>
+      <div class="count-pill"><div class="num">${done}</div><div class="label">Completed</div></div>
+      <div class="count-pill"><div class="num">${denim}</div><div class="label">Denim</div></div>
+      <div class="count-pill"><div class="num">${hos}</div><div class="label">Hosiery</div></div>
+    `;
+  }
+
+  function applyFilters() {
+    const q = $('search').value.trim().toLowerCase();
+    const stage = $('stageFilter').value;
+    const flow = $('flowFilter').value;
+    let items = ALL;
+    if (q) {
+      items = items.filter(l =>
+        (l.lot_no || '').toLowerCase().includes(q) ||
+        (l.sku || '').toLowerCase().includes(q)
+      );
+    }
+    if (flow) items = items.filter(l => l.flow_type === flow);
+    if (stage === 'with_me') items = items.filter(isLotWithMe);
+    else if (stage) items = items.filter(l => l.current_stage === stage);
+
+    renderCounts(items);
+    $('list').innerHTML = items.length
+      ? items.map(lotCard).join('')
+      : `<div class="empty-state"><i class="bi bi-inbox" style="font-size:32px;"></i><div style="margin-top:10px;">No lots match your filter.</div></div>`;
+  }
+
+  async function load() {
+    $('list').innerHTML = '<div class="empty-state">Loading…</div>';
+    const r = await fetch('/my-lots/data');
+    if (!r.ok) {
+      $('list').innerHTML = '<div class="empty-state">Failed to load. ' + r.status + '</div>';
+      return;
+    }
+    const data = await r.json();
+    ALL = data.lots || [];
+    applyFilters();
+  }
+
+  ['search','stageFilter','flowFilter'].forEach(id => {
+    $(id).addEventListener('input', applyFilters);
+    $(id).addEventListener('change', applyFilters);
+  });
+
+  load();
+</script>
+</body>
+</html>

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -46,6 +46,7 @@
             </div>
           </a>
           <ul class="dropdown-menu dropdown-menu-end">
+            <li><a class="dropdown-item" href="/my-lots"><i class="bi bi-bag-check me-2"></i>My Lots</a></li>
             <li><a class="dropdown-item" href="/profile"><i class="bi bi-person me-2"></i>Profile</a></li>
             <li><a class="dropdown-item" href="/settings"><i class="bi bi-gear me-2"></i>Settings</a></li>
             <li><hr class="dropdown-divider"></li>


### PR DESCRIPTION
My Lots page (GET /my-lots) shows every cutting lot the logged-in user has touched — as cutter, stitching/assembly/washing/wash-in/finishing master — with the full upstream + downstream chain. Each lot renders as a timeline: who cut it, who has it now (highlighted "YOU"), who's next. Filterable by stage / dept / search. Link added to the shared navbar dropdown so it appears on all 6 stage dashboards.

Also includes scripts/fix-orphan-assignments.js: CLI tool that finds *_assignments rows with is_approved IS NULL (orphaned by the post-events removal of legacy approve UIs) and auto-approves them — flips the assignment flag AND inserts a matching approve event into *_events with sizes_json broken into *_event_sizes. Run today against prod cleared 2,846 orphans across all five stages.