### PR TITLE
fix(rewash): populate washer_id on every rewash_requests insert

### DIFF
--- a/routes/washingInRoutes.js
+++ b/routes/washingInRoutes.js
@@ -641,9 +641,9 @@ router.post('/event/approve', isAuthenticated, isWashingInMaster, async (req, re
 
       const totalRewash = cleanRewash.reduce((a, s) => a + s.pieces, 0);
       const [rrIns] = await conn.query(
-        `INSERT INTO rewash_requests (washing_data_id, user_id, lot_no, sku, total_requested, status)
-         VALUES (?, ?, ?, ?, ?, 'pending')`,
-        [wd.id, userId, wd.lot_no, wd.sku, totalRewash]
+        `INSERT INTO rewash_requests (washing_data_id, washer_id, user_id, lot_no, sku, total_requested, status)
+         VALUES (?, ?, ?, ?, ?, ?, 'pending')`,
+        [wd.id, wd.user_id, userId, wd.lot_no, wd.sku, totalRewash]
       );
       rewashRequestId = rrIns.insertId;
 
@@ -1811,9 +1811,9 @@ router.post('/assign-rewash', isAuthenticated, isWashingInMaster, async (req, re
     // 3) Insert into rewash_requests
     const [rr] = await conn.query(`
       INSERT INTO rewash_requests
-        (washing_data_id, user_id, lot_no, sku, total_requested, status)
-      VALUES (?, ?, ?, ?, ?, 'pending')
-    `, [wd.id, userId, wd.lot_no, wd.sku, totalReq]);
+        (washing_data_id, washer_id, user_id, lot_no, sku, total_requested, status)
+      VALUES (?, ?, ?, ?, ?, ?, 'pending')
+    `, [wd.id, wd.user_id, userId, wd.lot_no, wd.sku, totalReq]);
     const rewashId = rr.insertId;
 
     // 4) Insert each size & deduct from washing_data_sizes + log in washing_data_updates


### PR DESCRIPTION
Two of the three INSERT paths in washingInRoutes.js (lines 643 and 1813) were inserting only (washing_data_id, user_id, lot_no, sku, total_requested, status) — washer_id was left NULL even though wd.user_id was already loaded one line above. The third path (line 2189) populated it correctly. Result: most existing rewash rows have washer_id NULL, so the washer dashboard's "My Rewash" download (filtered WHERE washer_id = current_user) returned empty.

Forward-fix: include wd.user_id as washer_id in both INSERTs. Backfill of 1,526 existing NULL rows was run separately against prod (washer_id derived from washing_data.user_id via existing washing_data_id FK).