### PR TITLE
Fix: bound fabric analysis response (Cloud Run 500) + prominent dashboard button

### DIFF
--- a/routes/fabricManagerRoutes.js
+++ b/routes/fabricManagerRoutes.js
@@ -9,6 +9,7 @@ const xlsx = require('xlsx');
 const ExcelJS = require('exceljs');
 const fs = require('fs');
 const fsPromises = fs.promises;
+const moment = require('moment');
 const { body, validationResult } = require('express-validator');
 const {
   groupConsumptionByFabricType,
@@ -435,15 +436,33 @@ router.post('/insert/invoice',
 // GET /fabric-manager/analysis — consumption analysis (3 tabs + date filter)
 router.get('/analysis', isAuthenticated, isFabricManager, async (req, res) => {
   try {
-    const from = req.query.from || '';
-    const to = req.query.to || '';
+    // Default to the last 30 days when no range is supplied — the all-time
+    // history can exceed Cloud Run's response size limit.
+    const from = req.query.from || moment().subtract(30, 'days').format('YYYY-MM-DD');
+    const to = req.query.to || moment().format('YYYY-MM-DD');
     const data = await loadConsumptionAnalysis(from, to);
+
+    // Bound the rendered payload so the HTML can never exceed the response limit.
+    const DETAIL_CAP = 1500;   // max roll rows rendered in the by-type detail
+    const LEDGER_CAP = 1500;   // max ledger rows rendered
+    const ADHOC_CAP  = 1500;   // max ad-hoc roll rows rendered
+
+    const rollRowCount = data.byType.reduce(
+      (n, g) => n + g.lots.reduce((m, l) => m + l.rolls.length, 0), 0);
+    const detailTruncated = rollRowCount > DETAIL_CAP;
+
     res.render('fabricConsumptionAnalysis', {
       user: req.session.user,
       from, to,
       byType: data.byType,
-      ledger: data.ledger,
-      adHocRolls: data.adHocRolls,
+      detailTruncated,
+      rollRowCount,
+      ledger: data.ledger.slice(0, LEDGER_CAP),
+      ledgerTruncated: data.ledger.length > LEDGER_CAP,
+      ledgerTotal: data.ledger.length,
+      adHocRolls: data.adHocRolls.slice(0, ADHOC_CAP),
+      adHocRollsTruncated: data.adHocRolls.length > ADHOC_CAP,
+      adHocRollsTotal: data.adHocRolls.length,
       adHocTypes: data.adHocTypes,
     });
   } catch (err) {

--- a/views/fabricConsumptionAnalysis.ejs
+++ b/views/fabricConsumptionAnalysis.ejs
@@ -646,8 +646,11 @@
           <i class="bi bi-check2"></i> Apply
         </button>
         <a href="/fabric-manager/analysis" class="btn btn-outline btn-sm">
-          <i class="bi bi-x-circle"></i> Clear
+          <i class="bi bi-arrow-counterclockwise"></i> Last 30 days
         </a>
+        <span style="font-size: var(--text-xs); color: var(--text-muted); align-self: center;">
+          Defaults to the last 30 days. Pick a wider range to see more (large ranges show summaries only).
+        </span>
       </form>
     </div>
 
@@ -720,12 +723,19 @@
               <p>No consumption recorded in this date range.<br>Try adjusting the date filter above.</p>
             </div>
           <% } else { %>
+            <% if (detailTruncated) { %>
+              <div class="empty-state" style="padding: 20px 24px; text-align: left; background: var(--warning-light); border: 1px solid rgba(196,135,58,0.3); border-radius: var(--radius-md); margin-bottom: 20px; color: var(--text-primary);">
+                <i class="bi bi-exclamation-triangle" style="font-size: 18px; display: inline; margin-bottom: 0; color: var(--warning);"></i>
+                This range includes <strong><%= rollRowCount %></strong> roll entries — too many to show the full lot/roll breakdown here.
+                Narrow the date range above, or use <strong>Export to Excel</strong> for the complete detail.
+              </div>
+            <% } %>
             <% byType.forEach(function(group, gi) { %>
               <div class="fabric-group" id="fabric-group-<%= gi %>">
                 <!-- Group Header -->
-                <button type="button" class="fabric-group-header" onclick="toggleGroup(this)">
+                <button type="button" class="fabric-group-header" <% if (!detailTruncated) { %>onclick="toggleGroup(this)"<% } %> style="<%= detailTruncated ? 'cursor: default;' : '' %>">
                   <div class="fabric-group-header-left">
-                    <i class="bi bi-chevron-right fabric-group-toggle"></i>
+                    <% if (!detailTruncated) { %><i class="bi bi-chevron-right fabric-group-toggle"></i><% } %>
                     <span class="fabric-group-name"><%= group.fabricType || 'Unknown Type' %></span>
                   </div>
                   <div class="fabric-group-meta">
@@ -740,6 +750,7 @@
                     </span>
                   </div>
                 </button>
+                <% if (!detailTruncated) { %>
                 <!-- Group Body: Lots -->
                 <div class="fabric-group-body">
                   <% if (!group.lots || group.lots.length === 0) { %>
@@ -804,6 +815,7 @@
                     <% }) %>
                   <% } %>
                 </div>
+                <% } %>
               </div>
             <% }) %>
           <% } %>
@@ -829,6 +841,12 @@
               <p>No ledger entries found for this date range.</p>
             </div>
           <% } else { %>
+            <% if (ledgerTruncated) { %>
+              <div class="empty-state" style="padding: 12px 16px; text-align: left; background: var(--warning-light); border: 1px solid rgba(196,135,58,0.3); border-radius: var(--radius-md); margin-bottom: 16px; color: var(--text-primary);">
+                <i class="bi bi-exclamation-triangle" style="font-size: 15px; display: inline; margin-bottom: 0; color: var(--warning);"></i>
+                Showing first <strong><%= ledger.length %></strong> of <strong><%= ledgerTotal %></strong> rolls — narrow the date range or use <strong>Export to Excel</strong> for all.
+              </div>
+            <% } %>
             <div class="table-card">
               <div class="table-responsive">
                 <table class="data-table">
@@ -901,6 +919,12 @@
               <p>No ad-hoc rolls found — all rolls are tracked in fabric data.</p>
             </div>
           <% } else { %>
+            <% if (adHocRollsTruncated) { %>
+              <div class="empty-state" style="padding: 12px 16px; text-align: left; background: var(--warning-light); border: 1px solid rgba(196,135,58,0.3); border-radius: var(--radius-md); margin-bottom: 16px; color: var(--text-primary);">
+                <i class="bi bi-exclamation-triangle" style="font-size: 15px; display: inline; margin-bottom: 0; color: var(--warning);"></i>
+                Showing first <strong><%= adHocRolls.length %></strong> of <strong><%= adHocRollsTotal %></strong> — use <strong>Export to Excel</strong> for all.
+              </div>
+            <% } %>
             <div class="table-card" style="margin-bottom: 28px;">
               <div class="table-responsive">
                 <table class="data-table">

--- a/views/fabricManagerDashboard.ejs
+++ b/views/fabricManagerDashboard.ejs
@@ -383,6 +383,9 @@
         </div>
       </div>
       <div class="page-header-actions no-print">
+        <a href="/fabric-manager/analysis" class="btn btn-primary btn-sm">
+          <i class="bi bi-graph-up"></i> Consumption Analysis
+        </a>
         <a href="/fabric-manager/download-excel?search=<%= encodeURIComponent(searchTerm) %>" class="btn btn-success btn-sm">
           <i class="bi bi-download"></i> Download Excel
         </a>


### PR DESCRIPTION
Hotfix for two issues reported after #426 shipped.

## 1. `/fabric-manager/analysis` returned 500 in production
**Root cause (confirmed via Cloud Run logs + local repro):** the page rendered the **entire all-time** consumption history inline. With a large dataset the HTML exceeds Cloud Run's **32 MiB** response limit, so Cloud Run returns a 500 ("Response size was too large") — *not* an app exception (none appears in the logs; the request took 2.2s = data fetched + huge render). Reproduced locally: 40k roll rows → **39.5 MiB** response.

**Fix:**
- Default the date filter to the **last 30 days** when no range is supplied (bounds DB load + response).
- Cap rendered detail at 1500 rows each (by-type detail / ledger / ad-hoc) with honest notices that point to narrowing the range or using **Export to Excel** (export stays the full-data path; xlsx is compressed). Summary totals remain accurate.
- Result: same 40k-row dataset now renders to **1.08 MiB**.

## 2. Dashboard UX
"Consumption Analysis" is now a prominent primary button in the **top-right page header** (was only at the bottom, requiring a scroll). Bottom link kept as a secondary entry point.

## Test Plan
- [x] Local render of the real view with a 40k-roll dataset: 39.5 MiB → **1.08 MiB** after fix (under limit)
- [x] Small dataset still renders full lot/roll detail
- [x] EJS compiles; route module loads; `npm test` 11/11
- [ ] After deploy: load `/fabric-manager/analysis` on erpkotty.in (defaults to last 30 days, no 500); widen range → summary + truncation notice; Export downloads full data

🤖 Generated with [Claude Code](https://claude.com/claude-code)