### PR TITLE
Denim-only weight auto-calc + fabric consumption analysis

### DIFF
--- a/docs/superpowers/plans/2026-06-01-cutting-weight-and-fabric-consumption.md
+++ b/docs/superpowers/plans/2026-06-01-cutting-weight-and-fabric-consumption.md
@@ -1,0 +1,959 @@
+# Cutting Weight Auto-Calc + Fabric Consumption Analysis — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** (1) Re-introduce the `weight_used = table_length × layers` auto-calc gated to denim lots only, with hosiery using a manual `Used = Full − Remaining` flow; (2) add a fabric-manager analysis page (consumption-by-type, roll ledger, ad-hoc/unknown rolls & types) with a date filter and Excel exports.
+
+**Architecture:** Both features push their error-prone logic into small, pure, dependency-free modules tested with Node's built-in test runner (`node --test`, Node v22). Feature 1's weight math lives in a browser-loadable UMD module (`public/js/cuttingWeight.js`) shared by the EJS form. Feature 2's row aggregation lives in a server-side CommonJS module (`utils/fabricConsumption.js`) consumed by a new route. The EJS/visual work is built with the `/frontend-design` skill. Feature 1 needs **no change to existing POST handlers** — both modes submit a hidden `remaining_weight` and the server already computes `used = full − remaining`.
+
+**Tech Stack:** Node v22 (built-in `node:test`), Express, EJS, MySQL (`mysql2/pool`), `exceljs` (already a dependency).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-cutting-weight-and-fabric-consumption-design.md`
+
+---
+
+## File Structure
+
+**Feature 1 — Denim-only weight auto-calc**
+- Create: `public/js/cuttingWeight.js` — pure weight math (UMD: browser global + CommonJS export).
+- Create: `test/cuttingWeight.test.js` — `node:test` unit tests for the math.
+- Modify: `routes/cuttingManagerRoutes.js` — pass `isDenim` to the dashboard render.
+- Modify: `views/cuttingManagerDashboard.ejs` — load the module, branch weight wiring on `isDenim`.
+- Modify: `routes/editcuttinglots.js` — branch the add-missed-roll form on `lot.flow_type`.
+- Modify: `package.json` — add `"test": "node --test"`.
+
+**Feature 2 — Fabric consumption analysis**
+- Create: `utils/fabricConsumption.js` — pure transforms (group by type, roll ledger, ad-hoc detection).
+- Create: `test/fabricConsumption.test.js` — `node:test` unit tests for the transforms.
+- Create: `views/fabricConsumptionAnalysis.ejs` — tabbed analysis page.
+- Modify: `routes/fabricManagerRoutes.js` — add `GET /analysis` and `GET /analysis/export`.
+- Modify: `views/fabricManagerDashboard.ejs` — add a link to the analysis page.
+
+---
+
+# PART A — Feature 1: Denim-only weight auto-calc
+
+## Task 1: Weight-math module + tests
+
+**Files:**
+- Create: `public/js/cuttingWeight.js`
+- Create: `test/cuttingWeight.test.js`
+- Modify: `package.json` (scripts)
+
+- [ ] **Step 1: Add the test script to package.json**
+
+In `package.json`, change the `scripts` block to include a `test` entry:
+
+```json
+  "scripts": {
+    "start": "node app.js",
+    "start:dev": "node --watch app.js",
+    "test": "node --test"
+  },
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `test/cuttingWeight.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { computeRollWeights } = require('../public/js/cuttingWeight.js');
+
+test('denim: used = tableLength * layers, remaining = full - used', () => {
+  const r = computeRollWeights('denim', { tableLength: 1.5, layers: 8, full: 50 });
+  assert.strictEqual(r.used, 12);
+  assert.strictEqual(r.remaining, 38);
+  assert.strictEqual(r.over, false);
+});
+
+test('denim: over-weight flags and clamps remaining to 0', () => {
+  const r = computeRollWeights('denim', { tableLength: 10, layers: 8, full: 50 });
+  assert.strictEqual(r.used, 80);
+  assert.strictEqual(r.remaining, 0);
+  assert.strictEqual(r.over, true);
+});
+
+test('denim: missing tableLength or layers yields nulls', () => {
+  const r = computeRollWeights('denim', { tableLength: '', layers: 8, full: 50 });
+  assert.strictEqual(r.used, null);
+  assert.strictEqual(r.remaining, null);
+});
+
+test('hosiery: used = full - remaining', () => {
+  const r = computeRollWeights('hosiery', { full: 30, remaining: 4 });
+  assert.strictEqual(r.used, 26);
+  assert.strictEqual(r.remaining, 4);
+  assert.strictEqual(r.over, false);
+});
+
+test('hosiery: empty remaining defaults to 0 so used = full', () => {
+  const r = computeRollWeights('hosiery', { full: 30, remaining: '' });
+  assert.strictEqual(r.used, 30);
+  assert.strictEqual(r.remaining, 0);
+});
+
+test('hosiery: remaining > full flags over and clamps used to 0', () => {
+  const r = computeRollWeights('hosiery', { full: 30, remaining: 40 });
+  assert.strictEqual(r.used, 0);
+  assert.strictEqual(r.over, true);
+});
+
+test('hosiery: missing full yields null used', () => {
+  const r = computeRollWeights('hosiery', { full: '', remaining: 5 });
+  assert.strictEqual(r.used, null);
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `npm test`
+Expected: FAIL — `Cannot find module '../public/js/cuttingWeight.js'`.
+
+- [ ] **Step 4: Write the module**
+
+Create `public/js/cuttingWeight.js`:
+
+```js
+// Pure weight math shared by the cutting-entry forms (browser) and tests (node).
+// UMD wrapper: attaches `CuttingWeight` to the browser global and also exports
+// for CommonJS so `node:test` can require it.
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.CuttingWeight = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  function num(v) {
+    const n = parseFloat(v);
+    return Number.isNaN(n) ? null : n;
+  }
+
+  // mode: 'denim' | 'hosiery'
+  // inputs: { tableLength, layers, full, remaining }
+  // returns: { used, remaining, over }  (used/remaining are numbers or null)
+  function computeRollWeights(mode, inputs) {
+    const full = num(inputs.full);
+
+    if (mode === 'denim') {
+      const tableLength = num(inputs.tableLength);
+      const layers = num(inputs.layers);
+      if (tableLength === null || layers === null) {
+        return { used: null, remaining: null, over: false };
+      }
+      const used = tableLength * layers;
+      const remaining = full === null ? null : Math.max(full - used, 0);
+      const over = full !== null && used > full;
+      return { used, remaining, over };
+    }
+
+    // hosiery: operator enters remaining (default 0); used = full - remaining
+    const remaining = num(inputs.remaining) === null ? 0 : num(inputs.remaining);
+    if (full === null) {
+      return { used: null, remaining, over: false };
+    }
+    const rawUsed = full - remaining;
+    const over = remaining > full;
+    return { used: Math.max(rawUsed, 0), remaining, over };
+  }
+
+  return { computeRollWeights };
+});
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `npm test`
+Expected: PASS — all 7 `cuttingWeight` tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json public/js/cuttingWeight.js test/cuttingWeight.test.js
+git commit -m "feat(cutting): add tested weight-math module (denim auto-calc / hosiery manual)"
+```
+
+---
+
+## Task 2: Pass `isDenim` to the cutting dashboard render
+
+**Files:**
+- Modify: `routes/cuttingManagerRoutes.js` (GET `/dashboard`, around lines 169-179)
+
+- [ ] **Step 1: Query the cutter's `is_denim_cutter` flag**
+
+In `routes/cuttingManagerRoutes.js`, inside the `GET /dashboard` handler, immediately before the `res.render('cuttingManagerDashboard', { ... })` call (currently ~line 172), add:
+
+```js
+    // Determine the cutter's flow type so the form renders in denim or hosiery mode.
+    const [[cutterFlag]] = await pool.query(
+      'SELECT is_denim_cutter FROM users WHERE id = ?',
+      [userId]
+    );
+    const isDenim = !!(cutterFlag && cutterFlag.is_denim_cutter);
+```
+
+- [ ] **Step 2: Add `isDenim` to the render payload**
+
+Change the render call to include `isDenim`:
+
+```js
+    res.render('cuttingManagerDashboard', {
+      user: req.session.user,
+      cuttingLots,
+      departmentUsers,
+      pendingAssignments,
+      rollsByFabricType, // Now includes vendor_name
+      generatedLotNumber, // Pass the generated lot number
+      isDenim,
+    });
+```
+
+- [ ] **Step 3: Verify the app boots**
+
+Run: `node -e "require('./routes/cuttingManagerRoutes.js'); console.log('OK')"`
+Expected: prints `OK` with no syntax/require error.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add routes/cuttingManagerRoutes.js
+git commit -m "feat(cutting): pass isDenim flag to cutting dashboard view"
+```
+
+---
+
+## Task 3: Branch the create-lot form weight wiring on `isDenim`
+
+> **Use the `/frontend-design` skill** for the EJS/markup edits in this task. The data contract and JS behavior below are fixed; apply the skill for styling/labels/affordances consistent with the existing dashboard.
+
+**Files:**
+- Modify: `views/cuttingManagerDashboard.ejs`
+  - Script include area (near line 1269)
+  - `updateWeightUsed()` (lines 819-835)
+  - Weight Used input markup (around line 550-552)
+  - The roll-section input listeners (`initializeRollNoAutocomplete` ~727-768, `addNewRoll` ~779-803)
+
+- [ ] **Step 1: Load the weight module and expose the mode flag**
+
+Near the other script includes (after line 1269 `<script src="/public/js/lot-size-expand.js"></script>`), add:
+
+```html
+<script src="/public/js/cuttingWeight.js"></script>
+```
+
+At the top of the main inline `<script>` that defines `updateWeightUsed` (before that function), add a mode constant sourced from the server flag:
+
+```js
+  const IS_DENIM = <%= isDenim ? 'true' : 'false' %>;
+  const FLOW_MODE = IS_DENIM ? 'denim' : 'hosiery';
+```
+
+- [ ] **Step 2: Replace `updateWeightUsed()` to branch on the mode**
+
+Replace the entire current `updateWeightUsed(rollSection)` function (lines 819-835) with:
+
+```js
+function updateWeightUsed(rollSection) {
+  const usedInput = rollSection.querySelector('.weightUsedInput');
+  const remInput  = rollSection.querySelector('.remainingWeightInput');
+  const full      = rollSection.querySelector('.fullWeightInput').value;
+
+  let res;
+  if (FLOW_MODE === 'denim') {
+    // Weight Used auto-computes from table_length × layers; remaining is derived (hidden-ish).
+    res = CuttingWeight.computeRollWeights('denim', {
+      tableLength: document.getElementById('table_length').value,
+      layers: rollSection.querySelector('.layersInput').value,
+      full: full,
+    });
+    if (res.used === null) { usedInput.value = ''; remInput.value = ''; usedInput.classList.remove('over-weight'); return; }
+    usedInput.value = res.used.toFixed(2);
+    remInput.value  = res.remaining === null ? '' : res.remaining.toFixed(2);
+  } else {
+    // Hosiery: operator enters Remaining; Weight Used is derived display-only.
+    res = CuttingWeight.computeRollWeights('hosiery', {
+      full: full,
+      remaining: remInput.value,
+    });
+    if (res.used === null) { usedInput.value = ''; usedInput.classList.remove('over-weight'); return; }
+    usedInput.value = res.used.toFixed(2);
+  }
+  usedInput.classList.toggle('over-weight', res.over);
+}
+```
+
+- [ ] **Step 3: Set input editability per mode in the Weight Used / Remaining markup**
+
+The Weight Used input (around line 550) must be **read-only in both modes** (denim auto, hosiery derived):
+
+```html
+        <input type="number" step="0.01" class="kotty-input weightUsedInput" name="weight_used[]" min="0" readonly placeholder="Weight used (auto)" />
+```
+
+Locate the Remaining input (`remainingWeightInput`, `name="roll_remaining_weight[]"`). Make it editable for hosiery and default to `0`, read-only for denim. Render its attributes conditionally:
+
+```html
+        <input type="number" step="0.01" class="kotty-input remainingWeightInput" name="roll_remaining_weight[]" min="0"
+               <%= isDenim ? 'readonly' : 'value="0"' %> placeholder="<%= isDenim ? 'Auto (full − used)' : 'Remaining (default 0)' %>" />
+```
+
+> If the Remaining input is currently a hidden field, convert it to a visible number input so hosiery operators can edit it. For denim it stays read-only/derived.
+
+- [ ] **Step 4: Add the Remaining-input listener (hosiery) and keep table_length re-trigger (denim)**
+
+In `initializeRollNoAutocomplete(rollSection, fabricType)` (after the existing `weightUsedInput` listener block ~763-767), add a listener on the remaining input:
+
+```js
+  remainingWeightInput.addEventListener('input', () => {
+    updateWeightUsed(rollSection);
+    updateWeightProgress(rollSection);
+    checkRollsCompletion();
+  });
+```
+
+In `addNewRoll()` (after the existing per-roll listeners ~796-800), add the same for the cloned roll:
+
+```js
+  newRoll.querySelector('.remainingWeightInput').addEventListener('input', () => {
+    updateWeightUsed(newRoll);
+    updateWeightProgress(newRoll);
+    checkRollsCompletion();
+  });
+```
+
+For denim, recompute all rolls when `table_length` changes. After the `addRollBtn`/`addSizeBtn` wiring near line 874, add:
+
+```js
+  const tableLengthInput = document.getElementById('table_length');
+  if (tableLengthInput && FLOW_MODE === 'denim') {
+    tableLengthInput.addEventListener('input', () => {
+      rollsContainer.querySelectorAll('.roll-section:not(.d-none)').forEach(rs => {
+        updateWeightUsed(rs);
+        updateWeightProgress(rs);
+      });
+      checkRollsCompletion();
+    });
+  }
+```
+
+- [ ] **Step 5: Require `table_length` for denim only**
+
+Find the `table_length` input in the form (id `table_length`). Make it `required` only for denim:
+
+```html
+        <input type="number" step="0.01" min="0" class="kotty-input" id="table_length" name="table_length" <%= isDenim ? 'required' : '' %> placeholder="<%= isDenim ? 'Table length (required for denim)' : 'Table length (optional)' %>" />
+```
+
+If `checkRollsCompletion()` gates the Create button, add a denim-only guard so the button stays disabled until `table_length` is a positive number. Inside `checkRollsCompletion()`, before it enables the submit button, add:
+
+```js
+  if (FLOW_MODE === 'denim') {
+    const tl = parseFloat(document.getElementById('table_length').value);
+    if (!(tl > 0)) { /* keep submit disabled */ allComplete = false; }
+  }
+```
+
+(Use the function's existing completion variable name in place of `allComplete` if it differs.)
+
+- [ ] **Step 6: Verify EJS parses**
+
+Run: `node -e "const ejs=require('ejs');const fs=require('fs');ejs.compile(fs.readFileSync('views/cuttingManagerDashboard.ejs','utf8'),{filename:'views/cuttingManagerDashboard.ejs'});console.log('EJS OK')"`
+Expected: prints `EJS OK` (template compiles; no syntax error).
+
+- [ ] **Step 7: Manual browser check (denim)**
+
+Run `npm start`, log in as a cutter whose `users.is_denim_cutter = 1`, open the cutting dashboard.
+Expected: Weight Used is read-only; setting `table_length=1.5`, picking an in-DB roll (Full auto-fills, e.g. 50), and entering `layers=8` shows Weight Used = `12.00`; Remaining shows `38.00`; the Create button stays disabled until table_length > 0.
+
+- [ ] **Step 8: Manual browser check (hosiery)**
+
+Log in as a cutter with `is_denim_cutter = 0`.
+Expected: Remaining input is editable and pre-filled `0`; picking an in-DB roll fills Full (e.g. 30) → Weight Used shows `30.00`; changing Remaining to `4` → Weight Used `26.00`; table_length is optional. Saving a lot deducts the used weight from `fabric_invoice_rolls` (verify the roll's available weight dropped).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add views/cuttingManagerDashboard.ejs
+git commit -m "feat(cutting): denim weight auto-calc vs hosiery manual remaining in create form"
+```
+
+---
+
+## Task 4: Branch the add-missed-roll form on `lot.flow_type`
+
+> **Use the `/frontend-design` skill** for the markup edits. The `lot` object in this route already carries `flow_type`.
+
+**Files:**
+- Modify: `routes/editcuttinglots.js` (the `GET /editcuttinglots/edit-form` handler that renders the add-missed-roll form, ~lines 405-560)
+
+- [ ] **Step 1: Compute an `isDenim` flag in the edit-form handler**
+
+In `routes/editcuttinglots.js`, after the `lot` row is loaded in the `edit-form` GET handler, add:
+
+```js
+          const isDenim = (lot.flow_type === 'denim');
+```
+
+Confirm the SELECT that loads `lot` includes `flow_type` (it joins `cutting_lots`); if not, add `flow_type` to that SELECT's column list.
+
+- [ ] **Step 2: Make Weight Used read-only and Remaining editable for hosiery**
+
+In the add-missed-roll markup, the Weight Used input becomes read-only in both modes:
+
+```html
+                        <input type="number" step="0.01" min="0" class="form-control" id="addRollWeightUsed" readonly placeholder="Weight used (auto)">
+```
+
+The Remaining input is editable + default `0` for hosiery, read-only for denim:
+
+```html
+                        <input type="number" step="0.01" min="0" class="form-control" id="addRollRemaining" ${isDenim ? 'readonly' : 'value="0"'} placeholder="${isDenim ? 'Auto' : 'Remaining (default 0)'}">
+```
+
+(Match the actual existing id for the remaining field — it is the `addRollRem`/`addRollRemaining` element used in `recomputeAddRollWeights`.)
+
+- [ ] **Step 3: Branch `recomputeAddRollWeights()` on the mode**
+
+Pass the table length and mode into the inline script, then branch. Add near the existing `ROLL_INVENTORY` constant:
+
+```js
+          const IS_DENIM = ${isDenim ? 'true' : 'false'};
+          const TABLE_LENGTH = ${lot.table_length ? Number(lot.table_length) : 'null'};
+```
+
+Replace `recomputeAddRollWeights()` with:
+
+```js
+          function recomputeAddRollWeights() {
+            const full = parseFloat(addRollFullW.value);
+            if (IS_DENIM) {
+              const layers = parseFloat(addRollLayers.value);
+              if (isNaN(layers) || TABLE_LENGTH == null) { addRollUsed.value=''; addRollRem.value=''; return; }
+              const used = TABLE_LENGTH * layers;
+              addRollUsed.value = used.toFixed(2);
+              addRollRem.value = isNaN(full) ? '' : Math.max(full - used, 0).toFixed(2);
+              addRollUsed.classList.toggle('text-danger', !isNaN(full) && used > full);
+            } else {
+              const remaining = addRollRem.value === '' ? 0 : parseFloat(addRollRem.value);
+              if (isNaN(full)) { addRollUsed.value=''; addRollUsed.classList.remove('text-danger'); return; }
+              addRollUsed.value = Math.max(full - remaining, 0).toFixed(2);
+              addRollUsed.classList.toggle('text-danger', remaining > full);
+            }
+          }
+```
+
+- [ ] **Step 4: Fix the input listeners for the mode**
+
+Replace the listener wiring so denim listens on layers and hosiery listens on remaining:
+
+```js
+          addRollFullW.addEventListener('input', recomputeAddRollWeights);
+          if (IS_DENIM) {
+            addRollLayers.addEventListener('input', recomputeAddRollWeights);
+          } else {
+            addRollRem.addEventListener('input', recomputeAddRollWeights);
+          }
+```
+
+- [ ] **Step 5: Re-add the denim-only "no table_length" blocker**
+
+Restore the warning + disabled button, gated to denim. In the markup intro paragraph add (denim only):
+
+```js
+                    ${isDenim && !lot.table_length ? `
+                      <div class="alert alert-danger py-2 mb-2 small">
+                        This denim lot has no <strong>table_length</strong> — Weight Used can't be computed. Set table_length on the lot first.
+                      </div>` : ''}
+```
+
+And the Add button:
+
+```js
+                      <button type="button" class="btn btn-primary btn-sm" id="addRollBtn"${isDenim && !lot.table_length ? ' disabled' : ''}>
+```
+
+- [ ] **Step 6: Verify the route module loads**
+
+Run: `node -e "require('./routes/editcuttinglots.js'); console.log('OK')"`
+Expected: prints `OK`.
+
+- [ ] **Step 7: Manual check**
+
+Run `npm start`, open the edit form for a denim lot and a hosiery lot via the operator UI.
+Expected: denim lot → Weight Used auto = table_length × layers, Add disabled when lot has no table_length; hosiery lot → Remaining editable (default 0), Weight Used = full − remaining.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add routes/editcuttinglots.js
+git commit -m "feat(cutting): denim/hosiery weight branching in add-missed-roll form"
+```
+
+---
+
+# PART B — Feature 2: Fabric consumption analysis
+
+## Task 5: Consumption transforms module + tests
+
+**Files:**
+- Create: `utils/fabricConsumption.js`
+- Create: `test/fabricConsumption.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/fabricConsumption.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  groupConsumptionByFabricType,
+  buildRollLedger,
+  findAdHocRolls,
+  findAdHocFabricTypes,
+} = require('../utils/fabricConsumption.js');
+
+const rows = [
+  { fabric_type: 'Denim', lot_no: 'L1', sku: 'S1', created_at: '2026-05-01', cutter: 'amy', cutting_lot_id: 1, roll_no: 'R1', full_weight: 50, weight_used: 12, remaining_weight: 38 },
+  { fabric_type: 'Denim', lot_no: 'L1', sku: 'S1', created_at: '2026-05-01', cutter: 'amy', cutting_lot_id: 1, roll_no: 'R2', full_weight: 40, weight_used: 10, remaining_weight: 30 },
+  { fabric_type: 'Denim', lot_no: 'L2', sku: 'S2', created_at: '2026-05-02', cutter: 'amy', cutting_lot_id: 2, roll_no: 'R1', full_weight: 38, weight_used: 8,  remaining_weight: 30 },
+  { fabric_type: 'Cotton', lot_no: 'L3', sku: 'S3', created_at: '2026-05-03', cutter: 'bob', cutting_lot_id: 3, roll_no: 'X9', full_weight: 20, weight_used: 5,  remaining_weight: 15 },
+];
+
+test('groupConsumptionByFabricType aggregates per type and lot', () => {
+  const g = groupConsumptionByFabricType(rows);
+  const denim = g.find(x => x.fabricType === 'Denim');
+  assert.strictEqual(denim.totalUsed, 30);
+  assert.strictEqual(denim.lotCount, 2);
+  assert.strictEqual(denim.rollCount, 3);
+  const l1 = denim.lots.find(l => l.lotNo === 'L1');
+  assert.strictEqual(l1.totalUsed, 22);
+  assert.strictEqual(l1.rolls.length, 2);
+});
+
+test('buildRollLedger sums used per roll across lots and resolves master', () => {
+  const master = [
+    { roll_no: 'R1', fabric_type: 'Denim', vendor_name: 'Acme', per_roll_weight: 30, unit: 'kg' },
+    { roll_no: 'R2', fabric_type: 'Denim', vendor_name: 'Acme', per_roll_weight: 30, unit: 'kg' },
+  ];
+  const ledger = buildRollLedger(rows, master);
+  const r1 = ledger.find(r => r.rollNo === 'R1');
+  assert.strictEqual(r1.totalUsed, 20);            // 12 + 8
+  assert.strictEqual(r1.currentAvailable, 30);
+  assert.strictEqual(r1.vendor, 'Acme');
+  assert.deepStrictEqual(r1.lots.sort(), ['L1', 'L2']);
+  const x9 = ledger.find(r => r.rollNo === 'X9');
+  assert.strictEqual(x9.currentAvailable, null);   // ad-hoc, not in master
+  assert.strictEqual(x9.vendor, '(ad-hoc)');
+});
+
+test('findAdHocRolls returns rolls absent from master', () => {
+  const adhoc = findAdHocRolls(rows, ['R1', 'R2']);
+  assert.strictEqual(adhoc.length, 1);
+  assert.strictEqual(adhoc[0].rollNo, 'X9');
+  assert.strictEqual(adhoc[0].lotNo, 'L3');
+});
+
+test('findAdHocFabricTypes is case-insensitive and deduped', () => {
+  const adhoc = findAdHocFabricTypes(['Denim', 'cotton', 'Linen', 'LINEN'], ['Denim', 'Cotton']);
+  assert.deepStrictEqual(adhoc, ['Linen']);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test test/fabricConsumption.test.js`
+Expected: FAIL — `Cannot find module '../utils/fabricConsumption.js'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `utils/fabricConsumption.js`:
+
+```js
+// Pure transforms for the fabric-manager consumption analysis page.
+// Input rows come from SQL (cutting_lot_rolls joined to cutting_lots + users).
+function round2(n) {
+  return Math.round((Number(n) || 0) * 100) / 100;
+}
+
+// rows: [{ fabric_type, lot_no, sku, created_at, cutter, cutting_lot_id, roll_no, full_weight, weight_used, remaining_weight }]
+function groupConsumptionByFabricType(rows) {
+  const byType = new Map();
+  for (const r of rows) {
+    const ft = r.fabric_type || '(none)';
+    if (!byType.has(ft)) byType.set(ft, { fabricType: ft, totalUsed: 0, lots: new Map() });
+    const g = byType.get(ft);
+    g.totalUsed += Number(r.weight_used) || 0;
+    if (!g.lots.has(r.cutting_lot_id)) {
+      g.lots.set(r.cutting_lot_id, {
+        lotNo: r.lot_no, sku: r.sku, createdAt: r.created_at, cutter: r.cutter, totalUsed: 0, rolls: [],
+      });
+    }
+    const lot = g.lots.get(r.cutting_lot_id);
+    lot.totalUsed += Number(r.weight_used) || 0;
+    lot.rolls.push({
+      rollNo: r.roll_no,
+      full: round2(r.full_weight),
+      used: round2(r.weight_used),
+      remaining: round2(r.remaining_weight),
+    });
+  }
+  return [...byType.values()].map(g => {
+    const lots = [...g.lots.values()].map(l => ({ ...l, totalUsed: round2(l.totalUsed) }));
+    return {
+      fabricType: g.fabricType,
+      totalUsed: round2(g.totalUsed),
+      lotCount: lots.length,
+      rollCount: lots.reduce((n, l) => n + l.rolls.length, 0),
+      lots,
+    };
+  });
+}
+
+// masterRows: [{ roll_no, fabric_type, vendor_name, per_roll_weight, unit }]
+function buildRollLedger(consumptionRows, masterRows) {
+  const master = new Map((masterRows || []).map(m => [m.roll_no, m]));
+  const byRoll = new Map();
+  for (const r of consumptionRows) {
+    if (!byRoll.has(r.roll_no)) {
+      const m = master.get(r.roll_no);
+      byRoll.set(r.roll_no, {
+        rollNo: r.roll_no,
+        fabricType: (m && m.fabric_type) || r.fabric_type || '(none)',
+        vendor: (m && m.vendor_name) || '(ad-hoc)',
+        currentAvailable: m ? round2(m.per_roll_weight) : null,
+        unit: (m && m.unit) || '',
+        totalUsed: 0,
+        lots: [],
+      });
+    }
+    const e = byRoll.get(r.roll_no);
+    e.totalUsed += Number(r.weight_used) || 0;
+    e.lots.push(r.lot_no);
+  }
+  return [...byRoll.values()].map(e => ({
+    ...e,
+    totalUsed: round2(e.totalUsed),
+    lots: [...new Set(e.lots)],
+  }));
+}
+
+function findAdHocRolls(consumptionRows, masterRollNos) {
+  const set = new Set(masterRollNos || []);
+  const out = new Map();
+  for (const r of consumptionRows) {
+    if (set.has(r.roll_no)) continue;
+    const key = r.roll_no + '|' + r.cutting_lot_id;
+    if (!out.has(key)) {
+      out.set(key, {
+        rollNo: r.roll_no,
+        fabricType: r.fabric_type || '(none)',
+        full: round2(r.full_weight),
+        used: round2(r.weight_used),
+        lotNo: r.lot_no,
+        cutter: r.cutter,
+      });
+    }
+  }
+  return [...out.values()];
+}
+
+function findAdHocFabricTypes(lotFabricTypes, masterFabricTypes) {
+  const master = new Set((masterFabricTypes || []).map(s => (s || '').toLowerCase().trim()));
+  const seen = new Set();
+  const out = [];
+  for (const ft of lotFabricTypes || []) {
+    if (!ft) continue;
+    const key = ft.toLowerCase().trim();
+    if (master.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    out.push(ft);
+  }
+  return out;
+}
+
+module.exports = {
+  round2,
+  groupConsumptionByFabricType,
+  buildRollLedger,
+  findAdHocRolls,
+  findAdHocFabricTypes,
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node --test test/fabricConsumption.test.js`
+Expected: PASS — all 4 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/fabricConsumption.js test/fabricConsumption.test.js
+git commit -m "feat(fabric): tested consumption-analysis transforms (group/ledger/ad-hoc)"
+```
+
+---
+
+## Task 6: Analysis route with date filter
+
+**Files:**
+- Modify: `routes/fabricManagerRoutes.js` (add `GET /analysis`; place near the other GET routes)
+
+- [ ] **Step 1: Import the transforms at the top of the file**
+
+Near the top of `routes/fabricManagerRoutes.js` with the other `require`s, add:
+
+```js
+const {
+  groupConsumptionByFabricType,
+  buildRollLedger,
+  findAdHocRolls,
+  findAdHocFabricTypes,
+} = require('../utils/fabricConsumption');
+```
+
+- [ ] **Step 2: Add a shared data-loader used by the page and the export**
+
+Add this helper function in the module (above the route definitions). It runs the queries with an optional date range and returns the four computed datasets:
+
+```js
+// Loads + computes all analysis datasets for an optional [from, to] date range
+// (inclusive of the whole `to` day). from/to are 'YYYY-MM-DD' strings or null.
+async function loadConsumptionAnalysis(from, to) {
+  const f = from || null;
+  const t = to || null;
+  const consumptionSql = `
+    SELECT cl.fabric_type, cl.lot_no, cl.sku, cl.created_at, u.username AS cutter,
+           cl.id AS cutting_lot_id, clr.roll_no, clr.full_weight, clr.weight_used, clr.remaining_weight
+    FROM cutting_lot_rolls clr
+    JOIN cutting_lots cl ON clr.cutting_lot_id = cl.id
+    JOIN users u ON cl.user_id = u.id
+    WHERE (? IS NULL OR cl.created_at >= ?)
+      AND (? IS NULL OR cl.created_at < DATE_ADD(?, INTERVAL 1 DAY))
+    ORDER BY cl.fabric_type ASC, cl.created_at DESC`;
+  const [consumptionRows] = await pool.query(consumptionSql, [f, f, t, t]);
+
+  const [masterRows] = await pool.query(`
+    SELECT fir.roll_no, fi.fabric_type, v.name AS vendor_name, fir.per_roll_weight, fir.unit
+    FROM fabric_invoice_rolls fir
+    JOIN fabric_invoices fi ON fir.invoice_id = fi.id
+    JOIN vendors v ON fir.vendor_id = v.id`);
+
+  const [lotTypeRows] = await pool.query(`SELECT DISTINCT fabric_type FROM cutting_lots WHERE fabric_type IS NOT NULL`);
+  const [masterTypeRows] = await pool.query(`SELECT DISTINCT fabric_type FROM fabric_invoices WHERE fabric_type IS NOT NULL`);
+
+  const masterRollNos = masterRows.map(m => m.roll_no);
+  const lotFabricTypes = lotTypeRows.map(r => r.fabric_type);
+  const masterFabricTypes = masterTypeRows.map(r => r.fabric_type);
+
+  return {
+    byType: groupConsumptionByFabricType(consumptionRows),
+    ledger: buildRollLedger(consumptionRows, masterRows),
+    adHocRolls: findAdHocRolls(consumptionRows, masterRollNos),
+    adHocTypes: findAdHocFabricTypes(lotFabricTypes, masterFabricTypes),
+  };
+}
+```
+
+> Note: confirm the pool variable name used elsewhere in this file (e.g. `pool` / `db`) and use that exact name. Confirm `isFabricManager` is the middleware imported in this file.
+
+- [ ] **Step 3: Add the GET /analysis route**
+
+```js
+// GET /fabric-manager/analysis — consumption analysis (3 tabs + date filter)
+router.get('/analysis', isAuthenticated, isFabricManager, async (req, res) => {
+  try {
+    const from = req.query.from || '';
+    const to = req.query.to || '';
+    const data = await loadConsumptionAnalysis(from, to);
+    res.render('fabricConsumptionAnalysis', {
+      user: req.session.user,
+      from, to,
+      byType: data.byType,
+      ledger: data.ledger,
+      adHocRolls: data.adHocRolls,
+      adHocTypes: data.adHocTypes,
+    });
+  } catch (err) {
+    console.error('Error loading fabric consumption analysis:', err);
+    req.flash('error', 'Failed to load fabric consumption analysis.');
+    res.redirect('/fabric-manager/dashboard');
+  }
+});
+```
+
+- [ ] **Step 4: Verify the module loads**
+
+Run: `node -e "require('./routes/fabricManagerRoutes.js'); console.log('OK')"`
+Expected: prints `OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add routes/fabricManagerRoutes.js
+git commit -m "feat(fabric): add /analysis route + date-filtered data loader"
+```
+
+---
+
+## Task 7: Analysis page view (3 tabs + date filter)
+
+> **Use the `/frontend-design` skill** to build this view consistent with `views/fabricManagerDashboard.ejs` styling. The data contract below is fixed.
+
+**Files:**
+- Create: `views/fabricConsumptionAnalysis.ejs`
+- Modify: `views/fabricManagerDashboard.ejs` (add a link to the analysis page in the bottom action area, ~lines 590-601)
+
+**Data contract passed to the view:**
+- `from`, `to` — date strings (may be empty).
+- `byType` — `[{ fabricType, totalUsed, lotCount, rollCount, lots: [{ lotNo, sku, createdAt, cutter, totalUsed, rolls: [{ rollNo, full, used, remaining }] }] }]`
+- `ledger` — `[{ rollNo, fabricType, vendor, currentAvailable, unit, totalUsed, lots: [lotNo, ...] }]`
+- `adHocRolls` — `[{ rollNo, fabricType, full, used, lotNo, cutter }]`
+- `adHocTypes` — `[fabricTypeString, ...]`
+
+- [ ] **Step 1: Create the view skeleton with the date filter and three tabs**
+
+Create `views/fabricConsumptionAnalysis.ejs`. Build with `/frontend-design`, fulfilling this structure:
+
+- A `GET` form at top with two `<input type="date" name="from">` / `name="to"` pre-filled from `from`/`to`, an Apply button, and a "Clear" link to `/fabric-manager/analysis`.
+- Three tabs (Bootstrap nav-tabs to match the existing dashboard):
+  - **Consumption by fabric type** — for each `byType` entry, a collapsible group header showing `fabricType`, `totalUsed`, `lotCount`, `rollCount`; expanding shows each lot (`lotNo`, `sku`, `createdAt`, `cutter`, `totalUsed`) and its `rolls` table (`rollNo`, `full`, `used`, `remaining`).
+  - **Roll ledger** — a table of `ledger` rows: `rollNo`, `fabricType`, `vendor`, `currentAvailable` (show `—` when null) + `unit`, `totalUsed`, and `lots` joined by `, `.
+  - **Unknown / ad-hoc** — two sub-tables: `adHocRolls` (`rollNo`, `fabricType`, `full`, `used`, `lotNo`, `cutter`) and `adHocTypes` (a simple list).
+- Each tab has an "Export to Excel" button linking to `/fabric-manager/analysis/export?tab=consumption|ledger|adhoc&from=<from>&to=<to>`.
+
+- [ ] **Step 2: Add the link from the fabric-manager dashboard**
+
+In `views/fabricManagerDashboard.ejs` bottom action area (~lines 590-601, alongside the bulk-upload / advanced-view buttons), add:
+
+```html
+<a href="/fabric-manager/analysis" class="btn btn-outline-primary">
+  <i class="bi bi-graph-up"></i> Consumption Analysis
+</a>
+```
+
+- [ ] **Step 3: Verify both views parse**
+
+Run:
+```bash
+node -e "const ejs=require('ejs'),fs=require('fs');['views/fabricConsumptionAnalysis.ejs','views/fabricManagerDashboard.ejs'].forEach(f=>{ejs.compile(fs.readFileSync(f,'utf8'),{filename:f});console.log(f,'OK')})"
+```
+Expected: both print `OK`.
+
+- [ ] **Step 4: Manual check**
+
+Run `npm start`, log in as a `fabric_manager`, click "Consumption Analysis".
+Expected: three tabs render with data; setting a from/to date and clicking Apply narrows the rows; "Clear" resets to all-time; ad-hoc tab lists rolls/types used in cutting that are not in fabric data.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add views/fabricConsumptionAnalysis.ejs views/fabricManagerDashboard.ejs
+git commit -m "feat(fabric): consumption analysis view (3 tabs + date filter) and dashboard link"
+```
+
+---
+
+## Task 8: Excel export for each tab
+
+**Files:**
+- Modify: `routes/fabricManagerRoutes.js` (add `GET /analysis/export`)
+
+- [ ] **Step 1: Add the export route**
+
+Add after the `/analysis` route. It reuses `loadConsumptionAnalysis` and builds a sheet per `tab`. Use `exceljs` (already a dependency); match the response-header style of the existing `/download-excel` route in this file.
+
+```js
+const ExcelJS = require('exceljs'); // if not already required at top; otherwise reuse the existing import
+
+// GET /fabric-manager/analysis/export?tab=consumption|ledger|adhoc&from=&to=
+router.get('/analysis/export', isAuthenticated, isFabricManager, async (req, res) => {
+  try {
+    const from = req.query.from || '';
+    const to = req.query.to || '';
+    const tab = req.query.tab || 'consumption';
+    const data = await loadConsumptionAnalysis(from, to);
+
+    const wb = new ExcelJS.Workbook();
+
+    if (tab === 'ledger') {
+      const ws = wb.addWorksheet('Roll Ledger');
+      ws.addRow(['Roll No', 'Fabric Type', 'Vendor', 'Current Available', 'Unit', 'Total Used', 'Lots']);
+      data.ledger.forEach(r => ws.addRow([
+        r.rollNo, r.fabricType, r.vendor,
+        r.currentAvailable == null ? '' : r.currentAvailable, r.unit,
+        r.totalUsed, r.lots.join(', '),
+      ]));
+    } else if (tab === 'adhoc') {
+      const ws1 = wb.addWorksheet('Ad-hoc Rolls');
+      ws1.addRow(['Roll No', 'Fabric Type', 'Full', 'Used', 'Lot No', 'Cutter']);
+      data.adHocRolls.forEach(r => ws1.addRow([r.rollNo, r.fabricType, r.full, r.used, r.lotNo, r.cutter]));
+      const ws2 = wb.addWorksheet('Ad-hoc Fabric Types');
+      ws2.addRow(['Fabric Type (not in fabric data)']);
+      data.adHocTypes.forEach(ft => ws2.addRow([ft]));
+    } else {
+      const ws = wb.addWorksheet('Consumption by Fabric Type');
+      ws.addRow(['Fabric Type', 'Lot No', 'SKU', 'Created At', 'Cutter', 'Roll No', 'Full', 'Used', 'Remaining']);
+      data.byType.forEach(g => g.lots.forEach(l => l.rolls.forEach(roll => {
+        ws.addRow([g.fabricType, l.lotNo, l.sku, l.createdAt, l.cutter, roll.rollNo, roll.full, roll.used, roll.remaining]);
+      })));
+    }
+
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition', `attachment; filename="fabric-${tab}.xlsx"`);
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error('Error exporting fabric analysis:', err);
+    req.flash('error', 'Failed to export fabric analysis.');
+    res.redirect('/fabric-manager/analysis');
+  }
+});
+```
+
+> If the file already `require`s `exceljs` (used by `/download-excel`), reuse that import instead of adding a second one.
+
+- [ ] **Step 2: Verify the module loads**
+
+Run: `node -e "require('./routes/fabricManagerRoutes.js'); console.log('OK')"`
+Expected: prints `OK`.
+
+- [ ] **Step 3: Manual check**
+
+Run `npm start`, on the analysis page click each tab's "Export to Excel".
+Expected: three downloads — `fabric-consumption.xlsx`, `fabric-ledger.xlsx`, `fabric-adhoc.xlsx` — each opening with the expected columns and respecting the active date filter.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add routes/fabricManagerRoutes.js
+git commit -m "feat(fabric): Excel export per analysis tab (date-filter aware)"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full unit suite**
+
+Run: `npm test`
+Expected: all `cuttingWeight` and `fabricConsumption` tests pass (11 tests total).
+
+- [ ] **Smoke-test the app boots**
+
+Run: `node -e "require('./app.js')" ` is not appropriate (starts server); instead confirm all touched route modules load:
+```bash
+node -e "require('./routes/cuttingManagerRoutes.js');require('./routes/editcuttinglots.js');require('./routes/fabricManagerRoutes.js');console.log('all routes OK')"
+```
+Expected: prints `all routes OK`.
+
+---
+
+## Self-Review notes (filled by plan author)
+
+- **Spec coverage:** Feature 1 denim auto-calc (Tasks 1-4), hosiery manual remaining default 0 (Tasks 1,3,4), roll lookup + stock deduction unchanged (no backend change — relies on existing POST). Feature 2 three tabs (Task 7), date filter (Tasks 6-8), ad-hoc rolls + types (Tasks 5-7), Excel exports honoring filter (Task 8), dashboard link (Task 7). All spec sections mapped.
+- **No new migrations / DB columns** — consistent with spec "no new DB columns."
+- **Type consistency:** `computeRollWeights(mode, inputs)` signature identical across Tasks 1/3. `loadConsumptionAnalysis` return keys (`byType`, `ledger`, `adHocRolls`, `adHocTypes`) identical across Tasks 6/7/8. Transform output property names (`fabricType`, `totalUsed`, `lotCount`, `rollCount`, `lots`, `rollNo`, `currentAvailable`) identical between Task 5 module, Task 7 view contract, and Task 8 export.
+- **Open confirmations for the executor (verify against live code, don't assume):** exact pool variable name and `isFabricManager`/`isAuthenticated` imports in `fabricManagerRoutes.js`; whether `exceljs` is already required there; the exact element id of the add-roll Remaining input in `editcuttinglots.js`; whether the create-form Remaining field is currently hidden (convert to visible number input for hosiery).

--- a/docs/superpowers/specs/2026-06-01-cutting-weight-and-fabric-consumption-design.md
+++ b/docs/superpowers/specs/2026-06-01-cutting-weight-and-fabric-consumption-design.md
@@ -150,10 +150,19 @@ filter/sort.
 - **Ad-hoc fabric types**: `cutting_lots.fabric_type` values not present in
   `fabric_invoices.fabric_type`.
 
+### Date filter
+
+A date-range filter (from / to, applied to `cutting_lots.created_at`) sits at the
+top of the page and constrains all three tabs. Default range: all-time (empty
+from/to). Filtering by consumption date means Tab 2's "total used" reflects only
+lots within the range, while the roll's current available weight remains the
+live `fabric_invoice_rolls.per_roll_weight`.
+
 ### Exports
 
-Each tab gets an Excel export, matching the existing fabric-manager download
-pattern (e.g. `/fabric-manager/download-excel`, `/invoice/:id/download-rolls`).
+Each tab gets an Excel export honoring the active date filter, matching the
+existing fabric-manager download pattern (e.g. `/fabric-manager/download-excel`,
+`/invoice/:id/download-rolls`).
 
 ### Frontend
 
@@ -162,7 +171,6 @@ existing fabric-manager dashboard styling.
 
 ### Out of scope
 
-- No date-range filter in v1 (show all-time). Can be added later.
 - No edits/writes — analysis is read-only.
 
 ---

--- a/docs/superpowers/specs/2026-06-01-cutting-weight-and-fabric-consumption-design.md
+++ b/docs/superpowers/specs/2026-06-01-cutting-weight-and-fabric-consumption-design.md
@@ -1,0 +1,174 @@
+# Design: Denim-only weight auto-calc + fabric consumption analysis
+
+Date: 2026-06-01
+Branch: feat/production-manager-dashboard
+Status: Approved (ready for implementation plan)
+
+## Summary
+
+Two independent features in the kotty-track manufacturing app:
+
+1. **Cutting dashboard** — re-introduce the `weight_used = table_length × layers`
+   auto-calculation, but gate it to **denim** lots only. Hosiery lots use the
+   "normal" manual flow (enter Remaining, derive Used). Both still look up rolls
+   in the fabric DB and deduct stock when the roll exists.
+2. **Fabric-manager dashboard** — a new analysis page (3 tabs) showing where
+   fabric is consumed, a roll-level ledger, and an unknown/ad-hoc data report
+   for rolls and fabric types typed into cutting lots but absent from fabric data.
+
+The two features share no code and can be built/merged independently.
+
+---
+
+## Feature 1 — Denim-only weight auto-calculation
+
+### Background
+
+The `weight_used = table_length × layers` auto-calc previously existed and was
+reverted to manual entry in commits `a836111` (create form) and `48320f0`
+(editcuttinglots add-roll). This feature brings the auto-calc back, but **only
+for denim**.
+
+A cutter is either a denim cutter or a hosiery cutter, determined by the
+existing `users.is_denim_cutter` flag. The create-lot POST already stamps
+`cutting_lots.flow_type` ('denim' | 'hosiery') from this flag
+(cuttingManagerRoutes.js ~229-234). So the create form renders in a **single
+mode** for the whole session — no per-roll toggle.
+
+### Behavior
+
+| Aspect | Denim (`is_denim_cutter = true`) | Hosiery (`is_denim_cutter = false`) |
+|---|---|---|
+| Weight Used | auto = `table_length × layers`, read-only | derived = `Full − Remaining`, read-only |
+| Operator weight input | none (driven by layers + table_length) | **Remaining** (default `0`, editable) |
+| `table_length` | **required** | not required |
+| Roll lookup from fabric DB | yes — Full auto-fills + locks when roll found | yes — same |
+| Roll not in DB | operator types Full | operator types Full |
+| Deduct `fabric_invoice_rolls.per_roll_weight` | yes, when roll in DB | yes, when roll in DB |
+
+### Why no backend change is needed
+
+Both modes submit a **hidden `remaining_weight`**, and the create-lot POST
+already recomputes `weight_used = full_weight − remaining_weight`
+(cuttingManagerRoutes.js:351 for in-DB rolls, :371 for ad-hoc rolls). Therefore:
+
+- **Denim frontend** computes `used = table_length × layers`, then back-fills the
+  hidden `remaining = max(full − used, 0)`. The server recovers the same `used`.
+- **Hosiery frontend** takes the operator's typed `remaining` directly.
+
+The POST handlers in `cuttingManagerRoutes.js` and the add-roll handler in
+`editcuttinglots.js` are unchanged. The only backend edits are passing an
+`isDenim` flag into the two `res.render` calls.
+
+Edge case (preserved from prior behavior): if denim `used > full`, the usage bar
+flags red and hidden `remaining` clamps to `0` (server then records
+`used = full`). This is the same clamp the pre-revert code had; we are not adding
+new server-side validation.
+
+### Worked examples
+
+**Denim** — Lot `table_length = 1.5`. Operator picks roll `R-123` →
+**Full = 50.00** auto-fills and locks. Enters **layers = 8** →
+**Used = 1.5 × 8 = 12.00** (read-only); hidden `remaining = 50 − 12 = 38`. Save
+deducts 12 from R-123 stock.
+
+**Hosiery** — Operator picks roll `H-7` → **Full = 30.00** auto-fills. Leaves
+**Remaining = 0** (default) → **Used = 30.00**. Or returns part: Remaining = 4 →
+**Used = 26.00**. Save deducts the used amount.
+
+### Scope / touchpoints
+
+- `routes/cuttingManagerRoutes.js` — in `GET /dashboard`, query the cutter's
+  `is_denim_cutter` and pass `isDenim` to `res.render('cuttingManagerDashboard', …)`.
+- `views/cuttingManagerDashboard.ejs` — branch `updateWeightUsed()` on `isDenim`:
+  - denim: `used = table_length × layers` (read-only Weight Used), back-fill
+    hidden remaining, re-add `table_length` required validation + the
+    create-button blocker when table_length is missing.
+  - hosiery: Remaining is the editable input (default `0`); Weight Used becomes
+    read-only derived = `full − remaining`.
+  - Keep roll autocomplete, Full-weight auto-fill/lock, and the usage progress
+    bar for both modes.
+- `routes/editcuttinglots.js` — the add-missed-roll form already has
+  `lot.flow_type`. Branch the same way: denim re-adds `table_length × layers`
+  auto-calc + the "no table_length" blocker; hosiery keeps manual
+  Remaining → derived Used.
+
+### Out of scope
+
+- No change to how `flow_type` / `is_denim_cutter` is set.
+- No bulk-upload changes (bulkUploadRoutes.js) unless trivially needed.
+- No new DB columns or migrations.
+
+---
+
+## Feature 2 — Fabric consumption analysis (fabric-manager dashboard)
+
+### Goal
+
+Give fabric managers visibility into where fabric is consumed, plus surface
+data-quality gaps (rolls/types used in cutting that were never recorded in
+fabric data).
+
+### Page
+
+New route `GET /fabric-manager/analysis`, gated by `isAuthenticated` +
+`isFabricManager`, rendered as a tabbed page. Linked from the existing
+fabric-manager dashboard action area.
+
+### Data sources
+
+- `cutting_lot_rolls` (roll_no, weight_used, full_weight, remaining_weight,
+  cutting_lot_id) joined to `cutting_lots` (lot_no, sku, fabric_type, flow_type,
+  created_at, user_id) for lot + fabric_type context.
+- `fabric_invoice_rolls` (roll_no, per_roll_weight, unit, vendor_id) +
+  `fabric_invoices` (fabric_type) + `vendors` (name) for the master/ledger side.
+- `users` for "created by".
+
+`cutting_lot_rolls` has no `fabric_type` column; fabric type comes from the
+parent `cutting_lots` row.
+
+### Tabs
+
+**Tab 1 — Consumption by fabric type**
+Grouped by `cutting_lots.fabric_type`. Each group header: total weight consumed,
+distinct lot count, distinct roll count. Expand a group to list each lot
+(`lot_no`, sku, created_at, cutter username, total used for that lot) and, under
+each lot, the roll-by-roll breakdown (roll_no, full, used, remaining).
+
+**Tab 2 — Roll-level ledger**
+One row per roll that has been consumed. Columns: roll_no, fabric type, vendor,
+original/current available weight (`fabric_invoice_rolls.per_roll_weight`, noting
+this is the *current* post-deduction value), total used across all lots,
+remaining, and the list of lots that consumed it. Fabric type usable as a
+filter/sort.
+
+**Tab 3 — Unknown / ad-hoc data**
+- **Ad-hoc rolls**: `roll_no` in `cutting_lot_rolls` with no match in
+  `fabric_invoice_rolls`. Show roll_no, fabric type (from the lot), full/used
+  entered, owning lot, and who entered it.
+  Detection: `LEFT JOIN fabric_invoice_rolls … WHERE fir.id IS NULL`.
+- **Ad-hoc fabric types**: `cutting_lots.fabric_type` values not present in
+  `fabric_invoices.fabric_type`.
+
+### Exports
+
+Each tab gets an Excel export, matching the existing fabric-manager download
+pattern (e.g. `/fabric-manager/download-excel`, `/invoice/:id/download-rolls`).
+
+### Frontend
+
+Build the analysis view with the `/frontend-design` skill, following the
+existing fabric-manager dashboard styling.
+
+### Out of scope
+
+- No date-range filter in v1 (show all-time). Can be added later.
+- No edits/writes — analysis is read-only.
+
+---
+
+## Notes
+
+- Frontend work for both features uses the `/frontend-design` skill per user
+  request.
+- Features are independent; either can ship without the other.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
-    "start:dev": "node --watch app.js"
+    "start:dev": "node --watch app.js",
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/public/js/cuttingWeight.js
+++ b/public/js/cuttingWeight.js
@@ -30,7 +30,7 @@
     }
 
     // hosiery: operator enters remaining (default 0); used = full - remaining
-    const remaining = num(inputs.remaining) === null ? 0 : num(inputs.remaining);
+    const remaining = num(inputs.remaining) ?? 0;
     if (full === null) {
       return { used: null, remaining, over: false };
     }

--- a/public/js/cuttingWeight.js
+++ b/public/js/cuttingWeight.js
@@ -1,0 +1,43 @@
+// Pure weight math shared by the cutting-entry forms (browser) and tests (node).
+// UMD wrapper: attaches `CuttingWeight` to the browser global and also exports
+// for CommonJS so `node:test` can require it.
+(function (root, factory) {
+  const api = factory();
+  if (typeof module === 'object' && module.exports) module.exports = api;
+  else root.CuttingWeight = api;
+})(typeof self !== 'undefined' ? self : this, function () {
+  function num(v) {
+    const n = parseFloat(v);
+    return Number.isNaN(n) ? null : n;
+  }
+
+  // mode: 'denim' | 'hosiery'
+  // inputs: { tableLength, layers, full, remaining }
+  // returns: { used, remaining, over }  (used/remaining are numbers or null)
+  function computeRollWeights(mode, inputs) {
+    const full = num(inputs.full);
+
+    if (mode === 'denim') {
+      const tableLength = num(inputs.tableLength);
+      const layers = num(inputs.layers);
+      if (tableLength === null || layers === null) {
+        return { used: null, remaining: null, over: false };
+      }
+      const used = tableLength * layers;
+      const remaining = full === null ? null : Math.max(full - used, 0);
+      const over = full !== null && used > full;
+      return { used, remaining, over };
+    }
+
+    // hosiery: operator enters remaining (default 0); used = full - remaining
+    const remaining = num(inputs.remaining) === null ? 0 : num(inputs.remaining);
+    if (full === null) {
+      return { used: null, remaining, over: false };
+    }
+    const rawUsed = full - remaining;
+    const over = remaining > full;
+    return { used: Math.max(rawUsed, 0), remaining, over };
+  }
+
+  return { computeRollWeights };
+});

--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -169,6 +169,13 @@ router.get('/dashboard', isAuthenticated, isCuttingManager, async (req, res) => 
     // Fetch rolls by fabric type
     const rollsByFabricType = await getRollsByFabricType();
 
+    // Determine the cutter's flow type so the form renders in denim or hosiery mode.
+    const [[cutterFlag]] = await pool.query(
+      'SELECT is_denim_cutter FROM users WHERE id = ?',
+      [userId]
+    );
+    const isDenim = !!(cutterFlag && cutterFlag.is_denim_cutter);
+
     res.render('cuttingManagerDashboard', {
       user: req.session.user,
       cuttingLots,
@@ -176,6 +183,7 @@ router.get('/dashboard', isAuthenticated, isCuttingManager, async (req, res) => 
       pendingAssignments,
       rollsByFabricType, // Now includes vendor_name
       generatedLotNumber, // Pass the generated lot number
+      isDenim,
     });
   } catch (err) {
     if (conn) {

--- a/routes/editcuttinglots.js
+++ b/routes/editcuttinglots.js
@@ -9,6 +9,114 @@ const { isAuthenticated, isOperator } = require('../middlewares/auth');
 const masterCache = { data: null, expires: 0 };
 const CACHE_TTL = 5 * 60 * 1000; // 5 minutes
 
+// Stages whose size breakdowns are keyed by the size_label STRING. Used by the
+// cascade below. Fixed whitelist (never user input) so it's safe to interpolate
+// into table names.
+const SIZE_STAGES = ['stitching', 'jeans_assembly', 'washing', 'washing_in', 'finishing'];
+
+/**
+ * Rename a size label for ONE cutting lot across every place a piece breakdown
+ * is tracked by the size_label string, so editing a cut size never desyncs
+ * downstream. Covers BOTH the new event model (*_event_sizes) and the legacy
+ * data model (*_data_sizes / *_data_updates), plus dispatches, rejects, rewash,
+ * self-assignment sizes, production_flow_events, and the assignment sizes_json
+ * blobs. Must run inside the caller's transaction (conn).
+ *
+ * Scope is the single lot (by cutting_lot_id for event/assignment tables, by
+ * lot_no for the legacy data tables). oldLabel/newLabel are exact-match strings.
+ */
+async function cascadeSizeRename(conn, lotId, lotNo, oldLabel, newLabel) {
+  // 1) New event model — *_event_sizes linked to the lot via *_events.cutting_lot_id
+  for (const s of SIZE_STAGES) {
+    await conn.query(
+      `UPDATE ${s}_event_sizes es JOIN ${s}_events e ON es.event_id = e.id
+          SET es.size_label = ?
+        WHERE e.cutting_lot_id = ? AND es.size_label = ?`,
+      [newLabel, lotId, oldLabel]
+    );
+  }
+  // 2) Legacy data model — *_data_sizes / *_data_updates linked via *_data.lot_no
+  for (const s of SIZE_STAGES) {
+    await conn.query(
+      `UPDATE ${s}_data_sizes x JOIN ${s}_data p ON x.${s}_data_id = p.id
+          SET x.size_label = ?
+        WHERE p.lot_no = ? AND x.size_label = ?`,
+      [newLabel, lotNo, oldLabel]
+    );
+    await conn.query(
+      `UPDATE ${s}_data_updates x JOIN ${s}_data p ON x.${s}_data_id = p.id
+          SET x.size_label = ?
+        WHERE p.lot_no = ? AND x.size_label = ?`,
+      [newLabel, lotNo, oldLabel]
+    );
+  }
+  // 3) Direct / other size_label-keyed tables for this lot
+  await conn.query(
+    `UPDATE finishing_dispatches SET size_label = ? WHERE lot_no = ? AND size_label = ?`,
+    [newLabel, lotNo, oldLabel]
+  );
+  await conn.query(
+    `UPDATE reject_data_sizes x JOIN reject_data r ON x.reject_data_id = r.id
+        SET x.size_label = ? WHERE r.lot_no = ? AND x.size_label = ?`,
+    [newLabel, lotNo, oldLabel]
+  );
+  await conn.query(
+    `UPDATE rewash_request_sizes x JOIN rewash_requests r ON x.rewash_request_id = r.id
+        SET x.size_label = ? WHERE r.lot_no = ? AND x.size_label = ?`,
+    [newLabel, lotNo, oldLabel]
+  );
+  await conn.query(
+    `UPDATE size_assignments x JOIN lot_assignments la ON x.lot_assignment_id = la.id
+        SET x.size_label = ? WHERE la.cutting_lot_id = ? AND x.size_label = ?`,
+    [newLabel, lotId, oldLabel]
+  );
+  await conn.query(
+    `UPDATE production_flow_events SET size_label = ? WHERE lot_number = ? AND size_label = ?`,
+    [newLabel, lotNo, oldLabel]
+  );
+  // 4) Assignment sizes_json blobs. Formats vary across tables
+  //    ({"size":..}, {"size_label":..}, ["26",..]) but every label is a quoted
+  //    token and no key/other value equals a label, so a single quoted-token
+  //    REPLACE is correct for all of them.
+  const from = '"' + oldLabel + '"';
+  const to = '"' + newLabel + '"';
+  const like = '%"' + oldLabel + '"%';
+  await conn.query(
+    `UPDATE stitching_assignments SET sizes_json = REPLACE(sizes_json, ?, ?)
+      WHERE cutting_lot_id = ? AND sizes_json LIKE ?`,
+    [from, to, lotId, like]
+  );
+  await conn.query(
+    `UPDATE jeans_assembly_assignments ja
+        JOIN stitching_assignments sa ON ja.stitching_assignment_id = sa.id
+        SET ja.sizes_json = REPLACE(ja.sizes_json, ?, ?)
+      WHERE sa.cutting_lot_id = ? AND ja.sizes_json LIKE ?`,
+    [from, to, lotId, like]
+  );
+  await conn.query(
+    `UPDATE washing_assignments wa
+        JOIN jeans_assembly_assignments ja ON wa.jeans_assembly_assignment_id = ja.id
+        JOIN stitching_assignments sa ON ja.stitching_assignment_id = sa.id
+        SET wa.sizes_json = REPLACE(wa.sizes_json, ?, ?)
+      WHERE sa.cutting_lot_id = ? AND wa.sizes_json LIKE ?`,
+    [from, to, lotId, like]
+  );
+  await conn.query(
+    `UPDATE washing_in_assignments wia
+        JOIN washing_data wd ON wia.washing_data_id = wd.id
+        SET wia.sizes_json = REPLACE(wia.sizes_json, ?, ?)
+      WHERE wd.lot_no = ? AND wia.sizes_json LIKE ?`,
+    [from, to, lotNo, like]
+  );
+  await conn.query(
+    `UPDATE finishing_assignments fa
+        JOIN washing_in_data wid ON fa.washing_in_data_id = wid.id
+        SET fa.sizes_json = REPLACE(fa.sizes_json, ?, ?)
+      WHERE wid.lot_no = ? AND fa.sizes_json LIKE ?`,
+    [from, to, lotNo, like]
+  );
+}
+
 /**
  * GET /operator/editcuttinglots
  * Renders the main page with cutting master selection.
@@ -245,13 +353,24 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
                 <!-- Sizes & Rolls Tab -->
                 <div class="tab-pane fade" id="tab-sizes" role="tabpanel">
                   <h5>Sizes & Patterns</h5>
+                  <p class="text-muted small mb-2">
+                    You can rename a <strong>Size</strong> (e.g. fix a wrong/duplicate label) and set
+                    <strong>Total Pieces</strong> per size directly. Total Pieces (lot) is the sum of all sizes below.
+                  </p>
+                  ${downstreamHits.length ? `
+                    <div class="alert alert-warning py-2 mb-2 small">
+                      <i class="bi bi-exclamation-triangle-fill"></i>
+                      <strong>Heads-up:</strong> this lot has already moved into <strong>${downstreamHits.join(', ')}</strong>.
+                      Renaming a size here will be <strong>cascaded</strong> to those stages so nothing desyncs.
+                    </div>` : ''}
                   ${sizes.map((size) => `
                     <div class="mb-3 border p-2 rounded">
                       <input type="hidden" name="size_id[]" value="${size.id}">
+                      <input type="hidden" name="orig_size_label[]" value="${size.size_label}">
                       <div class="row">
                         <div class="col-md-4">
                           <label class="form-label">Size</label>
-                          <input type="text" class="form-control" value="${size.size_label}" readonly>
+                          <input type="text" maxlength="10" class="form-control sizeLabelInput" name="size_label[]" value="${size.size_label}" required>
                         </div>
                         <div class="col-md-4">
                           <label class="form-label">Pattern Count</label>
@@ -259,7 +378,7 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
                         </div>
                         <div class="col-md-4">
                           <label class="form-label">Total Pieces (This Size)</label>
-                          <input type="number" class="form-control sizeTotalPieces" value="${size.total_pieces}" readonly>
+                          <input type="number" step="1" min="0" class="form-control sizeTotalPieces" name="size_pieces[]" value="${size.total_pieces}" required>
                         </div>
                       </div>
                     </div>
@@ -379,28 +498,18 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
           </div>
         </div>
         <script>
-          // Recalculate total pieces dynamically.
+          // Lot total = sum of the (editable) per-size piece counts.
           function recalcTotals() {
             const container = document.getElementById("editFormWrapper");
-            const patternInputs = container.querySelectorAll(".patternCountInput");
-            const layerInputs = container.querySelectorAll(".layersInput");
-            let totalPatterns = 0, totalLayers = 0;
-            patternInputs.forEach(input => {
-              totalPatterns += parseFloat(input.value) || 0;
+            const sizeTotalFields = container.querySelectorAll(".sizeTotalPieces");
+            let totalPieces = 0;
+            sizeTotalFields.forEach(input => {
+              totalPieces += parseFloat(input.value) || 0;
             });
-            layerInputs.forEach(input => {
-              totalLayers += parseFloat(input.value) || 0;
-            });
-            const totalPieces = totalPatterns * totalLayers;
             const totalDisplay = container.querySelector("#totalPiecesDisplay");
             if(totalDisplay) totalDisplay.textContent = totalPieces.toFixed(2);
-            const sizeTotalFields = container.querySelectorAll(".sizeTotalPieces");
-            patternInputs.forEach((input, idx) => {
-              const pattern = parseFloat(input.value) || 0;
-              if(sizeTotalFields[idx]) sizeTotalFields[idx].value = (pattern * totalLayers).toFixed(2);
-            });
           }
-          document.querySelectorAll(".patternCountInput, .layersInput").forEach(input => {
+          document.querySelectorAll(".sizeTotalPieces").forEach(input => {
             input.addEventListener("input", recalcTotals);
           });
           recalcTotals();
@@ -528,8 +637,14 @@ router.post('/editcuttinglots/update', isAuthenticated, isOperator, upload.none(
   const { managerId, lotId } = req.query;
   if (!managerId || !lotId) return res.status(400).json({ success: false, error: 'Manager and Lot IDs required.' });
   const { sku, fabric_type, remark } = req.body;
-  let { size_id, pattern_count } = req.body;
-  if (!Array.isArray(size_id)) { size_id = [size_id]; pattern_count = [pattern_count]; }
+  let { size_id, pattern_count, size_label, orig_size_label, size_pieces } = req.body;
+  if (!Array.isArray(size_id)) {
+    size_id = [size_id];
+    pattern_count = [pattern_count];
+    size_label = [size_label];
+    orig_size_label = [orig_size_label];
+    size_pieces = [size_pieces];
+  }
   let { roll_id, layers, weight_used } = req.body;
   if (!Array.isArray(roll_id)) { roll_id = [roll_id]; layers = [layers]; weight_used = [weight_used]; }
   let { assignment_id, assigned_to } = req.body;
@@ -550,12 +665,38 @@ router.post('/editcuttinglots/update', isAuthenticated, isOperator, upload.none(
       [sku, fabric_type, remark, lotId]
     );
 
-    let totalPatterns = 0;
+    // Need the lot_no to cascade size renames into the legacy data tables.
+    const [[lotRow]] = await conn.query(`SELECT lot_no FROM cutting_lots WHERE id = ? FOR UPDATE`, [lotId]);
+    if (!lotRow) throw new Error('Lot not found.');
+    const lotNo = lotRow.lot_no;
+
+    // Validate the resulting labels: non-empty, within length, and unique within the lot
+    // (no unique constraint exists on cutting_lot_sizes, but allowing two sizes to share
+    // a label would make downstream cascades ambiguous).
+    const newLabels = size_label.map(s => String(s == null ? '' : s).trim());
+    if (newLabels.some(l => l === '')) throw new Error('Size label cannot be empty.');
+    if (newLabels.some(l => l.length > 10)) throw new Error('Size label too long (max 10 characters).');
+    const dupLabel = newLabels.find((l, i) => newLabels.indexOf(l) !== i);
+    if (dupLabel) throw new Error(`Duplicate size label "${dupLabel}" — each size must be unique within the lot.`);
+
+    let totalPieces = 0;
     for (let i = 0; i < size_id.length; i++) {
       const newPattern = parseFloat(pattern_count[i]);
+      const newPieces = parseFloat(size_pieces[i]);
+      const newLabel = newLabels[i];
+      const oldLabel = String(orig_size_label[i] == null ? '' : orig_size_label[i]).trim();
       if (isNaN(newPattern) || newPattern < 0) throw new Error('Invalid pattern count.');
-      totalPatterns += newPattern;
-      await conn.query(`UPDATE cutting_lot_sizes SET pattern_count = ? WHERE id = ?`, [newPattern, size_id[i]]);
+      if (isNaN(newPieces) || newPieces < 0) throw new Error(`Invalid total pieces for size "${newLabel}".`);
+      totalPieces += newPieces;
+      // Per-size pieces are now authoritative (set directly), no longer derived from pattern × layers.
+      await conn.query(
+        `UPDATE cutting_lot_sizes SET size_label = ?, pattern_count = ?, total_pieces = ? WHERE id = ? AND cutting_lot_id = ?`,
+        [newLabel, newPattern, newPieces, size_id[i], lotId]
+      );
+      // Cascade a rename across every downstream stage so nothing desyncs by size_label.
+      if (oldLabel && newLabel !== oldLabel) {
+        await cascadeSizeRename(conn, lotId, lotNo, oldLabel, newLabel);
+      }
     }
 
     const rollPlaceholders = roll_id.map(() => '?').join(',');
@@ -596,9 +737,8 @@ router.post('/editcuttinglots/update', isAuthenticated, isOperator, upload.none(
       await conn.query(`UPDATE stitching_assignments SET user_id = ? WHERE id = ?`, [newAssignedTo, assignment_id[i]]);
     }
 
-    const totalPieces = totalLayers * totalPatterns;
+    // Lot total is the sum of the (now authoritative) per-size piece counts.
     await conn.query(`UPDATE cutting_lots SET total_pieces = ? WHERE id = ?`, [totalPieces, lotId]);
-    await conn.query(`UPDATE cutting_lot_sizes SET total_pieces = pattern_count * ? WHERE cutting_lot_id = ?`, [totalLayers, lotId]);
 
     await conn.commit();
     conn.release();
@@ -696,19 +836,24 @@ router.post('/editcuttinglots/add-roll', isAuthenticated, isOperator, upload.non
       [lotId, roll_no, weight_used, layers, newRollPieces, resolvedFullWeight, remaining_weight]
     );
 
-    // Recompute lot + per-size totals after the new roll
+    // Increment each size by this roll's contribution (pattern_count × new layers),
+    // preserving any manual per-size piece overrides made on the edit form. Then the
+    // lot total is the sum of the per-size pieces.
+    await conn.query(
+      `UPDATE cutting_lot_sizes SET total_pieces = total_pieces + (pattern_count * ?) WHERE cutting_lot_id = ?`,
+      [layers, lotId]
+    );
+    const [[sizeSumRow]] = await conn.query(
+      `SELECT COALESCE(SUM(total_pieces), 0) AS sum_pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ?`,
+      [lotId]
+    );
+    const newLotPieces = Number(sizeSumRow.sum_pieces) || 0;
+    await conn.query(`UPDATE cutting_lots SET total_pieces = ? WHERE id = ?`, [newLotPieces, lotId]);
     const [[layersRow]] = await conn.query(
       `SELECT COALESCE(SUM(layers), 0) AS sum_layers FROM cutting_lot_rolls WHERE cutting_lot_id = ?`,
       [lotId]
     );
     const sumLayers = Number(layersRow.sum_layers) || 0;
-    const newLotPieces = sumLayers * sumPatterns;
-
-    await conn.query(`UPDATE cutting_lots SET total_pieces = ? WHERE id = ?`, [newLotPieces, lotId]);
-    await conn.query(
-      `UPDATE cutting_lot_sizes SET total_pieces = pattern_count * ? WHERE cutting_lot_id = ?`,
-      [sumLayers, lotId]
-    );
 
     await conn.commit();
     res.json({

--- a/routes/editcuttinglots.js
+++ b/routes/editcuttinglots.js
@@ -293,6 +293,7 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
 
     if (!lotRows.length) return res.status(404).send('Lot not found.');
     const lot = lotRows[0];
+    const isDenim = (lot.flow_type === 'denim');
 
     // Rolls available in inventory for this lot's fabric_type (for the autocomplete)
     const [availableRolls] = await pool.query(
@@ -409,8 +410,12 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
                     <h5 class="mb-2"><i class="bi bi-plus-circle"></i> Add a missed roll</h5>
                     <p class="text-muted small mb-2">
                       Inserts a new roll into this lot, recomputes total pieces, and (if the roll exists in inventory) deducts the used weight from <code>fabric_invoice_rolls</code>.
-                      Enter <strong>Weight Used</strong> manually.
+                      ${isDenim ? 'Weight Used is auto-computed from <strong>table_length × layers</strong>.' : 'Enter <strong>Remaining</strong>; Weight Used is derived automatically.'}
                     </p>
+                    ${isDenim && !lot.table_length ? `
+                      <div class="alert alert-danger py-2 mb-2 small">
+                        This denim lot has no <strong>table_length</strong> — Weight Used can't be computed. Set table_length on the lot first.
+                      </div>` : ''}
                     ${downstreamHits.length ? `
                       <div class="alert alert-warning py-2 mb-2 small">
                         <i class="bi bi-exclamation-triangle-fill"></i>
@@ -436,16 +441,16 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
                       </div>
                       <div class="col-md-2">
                         <label class="form-label">Weight Used</label>
-                        <input type="number" step="0.01" min="0" class="form-control" id="addRollWeightUsed" placeholder="Weight used">
+                        <input type="number" step="0.01" min="0" class="form-control" id="addRollWeightUsed" readonly placeholder="Weight used (auto)">
                       </div>
                       <div class="col-md-2">
                         <label class="form-label">Remaining</label>
-                        <input type="number" step="0.01" class="form-control" id="addRollRemaining" readonly>
+                        <input type="number" step="0.01" min="0" class="form-control" id="addRollRemaining" ${isDenim ? 'readonly' : 'value="0"'} placeholder="${isDenim ? 'Auto' : 'Remaining (default 0)'}">
                       </div>
                     </div>
                     <div id="addRollError" class="text-danger small mt-2" style="display:none;"></div>
                     <div class="mt-3">
-                      <button type="button" class="btn btn-primary btn-sm" id="addRollBtn">
+                      <button type="button" class="btn btn-primary btn-sm" id="addRollBtn"${isDenim && !lot.table_length ? ' disabled' : ''}>
                         <i class="bi bi-plus-circle"></i> Add roll to lot
                       </button>
                     </div>
@@ -512,6 +517,8 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
 
           // ───── Add-missed-roll wiring ─────
           const ROLL_INVENTORY = ${JSON.stringify(availableRolls.map(r => ({ roll_no: r.roll_no, per_roll_weight: Number(r.per_roll_weight) || 0, unit: r.unit || '' })))};
+          const IS_DENIM = ${isDenim ? 'true' : 'false'};
+          const TABLE_LENGTH = ${lot.table_length ? Number(lot.table_length) : 'null'};
           const addRollNo        = document.getElementById('addRollNo');
           const addRollLayers    = document.getElementById('addRollLayers');
           const addRollFullW     = document.getElementById('addRollFullWeight');
@@ -521,13 +528,21 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
           const addRollErr       = document.getElementById('addRollError');
           const addRollBtn       = document.getElementById('addRollBtn');
 
-          // Weight Used is entered manually now; we only derive the Remaining display.
           function recomputeAddRollWeights() {
-            const used = parseFloat(addRollUsed.value);
             const full = parseFloat(addRollFullW.value);
-            if (isNaN(used) || isNaN(full)) { addRollRem.value = ''; addRollUsed.classList.remove('text-danger'); return; }
-            addRollRem.value = Math.max(full - used, 0).toFixed(2);
-            addRollUsed.classList.toggle('text-danger', used > full);
+            if (IS_DENIM) {
+              const layers = parseFloat(addRollLayers.value);
+              if (isNaN(layers) || TABLE_LENGTH == null) { addRollUsed.value=''; addRollRem.value=''; return; }
+              const used = TABLE_LENGTH * layers;
+              addRollUsed.value = used.toFixed(2);
+              addRollRem.value = isNaN(full) ? '' : Math.max(full - used, 0).toFixed(2);
+              addRollUsed.classList.toggle('text-danger', !isNaN(full) && used > full);
+            } else {
+              const remaining = addRollRem.value === '' ? 0 : parseFloat(addRollRem.value);
+              if (isNaN(full)) { addRollUsed.value=''; addRollUsed.classList.remove('text-danger'); return; }
+              addRollUsed.value = Math.max(full - remaining, 0).toFixed(2);
+              addRollUsed.classList.toggle('text-danger', remaining > full);
+            }
           }
           addRollNo.addEventListener('change', () => {
             const inv = ROLL_INVENTORY.find(r => r.roll_no === addRollNo.value.trim());
@@ -541,8 +556,12 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
             }
             recomputeAddRollWeights();
           });
-          addRollUsed.addEventListener('input', recomputeAddRollWeights);
           addRollFullW.addEventListener('input', recomputeAddRollWeights);
+          if (IS_DENIM) {
+            addRollLayers.addEventListener('input', recomputeAddRollWeights);
+          } else {
+            addRollRem.addEventListener('input', recomputeAddRollWeights);
+          }
 
           addRollBtn.addEventListener('click', async () => {
             addRollErr.style.display = 'none';

--- a/routes/editcuttinglots.js
+++ b/routes/editcuttinglots.js
@@ -409,17 +409,13 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
                     <h5 class="mb-2"><i class="bi bi-plus-circle"></i> Add a missed roll</h5>
                     <p class="text-muted small mb-2">
                       Inserts a new roll into this lot, recomputes total pieces, and (if the roll exists in inventory) deducts the used weight from <code>fabric_invoice_rolls</code>.
-                      Weight used auto-computes from <strong>table length × layers</strong>${lot.table_length ? ` (table length = <strong>${lot.table_length}</strong>)` : ''}.
+                      Enter <strong>Weight Used</strong> manually.
                     </p>
                     ${downstreamHits.length ? `
                       <div class="alert alert-warning py-2 mb-2 small">
                         <i class="bi bi-exclamation-triangle-fill"></i>
                         <strong>Heads-up:</strong> this lot has already moved into <strong>${downstreamHits.join(', ')}</strong>.
                         Adding pieces upstream is allowed (downstream stages track their own qty), but the next-stage master will see more pieces available than before.
-                      </div>` : ''}
-                    ${!lot.table_length ? `
-                      <div class="alert alert-danger py-2 mb-2 small">
-                        This lot has no <strong>table_length</strong> — Weight Used can't be computed. Set table_length on the lot first.
                       </div>` : ''}
                     <div class="row g-2">
                       <div class="col-md-4">
@@ -440,7 +436,7 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
                       </div>
                       <div class="col-md-2">
                         <label class="form-label">Weight Used</label>
-                        <input type="number" step="0.01" class="form-control" id="addRollWeightUsed" readonly>
+                        <input type="number" step="0.01" min="0" class="form-control" id="addRollWeightUsed" placeholder="Weight used">
                       </div>
                       <div class="col-md-2">
                         <label class="form-label">Remaining</label>
@@ -449,7 +445,7 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
                     </div>
                     <div id="addRollError" class="text-danger small mt-2" style="display:none;"></div>
                     <div class="mt-3">
-                      <button type="button" class="btn btn-primary btn-sm" id="addRollBtn"${lot.table_length ? '' : ' disabled'}>
+                      <button type="button" class="btn btn-primary btn-sm" id="addRollBtn">
                         <i class="bi bi-plus-circle"></i> Add roll to lot
                       </button>
                     </div>
@@ -515,7 +511,6 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
           recalcTotals();
 
           // ───── Add-missed-roll wiring ─────
-          const TABLE_LENGTH = ${lot.table_length ? Number(lot.table_length) : 'null'};
           const ROLL_INVENTORY = ${JSON.stringify(availableRolls.map(r => ({ roll_no: r.roll_no, per_roll_weight: Number(r.per_roll_weight) || 0, unit: r.unit || '' })))};
           const addRollNo        = document.getElementById('addRollNo');
           const addRollLayers    = document.getElementById('addRollLayers');
@@ -526,19 +521,13 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
           const addRollErr       = document.getElementById('addRollError');
           const addRollBtn       = document.getElementById('addRollBtn');
 
+          // Weight Used is entered manually now; we only derive the Remaining display.
           function recomputeAddRollWeights() {
-            const layers = parseFloat(addRollLayers.value);
-            const full   = parseFloat(addRollFullW.value);
-            if (isNaN(layers) || TABLE_LENGTH == null) { addRollUsed.value = ''; addRollRem.value = ''; return; }
-            const used = TABLE_LENGTH * layers;
-            addRollUsed.value = used.toFixed(2);
-            if (!isNaN(full)) {
-              addRollRem.value = Math.max(full - used, 0).toFixed(2);
-              addRollUsed.classList.toggle('text-danger', used > full);
-            } else {
-              addRollRem.value = '';
-              addRollUsed.classList.remove('text-danger');
-            }
+            const used = parseFloat(addRollUsed.value);
+            const full = parseFloat(addRollFullW.value);
+            if (isNaN(used) || isNaN(full)) { addRollRem.value = ''; addRollUsed.classList.remove('text-danger'); return; }
+            addRollRem.value = Math.max(full - used, 0).toFixed(2);
+            addRollUsed.classList.toggle('text-danger', used > full);
           }
           addRollNo.addEventListener('change', () => {
             const inv = ROLL_INVENTORY.find(r => r.roll_no === addRollNo.value.trim());
@@ -552,7 +541,7 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
             }
             recomputeAddRollWeights();
           });
-          addRollLayers.addEventListener('input', recomputeAddRollWeights);
+          addRollUsed.addEventListener('input', recomputeAddRollWeights);
           addRollFullW.addEventListener('input', recomputeAddRollWeights);
 
           addRollBtn.addEventListener('click', async () => {
@@ -564,7 +553,7 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
             if (!roll_no)            return showErr('Pick a roll number.');
             if (!(layers > 0))       return showErr('Layers must be greater than 0.');
             if (!(full_weight > 0))  return showErr('Full weight must be greater than 0.');
-            if (!(weight_used >= 0)) return showErr('Weight used could not be computed (check table length and layers).');
+            if (!(weight_used >= 0)) return showErr('Enter a valid Weight Used (0 or more).');
             if (weight_used > full_weight) return showErr('Weight used (' + weight_used.toFixed(2) + ') cannot exceed full weight (' + full_weight.toFixed(2) + ').');
 
             addRollBtn.disabled = true;

--- a/routes/editcuttinglots.js
+++ b/routes/editcuttinglots.js
@@ -518,7 +518,7 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
           // ───── Add-missed-roll wiring ─────
           const ROLL_INVENTORY = ${JSON.stringify(availableRolls.map(r => ({ roll_no: r.roll_no, per_roll_weight: Number(r.per_roll_weight) || 0, unit: r.unit || '' })))};
           const IS_DENIM = ${isDenim ? 'true' : 'false'};
-          const TABLE_LENGTH = ${lot.table_length ? Number(lot.table_length) : 'null'};
+          const TABLE_LENGTH = ${Number.isFinite(Number(lot.table_length)) ? Number(lot.table_length) : 'null'};
           const addRollNo        = document.getElementById('addRollNo');
           const addRollLayers    = document.getElementById('addRollLayers');
           const addRollFullW     = document.getElementById('addRollFullWeight');
@@ -528,6 +528,8 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
           const addRollErr       = document.getElementById('addRollError');
           const addRollBtn       = document.getElementById('addRollBtn');
 
+          // Mirrors CuttingWeight.computeRollWeights() in public/js/cuttingWeight.js
+          // (inlined here because this form is a server-rendered HTML fragment).
           function recomputeAddRollWeights() {
             const full = parseFloat(addRollFullW.value);
             if (IS_DENIM) {

--- a/routes/fabricManagerRoutes.js
+++ b/routes/fabricManagerRoutes.js
@@ -459,6 +459,7 @@ router.get('/analysis/export', isAuthenticated, isFabricManager, async (req, res
     const from = req.query.from || '';
     const to = req.query.to || '';
     const tab = req.query.tab || 'consumption';
+    const safeTab = ['consumption', 'ledger', 'adhoc'].includes(tab) ? tab : 'consumption';
     const data = await loadConsumptionAnalysis(from, to);
 
     const wb = new ExcelJS.Workbook();
@@ -486,7 +487,7 @@ router.get('/analysis/export', isAuthenticated, isFabricManager, async (req, res
       })));
     }
 
-    res.setHeader('Content-Disposition', `attachment; filename="fabric-${tab}.xlsx"`);
+    res.setHeader('Content-Disposition', `attachment; filename="fabric-${safeTab}.xlsx"`);
     res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
     await wb.xlsx.write(res);
     res.end();

--- a/routes/fabricManagerRoutes.js
+++ b/routes/fabricManagerRoutes.js
@@ -10,6 +10,12 @@ const ExcelJS = require('exceljs');
 const fs = require('fs');
 const fsPromises = fs.promises;
 const { body, validationResult } = require('express-validator');
+const {
+  groupConsumptionByFabricType,
+  buildRollLedger,
+  findAdHocRolls,
+  findAdHocFabricTypes,
+} = require('../utils/fabricConsumption');
 
 // Configure Multer for file uploads
 const upload = multer({ 
@@ -69,6 +75,43 @@ async function getInvoicesMap(invoiceNos) {
     const map = new Map();
     rows.forEach(r => map.set(r.invoice_no, { id: r.id, vendor_id: r.vendor_id }));
     return map;
+}
+
+// Loads + computes all analysis datasets for an optional [from, to] date range
+// (inclusive of the whole `to` day). from/to are 'YYYY-MM-DD' strings or null.
+async function loadConsumptionAnalysis(from, to) {
+  const f = from || null;
+  const t = to || null;
+  const consumptionSql = `
+    SELECT cl.fabric_type, cl.lot_no, cl.sku, cl.created_at, u.username AS cutter,
+           cl.id AS cutting_lot_id, clr.roll_no, clr.full_weight, clr.weight_used, clr.remaining_weight
+    FROM cutting_lot_rolls clr
+    JOIN cutting_lots cl ON clr.cutting_lot_id = cl.id
+    JOIN users u ON cl.user_id = u.id
+    WHERE (? IS NULL OR cl.created_at >= ?)
+      AND (? IS NULL OR cl.created_at < DATE_ADD(?, INTERVAL 1 DAY))
+    ORDER BY cl.fabric_type ASC, cl.created_at DESC`;
+  const [consumptionRows] = await pool.query(consumptionSql, [f, f, t, t]);
+
+  const [masterRows] = await pool.query(`
+    SELECT fir.roll_no, fi.fabric_type, v.name AS vendor_name, fir.per_roll_weight, fir.unit
+    FROM fabric_invoice_rolls fir
+    JOIN fabric_invoices fi ON fir.invoice_id = fi.id
+    JOIN vendors v ON fir.vendor_id = v.id`);
+
+  const [lotTypeRows] = await pool.query(`SELECT DISTINCT fabric_type FROM cutting_lots WHERE fabric_type IS NOT NULL`);
+  const [masterTypeRows] = await pool.query(`SELECT DISTINCT fabric_type FROM fabric_invoices WHERE fabric_type IS NOT NULL`);
+
+  const masterRollNos = masterRows.map(m => m.roll_no);
+  const lotFabricTypes = lotTypeRows.map(r => r.fabric_type);
+  const masterFabricTypes = masterTypeRows.map(r => r.fabric_type);
+
+  return {
+    byType: groupConsumptionByFabricType(consumptionRows),
+    ledger: buildRollLedger(consumptionRows, masterRows),
+    adHocRolls: findAdHocRolls(consumptionRows, masterRollNos),
+    adHocTypes: findAdHocFabricTypes(lotFabricTypes, masterFabricTypes),
+  };
 }
 
 /**
@@ -388,6 +431,27 @@ router.post('/insert/invoice',
         }
     }
 );
+
+// GET /fabric-manager/analysis — consumption analysis (3 tabs + date filter)
+router.get('/analysis', isAuthenticated, isFabricManager, async (req, res) => {
+  try {
+    const from = req.query.from || '';
+    const to = req.query.to || '';
+    const data = await loadConsumptionAnalysis(from, to);
+    res.render('fabricConsumptionAnalysis', {
+      user: req.session.user,
+      from, to,
+      byType: data.byType,
+      ledger: data.ledger,
+      adHocRolls: data.adHocRolls,
+      adHocTypes: data.adHocTypes,
+    });
+  } catch (err) {
+    console.error('Error loading fabric consumption analysis:', err);
+    req.flash('error', 'Failed to load fabric consumption analysis.');
+    res.redirect('/fabric-manager/dashboard');
+  }
+});
 
 /**
  * GET /fabric-manager/invoice/:id/rolls

--- a/routes/fabricManagerRoutes.js
+++ b/routes/fabricManagerRoutes.js
@@ -453,6 +453,50 @@ router.get('/analysis', isAuthenticated, isFabricManager, async (req, res) => {
   }
 });
 
+// GET /fabric-manager/analysis/export?tab=consumption|ledger|adhoc&from=&to=
+router.get('/analysis/export', isAuthenticated, isFabricManager, async (req, res) => {
+  try {
+    const from = req.query.from || '';
+    const to = req.query.to || '';
+    const tab = req.query.tab || 'consumption';
+    const data = await loadConsumptionAnalysis(from, to);
+
+    const wb = new ExcelJS.Workbook();
+
+    if (tab === 'ledger') {
+      const ws = wb.addWorksheet('Roll Ledger');
+      ws.addRow(['Roll No', 'Fabric Type', 'Vendor', 'Current Available', 'Unit', 'Total Used', 'Lots']);
+      data.ledger.forEach(r => ws.addRow([
+        r.rollNo, r.fabricType, r.vendor,
+        r.currentAvailable == null ? '' : r.currentAvailable, r.unit,
+        r.totalUsed, r.lots.join(', '),
+      ]));
+    } else if (tab === 'adhoc') {
+      const ws1 = wb.addWorksheet('Ad-hoc Rolls');
+      ws1.addRow(['Roll No', 'Fabric Type', 'Full', 'Used', 'Lot No', 'Cutter']);
+      data.adHocRolls.forEach(r => ws1.addRow([r.rollNo, r.fabricType, r.full, r.used, r.lotNo, r.cutter]));
+      const ws2 = wb.addWorksheet('Ad-hoc Fabric Types');
+      ws2.addRow(['Fabric Type (not in fabric data)']);
+      data.adHocTypes.forEach(ft => ws2.addRow([ft]));
+    } else {
+      const ws = wb.addWorksheet('Consumption by Fabric Type');
+      ws.addRow(['Fabric Type', 'Lot No', 'SKU', 'Created At', 'Cutter', 'Roll No', 'Full', 'Used', 'Remaining']);
+      data.byType.forEach(g => g.lots.forEach(l => l.rolls.forEach(roll => {
+        ws.addRow([g.fabricType, l.lotNo, l.sku, l.createdAt, l.cutter, roll.rollNo, roll.full, roll.used, roll.remaining]);
+      })));
+    }
+
+    res.setHeader('Content-Disposition', `attachment; filename="fabric-${tab}.xlsx"`);
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error('Error exporting fabric analysis:', err);
+    req.flash('error', 'Failed to export fabric analysis.');
+    res.redirect('/fabric-manager/analysis');
+  }
+});
+
 /**
  * GET /fabric-manager/invoice/:id/rolls
  * View rolls for a specific fabric invoice.

--- a/routes/inventoryOpsRoutes.js
+++ b/routes/inventoryOpsRoutes.js
@@ -401,7 +401,7 @@ router.get('/logs/fetch-live', isAuthenticated, allowRoles(['wishlinkops', 'mohi
   }
 
   const warehouseKey = warehouseName.toLowerCase();
-  const { getInventoryFromApi, isConfigured } = require('../utils/easyecomReturnsClient');
+  const { fetchFullInventoryReport, isConfigured } = require('../utils/easyecomReturnsClient');
 
   if (!isConfigured(warehouseName)) {
     return res.status(500).json({ error: `EasyEcom API not configured for warehouse: ${warehouseName}` });
@@ -477,7 +477,7 @@ router.get('/logs/fetch-live', isAuthenticated, allowRoles(['wishlinkops', 'mohi
   });
 
   try {
-    sendEvent('start', { jobId, warehouse: warehouseName, message: 'Starting inventory fetch...' });
+    sendEvent('start', { jobId, warehouse: warehouseName, message: 'Queueing inventory report at EasyEcom...' });
 
     const tempDir = os.tmpdir();
     const filePath = path.join(tempDir, `inventory_${jobId}.csv`);
@@ -503,38 +503,80 @@ router.get('/logs/fetch-live', isAuthenticated, allowRoles(['wishlinkops', 'mohi
       'Source Batch Code', 'Remarks', 'Force Allocate',
     ]);
 
-    let rowCount = 0;
-
-    for await (const item of getInventoryFromApi(warehouseName)) {
-      const currentJob = activeDownloads.get(warehouseKey);
-      if (currentJob?.cancelled) {
-        activeDownloads.delete(warehouseKey);
-        csvStream.end();
-        try { fs.unlinkSync(filePath); } catch (_) {}
-        sendEvent('error', { message: 'Download cancelled' });
-        res.end();
-        return;
+    // Adaptive header pickup — FULL_INVENTORY_REPORT column names are not
+    // contract-stable, so we try common variants.
+    const pickField = (row, candidates) => {
+      for (const k of candidates) {
+        if (row[k] !== undefined && row[k] !== null && String(row[k]).trim() !== '') return row[k];
       }
+      return undefined;
+    };
+    const SKU_KEYS  = ['sku', 'SKU', 'Sku', 'Product Code', 'Product Code*', 'productCode', 'product_code'];
+    const QTY_KEYS  = ['available', 'Available', 'availableInventory', 'Available Quantity', 'Available Qty', 'Qty Available', 'qty', 'Quantity', 'Quantity*', 'Inventory', 'inventoryCount', 'inventory_count', 'Stock'];
+    const BIN_KEYS  = ['Shelf Code', 'Shelf Code*', 'Shelf', 'shelf', 'shelf_code', 'Bin', 'Bin Code', 'bin', 'bin_code', 'Location', 'Location Key', 'location_key', 'Sub Location', 'sub_location'];
+
+    const onProgress = (info) => {
+      const elapsed = Math.round((Date.now() - startTime) / 1000);
+      const job = activeDownloads.get(warehouseKey);
+      const rowCount = job?.rowCount || 0;
+      let message;
+      switch (info.phase) {
+        case 'queueing':       message = 'Queueing report at EasyEcom...'; break;
+        case 'queued':         message = `Report queued (id ${info.reportId}). Waiting for generation...`; break;
+        case 'polling':        message = `Report status: ${info.status || 'pending'} (${info.elapsed || elapsed}s)`; break;
+        case 'downloading':    message = 'Report ready. Downloading CSV...'; break;
+        case 'downloading_s3': message = 'Downloading CSV from S3...'; break;
+        case 'parsing':        message = 'Parsing CSV...'; break;
+        case 'parsed':         message = `Parsed ${(info.rowCount || 0).toLocaleString()} rows. Writing output...`; break;
+        default:               message = info.phase;
+      }
+      sendEvent('progress', { fetched: rowCount, message, elapsed });
+    };
+
+    const reportRows = await fetchFullInventoryReport(
+      warehouseName,
+      { statuses: 'Available' },
+      onProgress
+    );
+
+    // Cancellation check between phases (we cannot interrupt EasyEcom's
+    // server-side report generation, but we can abandon the write).
+    if (activeDownloads.get(warehouseKey)?.cancelled) {
+      activeDownloads.delete(warehouseKey);
+      csvStream.end();
+      try { fs.unlinkSync(filePath); } catch (_) {}
+      sendEvent('error', { message: 'Download cancelled' });
+      res.end();
+      return;
+    }
+
+    let rowCount = 0;
+    let skipped = 0;
+    for (const r of reportRows) {
+      const sku = pickField(r, SKU_KEYS);
+      if (!sku) { skipped++; continue; }
+      const qtyRaw = pickField(r, QTY_KEYS);
+      const qty = qtyRaw === undefined ? 0 : (Number(qtyRaw) || 0);
+      const shelf = pickField(r, BIN_KEYS) || 'default';
 
       const drainPromise = writeRow([
-        item.sku, item.total_qty, 'default', 'replace',
+        sku, qty, shelf, 'replace',
         '', '', '', '', '', '',
       ]);
       if (drainPromise) await drainPromise;
       rowCount++;
 
-      if (rowCount % 100 === 0) {
-        activeDownloads.set(warehouseKey, { jobId, startTime, rowCount, cancelled: false });
-      }
-
       if (rowCount % 500 === 0) {
+        activeDownloads.set(warehouseKey, { jobId, startTime, rowCount, cancelled: false });
         sendEvent('progress', {
           fetched: rowCount,
-          message: `Fetched ${rowCount.toLocaleString()} SKUs...`,
+          message: `Wrote ${rowCount.toLocaleString()} rows...`,
           elapsed: Math.round((Date.now() - startTime) / 1000)
         });
       }
     }
+    activeDownloads.set(warehouseKey, { jobId, startTime, rowCount, cancelled: false });
+    if (skipped) console.log(`[fetch-live/report] skipped ${skipped} rows missing SKU for ${warehouseName}`);
 
     await new Promise((resolve, reject) => {
       csvStream.end((err) => (err ? reject(err) : resolve()));

--- a/routes/inventoryOpsRoutes.js
+++ b/routes/inventoryOpsRoutes.js
@@ -521,6 +521,7 @@ router.get('/logs/fetch-live', isAuthenticated, allowRoles(['wishlinkops', 'mohi
       const rowCount = job?.rowCount || 0;
       let message;
       switch (info.phase) {
+        case 'resolving_locations': message = 'Resolving warehouse locations...'; break;
         case 'queueing':       message = 'Queueing report at EasyEcom...'; break;
         case 'queued':         message = `Report queued (id ${info.reportId}). Waiting for generation...`; break;
         case 'polling':        message = `Report status: ${info.status || 'pending'} (${info.elapsed || elapsed}s)`; break;

--- a/test/cuttingWeight.test.js
+++ b/test/cuttingWeight.test.js
@@ -1,0 +1,47 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { computeRollWeights } = require('../public/js/cuttingWeight.js');
+
+test('denim: used = tableLength * layers, remaining = full - used', () => {
+  const r = computeRollWeights('denim', { tableLength: 1.5, layers: 8, full: 50 });
+  assert.strictEqual(r.used, 12);
+  assert.strictEqual(r.remaining, 38);
+  assert.strictEqual(r.over, false);
+});
+
+test('denim: over-weight flags and clamps remaining to 0', () => {
+  const r = computeRollWeights('denim', { tableLength: 10, layers: 8, full: 50 });
+  assert.strictEqual(r.used, 80);
+  assert.strictEqual(r.remaining, 0);
+  assert.strictEqual(r.over, true);
+});
+
+test('denim: missing tableLength or layers yields nulls', () => {
+  const r = computeRollWeights('denim', { tableLength: '', layers: 8, full: 50 });
+  assert.strictEqual(r.used, null);
+  assert.strictEqual(r.remaining, null);
+});
+
+test('hosiery: used = full - remaining', () => {
+  const r = computeRollWeights('hosiery', { full: 30, remaining: 4 });
+  assert.strictEqual(r.used, 26);
+  assert.strictEqual(r.remaining, 4);
+  assert.strictEqual(r.over, false);
+});
+
+test('hosiery: empty remaining defaults to 0 so used = full', () => {
+  const r = computeRollWeights('hosiery', { full: 30, remaining: '' });
+  assert.strictEqual(r.used, 30);
+  assert.strictEqual(r.remaining, 0);
+});
+
+test('hosiery: remaining > full flags over and clamps used to 0', () => {
+  const r = computeRollWeights('hosiery', { full: 30, remaining: 40 });
+  assert.strictEqual(r.used, 0);
+  assert.strictEqual(r.over, true);
+});
+
+test('hosiery: missing full yields null used', () => {
+  const r = computeRollWeights('hosiery', { full: '', remaining: 5 });
+  assert.strictEqual(r.used, null);
+});

--- a/test/fabricConsumption.test.js
+++ b/test/fabricConsumption.test.js
@@ -1,0 +1,54 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  groupConsumptionByFabricType,
+  buildRollLedger,
+  findAdHocRolls,
+  findAdHocFabricTypes,
+} = require('../utils/fabricConsumption.js');
+
+const rows = [
+  { fabric_type: 'Denim', lot_no: 'L1', sku: 'S1', created_at: '2026-05-01', cutter: 'amy', cutting_lot_id: 1, roll_no: 'R1', full_weight: 50, weight_used: 12, remaining_weight: 38 },
+  { fabric_type: 'Denim', lot_no: 'L1', sku: 'S1', created_at: '2026-05-01', cutter: 'amy', cutting_lot_id: 1, roll_no: 'R2', full_weight: 40, weight_used: 10, remaining_weight: 30 },
+  { fabric_type: 'Denim', lot_no: 'L2', sku: 'S2', created_at: '2026-05-02', cutter: 'amy', cutting_lot_id: 2, roll_no: 'R1', full_weight: 38, weight_used: 8,  remaining_weight: 30 },
+  { fabric_type: 'Cotton', lot_no: 'L3', sku: 'S3', created_at: '2026-05-03', cutter: 'bob', cutting_lot_id: 3, roll_no: 'X9', full_weight: 20, weight_used: 5,  remaining_weight: 15 },
+];
+
+test('groupConsumptionByFabricType aggregates per type and lot', () => {
+  const g = groupConsumptionByFabricType(rows);
+  const denim = g.find(x => x.fabricType === 'Denim');
+  assert.strictEqual(denim.totalUsed, 30);
+  assert.strictEqual(denim.lotCount, 2);
+  assert.strictEqual(denim.rollCount, 3);
+  const l1 = denim.lots.find(l => l.lotNo === 'L1');
+  assert.strictEqual(l1.totalUsed, 22);
+  assert.strictEqual(l1.rolls.length, 2);
+});
+
+test('buildRollLedger sums used per roll across lots and resolves master', () => {
+  const master = [
+    { roll_no: 'R1', fabric_type: 'Denim', vendor_name: 'Acme', per_roll_weight: 30, unit: 'kg' },
+    { roll_no: 'R2', fabric_type: 'Denim', vendor_name: 'Acme', per_roll_weight: 30, unit: 'kg' },
+  ];
+  const ledger = buildRollLedger(rows, master);
+  const r1 = ledger.find(r => r.rollNo === 'R1');
+  assert.strictEqual(r1.totalUsed, 20);            // 12 + 8
+  assert.strictEqual(r1.currentAvailable, 30);
+  assert.strictEqual(r1.vendor, 'Acme');
+  assert.deepStrictEqual(r1.lots.sort(), ['L1', 'L2']);
+  const x9 = ledger.find(r => r.rollNo === 'X9');
+  assert.strictEqual(x9.currentAvailable, null);   // ad-hoc, not in master
+  assert.strictEqual(x9.vendor, '(ad-hoc)');
+});
+
+test('findAdHocRolls returns rolls absent from master', () => {
+  const adhoc = findAdHocRolls(rows, ['R1', 'R2']);
+  assert.strictEqual(adhoc.length, 1);
+  assert.strictEqual(adhoc[0].rollNo, 'X9');
+  assert.strictEqual(adhoc[0].lotNo, 'L3');
+});
+
+test('findAdHocFabricTypes is case-insensitive and deduped', () => {
+  const adhoc = findAdHocFabricTypes(['Denim', 'cotton', 'Linen', 'LINEN'], ['Denim', 'Cotton']);
+  assert.deepStrictEqual(adhoc, ['Linen']);
+});

--- a/utils/easyecomReturnsClient.js
+++ b/utils/easyecomReturnsClient.js
@@ -908,22 +908,49 @@ async function fetchStatusWiseStockReport(warehouse = 'faridabad') {
   return waitForAndDownloadReport(reportId, warehouse);
 }
 
+// Per-warehouse cache of comma-joined location_key strings. EasyEcom requires
+// `selectedLocations` for FULL_INVENTORY_REPORT and the keys are stable, so we
+// only fetch them once per process.
+const cachedLocationKeys = {};
+
+async function getAllLocationKeys(warehouse = 'faridabad') {
+  const key = warehouse.toLowerCase();
+  if (cachedLocationKeys[key]) return cachedLocationKeys[key];
+  const api = await ensureAxiosForWarehouse(warehouse, 30000);
+  const resp = await api.get('/getAllLocation');
+  const rows = resp.data?.data || [];
+  const keys = rows
+    .map(r => r.location_key || r.locationKey || r.token)
+    .filter(Boolean)
+    .map(String);
+  if (!keys.length) {
+    throw new Error(`/getAllLocation returned no location_key entries for ${warehouse}`);
+  }
+  const joined = keys.join(',');
+  cachedLocationKeys[key] = joined;
+  return joined;
+}
+
 // FULL_INVENTORY_REPORT — queues, polls, follows the S3 downloadUrl if present,
 // and returns parsed rows. Emits onProgress({phase, status, elapsed, reportId})
 // callbacks so the SSE route can stream user-visible progress while the report
-// bakes server-side at EasyEcom.
+// bakes server-side at EasyEcom. `selectedLocations` is required by EasyEcom;
+// if caller omits it, we auto-discover via /getAllLocation.
 async function fetchFullInventoryReport(
   warehouse = 'faridabad',
   { statuses = 'Available', locations = '', skus = '', bins = '' } = {},
   onProgress = () => {}
 ) {
+  onProgress({ phase: 'resolving_locations' });
+  const selectedLocations = locations || await getAllLocationKeys(warehouse);
+
   const params = {
     skus,
     bins,
     inventoryStatuses: statuses,
+    selectedLocations,
     uomDetails: 1,
   };
-  if (locations) params.selectedLocations = locations;
 
   onProgress({ phase: 'queueing' });
   const reportId = await queueReport('FULL_INVENTORY_REPORT', params, warehouse);

--- a/utils/easyecomReturnsClient.js
+++ b/utils/easyecomReturnsClient.js
@@ -947,9 +947,26 @@ async function getAllLocationKeys(warehouse = 'faridabad') {
       .map(String);
   }
 
+  // Final fallback: probe one inventory row via getInventoryDetailsV3 — it
+  // always returns location_key per item. Single small call (limit=1).
   if (!extracted.length) {
-    const sampleShape = rows[0] ? JSON.stringify(rows[0]).slice(0, 300) : 'no rows';
-    throw new Error(`No location keys resolved for ${warehouse}. Last sample: ${sampleShape}`);
+    try {
+      const resp = await api.get('/getInventoryDetailsV3', { params: { limit: 1, includeLocations: 1 } });
+      const items = resp.data?.data?.inventoryData || [];
+      const seen = new Set();
+      for (const it of items) {
+        const k = it.location_key || it.locationKey;
+        if (k) seen.add(String(k));
+      }
+      extracted = Array.from(seen);
+      console.log(`[getAllLocationKeys:${warehouse}] inventory probe yielded ${extracted.length} key(s): ${extracted.join(',')}`);
+    } catch (err) {
+      console.warn(`[getAllLocationKeys:${warehouse}] inventory probe failed: ${err.response?.status || ''} ${err.message}`);
+    }
+  }
+
+  if (!extracted.length) {
+    throw new Error(`No location keys resolved for ${warehouse}. /getAllLocation, /account/v1/api/locations and inventory probe all empty.`);
   }
 
   const joined = extracted.join(',');

--- a/utils/easyecomReturnsClient.js
+++ b/utils/easyecomReturnsClient.js
@@ -917,17 +917,44 @@ async function getAllLocationKeys(warehouse = 'faridabad') {
   const key = warehouse.toLowerCase();
   if (cachedLocationKeys[key]) return cachedLocationKeys[key];
   const api = await ensureAxiosForWarehouse(warehouse, 30000);
-  const resp = await api.get('/getAllLocation');
-  const rows = resp.data?.data || [];
-  const keys = rows
-    .map(r => r.location_key || r.locationKey || r.token)
+
+  const FIELD_CANDIDATES = ['location_key', 'locationKey', 'token', 'location_token', 'companyToken', 'company_token', 'key'];
+  const tryEndpoint = async (path) => {
+    try {
+      const resp = await api.get(path);
+      const data = resp.data?.data ?? resp.data ?? [];
+      const rows = Array.isArray(data) ? data : (data?.locations || data?.companies || []);
+      const sample = JSON.stringify(rows[0] || {}).slice(0, 400);
+      console.log(`[getAllLocationKeys:${warehouse}] ${path} → ${rows.length} rows. Sample keys: ${rows[0] ? Object.keys(rows[0]).join(',') : 'n/a'}. Sample: ${sample}`);
+      return rows;
+    } catch (err) {
+      console.warn(`[getAllLocationKeys:${warehouse}] ${path} failed: ${err.response?.status || ''} ${err.message}`);
+      return [];
+    }
+  };
+
+  let rows = await tryEndpoint('/getAllLocation');
+  let extracted = rows
+    .map(r => FIELD_CANDIDATES.map(f => r[f]).find(Boolean))
     .filter(Boolean)
     .map(String);
-  if (!keys.length) {
-    throw new Error(`/getAllLocation returned no location_key entries for ${warehouse}`);
+
+  if (!extracted.length) {
+    rows = await tryEndpoint('/account/v1/api/locations');
+    extracted = rows
+      .map(r => FIELD_CANDIDATES.map(f => r[f]).find(Boolean))
+      .filter(Boolean)
+      .map(String);
   }
-  const joined = keys.join(',');
+
+  if (!extracted.length) {
+    const sampleShape = rows[0] ? JSON.stringify(rows[0]).slice(0, 300) : 'no rows';
+    throw new Error(`No location keys resolved for ${warehouse}. Last sample: ${sampleShape}`);
+  }
+
+  const joined = extracted.join(',');
   cachedLocationKeys[key] = joined;
+  console.log(`[getAllLocationKeys:${warehouse}] Resolved ${extracted.length} location key(s): ${joined.slice(0, 200)}`);
   return joined;
 }
 

--- a/utils/easyecomReturnsClient.js
+++ b/utils/easyecomReturnsClient.js
@@ -908,6 +908,82 @@ async function fetchStatusWiseStockReport(warehouse = 'faridabad') {
   return waitForAndDownloadReport(reportId, warehouse);
 }
 
+// FULL_INVENTORY_REPORT — queues, polls, follows the S3 downloadUrl if present,
+// and returns parsed rows. Emits onProgress({phase, status, elapsed, reportId})
+// callbacks so the SSE route can stream user-visible progress while the report
+// bakes server-side at EasyEcom.
+async function fetchFullInventoryReport(
+  warehouse = 'faridabad',
+  { statuses = 'Available', locations = '', skus = '', bins = '' } = {},
+  onProgress = () => {}
+) {
+  const params = {
+    skus,
+    bins,
+    inventoryStatuses: statuses,
+    uomDetails: 1,
+  };
+  if (locations) params.selectedLocations = locations;
+
+  onProgress({ phase: 'queueing' });
+  const reportId = await queueReport('FULL_INVENTORY_REPORT', params, warehouse);
+  onProgress({ phase: 'queued', reportId });
+
+  const api = await ensureAxiosForWarehouse(warehouse, 120000);
+  const pollIntervalMs = 5000;
+  const maxWaitMs = 900000; // 15 min — FULL_INVENTORY can be slower than smaller reports
+  const start = Date.now();
+  let ready = false;
+  let lastStatus = '';
+  while (Date.now() - start < maxWaitMs) {
+    let entry = null;
+    try {
+      const list = await listReports(warehouse);
+      entry = (Array.isArray(list) ? list : []).find(r =>
+        String(r.reportId || r.id || r.report_id) === String(reportId)
+      );
+    } catch (_) {}
+    const status = (entry?.status || entry?.report_status || entry?.reportStatus || '').toString().toLowerCase();
+    if (status && status !== lastStatus) {
+      lastStatus = status;
+      onProgress({ phase: 'polling', reportId, status, elapsed: Math.round((Date.now() - start) / 1000) });
+    }
+    if (status.includes('complete') || status.includes('ready') || status === 'done') { ready = true; break; }
+    if (status.includes('fail') || status.includes('error')) {
+      throw new Error(`Report ${reportId} failed: ${JSON.stringify(entry).slice(0, 200)}`);
+    }
+    await new Promise(r => setTimeout(r, pollIntervalMs));
+  }
+  if (!ready) throw new Error(`Report ${reportId} timed out after ${maxWaitMs}ms`);
+
+  onProgress({ phase: 'downloading', reportId });
+  const dl = await api.get('/reports/download', { params: { reportId }, responseType: 'text' });
+  const raw = typeof dl.data === 'string' ? dl.data : JSON.stringify(dl.data);
+
+  // EasyEcom may return either (a) raw CSV directly, or (b) a JSON envelope
+  // `{ data: { reportStatus, downloadUrl } }` pointing at a pre-signed S3 CSV.
+  // Handle both.
+  let csvText = raw;
+  if (raw && raw.trimStart().startsWith('{')) {
+    try {
+      const env = JSON.parse(raw);
+      const url = env?.data?.downloadUrl || env?.downloadUrl;
+      if (url) {
+        onProgress({ phase: 'downloading_s3', reportId });
+        const s3 = await axios.get(url, { timeout: 600000, responseType: 'text' });
+        csvText = typeof s3.data === 'string' ? s3.data : JSON.stringify(s3.data);
+      }
+    } catch (_) {
+      // Fall through and treat `raw` as CSV.
+    }
+  }
+
+  onProgress({ phase: 'parsing', reportId });
+  const rows = parseCsv(csvText);
+  onProgress({ phase: 'parsed', reportId, rowCount: rows.length });
+  return rows;
+}
+
 module.exports = {
   // Order operations
   getOrder,
@@ -937,6 +1013,7 @@ module.exports = {
   queueReport,
   listReports,
   waitForAndDownloadReport,
+  fetchFullInventoryReport,
   fetchMiniSalesReport,
   fetchInventoryAgingReport,
   fetchStatusWiseStockReport,

--- a/utils/fabricConsumption.js
+++ b/utils/fabricConsumption.js
@@ -1,0 +1,109 @@
+// Pure transforms for the fabric-manager consumption analysis page.
+// Input rows come from SQL (cutting_lot_rolls joined to cutting_lots + users).
+function round2(n) {
+  return Math.round((Number(n) || 0) * 100) / 100;
+}
+
+// rows: [{ fabric_type, lot_no, sku, created_at, cutter, cutting_lot_id, roll_no, full_weight, weight_used, remaining_weight }]
+function groupConsumptionByFabricType(rows) {
+  const byType = new Map();
+  for (const r of rows) {
+    const ft = r.fabric_type || '(none)';
+    if (!byType.has(ft)) byType.set(ft, { fabricType: ft, totalUsed: 0, lots: new Map() });
+    const g = byType.get(ft);
+    g.totalUsed += Number(r.weight_used) || 0;
+    if (!g.lots.has(r.cutting_lot_id)) {
+      g.lots.set(r.cutting_lot_id, {
+        lotNo: r.lot_no, sku: r.sku, createdAt: r.created_at, cutter: r.cutter, totalUsed: 0, rolls: [],
+      });
+    }
+    const lot = g.lots.get(r.cutting_lot_id);
+    lot.totalUsed += Number(r.weight_used) || 0;
+    lot.rolls.push({
+      rollNo: r.roll_no,
+      full: round2(r.full_weight),
+      used: round2(r.weight_used),
+      remaining: round2(r.remaining_weight),
+    });
+  }
+  return [...byType.values()].map(g => {
+    const lots = [...g.lots.values()].map(l => ({ ...l, totalUsed: round2(l.totalUsed) }));
+    return {
+      fabricType: g.fabricType,
+      totalUsed: round2(g.totalUsed),
+      lotCount: lots.length,
+      rollCount: lots.reduce((n, l) => n + l.rolls.length, 0),
+      lots,
+    };
+  });
+}
+
+// masterRows: [{ roll_no, fabric_type, vendor_name, per_roll_weight, unit }]
+function buildRollLedger(consumptionRows, masterRows) {
+  const master = new Map((masterRows || []).map(m => [m.roll_no, m]));
+  const byRoll = new Map();
+  for (const r of consumptionRows) {
+    if (!byRoll.has(r.roll_no)) {
+      const m = master.get(r.roll_no);
+      byRoll.set(r.roll_no, {
+        rollNo: r.roll_no,
+        fabricType: (m && m.fabric_type) || r.fabric_type || '(none)',
+        vendor: (m && m.vendor_name) || '(ad-hoc)',
+        currentAvailable: m ? round2(m.per_roll_weight) : null,
+        unit: (m && m.unit) || '',
+        totalUsed: 0,
+        lots: [],
+      });
+    }
+    const e = byRoll.get(r.roll_no);
+    e.totalUsed += Number(r.weight_used) || 0;
+    e.lots.push(r.lot_no);
+  }
+  return [...byRoll.values()].map(e => ({
+    ...e,
+    totalUsed: round2(e.totalUsed),
+    lots: [...new Set(e.lots)],
+  }));
+}
+
+function findAdHocRolls(consumptionRows, masterRollNos) {
+  const set = new Set(masterRollNos || []);
+  const out = new Map();
+  for (const r of consumptionRows) {
+    if (set.has(r.roll_no)) continue;
+    const key = r.roll_no + '|' + r.cutting_lot_id;
+    if (!out.has(key)) {
+      out.set(key, {
+        rollNo: r.roll_no,
+        fabricType: r.fabric_type || '(none)',
+        full: round2(r.full_weight),
+        used: round2(r.weight_used),
+        lotNo: r.lot_no,
+        cutter: r.cutter,
+      });
+    }
+  }
+  return [...out.values()];
+}
+
+function findAdHocFabricTypes(lotFabricTypes, masterFabricTypes) {
+  const master = new Set((masterFabricTypes || []).map(s => (s || '').toLowerCase().trim()));
+  const seen = new Set();
+  const out = [];
+  for (const ft of lotFabricTypes || []) {
+    if (!ft) continue;
+    const key = ft.toLowerCase().trim();
+    if (master.has(key) || seen.has(key)) continue;
+    seen.add(key);
+    out.push(ft);
+  }
+  return out;
+}
+
+module.exports = {
+  round2,
+  groupConsumptionByFabricType,
+  buildRollLedger,
+  findAdHocRolls,
+  findAdHocFabricTypes,
+};

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -746,7 +746,7 @@ function initializeRollNoAutocomplete(rollSection, fabricType) {
       rollSection.querySelector('.availableWeightTxt').textContent = '0';
       fullWeightInput.readOnly = false;
       fullWeightInput.value = '';
-      remainingWeightInput.value = '';
+      remainingWeightInput.value = (FLOW_MODE === 'hosiery') ? '0' : '';
     }
     updateWeightUsed(rollSection);
     updateWeightProgress(rollSection);
@@ -868,7 +868,7 @@ function populateRollNos(selectedFabricType) {
     rollSection.querySelector('.availableWeightTxt').textContent = '0';
     rollSection.querySelector('.weightUsedInput').value = '';
     rollSection.querySelector('.fullWeightInput').value = '';
-    rollSection.querySelector('.remainingWeightInput').value = '';
+    rollSection.querySelector('.remainingWeightInput').value = (FLOW_MODE === 'hosiery') ? '0' : '';
     rollSection.querySelector('.fullWeightInput').readOnly = false;
     const progressBar = rollSection.querySelector('.kotty-progress-bar');
     progressBar.style.width = '0%';
@@ -888,6 +888,18 @@ fabricTypeSel.addEventListener('change', () => {
 
 addSizeBtn.addEventListener('click', addNewSize);
 addRollBtn.addEventListener('click', addNewRoll);
+
+(function attachRemainingNormalizer() {
+  const lotForm = document.getElementById('lotForm');
+  if (!lotForm) return;
+  lotForm.addEventListener('submit', () => {
+    if (FLOW_MODE !== 'hosiery') return;
+    rollsContainer.querySelectorAll('.roll-section:not(.d-none) .remainingWeightInput').forEach(inp => {
+      if (inp.value === '' || inp.value === null) inp.value = '0';
+    });
+  });
+})();
+
 addNewSize();
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -457,7 +457,7 @@
                 </div>
                 <div class="col-md-4">
                   <label for="table_length" class="kotty-form-label"><i class="bi bi-rulers"></i><span data-i18n="tableLengthLabel">Table Length</span></label>
-                  <input type="number" class="kotty-input" id="table_length" name="table_length" placeholder="Enter table length" min="0" step="0.01" />
+                  <input type="number" class="kotty-input" id="table_length" name="table_length" <%= isDenim ? 'required' : '' %> placeholder="<%= isDenim ? 'Table length (required for denim)' : 'Table length (optional)' %>" min="0" step="0.01" />
                 </div>
                 <div class="col-md-4">
                   <label for="remark" class="kotty-form-label"><i class="bi bi-chat-left-text"></i><span data-i18n="remarkLabel">Remark</span></label>
@@ -550,7 +550,7 @@
       </div>
       <div class="col-md-4">
         <label class="kotty-form-label" data-i18n="weightUsedLabel">Weight Used</label>
-        <input type="number" step="0.01" class="kotty-input weightUsedInput" name="weight_used[]" min="0" required placeholder="Weight used" />
+        <input type="number" step="0.01" class="kotty-input weightUsedInput" name="weight_used[]" min="0" readonly placeholder="Weight used (auto)" />
       </div>
     </div>
     <div class="row g-3 mt-1">
@@ -560,7 +560,7 @@
       </div>
       <div class="col-md-6">
         <label class="kotty-form-label" data-i18n="remainingWeightLabel">Remaining Weight</label>
-        <input type="number" step="0.01" class="kotty-input remainingWeightInput" name="roll_remaining_weight[]" min="0" required readonly placeholder="Auto (full − used)" />
+        <input type="number" step="0.01" class="kotty-input remainingWeightInput" name="roll_remaining_weight[]" min="0" <%= isDenim ? 'readonly' : 'value="0"' %> placeholder="<%= isDenim ? 'Auto (full − used)' : 'Remaining (default 0)' %>" />
       </div>
     </div>
     <div class="mt-3">
@@ -573,7 +573,11 @@
   </div>
 </div>
 
+<script src="/public/js/cuttingWeight.js"></script>
 <script>
+const IS_DENIM = <%= isDenim ? 'true' : 'false' %>;
+const FLOW_MODE = IS_DENIM ? 'denim' : 'hosiery';
+
 const langData = {
   en: { cuttingManagerDashboardTitle: "Cutting Manager Dashboard", welcomeUser: "Welcome", existingCuttingLots: "Existing Cutting Lots", createNewCuttingLot: "Create New Cutting Lot", idLabel: "ID", lotNumberLabel: "Lot Number", skuLabel: "SKU", fabricTypeLabel: "Fabric Type", tableLengthLabel: "Table Length", remarkLabel: "Remark", imageLabel: "Image", createdByLabel: "Created By", creationTimeLabel: "Creation Time", totalPiecesLabel: "Total Pieces", sizesLabel: "Sizes", actionsLabel: "Actions", noCuttingLotsAvailable: "No cutting lots available.", sizeLabel: "Size", patternCountLabel: "Pattern Count", lotNumberGenerated: "Lot Number (Generated)", createLotBtn: "Create Lot", remove: "Remove", rollNumber: "Roll Number", layersLabel: "Layers", weightUsedLabel: "Weight Used (Calculated)", weightUsageProgress: "Weight Usage Progress", availableLabel: "Available", sizesAndPatterns: "Sizes and Patterns", rollsUsed: "Rolls Used", addNewSize: "Add New Size", addAnotherRoll: "Add Another Roll", totalPiecesCalc: "Total Pieces (Calculated)", fullWeightLabel: "Full Roll Weight", remainingWeightLabel: "Remaining Weight" },
   hi: { cuttingManagerDashboardTitle: "काटिंग मैनेजर डैशबोर्ड", welcomeUser: "स्वागत हे", existingCuttingLots: "मौजूदा काटिंग लॉट्स", createNewCuttingLot: "नया काटिंग लॉट बनाएं", idLabel: "आईडी", lotNumberLabel: "लॉट नंबर", skuLabel: "एसकेयू", fabricTypeLabel: "फैब्रिक प्रकार", tableLengthLabel: "टेबल लंबाई", remarkLabel: "टिप्पणी", imageLabel: "छवि", createdByLabel: "बनाने वाले", creationTimeLabel: "बनाने का समय", totalPiecesLabel: "कुल पीस", sizesLabel: "साइज़", actionsLabel: "कार्रवाई", noCuttingLotsAvailable: "कोई काटिंग लॉट उपलब्ध नहीं है।", sizeLabel: "साइज़", patternCountLabel: "पैटर्न की संख्या", lotNumberGenerated: "लॉट नंबर (सिस्टम द्वारा तैयार)", createLotBtn: "लॉट तैयार करें", remove: "हटाएं", rollNumber: "रोल नंबर", layersLabel: "लेयर्स", weightUsedLabel: "उपयोग किया गया वज़न (गणना)", weightUsageProgress: "वज़न उपयोग की प्रगति", availableLabel: "उपलब्ध", sizesAndPatterns: "साइज़ और पैटर्न", rollsUsed: "उपयोग किए गए रोल्स", addNewSize: "नया साइज़ जोड़ें", addAnotherRoll: "एक और रोल जोड़ें", totalPiecesCalc: "कुल पीस (हिसाब से)", fullWeightLabel: "रोल का कुल वज़न", remainingWeightLabel: "बचा हुआ वज़न" }
@@ -765,6 +769,11 @@ function initializeRollNoAutocomplete(rollSection, fabricType) {
     updateWeightProgress(rollSection);
     checkRollsCompletion();
   });
+  remainingWeightInput.addEventListener('input', () => {
+    updateWeightUsed(rollSection);
+    updateWeightProgress(rollSection);
+    checkRollsCompletion();
+  });
 }
 
 function addNewSize() {
@@ -798,6 +807,11 @@ function addNewRoll() {
     updateWeightProgress(newRoll);
     checkRollsCompletion();
   });
+  newRoll.querySelector('.remainingWeightInput').addEventListener('input', () => {
+    updateWeightUsed(newRoll);
+    updateWeightProgress(newRoll);
+    checkRollsCompletion();
+  });
   const currentFabricType = fabricTypeSel.value;
   if (currentFabricType) initializeRollNoAutocomplete(newRoll, currentFabricType);
 }
@@ -817,21 +831,29 @@ function updateWeightProgress(rollSection) {
 }
 
 function updateWeightUsed(rollSection) {
-  // Weight Used is entered MANUALLY now (previous behaviour). We only derive the
-  // hidden remaining_weight so the existing backend contract stays intact: the
-  // server recomputes used = full - remaining.
   const usedInput = rollSection.querySelector('.weightUsedInput');
   const remInput  = rollSection.querySelector('.remainingWeightInput');
-  const used      = parseFloat(usedInput.value);
-  const full      = parseFloat(rollSection.querySelector('.fullWeightInput').value);
+  const full      = rollSection.querySelector('.fullWeightInput').value;
 
-  if (isNaN(used) || isNaN(full)) {
-    remInput.value = '';
-    usedInput.classList.remove('over-weight');
-    return;
+  let res;
+  if (FLOW_MODE === 'denim') {
+    res = CuttingWeight.computeRollWeights('denim', {
+      tableLength: document.getElementById('table_length').value,
+      layers: rollSection.querySelector('.layersInput').value,
+      full: full,
+    });
+    if (res.used === null) { usedInput.value = ''; remInput.value = ''; usedInput.classList.remove('over-weight'); return; }
+    usedInput.value = res.used.toFixed(2);
+    remInput.value  = res.remaining === null ? '' : res.remaining.toFixed(2);
+  } else {
+    res = CuttingWeight.computeRollWeights('hosiery', {
+      full: full,
+      remaining: remInput.value,
+    });
+    if (res.used === null) { usedInput.value = ''; usedInput.classList.remove('over-weight'); return; }
+    usedInput.value = res.used.toFixed(2);
   }
-  remInput.value = Math.max(full - used, 0).toFixed(2);
-  usedInput.classList.toggle('over-weight', used > full);
+  usedInput.classList.toggle('over-weight', res.over);
 }
 
 function updateTotalPieces() {
@@ -884,8 +906,11 @@ document.addEventListener('DOMContentLoaded', () => {
 function checkRollsCompletion() {
   const allRollSections = rollsContainer.querySelectorAll('.roll-section');
   if (allRollSections.length === 0) { createLotBtn.disabled = true; return; }
-  const tableLengthOk = !!document.getElementById('table_length').value.trim();
-  let allFilled = tableLengthOk;
+  let allFilled = true;
+  if (FLOW_MODE === 'denim') {
+    const tl = parseFloat(document.getElementById('table_length').value);
+    if (!(tl > 0)) allFilled = false;
+  }
   if (allFilled) {
     allRollSections.forEach(roll => {
       if (
@@ -899,14 +924,17 @@ function checkRollsCompletion() {
   createLotBtn.disabled = !allFilled;
 }
 
-// Re-run weight computation across every roll when table length changes
-document.getElementById('table_length').addEventListener('input', () => {
-  rollsContainer.querySelectorAll('.roll-section').forEach(rs => {
-    updateWeightUsed(rs);
-    updateWeightProgress(rs);
+// Re-run weight computation across every roll when table length changes (denim only)
+const tableLengthInput = document.getElementById('table_length');
+if (tableLengthInput && FLOW_MODE === 'denim') {
+  tableLengthInput.addEventListener('input', () => {
+    rollsContainer.querySelectorAll('.roll-section:not(.d-none)').forEach(rs => {
+      updateWeightUsed(rs);
+      updateWeightProgress(rs);
+    });
+    checkRollsCompletion();
   });
-  checkRollsCompletion();
-});
+}
 
 // Bulk size input — parse "26-1,28-2,30-2,32-1,34-1" and rebuild #sizesContainer
 function parseBulkSizeInput(text) {

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -764,16 +764,13 @@ function initializeRollNoAutocomplete(rollSection, fabricType) {
     updateWeightProgress(rollSection);
     checkRollsCompletion();
   });
-  weightUsedInput.addEventListener('input', () => {
-    updateWeightUsed(rollSection);
-    updateWeightProgress(rollSection);
-    checkRollsCompletion();
-  });
-  remainingWeightInput.addEventListener('input', () => {
-    updateWeightUsed(rollSection);
-    updateWeightProgress(rollSection);
-    checkRollsCompletion();
-  });
+  if (FLOW_MODE === 'hosiery') {
+    remainingWeightInput.addEventListener('input', () => {
+      updateWeightUsed(rollSection);
+      updateWeightProgress(rollSection);
+      checkRollsCompletion();
+    });
+  }
 }
 
 function addNewSize() {
@@ -802,16 +799,13 @@ function addNewRoll() {
     updateWeightProgress(newRoll);
     checkRollsCompletion();
   });
-  newRoll.querySelector('.weightUsedInput').addEventListener('input', () => {
-    updateWeightUsed(newRoll);
-    updateWeightProgress(newRoll);
-    checkRollsCompletion();
-  });
-  newRoll.querySelector('.remainingWeightInput').addEventListener('input', () => {
-    updateWeightUsed(newRoll);
-    updateWeightProgress(newRoll);
-    checkRollsCompletion();
-  });
+  if (FLOW_MODE === 'hosiery') {
+    newRoll.querySelector('.remainingWeightInput').addEventListener('input', () => {
+      updateWeightUsed(newRoll);
+      updateWeightProgress(newRoll);
+      checkRollsCompletion();
+    });
+  }
   const currentFabricType = fabricTypeSel.value;
   if (currentFabricType) initializeRollNoAutocomplete(newRoll, currentFabricType);
 }

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -550,7 +550,7 @@
       </div>
       <div class="col-md-4">
         <label class="kotty-form-label" data-i18n="weightUsedLabel">Weight Used</label>
-        <input type="number" step="0.01" class="kotty-input weightUsedInput" name="weight_used[]" min="0" required placeholder="Weight used (calculated)" readonly />
+        <input type="number" step="0.01" class="kotty-input weightUsedInput" name="weight_used[]" min="0" required placeholder="Weight used" />
       </div>
     </div>
     <div class="row g-3 mt-1">
@@ -760,6 +760,11 @@ function initializeRollNoAutocomplete(rollSection, fabricType) {
     updateWeightProgress(rollSection);
     checkRollsCompletion();
   });
+  weightUsedInput.addEventListener('input', () => {
+    updateWeightUsed(rollSection);
+    updateWeightProgress(rollSection);
+    checkRollsCompletion();
+  });
 }
 
 function addNewSize() {
@@ -788,6 +793,11 @@ function addNewRoll() {
     updateWeightProgress(newRoll);
     checkRollsCompletion();
   });
+  newRoll.querySelector('.weightUsedInput').addEventListener('input', () => {
+    updateWeightUsed(newRoll);
+    updateWeightProgress(newRoll);
+    checkRollsCompletion();
+  });
   const currentFabricType = fabricTypeSel.value;
   if (currentFabricType) initializeRollNoAutocomplete(newRoll, currentFabricType);
 }
@@ -807,25 +817,15 @@ function updateWeightProgress(rollSection) {
 }
 
 function updateWeightUsed(rollSection) {
-  // weight_used = table_length × layers
-  // remaining_weight is back-filled (hidden) so the existing backend
-  // contract stays intact: server recomputes used = full - remaining.
-  const tableLength = parseFloat(document.getElementById('table_length').value);
-  const layers      = parseFloat(rollSection.querySelector('.layersInput').value);
-  const full        = parseFloat(rollSection.querySelector('.fullWeightInput').value);
-  const usedInput   = rollSection.querySelector('.weightUsedInput');
-  const remInput    = rollSection.querySelector('.remainingWeightInput');
+  // Weight Used is entered MANUALLY now (previous behaviour). We only derive the
+  // hidden remaining_weight so the existing backend contract stays intact: the
+  // server recomputes used = full - remaining.
+  const usedInput = rollSection.querySelector('.weightUsedInput');
+  const remInput  = rollSection.querySelector('.remainingWeightInput');
+  const used      = parseFloat(usedInput.value);
+  const full      = parseFloat(rollSection.querySelector('.fullWeightInput').value);
 
-  if (isNaN(tableLength) || isNaN(layers)) {
-    usedInput.value = '';
-    remInput.value = '';
-    usedInput.classList.remove('over-weight');
-    return;
-  }
-  const used = tableLength * layers;
-  usedInput.value = used.toFixed(2);
-
-  if (isNaN(full)) {
+  if (isNaN(used) || isNaN(full)) {
     remInput.value = '';
     usedInput.classList.remove('over-weight');
     return;

--- a/views/fabricConsumptionAnalysis.ejs
+++ b/views/fabricConsumptionAnalysis.ejs
@@ -258,19 +258,6 @@
     background: var(--gray-50);
   }
 
-  .empty-cell {
-    text-align: center;
-    padding: 48px 16px !important;
-    color: var(--text-muted);
-  }
-
-  .empty-cell i {
-    font-size: 36px;
-    display: block;
-    margin-bottom: 10px;
-    color: var(--gray-300);
-  }
-
   /* ── Accordion / Fabric Type Groups ──────────────────────── */
   .fabric-group {
     border: 1px solid var(--border-light);
@@ -281,6 +268,10 @@
   }
 
   .fabric-group-header {
+    width: 100%;
+    text-align: left;
+    border: none;
+    font: inherit;
     display: flex;
     align-items: center;
     justify-content: space-between;
@@ -355,6 +346,10 @@
   }
 
   .lot-card-header {
+    width: 100%;
+    text-align: left;
+    border: none;
+    font: inherit;
     display: flex;
     align-items: center;
     flex-wrap: wrap;
@@ -635,7 +630,7 @@
     <!-- Date Filter Bar -->
     <div class="filter-bar no-print">
       <form method="get" action="/fabric-manager/analysis" class="d-flex align-items-center flex-wrap gap-3 w-100">
-        <i class="bi bi-funnel text-terracotta" style="color: var(--terracotta); font-size: 15px;"></i>
+        <i class="bi bi-funnel text-terracotta" style="font-size: 15px;"></i>
         <strong style="font-size: var(--text-sm); color: var(--text-primary);">Filter by Date</strong>
         <div class="filter-divider"></div>
         <div class="filter-group">
@@ -728,7 +723,7 @@
             <% byType.forEach(function(group, gi) { %>
               <div class="fabric-group" id="fabric-group-<%= gi %>">
                 <!-- Group Header -->
-                <div class="fabric-group-header" onclick="toggleGroup(this)">
+                <button type="button" class="fabric-group-header" onclick="toggleGroup(this)">
                   <div class="fabric-group-header-left">
                     <i class="bi bi-chevron-right fabric-group-toggle"></i>
                     <span class="fabric-group-name"><%= group.fabricType || 'Unknown Type' %></span>
@@ -744,7 +739,7 @@
                       <i class="bi bi-layers"></i> <%= group.rollCount %> roll<% if (group.rollCount !== 1) { %>s<% } %>
                     </span>
                   </div>
-                </div>
+                </button>
                 <!-- Group Body: Lots -->
                 <div class="fabric-group-body">
                   <% if (!group.lots || group.lots.length === 0) { %>
@@ -755,7 +750,7 @@
                     <% group.lots.forEach(function(lot, li) { %>
                       <div class="lot-card" id="lot-<%= gi %>-<%= li %>">
                         <!-- Lot Header -->
-                        <div class="lot-card-header" onclick="toggleLot(this)">
+                        <button type="button" class="lot-card-header" onclick="toggleLot(this)">
                           <div class="lot-card-header-left">
                             <i class="bi bi-chevron-right lot-card-toggle"></i>
                             <span class="badge badge-neutral"><%= lot.lotNo %></span>
@@ -769,7 +764,7 @@
                               </span>
                             <% } %>
                           </div>
-                        </div>
+                        </button>
                         <!-- Lot Body -->
                         <div class="lot-card-body">
                           <div class="lot-meta">

--- a/views/fabricConsumptionAnalysis.ejs
+++ b/views/fabricConsumptionAnalysis.ejs
@@ -1,0 +1,988 @@
+<%- include('partials/header', { pageTitle: 'Fabric Consumption Analysis' }) %>
+<%- include('partials/navbar', { user: user, dashboardUrl: '/fabric-manager/dashboard' }) %>
+
+<style>
+  /* ── Page shell ─────────────────────────────────────────── */
+  .page-container {
+    padding-top: calc(var(--navbar-height) + 28px);
+    padding-bottom: 48px;
+    min-height: 100vh;
+  }
+
+  .page-wrapper {
+    max-width: var(--content-max-width);
+    margin: 0 auto;
+    padding: 0 24px;
+  }
+
+  /* ── Page Header ─────────────────────────────────────────── */
+  .page-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-bottom: 28px;
+  }
+
+  .page-header-left {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+  }
+
+  .page-icon {
+    width: 48px;
+    height: 48px;
+    border-radius: var(--radius-lg);
+    background: var(--terracotta-bg);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--terracotta);
+    font-size: 20px;
+    flex-shrink: 0;
+  }
+
+  .page-header-actions {
+    display: flex;
+    gap: 10px;
+    flex-wrap: wrap;
+  }
+
+  /* ── Breadcrumbs ─────────────────────────────────────────── */
+  .breadcrumbs {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: var(--text-sm);
+    color: var(--text-muted);
+    margin-bottom: 8px;
+  }
+
+  .breadcrumbs a {
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color var(--transition-fast);
+  }
+
+  .breadcrumbs a:hover {
+    color: var(--terracotta);
+  }
+
+  .breadcrumbs .separator {
+    color: var(--gray-300);
+    font-size: 11px;
+  }
+
+  /* ── Date Filter Bar ─────────────────────────────────────── */
+  .filter-bar {
+    background: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-lg);
+    padding: 16px 22px;
+    margin-bottom: 24px;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 12px;
+    box-shadow: var(--shadow-xs);
+  }
+
+  .filter-bar label {
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--text-secondary);
+    margin-right: 4px;
+  }
+
+  .filter-bar .form-control {
+    padding: 8px 12px;
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+    background: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    transition: all var(--transition-fast);
+    width: auto;
+  }
+
+  .filter-bar .form-control:focus {
+    outline: none;
+    border-color: var(--terracotta);
+    box-shadow: 0 0 0 3px var(--terracotta-bg);
+  }
+
+  .filter-bar .filter-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .filter-bar .filter-divider {
+    width: 1px;
+    height: 28px;
+    background: var(--border-light);
+  }
+
+  /* ── Tabs ────────────────────────────────────────────────── */
+  .analysis-tabs {
+    margin-bottom: 0;
+  }
+
+  .analysis-tabs .nav-tabs {
+    border-bottom: 2px solid var(--border-light);
+    gap: 4px;
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    padding-bottom: 0;
+  }
+
+  .analysis-tabs .nav-tabs::-webkit-scrollbar {
+    height: 0;
+  }
+
+  .analysis-tabs .nav-link {
+    font-family: var(--font-body);
+    font-size: var(--text-sm);
+    font-weight: 500;
+    color: var(--text-secondary);
+    border: none;
+    border-bottom: 2px solid transparent;
+    border-radius: 0;
+    padding: 10px 18px;
+    margin-bottom: -2px;
+    transition: all var(--transition-fast);
+    white-space: nowrap;
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    background: transparent;
+  }
+
+  .analysis-tabs .nav-link:hover {
+    color: var(--terracotta);
+    background: var(--terracotta-bg);
+    border-bottom-color: var(--terracotta-light);
+  }
+
+  .analysis-tabs .nav-link.active {
+    color: var(--terracotta);
+    border-bottom-color: var(--terracotta);
+    background: transparent;
+    font-weight: 600;
+  }
+
+  /* ── Tab Panes ────────────────────────────────────────────── */
+  .tab-pane-inner {
+    background: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-top: none;
+    border-radius: 0 0 var(--radius-lg) var(--radius-lg);
+    padding: 24px;
+    box-shadow: var(--shadow-xs);
+  }
+
+  .tab-pane-toolbar {
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 20px;
+  }
+
+  /* ── Table Card ───────────────────────────────────────────── */
+  .table-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-lg);
+    overflow: hidden;
+    box-shadow: var(--shadow-xs);
+  }
+
+  .table-responsive {
+    overflow-x: auto;
+  }
+
+  .table-responsive::-webkit-scrollbar {
+    height: 8px;
+  }
+
+  .table-responsive::-webkit-scrollbar-thumb {
+    background: var(--gray-300);
+    border-radius: var(--radius-full);
+  }
+
+  .table-responsive::-webkit-scrollbar-track {
+    background: var(--gray-100);
+  }
+
+  .data-table {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .data-table thead {
+    background: var(--gray-50);
+  }
+
+  .data-table th {
+    padding: 12px 16px;
+    text-align: left;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--text-secondary);
+    border-bottom: 1px solid var(--border-light);
+    white-space: nowrap;
+  }
+
+  .data-table th i {
+    margin-right: 6px;
+    color: var(--terracotta);
+  }
+
+  .data-table td {
+    padding: 12px 16px;
+    font-size: var(--text-sm);
+    color: var(--text-primary);
+    border-bottom: 1px solid var(--border-light);
+    vertical-align: middle;
+  }
+
+  .data-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  .data-table tbody tr:hover {
+    background: var(--gray-50);
+  }
+
+  .empty-cell {
+    text-align: center;
+    padding: 48px 16px !important;
+    color: var(--text-muted);
+  }
+
+  .empty-cell i {
+    font-size: 36px;
+    display: block;
+    margin-bottom: 10px;
+    color: var(--gray-300);
+  }
+
+  /* ── Accordion / Fabric Type Groups ──────────────────────── */
+  .fabric-group {
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-lg);
+    margin-bottom: 12px;
+    overflow: hidden;
+    box-shadow: var(--shadow-xs);
+  }
+
+  .fabric-group-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 14px 18px;
+    background: var(--gray-50);
+    cursor: pointer;
+    user-select: none;
+    transition: background var(--transition-fast);
+    gap: 12px;
+  }
+
+  .fabric-group-header:hover {
+    background: var(--cream-dark);
+  }
+
+  .fabric-group-header-left {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    min-width: 0;
+  }
+
+  .fabric-group-toggle {
+    color: var(--terracotta);
+    font-size: 13px;
+    transition: transform var(--transition-base);
+    flex-shrink: 0;
+  }
+
+  .fabric-group.open .fabric-group-toggle {
+    transform: rotate(90deg);
+  }
+
+  .fabric-group-name {
+    font-family: var(--font-display);
+    font-size: var(--text-base);
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .fabric-group-meta {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-wrap: wrap;
+    flex-shrink: 0;
+  }
+
+  .fabric-group-body {
+    display: none;
+    padding: 16px;
+    background: var(--bg-card);
+    border-top: 1px solid var(--border-light);
+  }
+
+  .fabric-group.open .fabric-group-body {
+    display: block;
+  }
+
+  /* ── Lot Cards ──────────────────────────────────────────── */
+  .lot-card {
+    border: 1px solid var(--border-light);
+    border-radius: var(--radius-md);
+    margin-bottom: 12px;
+    overflow: hidden;
+  }
+
+  .lot-card:last-child {
+    margin-bottom: 0;
+  }
+
+  .lot-card-header {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 10px;
+    padding: 10px 14px;
+    background: var(--gray-50);
+    border-bottom: 1px solid var(--border-light);
+    cursor: pointer;
+    user-select: none;
+    transition: background var(--transition-fast);
+  }
+
+  .lot-card-header:hover {
+    background: var(--cream-dark);
+  }
+
+  .lot-card-header-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .lot-card-toggle {
+    color: var(--text-muted);
+    font-size: 11px;
+    transition: transform var(--transition-base);
+    flex-shrink: 0;
+  }
+
+  .lot-card.open .lot-card-toggle {
+    transform: rotate(90deg);
+  }
+
+  .lot-card-body {
+    display: none;
+    padding: 12px 14px;
+  }
+
+  .lot-card.open .lot-card-body {
+    display: block;
+  }
+
+  .lot-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px 16px;
+    margin-bottom: 10px;
+    font-size: var(--text-xs);
+    color: var(--text-secondary);
+  }
+
+  .lot-meta span {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+  }
+
+  .lot-meta i {
+    color: var(--terracotta);
+    font-size: 11px;
+  }
+
+  /* ── Rolls Sub-table ─────────────────────────────────────── */
+  .rolls-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: var(--text-xs);
+  }
+
+  .rolls-table th {
+    padding: 7px 10px;
+    text-align: left;
+    font-size: var(--text-xs);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-muted);
+    background: var(--gray-50);
+    border-bottom: 1px solid var(--border-light);
+    white-space: nowrap;
+  }
+
+  .rolls-table td {
+    padding: 7px 10px;
+    color: var(--text-primary);
+    border-bottom: 1px solid var(--border-light);
+  }
+
+  .rolls-table tbody tr:last-child td {
+    border-bottom: none;
+  }
+
+  .rolls-table tbody tr:hover {
+    background: var(--gray-50);
+  }
+
+  /* ── Badges ──────────────────────────────────────────────── */
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    padding: 3px 9px;
+    border-radius: var(--radius-full);
+    font-size: var(--text-xs);
+    font-weight: 500;
+    line-height: 1.4;
+  }
+
+  .badge-terracotta {
+    background: var(--terracotta-bg);
+    color: var(--terracotta-dark);
+    border: 1px solid rgba(196, 92, 58, 0.2);
+  }
+
+  .badge-info {
+    background: var(--info-light);
+    color: var(--info);
+    border: 1px solid rgba(58, 126, 196, 0.2);
+  }
+
+  .badge-success {
+    background: var(--success-light);
+    color: var(--success);
+    border: 1px solid rgba(45, 138, 95, 0.2);
+  }
+
+  .badge-neutral {
+    background: var(--gray-100);
+    color: var(--text-secondary);
+    border: 1px solid var(--border-light);
+  }
+
+  .badge-warning {
+    background: var(--warning-light);
+    color: var(--warning);
+    border: 1px solid rgba(196, 135, 58, 0.2);
+  }
+
+  /* ── Sub-section header ──────────────────────────────────── */
+  .subsection-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-family: var(--font-display);
+    font-size: var(--text-base);
+    color: var(--text-primary);
+    margin-bottom: 16px;
+    margin-top: 24px;
+    padding-bottom: 8px;
+    border-bottom: 1px solid var(--border-light);
+  }
+
+  .subsection-header:first-child {
+    margin-top: 0;
+  }
+
+  .subsection-header i {
+    color: var(--terracotta);
+    font-size: 15px;
+  }
+
+  /* ── Empty State ─────────────────────────────────────────── */
+  .empty-state {
+    text-align: center;
+    padding: 40px 20px;
+    color: var(--text-muted);
+  }
+
+  .empty-state i {
+    font-size: 40px;
+    display: block;
+    margin-bottom: 10px;
+    color: var(--gray-300);
+  }
+
+  .empty-state p {
+    font-size: var(--text-sm);
+    margin: 0;
+  }
+
+  /* ── Ad-hoc type badges list ─────────────────────────────── */
+  .type-badge-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 4px 0;
+  }
+
+  /* ── Bottom Actions ──────────────────────────────────────── */
+  .bottom-actions {
+    margin-top: 28px;
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 12px;
+  }
+
+  /* ── Print ───────────────────────────────────────────────── */
+  @media print {
+    .no-print { display: none !important; }
+    .page-container { padding-top: 0; }
+    .kotty-navbar { display: none !important; }
+    .fabric-group-body { display: block !important; }
+    .lot-card-body { display: block !important; }
+  }
+
+  /* ── Responsive ──────────────────────────────────────────── */
+  @media (max-width: 768px) {
+    .page-wrapper { padding: 0 16px; }
+
+    .page-header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .filter-bar {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    .filter-bar .filter-divider {
+      width: 100%;
+      height: 1px;
+    }
+
+    .bottom-actions {
+      flex-direction: column;
+    }
+
+    .bottom-actions .btn {
+      width: 100%;
+      justify-content: center;
+    }
+
+    .tab-pane-toolbar {
+      justify-content: flex-start;
+    }
+
+    .fabric-group-header {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+</style>
+
+<div class="page-container">
+  <div class="page-wrapper">
+    <!-- Flash Messages -->
+    <%- include('partials/flashMessages') %>
+
+    <!-- Breadcrumbs -->
+    <div class="breadcrumbs">
+      <a href="/fabric-manager/dashboard">Dashboard</a>
+      <span class="separator"><i class="bi bi-chevron-right"></i></span>
+      <span>Consumption Analysis</span>
+    </div>
+
+    <!-- Page Header -->
+    <div class="page-header">
+      <div class="page-header-left">
+        <div class="page-icon">
+          <i class="bi bi-graph-up"></i>
+        </div>
+        <div>
+          <h1 class="page-title">Fabric Consumption Analysis</h1>
+          <p class="page-subtitle">Track usage across fabric types, rolls and lots</p>
+        </div>
+      </div>
+      <div class="page-header-actions no-print">
+        <a href="/fabric-manager/dashboard" class="btn btn-secondary btn-sm">
+          <i class="bi bi-arrow-left"></i> Back to Dashboard
+        </a>
+      </div>
+    </div>
+
+    <!-- Date Filter Bar -->
+    <div class="filter-bar no-print">
+      <form method="get" action="/fabric-manager/analysis" class="d-flex align-items-center flex-wrap gap-3 w-100">
+        <i class="bi bi-funnel text-terracotta" style="color: var(--terracotta); font-size: 15px;"></i>
+        <strong style="font-size: var(--text-sm); color: var(--text-primary);">Filter by Date</strong>
+        <div class="filter-divider"></div>
+        <div class="filter-group">
+          <label for="from">From</label>
+          <input type="date" id="from" name="from" class="form-control" value="<%= from %>">
+        </div>
+        <div class="filter-group">
+          <label for="to">To</label>
+          <input type="date" id="to" name="to" class="form-control" value="<%= to %>">
+        </div>
+        <div class="filter-divider"></div>
+        <button type="submit" class="btn btn-primary btn-sm">
+          <i class="bi bi-check2"></i> Apply
+        </button>
+        <a href="/fabric-manager/analysis" class="btn btn-outline btn-sm">
+          <i class="bi bi-x-circle"></i> Clear
+        </a>
+      </form>
+    </div>
+
+    <!-- Tabs -->
+    <div class="analysis-tabs">
+      <ul class="nav nav-tabs" id="analysisTabs" role="tablist">
+        <li class="nav-item" role="presentation">
+          <button
+            class="nav-link active"
+            id="tab-consumption"
+            data-bs-toggle="tab"
+            data-bs-target="#pane-consumption"
+            type="button"
+            role="tab"
+            aria-controls="pane-consumption"
+            aria-selected="true"
+          >
+            <i class="bi bi-layers"></i> Consumption by Fabric Type
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button
+            class="nav-link"
+            id="tab-ledger"
+            data-bs-toggle="tab"
+            data-bs-target="#pane-ledger"
+            type="button"
+            role="tab"
+            aria-controls="pane-ledger"
+            aria-selected="false"
+          >
+            <i class="bi bi-journal-text"></i> Roll Ledger
+          </button>
+        </li>
+        <li class="nav-item" role="presentation">
+          <button
+            class="nav-link"
+            id="tab-adhoc"
+            data-bs-toggle="tab"
+            data-bs-target="#pane-adhoc"
+            type="button"
+            role="tab"
+            aria-controls="pane-adhoc"
+            aria-selected="false"
+          >
+            <i class="bi bi-exclamation-triangle"></i> Unknown / Ad-hoc
+          </button>
+        </li>
+      </ul>
+
+      <div class="tab-content">
+
+        <!-- ═══════════════════════════════════════════════════
+             TAB 1 — Consumption by Fabric Type
+             ═══════════════════════════════════════════════════ -->
+        <div class="tab-pane fade show active tab-pane-inner" id="pane-consumption" role="tabpanel" aria-labelledby="tab-consumption">
+          <!-- Export button -->
+          <div class="tab-pane-toolbar no-print">
+            <a
+              href="/fabric-manager/analysis/export?tab=consumption&from=<%= encodeURIComponent(from) %>&to=<%= encodeURIComponent(to) %>"
+              class="btn btn-success btn-sm"
+            >
+              <i class="bi bi-file-earmark-excel"></i> Export to Excel
+            </a>
+          </div>
+
+          <% if (!byType || byType.length === 0) { %>
+            <div class="empty-state">
+              <i class="bi bi-inbox"></i>
+              <p>No consumption recorded in this date range.<br>Try adjusting the date filter above.</p>
+            </div>
+          <% } else { %>
+            <% byType.forEach(function(group, gi) { %>
+              <div class="fabric-group" id="fabric-group-<%= gi %>">
+                <!-- Group Header -->
+                <div class="fabric-group-header" onclick="toggleGroup(this)">
+                  <div class="fabric-group-header-left">
+                    <i class="bi bi-chevron-right fabric-group-toggle"></i>
+                    <span class="fabric-group-name"><%= group.fabricType || 'Unknown Type' %></span>
+                  </div>
+                  <div class="fabric-group-meta">
+                    <span class="badge badge-terracotta">
+                      <i class="bi bi-rulers"></i> <%= group.totalUsed %> used
+                    </span>
+                    <span class="badge badge-info">
+                      <i class="bi bi-folder"></i> <%= group.lotCount %> lot<% if (group.lotCount !== 1) { %>s<% } %>
+                    </span>
+                    <span class="badge badge-neutral">
+                      <i class="bi bi-layers"></i> <%= group.rollCount %> roll<% if (group.rollCount !== 1) { %>s<% } %>
+                    </span>
+                  </div>
+                </div>
+                <!-- Group Body: Lots -->
+                <div class="fabric-group-body">
+                  <% if (!group.lots || group.lots.length === 0) { %>
+                    <div class="empty-state" style="padding: 20px;">
+                      <p style="color: var(--text-muted); font-style: italic; margin: 0;">No lots in this group.</p>
+                    </div>
+                  <% } else { %>
+                    <% group.lots.forEach(function(lot, li) { %>
+                      <div class="lot-card" id="lot-<%= gi %>-<%= li %>">
+                        <!-- Lot Header -->
+                        <div class="lot-card-header" onclick="toggleLot(this)">
+                          <div class="lot-card-header-left">
+                            <i class="bi bi-chevron-right lot-card-toggle"></i>
+                            <span class="badge badge-neutral"><%= lot.lotNo %></span>
+                            <span style="font-size: var(--text-sm); color: var(--text-primary); font-weight: 500;"><%= lot.sku %></span>
+                          </div>
+                          <div style="display: flex; align-items: center; gap: 8px; flex-wrap: wrap;">
+                            <span class="badge badge-terracotta"><%= lot.totalUsed %> used</span>
+                            <% if (lot.cutter) { %>
+                              <span class="badge badge-neutral">
+                                <i class="bi bi-scissors"></i> <%= lot.cutter %>
+                              </span>
+                            <% } %>
+                          </div>
+                        </div>
+                        <!-- Lot Body -->
+                        <div class="lot-card-body">
+                          <div class="lot-meta">
+                            <span><i class="bi bi-calendar3"></i> <%= lot.createdAt %></span>
+                            <span><i class="bi bi-person"></i> <%= lot.cutter || 'N/A' %></span>
+                            <span><i class="bi bi-rulers"></i> Total used: <strong><%= lot.totalUsed %></strong></span>
+                          </div>
+
+                          <% if (!lot.rolls || lot.rolls.length === 0) { %>
+                            <p style="color: var(--text-muted); font-size: var(--text-xs); font-style: italic;">No roll data.</p>
+                          <% } else { %>
+                            <div class="table-responsive" style="border: 1px solid var(--border-light); border-radius: var(--radius-md); overflow: hidden;">
+                              <table class="rolls-table">
+                                <thead>
+                                  <tr>
+                                    <th>Roll No</th>
+                                    <th>Full</th>
+                                    <th>Used</th>
+                                    <th>Remaining</th>
+                                  </tr>
+                                </thead>
+                                <tbody>
+                                  <% lot.rolls.forEach(function(roll) { %>
+                                    <tr>
+                                      <td><span class="badge badge-neutral"><%= roll.rollNo %></span></td>
+                                      <td><%= roll.full %></td>
+                                      <td><strong style="color: var(--terracotta);"><%= roll.used %></strong></td>
+                                      <td><%= roll.remaining %></td>
+                                    </tr>
+                                  <% }) %>
+                                </tbody>
+                              </table>
+                            </div>
+                          <% } %>
+                        </div>
+                      </div>
+                    <% }) %>
+                  <% } %>
+                </div>
+              </div>
+            <% }) %>
+          <% } %>
+        </div>
+
+        <!-- ═══════════════════════════════════════════════════
+             TAB 2 — Roll Ledger
+             ═══════════════════════════════════════════════════ -->
+        <div class="tab-pane fade tab-pane-inner" id="pane-ledger" role="tabpanel" aria-labelledby="tab-ledger">
+          <!-- Export button -->
+          <div class="tab-pane-toolbar no-print">
+            <a
+              href="/fabric-manager/analysis/export?tab=ledger&from=<%= encodeURIComponent(from) %>&to=<%= encodeURIComponent(to) %>"
+              class="btn btn-success btn-sm"
+            >
+              <i class="bi bi-file-earmark-excel"></i> Export to Excel
+            </a>
+          </div>
+
+          <% if (!ledger || ledger.length === 0) { %>
+            <div class="empty-state">
+              <i class="bi bi-journal-x"></i>
+              <p>No ledger entries found for this date range.</p>
+            </div>
+          <% } else { %>
+            <div class="table-card">
+              <div class="table-responsive">
+                <table class="data-table">
+                  <thead>
+                    <tr>
+                      <th><i class="bi bi-upc-scan"></i> Roll No</th>
+                      <th><i class="bi bi-tag"></i> Fabric Type</th>
+                      <th><i class="bi bi-truck"></i> Vendor</th>
+                      <th><i class="bi bi-archive"></i> Current Available</th>
+                      <th><i class="bi bi-rulers"></i> Total Used</th>
+                      <th><i class="bi bi-folder2-open"></i> Lots</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% ledger.forEach(function(row) { %>
+                      <tr>
+                        <td><span class="badge badge-neutral"><%= row.rollNo %></span></td>
+                        <td><%= row.fabricType || '—' %></td>
+                        <td><%= row.vendor || '—' %></td>
+                        <td>
+                          <% if (row.currentAvailable === null || row.currentAvailable === undefined) { %>
+                            <span style="color: var(--text-muted);">—</span>
+                          <% } else { %>
+                            <span class="badge badge-success"><%= row.currentAvailable %> <%= row.unit || '' %></span>
+                          <% } %>
+                        </td>
+                        <td><strong style="color: var(--terracotta);"><%= row.totalUsed %></strong></td>
+                        <td>
+                          <% if (row.lots && row.lots.length > 0) { %>
+                            <span style="font-size: var(--text-xs); color: var(--text-secondary);"><%= row.lots.join(', ') %></span>
+                          <% } else { %>
+                            <span style="color: var(--text-muted);">—</span>
+                          <% } %>
+                        </td>
+                      </tr>
+                    <% }) %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          <% } %>
+        </div>
+
+        <!-- ═══════════════════════════════════════════════════
+             TAB 3 — Unknown / Ad-hoc
+             ═══════════════════════════════════════════════════ -->
+        <div class="tab-pane fade tab-pane-inner" id="pane-adhoc" role="tabpanel" aria-labelledby="tab-adhoc">
+          <!-- Export button -->
+          <div class="tab-pane-toolbar no-print">
+            <a
+              href="/fabric-manager/analysis/export?tab=adhoc&from=<%= encodeURIComponent(from) %>&to=<%= encodeURIComponent(to) %>"
+              class="btn btn-success btn-sm"
+            >
+              <i class="bi bi-file-earmark-excel"></i> Export to Excel
+            </a>
+          </div>
+
+          <!-- Sub-section 1: Ad-hoc rolls -->
+          <div class="subsection-header">
+            <i class="bi bi-exclamation-circle"></i>
+            Ad-hoc rolls
+            <span style="font-size: var(--text-sm); font-family: var(--font-body); font-weight: 400; color: var(--text-muted);">
+              (used in cutting but not found in fabric data)
+            </span>
+          </div>
+
+          <% if (!adHocRolls || adHocRolls.length === 0) { %>
+            <div class="empty-state" style="padding: 24px 20px;">
+              <i class="bi bi-check-circle" style="color: var(--success);"></i>
+              <p>No ad-hoc rolls found — all rolls are tracked in fabric data.</p>
+            </div>
+          <% } else { %>
+            <div class="table-card" style="margin-bottom: 28px;">
+              <div class="table-responsive">
+                <table class="data-table">
+                  <thead>
+                    <tr>
+                      <th><i class="bi bi-upc-scan"></i> Roll No</th>
+                      <th><i class="bi bi-tag"></i> Fabric Type</th>
+                      <th><i class="bi bi-rulers"></i> Full</th>
+                      <th><i class="bi bi-dash-circle"></i> Used</th>
+                      <th><i class="bi bi-folder2-open"></i> Lot No</th>
+                      <th><i class="bi bi-scissors"></i> Cutter</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <% adHocRolls.forEach(function(roll) { %>
+                      <tr>
+                        <td><span class="badge badge-warning"><%= roll.rollNo %></span></td>
+                        <td><%= roll.fabricType || '—' %></td>
+                        <td><%= roll.full %></td>
+                        <td><strong style="color: var(--terracotta);"><%= roll.used %></strong></td>
+                        <td><span class="badge badge-neutral"><%= roll.lotNo %></span></td>
+                        <td><%= roll.cutter || '—' %></td>
+                      </tr>
+                    <% }) %>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          <% } %>
+
+          <!-- Sub-section 2: Ad-hoc fabric types -->
+          <div class="subsection-header">
+            <i class="bi bi-question-diamond"></i>
+            Ad-hoc fabric types
+            <span style="font-size: var(--text-sm); font-family: var(--font-body); font-weight: 400; color: var(--text-muted);">
+              (typed on a lot but not in fabric master data)
+            </span>
+          </div>
+
+          <% if (!adHocTypes || adHocTypes.length === 0) { %>
+            <div class="empty-state" style="padding: 24px 20px;">
+              <i class="bi bi-check-circle" style="color: var(--success);"></i>
+              <p>No ad-hoc fabric types — all fabric types are known.</p>
+            </div>
+          <% } else { %>
+            <div class="type-badge-list">
+              <% adHocTypes.forEach(function(typeName) { %>
+                <span class="badge badge-warning" style="font-size: var(--text-sm); padding: 5px 12px;">
+                  <i class="bi bi-question-circle"></i> <%= typeName %>
+                </span>
+              <% }) %>
+            </div>
+          <% } %>
+
+        </div>
+      </div>
+    </div>
+
+    <!-- Bottom Actions -->
+    <div class="bottom-actions no-print">
+      <a href="/fabric-manager/dashboard" class="btn btn-outline">
+        <i class="bi bi-arrow-left"></i> Back to Dashboard
+      </a>
+    </div>
+  </div>
+</div>
+
+<script>
+  function toggleGroup(header) {
+    const group = header.closest('.fabric-group');
+    group.classList.toggle('open');
+  }
+
+  function toggleLot(header) {
+    const card = header.closest('.lot-card');
+    card.classList.toggle('open');
+  }
+</script>
+
+<%- include('partials/footer') %>

--- a/views/fabricManagerDashboard.ejs
+++ b/views/fabricManagerDashboard.ejs
@@ -594,6 +594,9 @@
       <a href="/fabric-manager/bulk-upload/rolls" class="btn btn-secondary">
         <i class="bi bi-upload"></i> Bulk Upload Fabric Invoice Rolls
       </a>
+      <a href="/fabric-manager/analysis" class="btn btn-outline-primary">
+        <i class="bi bi-graph-up"></i> Consumption Analysis
+      </a>
       <a href="/fabric-manager/view" class="btn btn-primary">
         <i class="bi bi-eye"></i> Advanced View
       </a>

--- a/views/fabricManagerDashboard.ejs
+++ b/views/fabricManagerDashboard.ejs
@@ -594,7 +594,7 @@
       <a href="/fabric-manager/bulk-upload/rolls" class="btn btn-secondary">
         <i class="bi bi-upload"></i> Bulk Upload Fabric Invoice Rolls
       </a>
-      <a href="/fabric-manager/analysis" class="btn btn-outline-primary">
+      <a href="/fabric-manager/analysis" class="btn btn-outline">
         <i class="bi bi-graph-up"></i> Consumption Analysis
       </a>
       <a href="/fabric-manager/view" class="btn btn-primary">

--- a/views/webhookLogs.ejs
+++ b/views/webhookLogs.ejs
@@ -827,8 +827,8 @@
           <label class="source-option selected">
             <input type="radio" name="downloadSource" value="live">
             <span>
-              <strong style="color: var(--success);">Live CSV</strong>
-              <small>Includes virtual inventory</small>
+              <strong style="color: var(--success);">Live Report</strong>
+              <small>Available stock, per location</small>
             </span>
           </label>
         </div>

--- a/views/webhookLogs.ejs
+++ b/views/webhookLogs.ejs
@@ -909,9 +909,9 @@
           if (isLive) {
             const name = selectedWarehouse === '176318' ? 'Delhi' : 'Faridabad';
             title.textContent = 'Live Inventory Download';
-            subtitle.innerHTML = 'Fetch <strong>' + name + '</strong> from EasyEcom API';
+            subtitle.innerHTML = 'Fetch <strong>' + name + '</strong> (Available, all locations) via EasyEcom report';
             document.getElementById('statRecords').textContent = '~95,000';
-            document.getElementById('statTime').textContent = '~3-5 min';
+            document.getElementById('statTime').textContent = '~1-2 min';
             stats.style.display = 'grid';
             confirmBtn.disabled = false;
           } else {


### PR DESCRIPTION
## Summary

This session's work (13 commits, `4d4700f..c785318`):

**Feature 1 — Cutting dashboard: denim vs hosiery weight entry**
- Re-introduces `weight_used = table_length × layers` auto-calc **gated to denim lots only** (driven by the cutter's existing `is_denim_cutter` / `flow_type` flag).
- Hosiery lots use the manual flow: enter Remaining (default `0`), `weight_used = full − remaining`. Roll DB lookup + stock deduction still apply to both when the roll exists in `fabric_invoice_rolls`.
- Shared, unit-tested weight math in `public/js/cuttingWeight.js` (UMD; used by the create form and node tests). Same branching applied to the operator add-missed-roll form in `routes/editcuttinglots.js`.
- No change to existing POST handlers — both modes submit a hidden `remaining_weight` and the server already recomputes `used = full − remaining`. Fixed an edge where a blank hosiery Remaining could be silently dropped by the server's roll-acceptance gate.

**Feature 2 — Fabric-manager: consumption analysis page**
- New `GET /fabric-manager/analysis` (+ Excel export) with a date filter and 3 tabs: consumption-by-fabric-type (lot + roll breakdown), roll-level ledger, and unknown/ad-hoc rolls & fabric types (used in cutting but absent from fabric data).
- Pure, unit-tested transforms in `utils/fabricConsumption.js`.

Design spec and implementation plan committed under `docs/superpowers/`.

> Note: this long-running branch also carries ~28 prior commits (production-manager-dashboard + inventory-ops work) that predate this session.

## Test Plan
- [x] `npm test` — 11/11 unit tests pass (weight math + consumption transforms)
- [x] All touched route modules load; all touched EJS views compile
- [ ] Manual: denim cutter — Weight Used auto = table_length × layers (read-only), table_length required, stock deducts
- [ ] Manual: hosiery cutter — enter Remaining (default 0) → Weight Used derived; clearing Remaining still saves the roll
- [ ] Manual: fabric manager — analysis page 3 tabs render, date filter narrows results, each tab's Excel export downloads and respects the filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)