### PR TITLE
fix(edit-cutting-lots): correct fabric_invoice_rolls join

### DIFF
--- a/routes/editcuttinglots.js
+++ b/routes/editcuttinglots.js
@@ -188,10 +188,11 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
 
     // Rolls available in inventory for this lot's fabric_type (for the autocomplete)
     const [availableRolls] = await pool.query(
-      `SELECT roll_no, per_roll_weight, unit
-         FROM fabric_invoice_rolls
-        WHERE fabric_type = ? AND per_roll_weight > 0
-     ORDER BY roll_no`,
+      `SELECT fir.roll_no, fir.per_roll_weight, fir.unit
+         FROM fabric_invoice_rolls fir
+         JOIN fabric_invoices fi ON fi.id = fir.invoice_id
+        WHERE fi.fabric_type = ? AND fir.per_roll_weight > 0
+     ORDER BY fir.roll_no`,
       [lot.fabric_type]
     );
 
@@ -656,8 +657,11 @@ router.post('/editcuttinglots/add-roll', isAuthenticated, isOperator, upload.non
 
     // Inventory check — deplete fabric_invoice_rolls if the roll exists there
     const [[inv]] = await conn.query(
-      `SELECT roll_no, per_roll_weight FROM fabric_invoice_rolls
-        WHERE roll_no = ? AND fabric_type = ? FOR UPDATE`,
+      `SELECT fir.roll_no, fir.per_roll_weight
+         FROM fabric_invoice_rolls fir
+         JOIN fabric_invoices fi ON fi.id = fir.invoice_id
+        WHERE fir.roll_no = ? AND fi.fabric_type = ?
+        FOR UPDATE`,
       [roll_no, lot.fabric_type]
     );
     let resolvedFullWeight = full_weight;


### PR DESCRIPTION
fabric_invoice_rolls has no fabric_type column — it's on the parent fabric_invoices table, linked via invoice_id. Both queries (the autocomplete inventory list and the add-roll inventory lookup) were missing the join, causing edit-form to 500:

  Error: Unknown column 'fabric_type' in 'where clause'
  at /app/routes/editcuttinglots.js:190

Fix: JOIN fabric_invoices fi ON fi.id = fir.invoice_id and filter on fi.fabric_type. Mirrors the same pattern used in cuttingManagerRoutes.js:34-37.