### PR TITLE
feat(lot-tat): dedicated cutting-remark filter + prominent card chip

### DIFF
--- a/routes/operatorLotTatRoutes.js
+++ b/routes/operatorLotTatRoutes.js
@@ -38,7 +38,7 @@ router.get('/', isAuthenticated, isOperator, async (req, res) => {
   return res.render('operatorLotTat', { tat: TAT_DAYS });
 });
 
-async function loadLotTat({ days, search, flow, overdue, limit }) {
+async function loadLotTat({ days, search, remark, flow, overdue, limit }) {
   const params = [];
   let where = '1=1';
   if (days && Number(days) > 0) {
@@ -50,9 +50,13 @@ async function loadLotTat({ days, search, flow, overdue, limit }) {
     params.push(flow);
   }
   if (search && search.trim()) {
-    where += ' AND (cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ?)';
+    where += ' AND (cl.lot_no LIKE ? OR cl.sku LIKE ?)';
     const q = `%${search.trim()}%`;
-    params.push(q, q, q);
+    params.push(q, q);
+  }
+  if (remark && remark.trim()) {
+    where += ' AND cl.remark LIKE ?';
+    params.push(`%${remark.trim()}%`);
   }
   const safeLimit = Math.min(Math.max(parseInt(limit, 10) || 500, 1), 2000);
   params.push(safeLimit);
@@ -214,6 +218,7 @@ router.get('/data', isAuthenticated, isOperator, async (req, res) => {
     const lots = await loadLotTat({
       days: req.query.days,
       search: req.query.search,
+      remark: req.query.remark,
       flow: req.query.flow,
       overdue: req.query.overdue,
       limit: req.query.limit,
@@ -230,6 +235,7 @@ router.get('/download', isAuthenticated, isOperator, async (req, res) => {
     const lots = await loadLotTat({
       days: req.query.days,
       search: req.query.search,
+      remark: req.query.remark,
       flow: req.query.flow,
       overdue: req.query.overdue,
       limit: req.query.limit || 2000,

--- a/views/operatorLotTat.ejs
+++ b/views/operatorLotTat.ejs
@@ -38,6 +38,14 @@
       box-shadow: 0 1px 2px rgba(0,0,0,0.03);
     }
     .lot-card.overdue { border-color: #fca5a5; box-shadow: 0 0 0 1px #fca5a5; }
+    .lot-remark {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: #fef3c7; color: #92400e;
+      padding: 3px 10px; border-radius: 6px;
+      font-size: 0.78rem; margin-top: 6px;
+      font-weight: 500; max-width: 100%;
+    }
+    .lot-remark i { color: #b45309; }
     .lot-head {
       display: flex; justify-content: space-between; align-items: center; gap: 10px;
       flex-wrap: wrap; margin-bottom: 12px;
@@ -101,7 +109,8 @@
       <span class="item">Finishing <strong>7d</strong></span>
     </div>
     <div class="controls">
-      <input type="text" id="search" placeholder="Filter by lot / SKU / remark" style="width: 260px;">
+      <input type="text" id="search" placeholder="Lot No / SKU" style="width: 200px;">
+      <input type="text" id="remarkFilter" placeholder="Cutting remark contains…" style="width: 240px;">
       <select id="flowFilter">
         <option value="">All depts</option>
         <option value="denim">Denim</option>
@@ -199,7 +208,7 @@
           <span class="lot-no">${lot.lot_no}</span>
           <span class="dept-chip ${lot.flow_type}">${lot.flow_type}</span>
           <span class="lot-meta">· ${lot.sku} · ${lot.pieces.toLocaleString()} pcs</span>
-          ${lot.remark ? `<div class="lot-meta" style="margin-top:4px;"><i class="bi bi-chat-left-text"></i> ${escapeHtml(lot.remark)}</div>` : ''}
+          ${lot.remark ? `<div class="lot-remark"><i class="bi bi-chat-left-text-fill"></i> <span><strong>Cutting remark:</strong> ${escapeHtml(lot.remark)}</span></div>` : ''}
         </div>
         <div class="lot-meta">Current: <strong>${lot.current_stage}</strong>${lot.any_overdue ? ' · <span style="color:#b91c1c;">OVERDUE</span>' : ''}</div>
       </div>
@@ -228,6 +237,8 @@
     const qs = new URLSearchParams();
     const s = $('search').value.trim();
     if (s) qs.set('search', s);
+    const r = $('remarkFilter').value.trim();
+    if (r) qs.set('remark', r);
     if ($('flowFilter').value) qs.set('flow', $('flowFilter').value);
     if ($('daysFilter').value) qs.set('days', $('daysFilter').value);
     if ($('overdueFilter').checked) qs.set('overdue', '1');
@@ -252,7 +263,9 @@
   }
 
   let typingTimer;
-  $('search').addEventListener('input', () => { clearTimeout(typingTimer); typingTimer = setTimeout(load, 300); });
+  ['search','remarkFilter'].forEach(id => {
+    $(id).addEventListener('input', () => { clearTimeout(typingTimer); typingTimer = setTimeout(load, 300); });
+  });
   ['flowFilter','daysFilter','overdueFilter'].forEach(id => {
     $(id).addEventListener('change', load);
   });


### PR DESCRIPTION
- Added a separate "Cutting remark contains…" input in the filter bar so the option is obvious; the existing free-text search now only matches lot_no / sku.
- /operator/lot-tat/data and /download accept a new `remark` query param (independent of `search`).
- Cutting remark on each lot card is now rendered as an amber chip ("Cutting remark: …") instead of a faint subtitle, so it stands out.