### PR TITLE
Admin switch: block ad-hoc fabric type / roll entry in cutting (default OFF)

### DIFF
--- a/docs/superpowers/plans/2026-06-01-adhoc-cutting-entry-switch.md
+++ b/docs/superpowers/plans/2026-06-01-adhoc-cutting-entry-switch.md
@@ -1,0 +1,537 @@
+# Ad-hoc Cutting Entry Switch — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a global, admin-controlled switch (`store_settings.allow_adhoc_cutting_entry`, default OFF) that blocks cutters from entering fabric types / roll numbers not in the fabric database — enforced in the UI and on the server across the create-lot form, add-missed-roll form, and bulk upload.
+
+**Architecture:** A shared `utils/storeSettings.js` reads the key/value `store_settings` table and resolves the switch to a fail-safe boolean (missing/garbage → OFF). Each entry point reads the flag and, when OFF, (a) makes the UI pickers strict and (b) rejects unknown fabric types / rolls server-side (server is the source of truth). An admin toggle on `/admin` flips the setting.
+
+**Tech Stack:** Node v22 (built-in `node:test`), Express, EJS, MySQL (`mysql2`, `const { pool } = require('../config/db')`).
+
+**Spec:** `docs/superpowers/specs/2026-06-01-adhoc-cutting-entry-switch-design.md`
+
+---
+
+## File Structure
+
+- Create: `utils/storeSettings.js` — `getStoreSetting`, `resolveAllowAdhoc`, `allowAdhocCuttingEntry`, `isKnownFabricType`, `ADHOC_KEY`.
+- Create: `test/storeSettings.test.js` — `node:test` for the pure functions.
+- Create: `sql/adhoc_cutting_entry_setting_migration.sql` — seed the setting row.
+- Modify: `routes/adminRoutes.js` — pass `allowAdhoc` to `/admin`; add `POST /admin/settings`.
+- Modify: `views/admin.ejs` — settings card with the toggle.
+- Modify: `routes/cuttingManagerRoutes.js` — pass `allowAdhoc` to dashboard; enforce in create-lot POST.
+- Modify: `views/cuttingManagerDashboard.ejs` — strict pickers when `!allowAdhoc`.
+- Modify: `routes/editcuttinglots.js` — enforce in add-roll POST + strict picker in edit-form.
+- Modify: `routes/bulkUploadRoutes.js` — fabric-type known-check when `!allowAdhoc`.
+
+---
+
+## Task 1: Shared store-settings util + tests
+
+**Files:**
+- Create: `utils/storeSettings.js`
+- Create: `test/storeSettings.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `test/storeSettings.test.js`:
+
+```js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { resolveAllowAdhoc, isKnownFabricType } = require('../utils/storeSettings.js');
+
+test('resolveAllowAdhoc: only literal true (any case) is true', () => {
+  assert.strictEqual(resolveAllowAdhoc('true'), true);
+  assert.strictEqual(resolveAllowAdhoc('TRUE'), true);
+  assert.strictEqual(resolveAllowAdhoc(' True '), true);
+  assert.strictEqual(resolveAllowAdhoc('false'), false);
+  assert.strictEqual(resolveAllowAdhoc(''), false);
+  assert.strictEqual(resolveAllowAdhoc('yes'), false);
+  assert.strictEqual(resolveAllowAdhoc('1'), false);
+  assert.strictEqual(resolveAllowAdhoc(undefined), false);
+  assert.strictEqual(resolveAllowAdhoc(null), false);
+});
+
+test('isKnownFabricType: case-insensitive, trimmed membership', () => {
+  const known = ['Denim', 'Cotton Lycra', 'Hosiery'];
+  assert.strictEqual(isKnownFabricType('Denim', known), true);
+  assert.strictEqual(isKnownFabricType('  denim ', known), true);
+  assert.strictEqual(isKnownFabricType('COTTON LYCRA', known), true);
+  assert.strictEqual(isKnownFabricType('Linen', known), false);
+  assert.strictEqual(isKnownFabricType('', known), false);
+  assert.strictEqual(isKnownFabricType('Denim', []), false);
+  assert.strictEqual(isKnownFabricType(null, known), false);
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `node --test test/storeSettings.test.js`
+Expected: FAIL — `Cannot find module '../utils/storeSettings.js'`.
+
+- [ ] **Step 3: Write the module**
+
+Create `utils/storeSettings.js`:
+
+```js
+// Shared access to the key/value `store_settings` table + the ad-hoc cutting switch.
+const { pool } = require('../config/db');
+
+const ADHOC_KEY = 'allow_adhoc_cutting_entry';
+
+// Reads a store_settings value; returns defaultValue on miss or error.
+async function getStoreSetting(key, defaultValue = null) {
+  try {
+    const [[row]] = await pool.query(
+      'SELECT setting_value FROM store_settings WHERE setting_key = ?',
+      [key]
+    );
+    return row ? row.setting_value : defaultValue;
+  } catch {
+    return defaultValue;
+  }
+}
+
+// Coerce a stored string to a boolean. Fail-safe: only the literal 'true'
+// (case-insensitive, trimmed) is true; everything else (incl. missing) is false.
+function resolveAllowAdhoc(value) {
+  return String(value == null ? '' : value).trim().toLowerCase() === 'true';
+}
+
+// Resolves the ad-hoc cutting switch to a boolean. Default OFF (false).
+async function allowAdhocCuttingEntry() {
+  const v = await getStoreSetting(ADHOC_KEY, 'false');
+  return resolveAllowAdhoc(v);
+}
+
+function normalize(s) {
+  return String(s == null ? '' : s).trim().toLowerCase();
+}
+
+// True if `type` matches one of knownTypes (case-insensitive, trimmed).
+function isKnownFabricType(type, knownTypes) {
+  const t = normalize(type);
+  if (!t) return false;
+  return (knownTypes || []).some((k) => normalize(k) === t);
+}
+
+module.exports = {
+  ADHOC_KEY,
+  getStoreSetting,
+  resolveAllowAdhoc,
+  allowAdhocCuttingEntry,
+  isKnownFabricType,
+};
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `node --test test/storeSettings.test.js`
+Expected: PASS — 2 tests pass.
+Also run `npm test` and confirm the whole suite still passes.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/storeSettings.js test/storeSettings.test.js
+git commit -m "feat(settings): shared store-settings util + ad-hoc switch resolver (tested)"
+```
+
+---
+
+## Task 2: Seed migration for the setting
+
+**Files:**
+- Create: `sql/adhoc_cutting_entry_setting_migration.sql`
+
+- [ ] **Step 1: Create the migration**
+
+Create `sql/adhoc_cutting_entry_setting_migration.sql`:
+
+```sql
+-- Seeds the global switch that controls whether cutters may enter fabric types /
+-- roll numbers not present in the fabric database. Default OFF ('false').
+-- The store_settings table is created by store_indent_revamp_migration.sql.
+INSERT IGNORE INTO store_settings (setting_key, setting_value)
+VALUES ('allow_adhoc_cutting_entry', 'false');
+```
+
+- [ ] **Step 2: Sanity-check the SQL parses (syntax only, no DB needed)**
+
+Run: `grep -c "allow_adhoc_cutting_entry" sql/adhoc_cutting_entry_setting_migration.sql`
+Expected: prints `1`.
+
+> Note: `allowAdhocCuttingEntry()` defaults to `false` when the row is absent, so the switch is OFF even before this migration runs. The migration just makes the row explicit; the admin POST (Task 3) also upserts it.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add sql/adhoc_cutting_entry_setting_migration.sql
+git commit -m "feat(settings): seed allow_adhoc_cutting_entry=false migration"
+```
+
+---
+
+## Task 3: Admin toggle (read on /admin + POST /admin/settings + UI)
+
+**Files:**
+- Modify: `routes/adminRoutes.js` (GET `/admin` render ~lines 66-73; add a POST route near the other POST routes)
+- Modify: `views/admin.ejs` (Overview tab, insert a settings card before the Overview pane closes ~line 553)
+
+- [ ] **Step 1: Import the helper in adminRoutes.js**
+
+At the top of `routes/adminRoutes.js`, with the other requires, add:
+
+```js
+const { allowAdhocCuttingEntry } = require('../utils/storeSettings');
+```
+
+- [ ] **Step 2: Pass `allowAdhoc` to the /admin render**
+
+In the GET `/admin` handler, before `res.render('admin', { ... })`, add:
+
+```js
+    const allowAdhoc = await allowAdhocCuttingEntry();
+```
+
+Add `allowAdhoc` to the render locals object (keep all existing keys: user, roles, users, dashboards, existingTables, auditLogs):
+
+```js
+    res.render('admin', {
+      user: req.session.user,
+      roles,
+      users,
+      dashboards,
+      existingTables,
+      auditLogs,
+      allowAdhoc,
+    });
+```
+
+- [ ] **Step 3: Add the POST /admin/settings route**
+
+Add this route in `routes/adminRoutes.js` near the other `router.post(...)` routes:
+
+```js
+// POST /admin/settings — toggle the ad-hoc cutting entry switch
+router.post('/settings', isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    // An unchecked checkbox is not submitted, so absence => 'false'.
+    const raw = req.body.allow_adhoc_cutting_entry;
+    const allow = (raw === 'on' || raw === 'true') ? 'true' : 'false';
+    await pool.query(
+      `INSERT INTO store_settings (setting_key, setting_value)
+       VALUES ('allow_adhoc_cutting_entry', ?)
+       ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)`,
+      [allow]
+    );
+    req.flash('success', `Ad-hoc cutting entry ${allow === 'true' ? 'ENABLED' : 'DISABLED'}.`);
+  } catch (err) {
+    console.error('Error updating ad-hoc cutting setting:', err);
+    req.flash('error', 'Failed to update the cutting entry setting.');
+  }
+  res.redirect('/admin');
+});
+```
+
+- [ ] **Step 4: Add the settings card to admin.ejs**
+
+In `views/admin.ejs`, inside the Overview tab pane (before its closing `</div>` around line 553, after the "Existing Tables" section), add a card matching the existing admin styling:
+
+```html
+        <!-- Cutting entry setting -->
+        <div class="admin-section">
+          <h3 class="admin-section-title"><i class="bi bi-scissors"></i> Cutting Entry</h3>
+          <form method="POST" action="/admin/settings" class="d-flex align-items-center" style="gap:12px; flex-wrap:wrap;">
+            <label class="form-check-label" style="display:flex; align-items:center; gap:8px;">
+              <input type="checkbox" name="allow_adhoc_cutting_entry" value="true" <%= allowAdhoc ? 'checked' : '' %>>
+              Allow cutters to enter fabric types / roll numbers <strong>not in the fabric database</strong>
+            </label>
+            <button type="submit" class="btn btn-primary btn-sm">Save</button>
+          </form>
+          <p class="text-muted small mb-0" style="margin-top:6px;">
+            Off (recommended): cutters can only pick existing fabric types and rolls. Currently
+            <strong><%= allowAdhoc ? 'ON (ad-hoc allowed)' : 'OFF (ad-hoc blocked)' %></strong>.
+          </p>
+        </div>
+```
+
+(If `admin-section` / `admin-section-title` classes don't exist verbatim, match the classes used by the adjacent Users / Dashboards sections.)
+
+- [ ] **Step 5: Verify modules load and EJS compiles**
+
+Run:
+```bash
+node -e "require('./routes/adminRoutes.js'); console.log('OK')"
+node -e "const ejs=require('ejs'),fs=require('fs');ejs.compile(fs.readFileSync('views/admin.ejs','utf8'),{filename:'views/admin.ejs'});console.log('admin EJS OK')"
+```
+Expected: `OK` and `admin EJS OK`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add routes/adminRoutes.js views/admin.ejs
+git commit -m "feat(admin): toggle for ad-hoc cutting entry switch"
+```
+
+---
+
+## Task 4: Enforce in create-lot (server + form)
+
+**Files:**
+- Modify: `routes/cuttingManagerRoutes.js` (GET `/dashboard` render ~179-187; POST `/create-lot` fabric-type check + roll loop ~349-383)
+- Modify: `views/cuttingManagerDashboard.ejs` (`initializeAutocomplete` ~614-722, fabric init ~725, `initializeRollNoAutocomplete` ~727-774)
+
+- [ ] **Step 1: Import the helpers in cuttingManagerRoutes.js**
+
+At the top with the other requires, add:
+
+```js
+const { allowAdhocCuttingEntry, isKnownFabricType } = require('../utils/storeSettings');
+```
+
+- [ ] **Step 2: Pass `allowAdhoc` to the dashboard render**
+
+In GET `/dashboard`, before the `res.render('cuttingManagerDashboard', { ... })` call, add:
+
+```js
+    const allowAdhoc = await allowAdhocCuttingEntry();
+```
+
+Add `allowAdhoc` to the render locals (keep existing keys incl. `isDenim`):
+
+```js
+      isDenim,
+      allowAdhoc,
+```
+
+- [ ] **Step 3: Enforce fabric-type + roll in the create-lot POST**
+
+In the POST `/create-lot` handler, near the start of the transaction work (after the rolls are parsed, before/at the start of the roll loop section ~line 326), add the flag read:
+
+```js
+        const allowAdhoc = await allowAdhocCuttingEntry();
+```
+
+When ad-hoc is OFF, validate the fabric type against the fabric DB. Add this just after the presence check (`if (!lot_no || !sku || !fabric_type) {...}`) — but it needs `conn`; place it after `conn` is available and before inserting the lot:
+
+```js
+        if (!allowAdhoc) {
+          const [knownTypeRows] = await conn.query(
+            'SELECT DISTINCT fabric_type FROM fabric_invoices WHERE fabric_type IS NOT NULL'
+          );
+          if (!isKnownFabricType(fabric_type, knownTypeRows.map((r) => r.fabric_type))) {
+            throw new Error(`Fabric type "${fabric_type}" is not in the fabric database. Ad-hoc entry is disabled.`);
+          }
+        }
+```
+
+In the roll loop, the `else` branch (the ad-hoc path, ~line 372) must reject when OFF. Change the start of that `else` block to:
+
+```js
+            } else {
+              if (!allowAdhoc) {
+                throw new Error(`Roll ${r.roll_no} is not in fabric inventory. Ad-hoc entry is disabled.`);
+              }
+              if (isNaN(r.full_weight) || isNaN(r.remaining_weight)) {
+                throw new Error(`Full and remaining weights are required for roll ${r.roll_no}`);
+              }
+              // ...rest of existing ad-hoc branch unchanged...
+```
+
+(The handler already wraps this in a try/catch that rolls back the transaction and flashes `err.message`; throwing is the established pattern here.)
+
+- [ ] **Step 4: Make the form pickers strict when OFF (view JS)**
+
+In `views/cuttingManagerDashboard.ejs`, near the top of the main inline `<script>` (where `IS_DENIM`/`FLOW_MODE` are defined), add:
+
+```js
+  const ALLOW_ADHOC = <%= allowAdhoc ? 'true' : 'false' %>;
+```
+
+Add a `strict` parameter to `initializeAutocomplete(inputField, hiddenField, optionsContainer, data, strict)`. In its no-match handling (the place it currently copies typed text into `hiddenField` when there's no matching option, ~line 681) and its blur fallback (~lines 698-704), gate the free-text copy on `!strict`. When `strict` and there is no matching option:
+- set `hiddenField.value = ''`,
+- add the `is-invalid` class to `inputField` (and remove it once a valid option is chosen).
+
+So the matched path stays the same; only the unmatched free-text fallback is suppressed under `strict`.
+
+Update the fabric-type init call (~line 725) to pass `!ALLOW_ADHOC` as `strict`:
+
+```js
+  initializeAutocomplete(fabricTypeSearch, fabricTypeSel, fabricTypeOptions,
+    fabricTypes.map(ft => ({ displayText: ft, value: ft })), !ALLOW_ADHOC);
+```
+
+Update the roll autocomplete init inside `initializeRollNoAutocomplete` (~line 732 where it calls `initializeAutocomplete(rollNoSearch, ...)`) to also pass `!ALLOW_ADHOC` as `strict`.
+
+In the roll-select change handler (~lines 739-754): when `!ALLOW_ADHOC` and the selected value is NOT found in `availableRolls`, treat it as invalid — clear `rollNoSel.value`, keep `fullWeightInput` read-only and empty, and add `is-invalid` to the roll search input. When `ALLOW_ADHOC`, keep today's behavior (unknown roll → `fullWeightInput.readOnly = false` for manual entry).
+
+- [ ] **Step 5: Verify**
+
+Run:
+```bash
+node -e "require('./routes/cuttingManagerRoutes.js'); console.log('OK')"
+node -e "const ejs=require('ejs'),fs=require('fs');ejs.compile(fs.readFileSync('views/cuttingManagerDashboard.ejs','utf8'),{filename:'views/cuttingManagerDashboard.ejs'});console.log('EJS OK')"
+```
+Expected: `OK` and `EJS OK`.
+
+- [ ] **Step 6: Manual check**
+
+`npm start`, log in as a cutting manager with the switch OFF (default): typing a fabric type or roll not in the DB does not stick (field flags invalid / clears), full weight can't be hand-entered for unknown rolls; submitting an ad-hoc value via direct POST is rejected with the flash error. Toggle ON via `/admin`: ad-hoc entry works as before.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add routes/cuttingManagerRoutes.js views/cuttingManagerDashboard.ejs
+git commit -m "feat(cutting): enforce ad-hoc switch in create-lot (strict pickers + server validation)"
+```
+
+---
+
+## Task 5: Enforce in add-missed-roll (server + edit-form)
+
+**Files:**
+- Modify: `routes/editcuttinglots.js` (edit-form GET render of the add-roll HTML; add-roll POST inventory block ~809-832)
+
+- [ ] **Step 1: Import the helper**
+
+At the top of `routes/editcuttinglots.js` with the other requires, add:
+
+```js
+const { allowAdhocCuttingEntry } = require('../utils/storeSettings');
+```
+
+- [ ] **Step 2: Reject unknown roll in the add-roll POST when OFF**
+
+In the add-roll POST handler, after the inventory lookup (`const [[inv]] = await conn.query(...)` ~line 809-816), the code currently treats "not found" as ad-hoc (no else). Add the read and a guard. Just before that lookup, add:
+
+```js
+    const allowAdhoc = await allowAdhocCuttingEntry();
+```
+
+After the `if (inv) { ...deplete... }` block (~line 831), add an else-if:
+
+```js
+    if (inv) {
+      // ...existing deplete logic unchanged...
+    } else if (!allowAdhoc) {
+      throw new Error(`Roll ${roll_no} is not in fabric inventory. Ad-hoc entry is disabled.`);
+    }
+```
+
+(The handler's catch returns `res.json({ success:false, error: err.message })` and rolls back — matching its existing error pattern.)
+
+- [ ] **Step 3: Strict roll picker in the edit-form**
+
+In the edit-form GET handler that renders the add-roll HTML string, add near where `isDenim` is computed:
+
+```js
+          const allowAdhoc = await allowAdhocCuttingEntry();
+```
+
+Inject it into the inline script alongside `IS_DENIM`/`ROLL_INVENTORY`:
+
+```js
+          const ALLOW_ADHOC = ${allowAdhoc ? 'true' : 'false'};
+```
+
+In the add-roll click handler / validation, when `!ALLOW_ADHOC`, require the typed roll to exist in `ROLL_INVENTORY`; if it doesn't, show the existing error UI (`showErr('Roll is not in fabric inventory; ad-hoc entry is disabled.')`) and do not submit. When `ALLOW_ADHOC`, keep today's behavior.
+
+- [ ] **Step 4: Verify**
+
+Run: `node -e "require('./routes/editcuttinglots.js'); console.log('OK')"`
+Expected: `OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add routes/editcuttinglots.js
+git commit -m "feat(cutting): enforce ad-hoc switch in add-missed-roll (server + edit-form)"
+```
+
+---
+
+## Task 6: Enforce fabric type in bulk upload when OFF
+
+**Files:**
+- Modify: `routes/bulkUploadRoutes.js` (lot loop, before the lot INSERT ~194-198)
+
+- [ ] **Step 1: Import the helpers**
+
+At the top of `routes/bulkUploadRoutes.js` with the other requires, add:
+
+```js
+const { allowAdhocCuttingEntry, isKnownFabricType } = require('../utils/storeSettings');
+```
+
+- [ ] **Step 2: Load the flag + known types once, before processing lots**
+
+In the upload-lots POST handler, before the loop that inserts lots (and inside the transaction where `conn` exists), add:
+
+```js
+    const allowAdhoc = await allowAdhocCuttingEntry();
+    let knownFabricTypes = [];
+    if (!allowAdhoc) {
+      const [knownTypeRows] = await conn.query(
+        'SELECT DISTINCT fabric_type FROM fabric_invoices WHERE fabric_type IS NOT NULL'
+      );
+      knownFabricTypes = knownTypeRows.map((r) => r.fabric_type);
+    }
+```
+
+- [ ] **Step 3: Validate each lot's fabric type when OFF**
+
+Immediately before the lot `INSERT INTO cutting_lots ...` (~line 194), add:
+
+```js
+      if (!allowAdhoc && !isKnownFabricType(lot.fabric_type, knownFabricTypes)) {
+        throw new Error(`Fabric type "${lot.fabric_type}" for lot ${lot.lot_no} is not in the fabric database. Ad-hoc entry is disabled.`);
+      }
+```
+
+(Rolls are already rejected when unknown — unchanged. The handler's catch rolls back and reports the error.)
+
+- [ ] **Step 4: Verify**
+
+Run: `node -e "require('./routes/bulkUploadRoutes.js'); console.log('OK')"`
+Expected: `OK`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add routes/bulkUploadRoutes.js
+git commit -m "feat(cutting): bulk upload rejects unknown fabric type when ad-hoc switch is off"
+```
+
+---
+
+## Final verification
+
+- [ ] **Run the full unit suite**
+
+Run: `npm test`
+Expected: all pass (cuttingWeight 7 + fabricConsumption 4 + storeSettings 2 = 13).
+
+- [ ] **All touched route modules load**
+
+```bash
+node -e "require('./routes/adminRoutes.js');require('./routes/cuttingManagerRoutes.js');require('./routes/editcuttinglots.js');require('./routes/bulkUploadRoutes.js');require('./utils/storeSettings.js');console.log('all OK')"
+```
+Expected: `all OK`.
+
+- [ ] **All touched views compile**
+
+```bash
+node -e "const ejs=require('ejs'),fs=require('fs');['views/admin.ejs','views/cuttingManagerDashboard.ejs'].forEach(f=>{ejs.compile(fs.readFileSync(f,'utf8'),{filename:f});console.log(f,'OK')})"
+```
+Expected: both `OK`.
+
+---
+
+## Self-Review notes (plan author)
+
+- **Spec coverage:** storage/default + fail-safe (Task 1, helper defaults to false; Task 2 seed). Admin toggle (Task 3). Create-lot UI+server (Task 4). Add-missed-roll UI+server (Task 5). Bulk fabric-type check, rolls already strict (Task 6). Known-value sources = `fabric_invoices.fabric_type` / `fabric_invoice_rolls` (Tasks 4-6). Defence-in-depth (server is source of truth) in every entry point. Non-goals (no migration of old data) respected — no data backfill task.
+- **DRY note:** an existing `getStoreSetting` lives privately in `routes/indentRoutes.js`; this plan adds a shared `utils/storeSettings.js` for the new code and intentionally does NOT refactor indentRoutes (out of scope, avoid unrelated churn).
+- **Type/name consistency:** `allowAdhocCuttingEntry()` (async→bool), `isKnownFabricType(type, knownTypes)`, `resolveAllowAdhoc(value)`, view flag `ALLOW_ADHOC`, render local `allowAdhoc`, setting key `allow_adhoc_cutting_entry` — used identically across Tasks 1/3/4/5/6.
+- **Executor confirmations (verify against live code, don't assume):** exact admin.ejs section classes; the precise lines of `initializeAutocomplete`'s free-text fallback to gate on `strict`; that the create-lot and add-roll handlers' catch blocks flash/JSON the thrown `err.message` (they do per current code); the add-roll edit-form's existing `showErr` helper + `ROLL_INVENTORY` variable names.

--- a/docs/superpowers/specs/2026-06-01-adhoc-cutting-entry-switch-design.md
+++ b/docs/superpowers/specs/2026-06-01-adhoc-cutting-entry-switch-design.md
@@ -1,0 +1,92 @@
+# Design: Admin switch for ad-hoc fabric type / roll entry in cutting
+
+Date: 2026-06-01
+Status: Approved (ready for implementation plan)
+
+## Summary
+
+Add a global, admin-controlled on/off switch that governs whether cutters may
+enter **fabric types and roll numbers that are not in the fabric database**
+("ad-hoc" entries). **Default: OFF** (ad-hoc entry blocked). The rule is enforced
+both in the UI and on the server, across all three cutting entry points.
+
+Today the system effectively behaves as "ON": the create-lot form, the
+add-missed-roll form, and (for fabric type only) bulk upload all accept free-text
+/ ad-hoc values. This feature makes OFF the default and gives an admin a toggle.
+
+## Storage & default
+
+- One row in the existing `store_settings` (key/value) table:
+  `allow_adhoc_cutting_entry = 'false'`.
+- A helper `getSetting(key, defaultValue)` reads `store_settings`, returning the
+  default when the row is absent. The ad-hoc helper resolves to a boolean and is
+  **fail-safe**: missing/invalid → treated as `false` (locked down).
+- Seeded via a migration that `INSERT IGNORE`s the row as `'false'`.
+
+## Admin toggle
+
+- A "Cutting entry" settings card on the existing `/admin` dashboard
+  (`isAuthenticated` + `isAdmin`) with an on/off control.
+- New `POST /admin/settings` route (admin-only) that upserts the
+  `allow_adhoc_cutting_entry` row to `'true'`/`'false'`, then redirects back to
+  `/admin` with a flash confirmation.
+- Label: "Allow cutters to enter fabric types / roll numbers not in the fabric
+  database." Helper text notes OFF is the safe default.
+
+## Known-value sources
+
+- Known **fabric types**: `SELECT DISTINCT fabric_type FROM fabric_invoices WHERE fabric_type IS NOT NULL`.
+- Known **rolls**: `roll_no` present in `fabric_invoice_rolls`.
+
+## Enforcement (defence in depth: UI + server)
+
+For every entry point, the UI restriction is convenience only; the **server
+validation is the source of truth** (the API can be called directly).
+
+### Create-lot form (`views/cuttingManagerDashboard.ejs` + `routes/cuttingManagerRoutes.js`)
+- **UI when OFF:** the fabric-type and roll search boxes become strict pickers —
+  the free-text fallback in `initializeAutocomplete` (which copies typed text into
+  the hidden field on no-match / on blur) is suppressed, so a non-matching value
+  cannot be submitted. The "unknown roll → enter your own full weight" path is
+  disabled (full weight stays sourced from inventory only).
+- **Server when OFF:** reject the request if `fabric_type` is not a known type, or
+  if any `roll_no` is not in `fabric_invoice_rolls`. Clear flash error naming the
+  offending value; no partial insert (existing transaction rolls back).
+- The view receives an `allowAdhoc` boolean (passed from the GET handler) to drive
+  the UI mode.
+
+### Add-missed-roll form (`routes/editcuttinglots.js`)
+- **UI when OFF:** the roll picker in the edit-form is strict (no free-text roll).
+- **Server when OFF:** the add-roll POST rejects a `roll_no` not in
+  `fabric_invoice_rolls` (today it silently accepts and treats it as ad-hoc).
+- Fabric type is inherited from the existing lot here, so only the roll is gated.
+
+### Bulk upload (`routes/bulkUploadRoutes.js`)
+- Rolls: bulk **already** rejects unknown rolls and has no mechanism to supply an
+  ad-hoc roll's full weight via Excel, so **bulk rolls remain DB-only regardless of
+  the switch**. (Documented nuance — accepted by the user.)
+- **Server when OFF:** add a fabric-type-must-be-known check (today bulk accepts
+  any fabric type as free text). When ON, fabric type stays free-text as today.
+
+## When ON
+
+Exactly today's behavior: free-text fabric types and ad-hoc rolls in the create
+and add-roll forms; free-text fabric type in bulk. No other change.
+
+## Non-goals / edges
+
+- Existing lots and previously-entered ad-hoc data are untouched; the switch
+  governs new entries only.
+- The Fabric Consumption "Unknown / Ad-hoc" tab keeps working; with the switch
+  OFF, that list simply stops growing.
+- No per-user or per-role granularity (explicitly global).
+- The setting is read per request (single-row lookup); no caching layer needed.
+
+## Testing
+
+- Unit-test the `allow_adhoc_cutting_entry` resolution helper (string `'true'`/
+  `'false'`/missing/garbage → correct boolean, default false) with `node:test`.
+- Unit-test pure validators: `isKnownFabricType(type, knownTypes)` and
+  `isKnownRoll(rollNo, knownRollNos)` (case/whitespace handling), with `node:test`.
+- Manual: toggle in admin; confirm create/add-roll/bulk block ad-hoc when OFF and
+  allow when ON; confirm server rejects ad-hoc via direct POST when OFF.

--- a/routes/adminRoutes.js
+++ b/routes/adminRoutes.js
@@ -3,6 +3,7 @@ const bcrypt = require('bcryptjs');
 const router = express.Router();
 const { pool } = require('../config/db');
 const { isAuthenticated, isAdmin } = require('../middlewares/auth');
+const { allowAdhocCuttingEntry } = require('../utils/storeSettings');
 const { body, validationResult } = require('express-validator');
 
 // Utility: Fetch existing tables (cached to avoid heavy INFORMATION_SCHEMA calls)
@@ -63,13 +64,16 @@ router.get('/', isAuthenticated, isAdmin, async (req, res) => {
     const dashboards = dashboardsData[0];
     const auditLogs = auditLogData[0];
 
+    const allowAdhoc = await allowAdhocCuttingEntry();
+
     res.render('admin', {
       user: req.session.user,
       roles,
       users,
       dashboards,
       existingTables,
-      auditLogs
+      auditLogs,
+      allowAdhoc
     });
   } catch (err) {
     console.error('Error loading admin page:', err);
@@ -417,5 +421,25 @@ router.post(
     }
   }
 );
+
+// POST /admin/settings — toggle the ad-hoc cutting entry switch
+router.post('/settings', isAuthenticated, isAdmin, async (req, res) => {
+  try {
+    // An unchecked checkbox is not submitted, so absence => 'false'.
+    const raw = req.body.allow_adhoc_cutting_entry;
+    const allow = (raw === 'on' || raw === 'true') ? 'true' : 'false';
+    await pool.query(
+      `INSERT INTO store_settings (setting_key, setting_value)
+       VALUES ('allow_adhoc_cutting_entry', ?)
+       ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)`,
+      [allow]
+    );
+    req.flash('success', `Ad-hoc cutting entry ${allow === 'true' ? 'ENABLED' : 'DISABLED'}.`);
+  } catch (err) {
+    console.error('Error updating ad-hoc cutting setting:', err);
+    req.flash('error', 'Failed to update the cutting entry setting.');
+  }
+  res.redirect('/admin');
+});
 
 module.exports = router;

--- a/routes/bulkUploadRoutes.js
+++ b/routes/bulkUploadRoutes.js
@@ -7,6 +7,7 @@ const path = require('path');
 const ExcelJS = require('exceljs');
 const { pool } = require('../config/db');
 const { isAuthenticated, isCuttingManager } = require('../middlewares/auth');
+const { allowAdhocCuttingEntry, isKnownFabricType } = require('../utils/storeSettings');
 
 // Set up Multer for Excel file uploads
 const storage = multer.diskStorage({
@@ -183,6 +184,16 @@ router.post('/bulk-upload/upload-lots', isAuthenticated, isCuttingManager, uploa
     await conn.beginTransaction();
     console.log('Database transaction started for bulk lot upload.');
 
+    // Load ad-hoc switch and known fabric types once (before the per-lot loop)
+    const allowAdhoc = await allowAdhocCuttingEntry();
+    let knownFabricTypes = [];
+    if (!allowAdhoc) {
+      const [knownTypeRows] = await conn.query(
+        'SELECT DISTINCT fabric_type FROM fabric_invoices WHERE fabric_type IS NOT NULL'
+      );
+      knownFabricTypes = knownTypeRows.map((r) => r.fabric_type);
+    }
+
     // Process each lot row from the Lots sheet
     for (const lot of lotsData) {
       const lotSizes = sizesData[lot.lot_no] || [];
@@ -190,6 +201,10 @@ router.post('/bulk-upload/upload-lots', isAuthenticated, isCuttingManager, uploa
       const sumPatterns = lotSizes.reduce((sum, s) => sum + s.pattern_count, 0);
       const sumLayers = lotRolls.reduce((sum, r) => sum + r.layers, 0);
       const totalPieces = sumPatterns * sumLayers;
+
+      if (!allowAdhoc && !isKnownFabricType(lot.fabric_type, knownFabricTypes)) {
+        throw new Error(`Fabric type "${lot.fabric_type}" for lot ${lot.lot_no} is not in the fabric database. Ad-hoc entry is disabled.`);
+      }
 
       const [result] = await conn.query(
         `INSERT INTO cutting_lots (lot_no, sku, fabric_type, remark, user_id, total_pieces)

--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -9,6 +9,7 @@ const path = require('path');
 const PDFDocument = require('pdfkit');
 const generateLotNumber = require('../utils/generateLotNumber'); // Import the utility function
 const { cache } = require('../utils/cache');
+const { allowAdhocCuttingEntry, isKnownFabricType } = require('../utils/storeSettings');
 
 // Multer setup for image uploads
 const storage = multer.diskStorage({
@@ -176,6 +177,8 @@ router.get('/dashboard', isAuthenticated, isCuttingManager, async (req, res) => 
     );
     const isDenim = !!(cutterFlag && cutterFlag.is_denim_cutter);
 
+    const allowAdhoc = await allowAdhocCuttingEntry();
+
     res.render('cuttingManagerDashboard', {
       user: req.session.user,
       cuttingLots,
@@ -184,6 +187,7 @@ router.get('/dashboard', isAuthenticated, isCuttingManager, async (req, res) => 
       rollsByFabricType, // Now includes vendor_name
       generatedLotNumber, // Pass the generated lot number
       isDenim,
+      allowAdhoc,
     });
   } catch (err) {
     if (conn) {
@@ -240,6 +244,17 @@ router.post(
           [userId]
         );
         const flowType = cutter && cutter.is_denim_cutter ? 'denim' : 'hosiery';
+
+        // Enforce ad-hoc cutting entry switch
+        const allowAdhoc = await allowAdhocCuttingEntry();
+        if (!allowAdhoc) {
+          const [knownTypeRows] = await conn.query(
+            'SELECT DISTINCT fabric_type FROM fabric_invoices WHERE fabric_type IS NOT NULL'
+          );
+          if (!isKnownFabricType(fabric_type, knownTypeRows.map((r) => r.fabric_type))) {
+            throw new Error(`Fabric type "${fabric_type}" is not in the fabric database. Ad-hoc entry is disabled.`);
+          }
+        }
 
         // Insert the new cutting lot with total_pieces = 0
         const [result] = await conn.query(
@@ -370,6 +385,9 @@ router.post(
                 throw new Error(`Insufficient weight or invalid roll ${r.roll_no}`);
               }
             } else {
+              if (!allowAdhoc) {
+                throw new Error(`Roll ${r.roll_no} is not in fabric inventory. Ad-hoc entry is disabled.`);
+              }
               if (isNaN(r.full_weight) || isNaN(r.remaining_weight)) {
                 throw new Error(`Full and remaining weights are required for roll ${r.roll_no}`);
               }

--- a/routes/editcuttinglots.js
+++ b/routes/editcuttinglots.js
@@ -4,6 +4,7 @@ const multer  = require('multer');
 const upload = multer(); // This will parse multipart/form-data
 const { pool } = require('../config/db');
 const { isAuthenticated, isOperator } = require('../middlewares/auth');
+const { allowAdhocCuttingEntry } = require('../utils/storeSettings');
 
 // simple in-memory cache for cutting masters
 const masterCache = { data: null, expires: 0 };
@@ -305,6 +306,8 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
       [lot.fabric_type]
     );
 
+    const allowAdhoc = await allowAdhocCuttingEntry();
+
     // Has any downstream stage seen this lot?
     const downstreamHits = downstream.filter(d => d.c > 0).map(d => d.stage);
 
@@ -518,6 +521,7 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
           // ───── Add-missed-roll wiring ─────
           const ROLL_INVENTORY = ${JSON.stringify(availableRolls.map(r => ({ roll_no: r.roll_no, per_roll_weight: Number(r.per_roll_weight) || 0, unit: r.unit || '' })))};
           const IS_DENIM = ${isDenim ? 'true' : 'false'};
+          const ALLOW_ADHOC = ${allowAdhoc ? 'true' : 'false'};
           const TABLE_LENGTH = ${Number.isFinite(Number(lot.table_length)) ? Number(lot.table_length) : 'null'};
           const addRollNo        = document.getElementById('addRollNo');
           const addRollLayers    = document.getElementById('addRollLayers');
@@ -572,6 +576,9 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
             const full_weight = parseFloat(addRollFullW.value);
             const weight_used = parseFloat(addRollUsed.value);
             if (!roll_no)            return showErr('Pick a roll number.');
+            if (!ALLOW_ADHOC && !ROLL_INVENTORY.some(r => r.roll_no === roll_no)) {
+              return showErr('Roll is not in fabric inventory; ad-hoc entry is disabled.');
+            }
             if (!(layers > 0))       return showErr('Layers must be greater than 0.');
             if (!(full_weight > 0))  return showErr('Full weight must be greater than 0.');
             if (!(weight_used >= 0)) return showErr('Enter a valid Weight Used (0 or more).');
@@ -806,6 +813,7 @@ router.post('/editcuttinglots/add-roll', isAuthenticated, isOperator, upload.non
     if (dup) throw new Error('This roll number is already in this lot.');
 
     // Inventory check — deplete fabric_invoice_rolls if the roll exists there
+    const allowAdhoc = await allowAdhocCuttingEntry();
     const [[inv]] = await conn.query(
       `SELECT fir.roll_no, fir.per_roll_weight
          FROM fabric_invoice_rolls fir
@@ -828,6 +836,8 @@ router.post('/editcuttinglots/add-roll', isAuthenticated, isOperator, upload.non
       if (upd.affectedRows === 0) {
         throw new Error(`Insufficient inventory for roll ${roll_no}.`);
       }
+    } else if (!allowAdhoc) {
+      throw new Error(`Roll ${roll_no} is not in fabric inventory. Ad-hoc entry is disabled.`);
     }
     const remaining_weight = Math.max(resolvedFullWeight - weight_used, 0);
 

--- a/sql/adhoc_cutting_entry_setting_migration.sql
+++ b/sql/adhoc_cutting_entry_setting_migration.sql
@@ -1,0 +1,5 @@
+-- Seeds the global switch that controls whether cutters may enter fabric types /
+-- roll numbers not present in the fabric database. Default OFF ('false').
+-- The store_settings table is created by store_indent_revamp_migration.sql.
+INSERT IGNORE INTO store_settings (setting_key, setting_value)
+VALUES ('allow_adhoc_cutting_entry', 'false');

--- a/test/storeSettings.test.js
+++ b/test/storeSettings.test.js
@@ -1,0 +1,26 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { resolveAllowAdhoc, isKnownFabricType } = require('../utils/storeSettings.js');
+
+test('resolveAllowAdhoc: only literal true (any case) is true', () => {
+  assert.strictEqual(resolveAllowAdhoc('true'), true);
+  assert.strictEqual(resolveAllowAdhoc('TRUE'), true);
+  assert.strictEqual(resolveAllowAdhoc(' True '), true);
+  assert.strictEqual(resolveAllowAdhoc('false'), false);
+  assert.strictEqual(resolveAllowAdhoc(''), false);
+  assert.strictEqual(resolveAllowAdhoc('yes'), false);
+  assert.strictEqual(resolveAllowAdhoc('1'), false);
+  assert.strictEqual(resolveAllowAdhoc(undefined), false);
+  assert.strictEqual(resolveAllowAdhoc(null), false);
+});
+
+test('isKnownFabricType: case-insensitive, trimmed membership', () => {
+  const known = ['Denim', 'Cotton Lycra', 'Hosiery'];
+  assert.strictEqual(isKnownFabricType('Denim', known), true);
+  assert.strictEqual(isKnownFabricType('  denim ', known), true);
+  assert.strictEqual(isKnownFabricType('COTTON LYCRA', known), true);
+  assert.strictEqual(isKnownFabricType('Linen', known), false);
+  assert.strictEqual(isKnownFabricType('', known), false);
+  assert.strictEqual(isKnownFabricType('Denim', []), false);
+  assert.strictEqual(isKnownFabricType(null, known), false);
+});

--- a/utils/storeSettings.js
+++ b/utils/storeSettings.js
@@ -1,0 +1,48 @@
+// Shared access to the key/value `store_settings` table + the ad-hoc cutting switch.
+const { pool } = require('../config/db');
+
+const ADHOC_KEY = 'allow_adhoc_cutting_entry';
+
+// Reads a store_settings value; returns defaultValue on miss or error.
+async function getStoreSetting(key, defaultValue = null) {
+  try {
+    const [[row]] = await pool.query(
+      'SELECT setting_value FROM store_settings WHERE setting_key = ?',
+      [key]
+    );
+    return row ? row.setting_value : defaultValue;
+  } catch {
+    return defaultValue;
+  }
+}
+
+// Coerce a stored string to a boolean. Fail-safe: only the literal 'true'
+// (case-insensitive, trimmed) is true; everything else (incl. missing) is false.
+function resolveAllowAdhoc(value) {
+  return String(value == null ? '' : value).trim().toLowerCase() === 'true';
+}
+
+// Resolves the ad-hoc cutting switch to a boolean. Default OFF (false).
+async function allowAdhocCuttingEntry() {
+  const v = await getStoreSetting(ADHOC_KEY, 'false');
+  return resolveAllowAdhoc(v);
+}
+
+function normalize(s) {
+  return String(s == null ? '' : s).trim().toLowerCase();
+}
+
+// True if `type` matches one of knownTypes (case-insensitive, trimmed).
+function isKnownFabricType(type, knownTypes) {
+  const t = normalize(type);
+  if (!t) return false;
+  return (knownTypes || []).some((k) => normalize(k) === t);
+}
+
+module.exports = {
+  ADHOC_KEY,
+  getStoreSetting,
+  resolveAllowAdhoc,
+  allowAdhocCuttingEntry,
+  isKnownFabricType,
+};

--- a/utils/storeSettings.js
+++ b/utils/storeSettings.js
@@ -1,11 +1,13 @@
 // Shared access to the key/value `store_settings` table + the ad-hoc cutting switch.
-const { pool } = require('../config/db');
+// The DB pool is required lazily inside getStoreSetting so that importing the pure
+// helpers (resolveAllowAdhoc/isKnownFabricType) for unit tests does not load config/db.
 
 const ADHOC_KEY = 'allow_adhoc_cutting_entry';
 
 // Reads a store_settings value; returns defaultValue on miss or error.
 async function getStoreSetting(key, defaultValue = null) {
   try {
+    const { pool } = require('../config/db');
     const [[row]] = await pool.query(
       'SELECT setting_value FROM store_settings WHERE setting_key = ?',
       [key]

--- a/views/admin.ejs
+++ b/views/admin.ejs
@@ -551,6 +551,22 @@
           </div>
         <% }); %>
       </div>
+
+      <!-- Cutting Entry setting -->
+      <h3 class="section-header"><i class="bi bi-scissors"></i> Cutting Entry</h3>
+      <div class="admin-table-container" style="padding: 20px;">
+        <form method="POST" action="/admin/settings" style="display:flex; align-items:center; gap:12px; flex-wrap:wrap;">
+          <label style="display:flex; align-items:center; gap:8px; margin:0;">
+            <input type="checkbox" name="allow_adhoc_cutting_entry" value="true" <%= allowAdhoc ? 'checked' : '' %>>
+            Allow cutters to enter fabric types / roll numbers <strong>not in the fabric database</strong>
+          </label>
+          <button type="submit" class="btn btn-primary btn-sm">Save</button>
+        </form>
+        <p class="text-muted small" style="margin-top:6px; margin-bottom:0;">
+          Off (recommended): cutters can only pick existing fabric types and rolls. Currently
+          <strong><%= allowAdhoc ? 'ON (ad-hoc allowed)' : 'OFF (ad-hoc blocked)' %></strong>.
+        </p>
+      </div>
     </div>
 
     <!-- Create Dashboard Tab -->

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -685,6 +685,7 @@ function initializeAutocomplete(inputField, hiddenField, optionsContainer, data 
     } else if (strict) {
       hiddenField.value = '';
       if (typedValue) inputField.classList.add('is-invalid');
+      else inputField.classList.remove('is-invalid');
     } else {
       hiddenField.value = typedValue;
     }
@@ -720,7 +721,7 @@ function initializeAutocomplete(inputField, hiddenField, optionsContainer, data 
       } else {
         hiddenField.value = value;
       }
-      hiddenField.dispatchEvent(new Event('change'));
+      if (hiddenField.value) hiddenField.dispatchEvent(new Event('change'));
     }
   });
 
@@ -895,7 +896,7 @@ function populateRollNos(selectedFabricType) {
     const rollSection = rollNoSel.closest('.roll-section');
     const availableRolls = rollsByFabricType[selectedFabricType] || [];
     const rollData = availableRolls.map(roll => ({ displayText: `${roll.roll_no} (Available: ${roll.per_roll_weight} ${roll.unit}) (Vendor: ${roll.vendor_name})`, value: roll.roll_no, availableWeight: roll.per_roll_weight }));
-    initializeAutocomplete(rollSection.querySelector('.rollNo_search'), rollNoSel, rollSection.querySelector('.autocomplete-items'), rollData);
+    initializeAutocomplete(rollSection.querySelector('.rollNo_search'), rollNoSel, rollSection.querySelector('.autocomplete-items'), rollData, !ALLOW_ADHOC);
     rollSection.querySelector('.rollNo_search').placeholder = `Search Roll (${selectedFabricType})...`;
     rollSection.querySelector('.availableWeightTxt').textContent = '0';
     rollSection.querySelector('.weightUsedInput').value = '';

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -577,6 +577,7 @@
 <script>
 const IS_DENIM = <%= isDenim ? 'true' : 'false' %>;
 const FLOW_MODE = IS_DENIM ? 'denim' : 'hosiery';
+const ALLOW_ADHOC = <%= allowAdhoc ? 'true' : 'false' %>;
 
 const langData = {
   en: { cuttingManagerDashboardTitle: "Cutting Manager Dashboard", welcomeUser: "Welcome", existingCuttingLots: "Existing Cutting Lots", createNewCuttingLot: "Create New Cutting Lot", idLabel: "ID", lotNumberLabel: "Lot Number", skuLabel: "SKU", fabricTypeLabel: "Fabric Type", tableLengthLabel: "Table Length", remarkLabel: "Remark", imageLabel: "Image", createdByLabel: "Created By", creationTimeLabel: "Creation Time", totalPiecesLabel: "Total Pieces", sizesLabel: "Sizes", actionsLabel: "Actions", noCuttingLotsAvailable: "No cutting lots available.", sizeLabel: "Size", patternCountLabel: "Pattern Count", lotNumberGenerated: "Lot Number (Generated)", createLotBtn: "Create Lot", remove: "Remove", rollNumber: "Roll Number", layersLabel: "Layers", weightUsedLabel: "Weight Used (Calculated)", weightUsageProgress: "Weight Usage Progress", availableLabel: "Available", sizesAndPatterns: "Sizes and Patterns", rollsUsed: "Rolls Used", addNewSize: "Add New Size", addAnotherRoll: "Add Another Roll", totalPiecesCalc: "Total Pieces (Calculated)", fullWeightLabel: "Full Roll Weight", remainingWeightLabel: "Remaining Weight" },
@@ -611,7 +612,7 @@ function debounce(func, delay) {
   return function(...args) { clearTimeout(t); t = setTimeout(() => func.apply(this, args), delay); };
 }
 
-function initializeAutocomplete(inputField, hiddenField, optionsContainer, data = []) {
+function initializeAutocomplete(inputField, hiddenField, optionsContainer, data = [], strict = false) {
   function populateOptions() {
     optionsContainer.innerHTML = '';
     data.forEach(item => {
@@ -678,7 +679,15 @@ function initializeAutocomplete(inputField, hiddenField, optionsContainer, data 
 
     const typedValue = inputField.value.trim();
     const matchingOption = data.find(d => (typeof d === 'object' ? d.value : d).toLowerCase() === typedValue.toLowerCase());
-    hiddenField.value = matchingOption ? (typeof matchingOption === 'object' ? matchingOption.value : matchingOption) : typedValue;
+    if (matchingOption) {
+      hiddenField.value = typeof matchingOption === 'object' ? matchingOption.value : matchingOption;
+      inputField.classList.remove('is-invalid');
+    } else if (strict) {
+      hiddenField.value = '';
+      if (typedValue) inputField.classList.add('is-invalid');
+    } else {
+      hiddenField.value = typedValue;
+    }
     hiddenField.dispatchEvent(new Event('change'));
     checkRollsCompletion();
   }, 300));
@@ -687,6 +696,7 @@ function initializeAutocomplete(inputField, hiddenField, optionsContainer, data 
     if (e.target && e.target.matches('li.list-group-item') && !e.target.classList.contains('no-results')) {
       hiddenField.value = e.target.dataset.value;
       inputField.value = e.target.textContent;
+      inputField.classList.remove('is-invalid');
       optionsContainer.classList.remove('d-block');
       optionsContainer.classList.add('d-none');
       inputField.setAttribute('aria-expanded', 'false');
@@ -698,7 +708,18 @@ function initializeAutocomplete(inputField, hiddenField, optionsContainer, data 
   inputField.addEventListener('blur', () => {
     const value = inputField.value.trim();
     if (value && !hiddenField.value) {
-      hiddenField.value = value;
+      if (strict) {
+        const matched = data.find(d => (typeof d === 'object' ? d.value : d).toLowerCase() === value.toLowerCase());
+        if (matched) {
+          hiddenField.value = typeof matched === 'object' ? matched.value : matched;
+          inputField.classList.remove('is-invalid');
+        } else {
+          inputField.classList.add('is-invalid');
+          // keep hiddenField.value = '' — do not accept free text
+        }
+      } else {
+        hiddenField.value = value;
+      }
       hiddenField.dispatchEvent(new Event('change'));
     }
   });
@@ -722,7 +743,8 @@ function initializeAutocomplete(inputField, hiddenField, optionsContainer, data 
 }
 
 const fabricTypes = Object.keys(rollsByFabricType);
-initializeAutocomplete(fabricTypeSearch, fabricTypeSel, fabricTypeOptions, fabricTypes.map(ft => ({ displayText: ft, value: ft })));
+initializeAutocomplete(fabricTypeSearch, fabricTypeSel, fabricTypeOptions,
+  fabricTypes.map(ft => ({ displayText: ft, value: ft })), !ALLOW_ADHOC);
 
 function initializeRollNoAutocomplete(rollSection, fabricType) {
   const rollNoSel = rollSection.querySelector('.rollNoSel');
@@ -733,7 +755,7 @@ function initializeRollNoAutocomplete(rollSection, fabricType) {
   const remainingWeightInput = rollSection.querySelector('.remainingWeightInput');
   const availableRolls = rollsByFabricType[fabricType] || [];
   const rollData = availableRolls.map(roll => ({ displayText: `${roll.roll_no} (Available: ${roll.per_roll_weight} ${roll.unit}) (Vendor: ${roll.vendor_name})`, value: roll.roll_no, availableWeight: roll.per_roll_weight, unit: roll.unit }));
-  initializeAutocomplete(rollNoSearch, rollNoSel, rollNoOptions, rollData);
+  initializeAutocomplete(rollNoSearch, rollNoSel, rollNoOptions, rollData, !ALLOW_ADHOC);
   rollNoSearch.placeholder = `Search Roll (${fabricType})...`;
 
   rollNoSel.addEventListener('change', () => {
@@ -743,10 +765,20 @@ function initializeRollNoAutocomplete(rollSection, fabricType) {
       fullWeightInput.value = parseFloat(selectedRoll.per_roll_weight).toFixed(2);
       fullWeightInput.readOnly = true;
     } else {
-      rollSection.querySelector('.availableWeightTxt').textContent = '0';
-      fullWeightInput.readOnly = false;
-      fullWeightInput.value = '';
-      remainingWeightInput.value = (FLOW_MODE === 'hosiery') ? '0' : '';
+      if (!ALLOW_ADHOC) {
+        // Unknown roll not permitted — reset the selection
+        rollNoSel.value = '';
+        rollNoSearch.classList.add('is-invalid');
+        fullWeightInput.readOnly = true;
+        fullWeightInput.value = '';
+        remainingWeightInput.value = '';
+        rollSection.querySelector('.availableWeightTxt').textContent = '0';
+      } else {
+        rollSection.querySelector('.availableWeightTxt').textContent = '0';
+        fullWeightInput.readOnly = false;
+        fullWeightInput.value = '';
+        remainingWeightInput.value = (FLOW_MODE === 'hosiery') ? '0' : '';
+      }
     }
     updateWeightUsed(rollSection);
     updateWeightProgress(rollSection);


### PR DESCRIPTION
## Summary
Adds a global, admin-controlled switch — `store_settings.allow_adhoc_cutting_entry`, **default OFF** — that controls whether cutters may enter fabric types / roll numbers **not present in the fabric database**. Enforced in the UI *and* on the server (server is the source of truth) across all three entry points.

- **Util** `utils/storeSettings.js` — `getStoreSetting`, `resolveAllowAdhoc`, `allowAdhocCuttingEntry()` (fail-safe: missing/garbage → OFF), `isKnownFabricType`. Unit-tested with `node:test`.
- **Admin toggle** on `/admin` (`POST /admin/settings`) to flip the switch; off by default.
- **Create-lot** (`cuttingManagerRoutes` + `cuttingManagerDashboard.ejs`): when OFF, fabric-type and roll boxes become strict pickers (no free-text), unknown-roll manual-weight path disabled; server rejects unknown fabric types / rolls.
- **Add-missed-roll** (`editcuttinglots`): when OFF, rejects rolls not in inventory (server + strict edit-form picker).
- **Bulk upload** (`bulkUploadRoutes`): when OFF, rejects unknown fabric types (rolls were already DB-only; documented — Excel can't carry an ad-hoc roll's weight).

When the switch is **ON**, every entry point behaves exactly as before this change.

## Behavior change
The system effectively behaved as "ON" before; with the default OFF, cutters can no longer enter ad-hoc fabric types/rolls until an admin enables it. Existing lots/data are untouched. The Fabric Consumption "Ad-hoc" tab simply stops growing while OFF.

## Notes (from final review, non-blocking)
- Roll membership is validated inline against live inventory (Map/SQL), not via a shared pure helper — correct & fail-safe, just not unit-tested like the fabric-type helper.
- Strict pickers source rolls from the view's available-rolls list; a fully-depleted but DB-known roll would be slightly *more* restricted in the UI than the server (fail-safe direction).

## Test Plan
- [x] `npm test` — 13/13 (incl. `resolveAllowAdhoc` / `isKnownFabricType`)
- [x] All touched route modules load; admin + cutting views compile
- [ ] After deploy: admin toggle flips the setting; with OFF, create-lot / add-roll / bulk reject ad-hoc fabric types & rolls (incl. direct POST); with ON, ad-hoc works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)