### PR TITLE
feat: Excel downloads for My Lots, Wash-In rewash, Finishing dispatch

### DIFF
--- a/app.js
+++ b/app.js
@@ -203,6 +203,7 @@ app.use('/health', healthRoutes);
 app.use('/', authRoutes);
 app.use('/', launcherRoutes);                       // /launcher + /switch-role
 app.use('/my-lots', require('./routes/myLotsRoutes'));
+app.use('/operator/lot-tat', require('./routes/operatorLotTatRoutes'));
 app.use('/admin/user-roles', adminUserRolesRoutes); // mohitOperator-only
 app.use('/return-challan', returnChallanRoutes);    // returnchallan role
 app.use('/admin', adminRoutes);

--- a/routes/finishingRoutes.js
+++ b/routes/finishingRoutes.js
@@ -2362,4 +2362,77 @@ router.get('/history-download', isAuthenticated, isFinishingMaster, async (req, 
   }
 });
 
+/**
+ * GET /finishingdashboard/dispatch-download
+ * Excel dump of every dispatch row (warehouse / PO / return / other)
+ * for the current finishing master's lots. One row per
+ * (lot, destination, size).
+ */
+router.get('/dispatch-download', isAuthenticated, isFinishingMaster, async (req, res) => {
+  try {
+    const userId = req.session.user.id;
+
+    const [rows] = await pool.query(
+      `SELECT fd.lot_no, fd.sku,
+              d.destination,
+              fd.destination_remark,
+              d.size_label,
+              d.quantity,
+              d.total_sent,
+              d.sent_at,
+              fd.total_pieces AS batch_total,
+              cl.remark        AS cutting_remark
+         FROM finishing_dispatches d
+         JOIN finishing_data fd ON fd.id = d.finishing_data_id
+    LEFT JOIN cutting_lots cl ON cl.lot_no = fd.lot_no
+        WHERE fd.user_id = ?
+     ORDER BY d.sent_at DESC, fd.lot_no, d.destination, d.size_label`,
+      [userId]
+    );
+
+    const ExcelJS = require('exceljs');
+    const wb = new ExcelJS.Workbook();
+    const sheet = wb.addWorksheet('Dispatches');
+    sheet.columns = [
+      { header: 'Lot No',          key: 'lot_no',          width: 14 },
+      { header: 'SKU',             key: 'sku',             width: 22 },
+      { header: 'Destination',     key: 'destination',     width: 14 },
+      { header: 'Destination Note', key: 'destination_remark', width: 24 },
+      { header: 'Size',            key: 'size_label',      width: 8  },
+      { header: 'Qty Dispatched',  key: 'quantity',        width: 12 },
+      { header: 'Total Sent',      key: 'total_sent',      width: 12 },
+      { header: 'Batch Total',     key: 'batch_total',     width: 12 },
+      { header: 'Dispatched On',   key: 'sent_at',         width: 14 },
+      { header: 'Cutting Remark',  key: 'cutting_remark',  width: 22 },
+    ];
+
+    const fmt = d => d ? new Date(d).toLocaleDateString('en-IN', { day: '2-digit', month: 'short', year: 'numeric', timeZone: 'Asia/Kolkata' }) : '';
+    for (const r of rows) {
+      sheet.addRow({
+        lot_no: r.lot_no, sku: r.sku,
+        destination: r.destination || '',
+        destination_remark: r.destination_remark || '',
+        size_label: r.size_label || '',
+        quantity: r.quantity || 0,
+        total_sent: r.total_sent || 0,
+        batch_total: r.batch_total || 0,
+        sent_at: fmt(r.sent_at),
+        cutting_remark: r.cutting_remark || '',
+      });
+    }
+
+    sheet.getRow(1).font = { bold: true, color: { argb: 'FFFFFFFF' } };
+    sheet.getRow(1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF1F2937' } };
+
+    const today = new Date().toLocaleDateString('en-IN', { timeZone: 'Asia/Kolkata' }).replace(/\//g, '-');
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', `attachment; filename="Dispatches-${today}.xlsx"`);
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error('[ERROR] GET /dispatch-download =>', err);
+    return res.status(500).send('Failed to export dispatch list');
+  }
+});
+
 module.exports = router;

--- a/routes/myLotsRoutes.js
+++ b/routes/myLotsRoutes.js
@@ -10,6 +10,7 @@
 
 const express = require('express');
 const router = express.Router();
+const ExcelJS = require('exceljs');
 const { pool } = require('../config/db');
 const { isAuthenticated } = require('../middlewares/auth');
 
@@ -22,9 +23,7 @@ router.get('/', isAuthenticated, async (req, res) => {
   }
 });
 
-router.get('/data', isAuthenticated, async (req, res) => {
-  const userId = req.session.user.id;
-  try {
+async function loadUserLots(userId) {
     // 1) Find every cutting_lot_id the current user touched — via legacy
     //    assignments OR via the new events tables. The events tables are
     //    authoritative now; a user can have events without an assignment.
@@ -71,14 +70,10 @@ router.get('/data', isAuthenticated, async (req, res) => {
        userId, userId, userId, userId, userId]
     );
 
-    if (lotIdRows.length === 0) {
-      return res.json({ user: req.session.user, lots: [] });
-    }
+    if (lotIdRows.length === 0) return [];
 
     const lotIds = lotIdRows.map(r => r.lot_id).filter(x => x);
-    if (lotIds.length === 0) {
-      return res.json({ user: req.session.user, lots: [] });
-    }
+    if (lotIds.length === 0) return [];
 
     // 2) Load lot metadata.
     const [lots] = await pool.query(
@@ -355,10 +350,110 @@ router.get('/data', isAuthenticated, async (req, res) => {
       return db - da;
     });
 
-    return res.json({ user: req.session.user, lots: result });
+    return result;
+}
+
+router.get('/data', isAuthenticated, async (req, res) => {
+  try {
+    const lots = await loadUserLots(req.session.user.id);
+    return res.json({ user: req.session.user, lots });
   } catch (err) {
     console.error('GET /my-lots/data error:', err);
     return res.status(500).json({ error: 'Failed to load my-lots data' });
+  }
+});
+
+router.get('/download', isAuthenticated, async (req, res) => {
+  try {
+    const lots = await loadUserLots(req.session.user.id);
+
+    const wb = new ExcelJS.Workbook();
+    const sheet = wb.addWorksheet('My Lots');
+    sheet.columns = [
+      { header: 'Lot No',         key: 'lot_no',          width: 14 },
+      { header: 'SKU',            key: 'sku',             width: 22 },
+      { header: 'Dept',           key: 'flow_type',       width: 10 },
+      { header: 'Pieces',         key: 'pieces',          width: 10 },
+      { header: 'Remark',         key: 'remark',          width: 28 },
+      { header: 'Created',        key: 'created_at',      width: 14 },
+      { header: 'Cutter',         key: 'cutter',          width: 18 },
+      { header: 'Current Stage',  key: 'current_stage',   width: 14 },
+      { header: 'Stitching',      key: 'stitching',       width: 22 },
+      { header: 'Stitching Status', key: 'stitching_status', width: 13 },
+      { header: 'Stitching Date', key: 'stitching_date',  width: 12 },
+      { header: 'Assembly',       key: 'assembly',        width: 22 },
+      { header: 'Assembly Status', key: 'assembly_status', width: 13 },
+      { header: 'Assembly Date',  key: 'assembly_date',   width: 12 },
+      { header: 'Washing',        key: 'washing',         width: 22 },
+      { header: 'Washing Status', key: 'washing_status',  width: 13 },
+      { header: 'Washing Date',   key: 'washing_date',    width: 12 },
+      { header: 'Wash-In',        key: 'washing_in',      width: 22 },
+      { header: 'Wash-In Status', key: 'washing_in_status', width: 13 },
+      { header: 'Wash-In Date',   key: 'washing_in_date', width: 12 },
+      { header: 'Finishing',      key: 'finishing',       width: 22 },
+      { header: 'Finishing Status', key: 'finishing_status', width: 13 },
+      { header: 'Finishing Date', key: 'finishing_date',  width: 12 },
+    ];
+
+    const completedFlagMap = {
+      stitching: 'stitching_completed', assembly: 'assembly_completed',
+      washing: 'washing_completed', washing_in: 'washing_in_completed',
+      finishing: 'finishing_completed',
+    };
+
+    const fmt = d => {
+      if (!d) return '';
+      const x = new Date(d);
+      if (isNaN(x.getTime())) return '';
+      return x.toLocaleDateString('en-IN', { day: '2-digit', month: 'short', year: 'numeric', timeZone: 'Asia/Kolkata' });
+    };
+
+    const stageInfo = (lot, stage) => {
+      const data = lot[stage];
+      if (!data) return { name: '', status: 'Not assigned', date: '' };
+      const completed = lot[completedFlagMap[stage]] || data.completed;
+      if (completed) {
+        return { name: data.name || '', status: 'Completed', date: fmt(data.completed_on || data.approved_on || data.assigned_on) };
+      }
+      if (data.approved) {
+        return { name: data.name || '', status: 'Approved', date: fmt(data.approved_on || data.assigned_on) };
+      }
+      return { name: data.name || '', status: 'Assigned', date: fmt(data.assigned_on) };
+    };
+
+    for (const lot of lots) {
+      const isDenim = lot.flow_type === 'denim';
+      const naStages = isDenim ? [] : ['assembly', 'washing', 'washing_in'];
+      const row = {
+        lot_no: lot.lot_no, sku: lot.sku, flow_type: lot.flow_type,
+        pieces: lot.pieces, remark: lot.remark || '',
+        created_at: fmt(lot.created_at),
+        cutter: lot.cutter ? lot.cutter.name || '' : '',
+        current_stage: lot.current_stage,
+      };
+      for (const s of ['stitching','assembly','washing','washing_in','finishing']) {
+        if (naStages.includes(s)) {
+          row[s] = 'N/A'; row[s + '_status'] = '—'; row[s + '_date'] = '';
+        } else {
+          const i = stageInfo(lot, s);
+          row[s] = i.name; row[s + '_status'] = i.status; row[s + '_date'] = i.date;
+        }
+      }
+      sheet.addRow(row);
+    }
+
+    sheet.getRow(1).font = { bold: true };
+    sheet.getRow(1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF1F2937' } };
+    sheet.getRow(1).font = { bold: true, color: { argb: 'FFFFFFFF' } };
+
+    const today = new Date().toLocaleDateString('en-IN', { timeZone: 'Asia/Kolkata' }).replace(/\//g, '-');
+    res.setHeader('Content-Disposition', `attachment; filename="MyLots-${today}.xlsx"`);
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error('GET /my-lots/download error:', err);
+    return res.status(500).send('Failed to export My Lots');
   }
 });
 

--- a/routes/operatorLotTatRoutes.js
+++ b/routes/operatorLotTatRoutes.js
@@ -1,0 +1,325 @@
+/**
+ * Operator — Lot TAT.
+ *
+ * Replica of /my-lots scoped to operators. Shows EVERY lot (subject
+ * to optional filters), with per-stage elapsed days vs the stage's
+ * TAT target. Lots overdue at any stage are highlighted.
+ *
+ * Timing is derived strictly from *_events (the new truth source).
+ * Cutting start = cutting_lots.created_at. Stage entered = first event
+ * row's created_at for that lot in that stage's events table. Stage
+ * exited = first event of the next stage (or NOW if no next yet).
+ */
+
+const express = require('express');
+const router = express.Router();
+const ExcelJS = require('exceljs');
+const { pool } = require('../config/db');
+const { isAuthenticated, isOperator } = require('../middlewares/auth');
+
+const TAT_DAYS = {
+  cutting: 3,
+  stitching: 7,
+  assembly: 7,
+  washing: 15,
+  washing_in: 7,
+  finishing: 7,
+};
+
+const STAGE_EVENT_TABLE = {
+  stitching: 'stitching_events',
+  assembly: 'jeans_assembly_events',
+  washing: 'washing_events',
+  washing_in: 'washing_in_events',
+  finishing: 'finishing_events',
+};
+
+router.get('/', isAuthenticated, isOperator, async (req, res) => {
+  return res.render('operatorLotTat', { tat: TAT_DAYS });
+});
+
+async function loadLotTat({ days, search, flow, overdue, limit }) {
+  const params = [];
+  let where = '1=1';
+  if (days && Number(days) > 0) {
+    where += ' AND cl.created_at >= DATE_SUB(NOW(), INTERVAL ? DAY)';
+    params.push(Number(days));
+  }
+  if (flow === 'denim' || flow === 'hosiery') {
+    where += ' AND cl.flow_type = ?';
+    params.push(flow);
+  }
+  if (search && search.trim()) {
+    where += ' AND (cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ?)';
+    const q = `%${search.trim()}%`;
+    params.push(q, q, q);
+  }
+  const safeLimit = Math.min(Math.max(parseInt(limit, 10) || 500, 1), 2000);
+  params.push(safeLimit);
+
+  const [lots] = await pool.query(
+    `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.flow_type, cl.remark,
+            cl.created_at, cl.user_id AS cutter_id, cu.username AS cutter_name
+       FROM cutting_lots cl
+  LEFT JOIN users cu ON cu.id = cl.user_id
+      WHERE ${where}
+   ORDER BY cl.created_at DESC
+      LIMIT ?`,
+    params
+  );
+
+  if (lots.length === 0) return [];
+
+  const lotIds = lots.map(l => l.id);
+  const lotById = {};
+  for (const l of lots) {
+    lotById[l.id] = {
+      lot_id: l.id, lot_no: l.lot_no, sku: l.sku,
+      pieces: Number(l.total_pieces) || 0,
+      flow_type: l.flow_type || 'unknown',
+      remark: l.remark || '',
+      created_at: l.created_at,
+      cutter: { user_id: l.cutter_id, name: l.cutter_name },
+      stages: {}, // per-stage timing + master
+    };
+  }
+
+  // For each stage's events table, fetch every event for these lots
+  // and reduce in JS: entered_at = min, completed_at = max(complete),
+  // master = operator of FIRST approve event (the one accountable).
+  for (const [stageKey, table] of Object.entries(STAGE_EVENT_TABLE)) {
+    const [rows] = await pool.query(
+      `SELECT e.cutting_lot_id, e.event_type, e.operator_id, e.created_at, u.username
+         FROM \`${table}\` e
+    LEFT JOIN users u ON u.id = e.operator_id
+        WHERE e.cutting_lot_id IN (?)
+     ORDER BY e.cutting_lot_id, e.created_at`,
+      [lotIds]
+    );
+    const byLot = {};
+    for (const r of rows) {
+      const slot = byLot[r.cutting_lot_id] || (byLot[r.cutting_lot_id] = {
+        entered_at: null, completed_at: null, master_id: null, master: null,
+      });
+      if (!slot.entered_at) slot.entered_at = r.created_at;
+      if (r.event_type === 'complete') {
+        if (!slot.completed_at || new Date(r.created_at) > new Date(slot.completed_at)) {
+          slot.completed_at = r.created_at;
+        }
+      }
+      if (r.event_type === 'approve' && !slot.master_id) {
+        slot.master_id = r.operator_id;
+        slot.master = r.username;
+      }
+    }
+    for (const [lotIdStr, slot] of Object.entries(byLot)) {
+      const lot = lotById[lotIdStr];
+      if (lot) lot.stages[stageKey] = slot;
+    }
+  }
+
+  // Compute per-stage elapsed days + overdue flags.
+  const STAGES_DENIM   = ['cutting', 'stitching', 'assembly', 'washing', 'washing_in', 'finishing'];
+  const STAGES_HOSIERY = ['cutting', 'stitching', 'finishing'];
+
+  const now = Date.now();
+  const dayMs = 86400000;
+  const result = [];
+
+  for (const lot of Object.values(lotById)) {
+    const stages = lot.flow_type === 'denim' ? STAGES_DENIM : STAGES_HOSIERY;
+    const timeline = [];
+
+    // Cutting is special — no events table; created_at IS the entry point.
+    let prevExit = lot.created_at;
+
+    for (let i = 0; i < stages.length; i++) {
+      const stage = stages[i];
+      const next  = stages[i + 1];
+
+      let entered, master, masterId, completedAt;
+      if (stage === 'cutting') {
+        entered = lot.created_at;
+        master  = lot.cutter.name;
+        masterId = lot.cutter.user_id;
+      } else {
+        const ev = lot.stages[stage];
+        entered = ev ? ev.entered_at : null;
+        master  = ev ? ev.master : null;
+        masterId = ev ? ev.master_id : null;
+        completedAt = ev ? ev.completed_at : null;
+      }
+
+      // Exit = entered_at of next stage in this chain. For finishing,
+      // exit = completed_at if available.
+      let exit = null;
+      if (next) {
+        const ne = lot.stages[next];
+        exit = ne ? ne.entered_at : null;
+      } else {
+        // last stage (finishing)
+        exit = completedAt || null;
+      }
+
+      // Days in this stage
+      const startMs = entered ? new Date(entered).getTime() : null;
+      const endMs   = exit ? new Date(exit).getTime() : (startMs ? now : null);
+      const days = startMs != null && endMs != null
+        ? Math.max(0, Math.round((endMs - startMs) / dayMs))
+        : null;
+      const inProgress = startMs != null && exit == null;
+      const tat = TAT_DAYS[stage];
+      const overdueFlag = days != null && days > tat;
+
+      timeline.push({
+        stage,
+        entered: entered || null,
+        exited: exit,
+        days,
+        tat,
+        overdue: overdueFlag,
+        in_progress: inProgress,
+        not_started: startMs == null,
+        master: master || null,
+        master_id: masterId || null,
+      });
+
+      if (entered) prevExit = entered;
+    }
+
+    // Current stage = first stage that's in_progress (entered but not exited).
+    let currentStage = 'Done';
+    for (const t of timeline) {
+      if (t.in_progress) { currentStage = t.stage; break; }
+      if (t.not_started) { currentStage = t.stage; break; }
+    }
+
+    // Per-lot any-overdue flag (for filter)
+    const anyOverdue = timeline.some(t => t.overdue);
+
+    lot.timeline = timeline;
+    lot.current_stage = currentStage;
+    lot.any_overdue = anyOverdue;
+    result.push(lot);
+  }
+
+  if (overdue === '1' || overdue === 'true') {
+    return result.filter(l => l.any_overdue);
+  }
+  return result;
+}
+
+router.get('/data', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const lots = await loadLotTat({
+      days: req.query.days,
+      search: req.query.search,
+      flow: req.query.flow,
+      overdue: req.query.overdue,
+      limit: req.query.limit,
+    });
+    return res.json({ tat: TAT_DAYS, lots });
+  } catch (err) {
+    console.error('GET /operator/lot-tat/data error:', err);
+    return res.status(500).json({ error: 'Failed to load lot TAT data' });
+  }
+});
+
+router.get('/download', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const lots = await loadLotTat({
+      days: req.query.days,
+      search: req.query.search,
+      flow: req.query.flow,
+      overdue: req.query.overdue,
+      limit: req.query.limit || 2000,
+    });
+
+    const wb = new ExcelJS.Workbook();
+    const sheet = wb.addWorksheet('Lot TAT');
+    sheet.columns = [
+      { header: 'Lot No',        key: 'lot_no',         width: 14 },
+      { header: 'SKU',           key: 'sku',            width: 22 },
+      { header: 'Dept',          key: 'dept',           width: 9 },
+      { header: 'Pieces',        key: 'pieces',         width: 9 },
+      { header: 'Remark',        key: 'remark',         width: 22 },
+      { header: 'Cutter',        key: 'cutter',         width: 14 },
+      { header: 'Cut Date',      key: 'cut_date',       width: 12 },
+      { header: 'Current Stage', key: 'current_stage',  width: 13 },
+      { header: 'Cutting (3d)',   key: 'cutting_days',     width: 11 },
+      { header: 'Cutting Master',  key: 'cutting_master',  width: 14 },
+      { header: 'Stitching (7d)', key: 'stitching_days',  width: 11 },
+      { header: 'Stitching Master', key: 'stitching_master', width: 14 },
+      { header: 'Assembly (7d)',  key: 'assembly_days',   width: 11 },
+      { header: 'Assembly Master', key: 'assembly_master', width: 14 },
+      { header: 'Washing (15d)',  key: 'washing_days',    width: 11 },
+      { header: 'Washing Master',  key: 'washing_master',  width: 14 },
+      { header: 'Wash-In (7d)',   key: 'washing_in_days', width: 11 },
+      { header: 'Wash-In Master',  key: 'washing_in_master', width: 14 },
+      { header: 'Finishing (7d)', key: 'finishing_days',  width: 11 },
+      { header: 'Finishing Master', key: 'finishing_master', width: 14 },
+      { header: 'Any Overdue',   key: 'any_overdue',    width: 10 },
+    ];
+
+    const fmt = d => d ? new Date(d).toLocaleDateString('en-IN', {
+      day: '2-digit', month: 'short', year: 'numeric', timeZone: 'Asia/Kolkata'
+    }) : '';
+
+    const dayCell = t => {
+      if (!t) return '';
+      if (t.not_started) return '—';
+      if (t.in_progress) return `${t.days}d (ongoing)`;
+      return `${t.days}d`;
+    };
+
+    for (const lot of lots) {
+      const byStage = Object.fromEntries(lot.timeline.map(t => [t.stage, t]));
+      const row = {
+        lot_no: lot.lot_no, sku: lot.sku, dept: lot.flow_type,
+        pieces: lot.pieces, remark: lot.remark || '',
+        cutter: lot.cutter.name || '', cut_date: fmt(lot.created_at),
+        current_stage: lot.current_stage,
+        cutting_days: dayCell(byStage.cutting),
+        cutting_master: byStage.cutting ? byStage.cutting.master || '' : '',
+        stitching_days: dayCell(byStage.stitching),
+        stitching_master: byStage.stitching ? byStage.stitching.master || '' : '',
+        assembly_days: lot.flow_type === 'denim' ? dayCell(byStage.assembly) : 'N/A',
+        assembly_master: lot.flow_type === 'denim' && byStage.assembly ? byStage.assembly.master || '' : '',
+        washing_days: lot.flow_type === 'denim' ? dayCell(byStage.washing) : 'N/A',
+        washing_master: lot.flow_type === 'denim' && byStage.washing ? byStage.washing.master || '' : '',
+        washing_in_days: lot.flow_type === 'denim' ? dayCell(byStage.washing_in) : 'N/A',
+        washing_in_master: lot.flow_type === 'denim' && byStage.washing_in ? byStage.washing_in.master || '' : '',
+        finishing_days: dayCell(byStage.finishing),
+        finishing_master: byStage.finishing ? byStage.finishing.master || '' : '',
+        any_overdue: lot.any_overdue ? 'YES' : '',
+      };
+      const r = sheet.addRow(row);
+      // Highlight overdue cells in red
+      const stageColMap = {
+        cutting: 9, stitching: 11, assembly: 13, washing: 15, washing_in: 17, finishing: 19,
+      };
+      for (const t of lot.timeline) {
+        if (t.overdue) {
+          r.getCell(stageColMap[t.stage]).fill = {
+            type: 'pattern', pattern: 'solid', fgColor: { argb: 'FFFEE2E2' },
+          };
+          r.getCell(stageColMap[t.stage]).font = { color: { argb: 'FFB91C1C' }, bold: true };
+        }
+      }
+    }
+
+    sheet.getRow(1).font = { bold: true, color: { argb: 'FFFFFFFF' } };
+    sheet.getRow(1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF1F2937' } };
+
+    const today = new Date().toLocaleDateString('en-IN', { timeZone: 'Asia/Kolkata' }).replace(/\//g, '-');
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', `attachment; filename="LotTAT-${today}.xlsx"`);
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error('GET /operator/lot-tat/download error:', err);
+    return res.status(500).send('Failed to export lot TAT');
+  }
+});
+
+module.exports = router;

--- a/routes/washingInRoutes.js
+++ b/routes/washingInRoutes.js
@@ -2438,4 +2438,92 @@ router.get('/history-download', isAuthenticated, isWashingInMaster, async (req, 
   }
 });
 
+/**
+ * GET /washingin/rewash-download
+ * Excel dump of every rewash request belonging to the current
+ * washing-in master, with sizes broken out per row.
+ */
+router.get('/rewash-download', isAuthenticated, isWashingInMaster, async (req, res) => {
+  try {
+    const userId = req.session.user.id;
+
+    const [rows] = await pool.query(
+      `SELECT rr.id, rr.lot_no, rr.sku, rr.total_requested, rr.status,
+              rr.created_at, rr.completed_at, rr.debit_id,
+              wu.username  AS washer,
+              wiu.username AS washing_in_master,
+              cu.username  AS completed_by_name,
+              cl.remark    AS cutting_remark
+         FROM rewash_requests rr
+    LEFT JOIN users wu  ON wu.id  = rr.washer_id
+    LEFT JOIN users wiu ON wiu.id = rr.user_id
+    LEFT JOIN users cu  ON cu.id  = rr.completed_by
+    LEFT JOIN cutting_lots cl ON cl.lot_no = rr.lot_no
+        WHERE rr.user_id = ?
+     ORDER BY rr.created_at DESC`,
+      [userId]
+    );
+
+    const rrIds = rows.map(r => r.id);
+    let sizesByRR = {};
+    if (rrIds.length) {
+      const [sizeRows] = await pool.query(
+        `SELECT rewash_request_id, size_label, pieces_requested
+           FROM rewash_request_sizes
+          WHERE rewash_request_id IN (?)
+          ORDER BY size_label`,
+        [rrIds]
+      );
+      for (const s of sizeRows) {
+        (sizesByRR[s.rewash_request_id] = sizesByRR[s.rewash_request_id] || [])
+          .push(`${s.size_label}:${s.pieces_requested}`);
+      }
+    }
+
+    const ExcelJS = require('exceljs');
+    const wb = new ExcelJS.Workbook();
+    const sheet = wb.addWorksheet('Rewash Requests');
+    sheet.columns = [
+      { header: 'Lot No',           key: 'lot_no',          width: 14 },
+      { header: 'SKU',              key: 'sku',             width: 22 },
+      { header: 'Pieces',           key: 'total_requested', width: 10 },
+      { header: 'Status',           key: 'status',          width: 12 },
+      { header: 'Washer',           key: 'washer',          width: 18 },
+      { header: 'Wash-In Master',   key: 'washing_in_master', width: 18 },
+      { header: 'Sizes',            key: 'sizes',           width: 28 },
+      { header: 'Cutting Remark',   key: 'cutting_remark',  width: 22 },
+      { header: 'Requested On',     key: 'created_at',      width: 14 },
+      { header: 'Completed By',     key: 'completed_by_name', width: 18 },
+      { header: 'Completed On',     key: 'completed_at',    width: 14 },
+      { header: 'Debit ID',         key: 'debit_id',        width: 10 },
+    ];
+
+    const fmt = d => d ? new Date(d).toLocaleDateString('en-IN', { day: '2-digit', month: 'short', year: 'numeric', timeZone: 'Asia/Kolkata' }) : '';
+    for (const r of rows) {
+      sheet.addRow({
+        lot_no: r.lot_no, sku: r.sku, total_requested: r.total_requested,
+        status: r.status, washer: r.washer || '',
+        washing_in_master: r.washing_in_master || '',
+        sizes: (sizesByRR[r.id] || []).join(', '),
+        cutting_remark: r.cutting_remark || '',
+        created_at: fmt(r.created_at), completed_at: fmt(r.completed_at),
+        completed_by_name: r.completed_by_name || '',
+        debit_id: r.debit_id || '',
+      });
+    }
+
+    sheet.getRow(1).font = { bold: true, color: { argb: 'FFFFFFFF' } };
+    sheet.getRow(1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF1F2937' } };
+
+    const today = new Date().toLocaleDateString('en-IN', { timeZone: 'Asia/Kolkata' }).replace(/\//g, '-');
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', `attachment; filename="Rewash-${today}.xlsx"`);
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error('[ERROR] GET /rewash-download =>', err);
+    return res.status(500).send('Failed to export rewash list');
+  }
+});
+
 module.exports = router;

--- a/views/finishingDashboard.ejs
+++ b/views/finishingDashboard.ejs
@@ -336,6 +336,7 @@
 
     <div class="quick-links">
       <a href="/my-lots" class="quick-link" style="background:#6366f1;color:#fff;"><i class="bi bi-bag-check"></i> My Lots</a>
+      <a href="/finishingdashboard/dispatch-download" class="quick-link" style="background:#10b981;color:#fff;"><i class="bi bi-file-earmark-excel"></i> Dispatch Excel</a>
       <a href="/payments/my-payments" class="quick-link"><i class="bi bi-wallet2"></i> My Payments</a>
       <button type="button" class="quick-link" onclick="toggleHistorySection()"><i class="bi bi-clock-history"></i> History</button>
       <button type="button" class="quick-link" onclick="toggleIndentSection()"><i class="bi bi-box-seam"></i> Raise Indent</button>

--- a/views/myLots.ejs
+++ b/views/myLots.ejs
@@ -106,6 +106,9 @@
         <option value="denim">Denim</option>
         <option value="hosiery">Hosiery</option>
       </select>
+      <a href="/my-lots/download" class="btn btn-sm btn-light" style="margin-left:auto;">
+        <i class="bi bi-file-earmark-excel"></i> Download Excel
+      </a>
     </div>
   </div>
 

--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -729,6 +729,10 @@
           <i class="bi bi-calendar-check"></i>
           <span class="action-card-title">Day Activity</span>
         </a>
+        <a href="/operator/lot-tat" class="action-card">
+          <i class="bi bi-stopwatch"></i>
+          <span class="action-card-title">Lot TAT</span>
+        </a>
         <a href="/operator/editcuttinglots" class="action-card">
           <i class="bi bi-scissors"></i>
           <span class="action-card-title">Edit Lots</span>

--- a/views/operatorLotTat.ejs
+++ b/views/operatorLotTat.ejs
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Lot TAT — Operator</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+  <style>
+    body { background: #f6f7fb; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+    .page-head {
+      background: linear-gradient(135deg, #0f172a, #1e293b);
+      color: #fff; padding: 22px 24px; margin-bottom: 18px;
+      border-radius: 0 0 14px 14px;
+    }
+    .page-head h1 { font-size: 1.35rem; font-weight: 600; margin: 0; }
+    .page-head .sub { color: #94a3b8; font-size: 0.9rem; margin-top: 4px; }
+    .tat-banner {
+      display: flex; gap: 14px; flex-wrap: wrap; margin-top: 14px;
+      font-size: 0.78rem; color: #cbd5e1;
+    }
+    .tat-banner .item strong { color: #fff; }
+    .controls { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 14px; align-items: center; }
+    .controls input, .controls select {
+      background: #fff; border: 0; padding: 6px 10px; border-radius: 8px;
+      font-size: 0.88rem;
+    }
+    .counts { display: flex; gap: 14px; flex-wrap: wrap; margin-bottom: 14px; }
+    .count-pill {
+      background: #fff; border: 1px solid #e5e7eb; border-radius: 10px;
+      padding: 10px 14px; min-width: 130px;
+    }
+    .count-pill .num { font-size: 1.4rem; font-weight: 600; color: #111827; }
+    .count-pill .label { font-size: 0.75rem; color: #6b7280; text-transform: uppercase; letter-spacing: 0.3px; }
+    .lot-card {
+      background: #fff; border: 1px solid #e5e7eb; border-radius: 12px;
+      padding: 14px 16px; margin-bottom: 12px;
+      box-shadow: 0 1px 2px rgba(0,0,0,0.03);
+    }
+    .lot-card.overdue { border-color: #fca5a5; box-shadow: 0 0 0 1px #fca5a5; }
+    .lot-head {
+      display: flex; justify-content: space-between; align-items: center; gap: 10px;
+      flex-wrap: wrap; margin-bottom: 12px;
+    }
+    .lot-no { font-weight: 600; font-size: 1.05rem; color: #111827; }
+    .lot-meta { font-size: 0.8rem; color: #6b7280; }
+    .dept-chip { font-size: 0.7rem; padding: 2px 8px; border-radius: 999px; }
+    .dept-chip.denim { background: #dbeafe; color: #1e40af; }
+    .dept-chip.hosiery { background: #fef3c7; color: #92400e; }
+    .dept-chip.unknown { background: #f3f4f6; color: #6b7280; }
+    .timeline { display: flex; gap: 0; flex-wrap: nowrap; overflow-x: auto; padding: 4px 0; }
+    .step {
+      flex: 1; min-width: 150px; padding: 8px 10px;
+      border-left: 3px solid transparent; position: relative;
+    }
+    .step + .step { border-left-color: #e5e7eb; }
+    .step .stage-name {
+      font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.3px;
+      color: #6b7280; margin-bottom: 4px; font-weight: 500;
+    }
+    .step .master { font-weight: 500; font-size: 0.88rem; color: #111827; }
+    .step .ts { font-size: 0.72rem; color: #9ca3af; margin-top: 2px; }
+    .step .days {
+      font-size: 0.85rem; font-weight: 600; color: #111827; margin-top: 3px;
+    }
+    .step .tat-tag {
+      font-size: 0.68rem; color: #9ca3af;
+    }
+    .step.done .stage-name { color: #16a34a; }
+    .step.done .stage-name::after { content: ' ✓'; }
+    .step.done { background: linear-gradient(to right, rgba(34,197,94,0.05), transparent); }
+    .step.in-progress { background: linear-gradient(to right, rgba(251,191,36,0.08), transparent); }
+    .step.in-progress .stage-name { color: #d97706; }
+    .step.in-progress.overdue { background: linear-gradient(to right, rgba(239,68,68,0.12), transparent); }
+    .step.in-progress.overdue .stage-name { color: #b91c1c; font-weight: 600; }
+    .step.in-progress.overdue .days { color: #b91c1c; }
+    .step.done.overdue .days { color: #b91c1c; }
+    .step.done.overdue .stage-name { color: #b91c1c; }
+    .step.not-started { opacity: 0.45; }
+    .step.not-started .master::before { content: '—'; }
+    .step.not-started .master { color: transparent; }
+    .step.na { opacity: 0.4; }
+    .step.na .master::before { content: '—'; }
+    .step.na .master { color: transparent; }
+    .empty-state {
+      background: #fff; border: 1px dashed #d1d5db; border-radius: 12px;
+      padding: 40px 20px; text-align: center; color: #6b7280;
+    }
+  </style>
+</head>
+<body>
+  <div class="page-head">
+    <h1><i class="bi bi-speedometer2"></i> Lot TAT</h1>
+    <div class="sub">All lots, per-stage elapsed days vs TAT (from events).</div>
+    <div class="tat-banner">
+      <span class="item">Cutting <strong>3d</strong></span>
+      <span class="item">Stitching <strong>7d</strong></span>
+      <span class="item">Assembly <strong>7d</strong></span>
+      <span class="item">Washing <strong>15d</strong></span>
+      <span class="item">Wash-In <strong>7d</strong></span>
+      <span class="item">Finishing <strong>7d</strong></span>
+    </div>
+    <div class="controls">
+      <input type="text" id="search" placeholder="Filter by lot / SKU / remark" style="width: 260px;">
+      <select id="flowFilter">
+        <option value="">All depts</option>
+        <option value="denim">Denim</option>
+        <option value="hosiery">Hosiery</option>
+      </select>
+      <select id="daysFilter">
+        <option value="30" selected>Last 30 days</option>
+        <option value="7">Last 7 days</option>
+        <option value="60">Last 60 days</option>
+        <option value="90">Last 90 days</option>
+        <option value="180">Last 180 days</option>
+        <option value="">All time</option>
+      </select>
+      <label style="color:#cbd5e1; font-size:0.85rem;">
+        <input type="checkbox" id="overdueFilter"> Overdue only
+      </label>
+      <a id="dlBtn" href="#" class="btn btn-sm btn-light" style="margin-left:auto;">
+        <i class="bi bi-file-earmark-excel"></i> Download Excel
+      </a>
+      <a href="/operator/dashboard" class="btn btn-sm btn-outline-light">
+        <i class="bi bi-arrow-left"></i> Back
+      </a>
+    </div>
+  </div>
+
+  <div class="container-fluid" style="max-width: 1400px;">
+    <div class="counts" id="counts"></div>
+    <div id="list"></div>
+  </div>
+
+<script>
+  const $ = (id) => document.getElementById(id);
+
+  function fmtDate(s) {
+    if (!s) return '';
+    const d = new Date(s);
+    if (isNaN(d.getTime())) return '';
+    return d.toLocaleDateString('en-IN', { day: '2-digit', month: 'short', year: 'numeric', timeZone: 'Asia/Kolkata' });
+  }
+
+  function stepClass(t, lot) {
+    const cls = ['step'];
+    const isDenim = lot.flow_type === 'denim';
+    if (!isDenim && ['assembly','washing','washing_in'].includes(t.stage)) {
+      cls.push('na'); return cls.join(' ');
+    }
+    if (t.not_started) cls.push('not-started');
+    else if (t.in_progress) cls.push('in-progress');
+    else cls.push('done');
+    if (t.overdue) cls.push('overdue');
+    return cls.join(' ');
+  }
+
+  function stepHtml(t, lot) {
+    const cls = stepClass(t, lot);
+    const label = {
+      cutting: 'Cutting', stitching: 'Stitching', assembly: 'Assembly',
+      washing: 'Washing', washing_in: 'Wash-In', finishing: 'Finishing',
+    }[t.stage];
+    if (cls.includes('na')) {
+      return `<div class="${cls}">
+        <div class="stage-name">${label}</div>
+        <div class="master">—</div>
+        <div class="tat-tag">TAT ${t.tat}d</div>
+      </div>`;
+    }
+    if (cls.includes('not-started')) {
+      return `<div class="${cls}">
+        <div class="stage-name">${label}</div>
+        <div class="master">Not started</div>
+        <div class="tat-tag">TAT ${t.tat}d</div>
+      </div>`;
+    }
+    let dayLine;
+    if (t.in_progress) {
+      dayLine = `<div class="days">${t.days}d <span style="font-weight:400;color:#9ca3af;">ongoing</span></div>`;
+    } else {
+      dayLine = `<div class="days">${t.days}d</div>`;
+    }
+    return `<div class="${cls}">
+      <div class="stage-name">${label}</div>
+      <div class="master">${t.master || '—'}</div>
+      <div class="ts">${fmtDate(t.entered)}${t.exited ? ' → ' + fmtDate(t.exited) : ''}</div>
+      ${dayLine}
+      <div class="tat-tag">TAT ${t.tat}d ${t.overdue ? '· over' : ''}</div>
+    </div>`;
+  }
+
+  function lotCard(lot) {
+    const stages = lot.timeline.map(t => stepHtml(t, lot)).join('');
+    const overdueCls = lot.any_overdue ? ' overdue' : '';
+    return `<div class="lot-card${overdueCls}">
+      <div class="lot-head">
+        <div>
+          <span class="lot-no">${lot.lot_no}</span>
+          <span class="dept-chip ${lot.flow_type}">${lot.flow_type}</span>
+          <span class="lot-meta">· ${lot.sku} · ${lot.pieces.toLocaleString()} pcs</span>
+          ${lot.remark ? `<div class="lot-meta" style="margin-top:4px;"><i class="bi bi-chat-left-text"></i> ${escapeHtml(lot.remark)}</div>` : ''}
+        </div>
+        <div class="lot-meta">Current: <strong>${lot.current_stage}</strong>${lot.any_overdue ? ' · <span style="color:#b91c1c;">OVERDUE</span>' : ''}</div>
+      </div>
+      <div class="timeline">${stages}</div>
+    </div>`;
+  }
+
+  function escapeHtml(s) {
+    return String(s || '').replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  }
+
+  function renderCounts(items) {
+    const total = items.length;
+    const overdue = items.filter(l => l.any_overdue).length;
+    const denim = items.filter(l => l.flow_type === 'denim').length;
+    const hos   = items.filter(l => l.flow_type === 'hosiery').length;
+    $('counts').innerHTML = `
+      <div class="count-pill"><div class="num">${total}</div><div class="label">Total lots</div></div>
+      <div class="count-pill" style="border-color:#fecaca;"><div class="num" style="color:#b91c1c;">${overdue}</div><div class="label">Overdue</div></div>
+      <div class="count-pill"><div class="num">${denim}</div><div class="label">Denim</div></div>
+      <div class="count-pill"><div class="num">${hos}</div><div class="label">Hosiery</div></div>
+    `;
+  }
+
+  function buildQS() {
+    const qs = new URLSearchParams();
+    const s = $('search').value.trim();
+    if (s) qs.set('search', s);
+    if ($('flowFilter').value) qs.set('flow', $('flowFilter').value);
+    if ($('daysFilter').value) qs.set('days', $('daysFilter').value);
+    if ($('overdueFilter').checked) qs.set('overdue', '1');
+    return qs.toString();
+  }
+
+  async function load() {
+    $('list').innerHTML = '<div class="empty-state">Loading…</div>';
+    const qs = buildQS();
+    $('dlBtn').href = '/operator/lot-tat/download' + (qs ? '?' + qs : '');
+    const r = await fetch('/operator/lot-tat/data' + (qs ? '?' + qs : ''));
+    if (!r.ok) {
+      $('list').innerHTML = '<div class="empty-state">Failed to load. ' + r.status + '</div>';
+      return;
+    }
+    const data = await r.json();
+    const lots = data.lots || [];
+    renderCounts(lots);
+    $('list').innerHTML = lots.length
+      ? lots.map(lotCard).join('')
+      : `<div class="empty-state"><i class="bi bi-inbox" style="font-size:32px;"></i><div style="margin-top:10px;">No lots match your filter.</div></div>`;
+  }
+
+  let typingTimer;
+  $('search').addEventListener('input', () => { clearTimeout(typingTimer); typingTimer = setTimeout(load, 300); });
+  ['flowFilter','daysFilter','overdueFilter'].forEach(id => {
+    $(id).addEventListener('change', load);
+  });
+
+  load();
+</script>
+</body>
+</html>

--- a/views/washingInDashboard.ejs
+++ b/views/washingInDashboard.ejs
@@ -444,6 +444,7 @@
     <h1>Washing&nbsp;In</h1>
     <div style="display: inline-flex; gap: 8px;">
       <a href="/my-lots" class="wi-payLink" style="background:#6366f1;color:#fff;"><i class="bi bi-bag-check"></i> My Lots</a>
+      <a href="/washingin/rewash-download" class="wi-payLink" style="background:#10b981;color:#fff;"><i class="bi bi-file-earmark-excel"></i> Rewash Excel</a>
       <a href="/payments/my-payments" class="wi-payLink"><i class="bi bi-wallet2"></i> Payments</a>
     </div>
   </div>


### PR DESCRIPTION
- /my-lots/download: per-user lot trace as Excel (lot/SKU/dept/pieces/ remark/cutter + per-stage master + Completed/Approved/Assigned status
  + stage date). Download button in the page filter bar.
- /washingin/rewash-download: rewash_requests belonging to the current wash-in master, with washer / completed_by / debit_id / sizes string and cutting remark. Button on washing-in dashboard.
- /finishingdashboard/dispatch-download: per-dispatch row (one per lot/destination/size) — destination (warehouse/po/return/other), destination_remark, qty, total_sent, batch_total, sent_at, cutting remark. Button on finishing dashboard.