### PR TITLE
fix(cutting): show remaining weight as read-only (not hidden)

### DIFF
--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -554,12 +554,15 @@
       </div>
     </div>
     <div class="row g-3 mt-1">
-      <div class="col-md-12">
+      <div class="col-md-6">
         <label class="kotty-form-label" data-i18n="fullWeightLabel">Full Roll Weight</label>
         <input type="number" step="0.01" class="kotty-input fullWeightInput" name="roll_full_weight[]" min="0" required placeholder="Full weight" />
       </div>
+      <div class="col-md-6">
+        <label class="kotty-form-label" data-i18n="remainingWeightLabel">Remaining Weight</label>
+        <input type="number" step="0.01" class="kotty-input remainingWeightInput" name="roll_remaining_weight[]" min="0" required readonly placeholder="Auto (full − used)" />
+      </div>
     </div>
-    <input type="hidden" class="remainingWeightInput" name="roll_remaining_weight[]" />
     <div class="mt-3">
       <label class="kotty-form-label"><i class="bi bi-graph-up"></i><span data-i18n="weightUsageProgress">Weight Usage Progress</span></label>
       <div class="kotty-progress">


### PR DESCRIPTION
User feedback: removing the field from the UI hid useful info. Restore it as a visible readonly input so the cutter can see how much of the roll is left after cutting. Still back-filled from full - (table_length × layers); user can't edit it.