### PR TITLE
feat(rewash): scope-aware Excel exports for operator/wash-in/washer

### DIFF
--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -3906,4 +3906,18 @@ router.get('/day-activity/data', isAuthenticated, isOperator, async (req, res) =
   }
 });
 
+/**
+ * GET /operator/rewash-download
+ * ALL rewash requests — operator has system-wide visibility.
+ */
+router.get('/rewash-download', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const { exportRewashExcel } = require('../utils/rewashExport');
+    await exportRewashExcel(res); // no scope → all
+  } catch (err) {
+    console.error('GET /operator/rewash-download error:', err);
+    return res.status(500).send('Failed to export rewash list');
+  }
+});
+
 module.exports = router;

--- a/routes/washingInRoutes.js
+++ b/routes/washingInRoutes.js
@@ -2440,86 +2440,12 @@ router.get('/history-download', isAuthenticated, isWashingInMaster, async (req, 
 
 /**
  * GET /washingin/rewash-download
- * Excel dump of every rewash request belonging to the current
- * washing-in master, with sizes broken out per row.
+ * ALL rewash requests (wash-in master is supervisory).
  */
 router.get('/rewash-download', isAuthenticated, isWashingInMaster, async (req, res) => {
   try {
-    const userId = req.session.user.id;
-
-    const [rows] = await pool.query(
-      `SELECT rr.id, rr.lot_no, rr.sku, rr.total_requested, rr.status,
-              rr.created_at, rr.completed_at, rr.debit_id,
-              wu.username  AS washer,
-              wiu.username AS washing_in_master,
-              cu.username  AS completed_by_name,
-              cl.remark    AS cutting_remark
-         FROM rewash_requests rr
-    LEFT JOIN users wu  ON wu.id  = rr.washer_id
-    LEFT JOIN users wiu ON wiu.id = rr.user_id
-    LEFT JOIN users cu  ON cu.id  = rr.completed_by
-    LEFT JOIN cutting_lots cl ON cl.lot_no = rr.lot_no
-        WHERE rr.user_id = ?
-     ORDER BY rr.created_at DESC`,
-      [userId]
-    );
-
-    const rrIds = rows.map(r => r.id);
-    let sizesByRR = {};
-    if (rrIds.length) {
-      const [sizeRows] = await pool.query(
-        `SELECT rewash_request_id, size_label, pieces_requested
-           FROM rewash_request_sizes
-          WHERE rewash_request_id IN (?)
-          ORDER BY size_label`,
-        [rrIds]
-      );
-      for (const s of sizeRows) {
-        (sizesByRR[s.rewash_request_id] = sizesByRR[s.rewash_request_id] || [])
-          .push(`${s.size_label}:${s.pieces_requested}`);
-      }
-    }
-
-    const ExcelJS = require('exceljs');
-    const wb = new ExcelJS.Workbook();
-    const sheet = wb.addWorksheet('Rewash Requests');
-    sheet.columns = [
-      { header: 'Lot No',           key: 'lot_no',          width: 14 },
-      { header: 'SKU',              key: 'sku',             width: 22 },
-      { header: 'Pieces',           key: 'total_requested', width: 10 },
-      { header: 'Status',           key: 'status',          width: 12 },
-      { header: 'Washer',           key: 'washer',          width: 18 },
-      { header: 'Wash-In Master',   key: 'washing_in_master', width: 18 },
-      { header: 'Sizes',            key: 'sizes',           width: 28 },
-      { header: 'Cutting Remark',   key: 'cutting_remark',  width: 22 },
-      { header: 'Requested On',     key: 'created_at',      width: 14 },
-      { header: 'Completed By',     key: 'completed_by_name', width: 18 },
-      { header: 'Completed On',     key: 'completed_at',    width: 14 },
-      { header: 'Debit ID',         key: 'debit_id',        width: 10 },
-    ];
-
-    const fmt = d => d ? new Date(d).toLocaleDateString('en-IN', { day: '2-digit', month: 'short', year: 'numeric', timeZone: 'Asia/Kolkata' }) : '';
-    for (const r of rows) {
-      sheet.addRow({
-        lot_no: r.lot_no, sku: r.sku, total_requested: r.total_requested,
-        status: r.status, washer: r.washer || '',
-        washing_in_master: r.washing_in_master || '',
-        sizes: (sizesByRR[r.id] || []).join(', '),
-        cutting_remark: r.cutting_remark || '',
-        created_at: fmt(r.created_at), completed_at: fmt(r.completed_at),
-        completed_by_name: r.completed_by_name || '',
-        debit_id: r.debit_id || '',
-      });
-    }
-
-    sheet.getRow(1).font = { bold: true, color: { argb: 'FFFFFFFF' } };
-    sheet.getRow(1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF1F2937' } };
-
-    const today = new Date().toLocaleDateString('en-IN', { timeZone: 'Asia/Kolkata' }).replace(/\//g, '-');
-    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-    res.setHeader('Content-Disposition', `attachment; filename="Rewash-${today}.xlsx"`);
-    await wb.xlsx.write(res);
-    res.end();
+    const { exportRewashExcel } = require('../utils/rewashExport');
+    await exportRewashExcel(res); // no scope → all
   } catch (err) {
     console.error('[ERROR] GET /rewash-download =>', err);
     return res.status(500).send('Failed to export rewash list');

--- a/routes/washingRoutes.js
+++ b/routes/washingRoutes.js
@@ -1977,4 +1977,18 @@ router.post('/complete-rewash/:id', isAuthenticated, isWashingMaster, async (req
   }
 });
 
+/**
+ * GET /washingdashboard/rewash-download
+ * Washer's own rewash requests only (filtered by washer_id).
+ */
+router.get('/rewash-download', isAuthenticated, isWashingMaster, async (req, res) => {
+  try {
+    const { exportRewashExcel } = require('../utils/rewashExport');
+    await exportRewashExcel(res, { washerId: req.session.user.id });
+  } catch (err) {
+    console.error('GET /washingdashboard/rewash-download error:', err);
+    return res.status(500).send('Failed to export rewash list');
+  }
+});
+
 module.exports = router;

--- a/utils/rewashExport.js
+++ b/utils/rewashExport.js
@@ -1,0 +1,95 @@
+/**
+ * Shared rewash Excel export.
+ *
+ * exportRewashExcel(res, { washerId }) — if washerId is set, filters
+ * rewash_requests.washer_id = washerId (washer's own view). Otherwise
+ * exports every row (operator / washing-in master view).
+ */
+
+const ExcelJS = require('exceljs');
+const { pool } = require('../config/db');
+
+async function exportRewashExcel(res, { washerId } = {}) {
+  let where = '';
+  const params = [];
+  if (washerId) { where = 'WHERE rr.washer_id = ?'; params.push(washerId); }
+
+  const [rows] = await pool.query(
+    `SELECT rr.id, rr.lot_no, rr.sku, rr.total_requested, rr.status,
+            rr.created_at, rr.completed_at, rr.debit_id,
+            wu.username  AS washer,
+            wiu.username AS washing_in_master,
+            cu.username  AS completed_by_name,
+            cl.remark    AS cutting_remark
+       FROM rewash_requests rr
+  LEFT JOIN users wu  ON wu.id  = rr.washer_id
+  LEFT JOIN users wiu ON wiu.id = rr.user_id
+  LEFT JOIN users cu  ON cu.id  = rr.completed_by
+  LEFT JOIN cutting_lots cl ON cl.lot_no = rr.lot_no
+      ${where}
+   ORDER BY rr.created_at DESC`,
+    params
+  );
+
+  const rrIds = rows.map(r => r.id);
+  const sizesByRR = {};
+  if (rrIds.length) {
+    const [sizeRows] = await pool.query(
+      `SELECT rewash_request_id, size_label, pieces_requested
+         FROM rewash_request_sizes
+        WHERE rewash_request_id IN (?)
+        ORDER BY size_label`,
+      [rrIds]
+    );
+    for (const s of sizeRows) {
+      (sizesByRR[s.rewash_request_id] = sizesByRR[s.rewash_request_id] || [])
+        .push(`${s.size_label}:${s.pieces_requested}`);
+    }
+  }
+
+  const wb = new ExcelJS.Workbook();
+  const sheet = wb.addWorksheet('Rewash Requests');
+  sheet.columns = [
+    { header: 'Lot No',           key: 'lot_no',          width: 14 },
+    { header: 'SKU',              key: 'sku',             width: 22 },
+    { header: 'Pieces',           key: 'total_requested', width: 10 },
+    { header: 'Status',           key: 'status',          width: 12 },
+    { header: 'Washer',           key: 'washer',          width: 18 },
+    { header: 'Wash-In Master',   key: 'washing_in_master', width: 18 },
+    { header: 'Sizes',            key: 'sizes',           width: 28 },
+    { header: 'Cutting Remark',   key: 'cutting_remark',  width: 22 },
+    { header: 'Requested On',     key: 'created_at',      width: 14 },
+    { header: 'Completed By',     key: 'completed_by_name', width: 18 },
+    { header: 'Completed On',     key: 'completed_at',    width: 14 },
+    { header: 'Debit ID',         key: 'debit_id',        width: 10 },
+  ];
+
+  const fmt = d => d ? new Date(d).toLocaleDateString('en-IN', {
+    day: '2-digit', month: 'short', year: 'numeric', timeZone: 'Asia/Kolkata'
+  }) : '';
+
+  for (const r of rows) {
+    sheet.addRow({
+      lot_no: r.lot_no, sku: r.sku, total_requested: r.total_requested,
+      status: r.status, washer: r.washer || '',
+      washing_in_master: r.washing_in_master || '',
+      sizes: (sizesByRR[r.id] || []).join(', '),
+      cutting_remark: r.cutting_remark || '',
+      created_at: fmt(r.created_at), completed_at: fmt(r.completed_at),
+      completed_by_name: r.completed_by_name || '',
+      debit_id: r.debit_id || '',
+    });
+  }
+
+  sheet.getRow(1).font = { bold: true, color: { argb: 'FFFFFFFF' } };
+  sheet.getRow(1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF1F2937' } };
+
+  const today = new Date().toLocaleDateString('en-IN', { timeZone: 'Asia/Kolkata' }).replace(/\//g, '-');
+  const scope = washerId ? 'MyRewash' : 'Rewash';
+  res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+  res.setHeader('Content-Disposition', `attachment; filename="${scope}-${today}.xlsx"`);
+  await wb.xlsx.write(res);
+  res.end();
+}
+
+module.exports = { exportRewashExcel };

--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -733,6 +733,10 @@
           <i class="bi bi-stopwatch"></i>
           <span class="action-card-title">Lot TAT</span>
         </a>
+        <a href="/operator/rewash-download" class="action-card">
+          <i class="bi bi-arrow-repeat"></i>
+          <span class="action-card-title">Rewash Excel</span>
+        </a>
         <a href="/operator/editcuttinglots" class="action-card">
           <i class="bi bi-scissors"></i>
           <span class="action-card-title">Edit Lots</span>

--- a/views/washingDashboard.ejs
+++ b/views/washingDashboard.ejs
@@ -545,6 +545,9 @@
       <a href="/my-lots" class="btn-payments" style="background:#6366f1;">
         <i class="bi bi-bag-check"></i> My Lots
       </a>
+      <a href="/washingdashboard/rewash-download" class="btn-payments" style="background:#10b981;">
+        <i class="bi bi-file-earmark-excel"></i> My Rewash
+      </a>
       <a href="/payments/my-payments" class="btn-payments">
         <i class="bi bi-wallet2"></i> Payments
       </a>


### PR DESCRIPTION
- Extracted rewash export to utils/rewashExport.js (exportRewashExcel takes optional washerId to scope to a single washer; without it, exports every rewash_requests row).
- /washingin/rewash-download (existing): now shows ALL data (was filtered by req.user.id, which only matched if that user happened to be the requester — now supervisory view).
- /operator/rewash-download (new): operator-only, ALL data. Tile added to operator dashboard's Production category.
- /washingdashboard/rewash-download (new): washer-only, filtered to rewash_requests.washer_id = current user. Button "My Rewash" on the washing dashboard header.