### PR TITLE
Creatable Unit field for indent/store item types (units master table)

### DIFF
--- a/routes/indentRoutes.js
+++ b/routes/indentRoutes.js
@@ -7,6 +7,7 @@ const {
   isIndentFiller,
   isStoreManager
 } = require('../middlewares/auth');
+const { getUnits, ensureUnit, ensureUnitsTable } = require('../utils/unitsMaster');
 
 const ALLOWED_STATUSES = ['open', 'proceeding', 'arrived'];
 
@@ -95,6 +96,8 @@ async function ensureMigration() {
       updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
     )`);
     await pool.query(`INSERT IGNORE INTO store_settings (setting_key, setting_value) VALUES ('allow_freetext_indent', 'true')`);
+    // Units master (canonical unit-of-measure list for item types)
+    await ensureUnitsTable(pool);
     // Add columns to incoming_data
     const [incCols] = await pool.query(`SHOW COLUMNS FROM incoming_data LIKE 'invoice_number'`);
     if (incCols.length === 0) {
@@ -338,7 +341,7 @@ router.post('/create', isAuthenticated, isIndentFiller, async (req, res) => {
 router.get('/manage', isAuthenticated, isStoreManager, async (req, res) => {
   try {
     await ensureMigration();
-    const [[requests], [statsRows], allowFreetext, [goods]] = await Promise.all([
+    const [[requests], [statsRows], allowFreetext, [goods], units] = await Promise.all([
       pool.query(
         `SELECT ir.*, uf.username AS filler_name,
                 up.username AS proceeded_by_name,
@@ -362,7 +365,8 @@ router.get('/manage', isAuthenticated, isStoreManager, async (req, res) => {
           GROUP BY status`
       ),
       getStoreSetting('allow_freetext_indent', 'true'),
-      pool.query('SELECT * FROM goods_inventory ORDER BY description_of_goods, shade, size')
+      pool.query('SELECT * FROM goods_inventory ORDER BY description_of_goods, shade, size'),
+      getUnits(pool)
     ]);
 
     const stats = ALLOWED_STATUSES.reduce((acc, status) => {
@@ -380,6 +384,7 @@ router.get('/manage', isAuthenticated, isStoreManager, async (req, res) => {
       requests,
       stats,
       goods,
+      units,
       allowFreetext: allowFreetext === 'true'
     });
   } catch (error) {
@@ -866,9 +871,10 @@ router.post('/manage/items/create', isAuthenticated, isStoreManager, async (req,
     return res.redirect('/indent/manage');
   }
   try {
+    const unitNorm = await ensureUnit(pool, unit);
     await pool.query(
       'INSERT INTO goods_inventory (description_of_goods, shade, unit, size, qty) VALUES (?, ?, ?, ?, 0)',
-      [description.trim(), shade || null, unit, size || null]
+      [description.trim(), shade || null, unitNorm, size || null]
     );
     req.flash('success', 'Item type created.');
   } catch (err) {

--- a/routes/storeAdminRoutes.js
+++ b/routes/storeAdminRoutes.js
@@ -2,6 +2,7 @@ const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/db');
 const { isAuthenticated, isStoreAdmin } = require('../middlewares/auth');
+const { getUnits, ensureUnit, ensureUnitsTable } = require('../utils/unitsMaster');
 
 // Simple in-memory cache for goods list
 const CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
@@ -22,16 +23,18 @@ async function getGoodsCached() {
 // GET dashboard for store admin
 router.get('/dashboard', isAuthenticated, isStoreAdmin, async (req, res) => {
   try {
-    const [goods, dispatched] = await Promise.all([
+    await ensureUnitsTable(pool);
+    const [goods, dispatched, units] = await Promise.all([
       getGoodsCached(),
       pool
         .query(`SELECT d.*, g.description_of_goods, g.size, g.unit
                    FROM dispatched_data d
               LEFT JOIN goods_inventory g ON d.goods_id = g.id
                   ORDER BY d.dispatched_at DESC LIMIT 50`)
-        .then(r => r[0])
+        .then(r => r[0]),
+      getUnits(pool)
     ]);
-    res.render('storeAdminDashboard', { user: req.session.user, goods, dispatched });
+    res.render('storeAdminDashboard', { user: req.session.user, goods, dispatched, units });
   } catch (err) {
     console.error('Error loading store admin dashboard:', err);
     req.flash('error', 'Could not load dashboard');
@@ -47,9 +50,10 @@ router.post('/create', isAuthenticated, isStoreAdmin, async (req, res) => {
     return res.redirect('/store-admin/dashboard');
   }
   try {
+    const unitNorm = await ensureUnit(pool, unit);
     await pool.query(
       'INSERT INTO goods_inventory (description_of_goods, size, unit, shade, qty) VALUES (?, ?, ?, ?, 0)',
-      [description, size || null, unit, shade || null]
+      [description, size || null, unitNorm, shade || null]
     );
     goodsCache = { data: null, expiry: 0 };
     req.flash('success', 'Item created');

--- a/sql/units_master_migration.sql
+++ b/sql/units_master_migration.sql
@@ -1,0 +1,17 @@
+-- Units master table: the canonical unit-of-measure list for item types.
+-- Also applied at runtime in routes/indentRoutes.js ensureMigration().
+
+CREATE TABLE IF NOT EXISTS units (
+  id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(50) NOT NULL UNIQUE,
+  created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Seed the previously-hardcoded units.
+INSERT IGNORE INTO units (name) VALUES ('PCS'), ('ROLL'), ('CONE'), ('GROSS'), ('MTR');
+
+-- Backfill any units already present in inventory so nothing is lost.
+INSERT IGNORE INTO units (name)
+SELECT DISTINCT UPPER(TRIM(unit))
+FROM goods_inventory
+WHERE unit IS NOT NULL AND TRIM(unit) <> '';

--- a/test/unitsMaster.test.js
+++ b/test/unitsMaster.test.js
@@ -1,0 +1,50 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { normalizeUnit, ensureUnit, getUnits } = require('../utils/unitsMaster.js');
+
+test('normalizeUnit trims and uppercases', () => {
+  assert.strictEqual(normalizeUnit('  pcs '), 'PCS');
+  assert.strictEqual(normalizeUnit('Box'), 'BOX');
+  assert.strictEqual(normalizeUnit('GROSS'), 'GROSS');
+});
+
+test('normalizeUnit handles null/undefined/blank', () => {
+  assert.strictEqual(normalizeUnit(''), '');
+  assert.strictEqual(normalizeUnit(null), '');
+  assert.strictEqual(normalizeUnit(undefined), '');
+  assert.strictEqual(normalizeUnit('   '), '');
+});
+
+function stubPool() {
+  const calls = [];
+  return {
+    calls,
+    async query(sql, params) {
+      calls.push({ sql, params });
+      if (/^SELECT name FROM units/i.test(sql)) return [[{ name: 'CONE' }, { name: 'PCS' }]];
+      return [{ affectedRows: 1 }];
+    },
+  };
+}
+
+test('ensureUnit normalizes, INSERT IGNOREs, and returns canonical name', async () => {
+  const pool = stubPool();
+  const out = await ensureUnit(pool, ' box ');
+  assert.strictEqual(out, 'BOX');
+  assert.strictEqual(pool.calls.length, 1);
+  assert.match(pool.calls[0].sql, /INSERT IGNORE INTO units/i);
+  assert.deepStrictEqual(pool.calls[0].params, ['BOX']);
+});
+
+test('ensureUnit skips the DB write for blank input', async () => {
+  const pool = stubPool();
+  const out = await ensureUnit(pool, '   ');
+  assert.strictEqual(out, '');
+  assert.strictEqual(pool.calls.length, 0);
+});
+
+test('getUnits returns the names array', async () => {
+  const pool = stubPool();
+  const units = await getUnits(pool);
+  assert.deepStrictEqual(units, ['CONE', 'PCS']);
+});

--- a/utils/unitsMaster.js
+++ b/utils/unitsMaster.js
@@ -1,0 +1,43 @@
+// Units master: the canonical unit-of-measure list for item types.
+// Names are stored normalized (trimmed + uppercased) so 'pcs' and 'PCS' collapse to one.
+
+function normalizeUnit(name) {
+  return String(name == null ? '' : name).trim().toUpperCase();
+}
+
+// Creates + seeds the units table once per process (idempotent). Safe to call
+// from any route so the table exists regardless of which page loads first.
+let tableEnsured = false;
+async function ensureUnitsTable(pool) {
+  if (tableEnsured) return;
+  await pool.query(`CREATE TABLE IF NOT EXISTS units (
+    id INT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+    name VARCHAR(50) NOT NULL UNIQUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+  )`);
+  await pool.query(`INSERT IGNORE INTO units (name) VALUES ('PCS'),('ROLL'),('CONE'),('GROSS'),('MTR')`);
+  // Backfill any units already used in inventory (best-effort).
+  try {
+    await pool.query(`INSERT IGNORE INTO units (name)
+      SELECT DISTINCT UPPER(TRIM(unit)) FROM goods_inventory
+      WHERE unit IS NOT NULL AND TRIM(unit) <> ''`);
+  } catch (_) { /* goods_inventory may be absent in some contexts */ }
+  tableEnsured = true;
+}
+
+// Returns the list of known unit names, sorted.
+async function getUnits(pool) {
+  const [rows] = await pool.query('SELECT name FROM units ORDER BY name');
+  return rows.map(r => r.name);
+}
+
+// Normalizes a unit and persists it (INSERT IGNORE) if non-empty.
+// Returns the canonical (normalized) name, or '' for blank input.
+async function ensureUnit(pool, name) {
+  const u = normalizeUnit(name);
+  if (!u) return '';
+  await pool.query('INSERT IGNORE INTO units (name) VALUES (?)', [u]);
+  return u;
+}
+
+module.exports = { normalizeUnit, getUnits, ensureUnit, ensureUnitsTable };

--- a/views/storeAdminDashboard.ejs
+++ b/views/storeAdminDashboard.ejs
@@ -180,12 +180,12 @@
                 </div>
                 <div class="form-group mb-0">
                   <label class="form-label">Unit <span class="text-danger">*</span></label>
-                  <select name="unit" class="form-select form-input" required>
-                    <option value="PCS">PCS</option>
-                    <option value="ROLL">ROLL</option>
-                    <option value="CONE">CONE</option>
-                    <option value="GROSS">GROSS</option>
-                  </select>
+                  <input list="unitsList" name="unit" class="form-control form-input" required
+                         placeholder="Select or type a unit" autocomplete="off"
+                         oninput="this.value=this.value.toUpperCase()">
+                  <datalist id="unitsList">
+                    <% (typeof units !== 'undefined' ? units : []).forEach(function(u){ %><option value="<%= u %>"></option><% }); %>
+                  </datalist>
                 </div>
                 <div class="form-group mb-0">
                   <label class="form-label">Size <small class="text-muted">(optional)</small></label>

--- a/views/storeManagerIndentDashboard.ejs
+++ b/views/storeManagerIndentDashboard.ejs
@@ -270,13 +270,11 @@
             </div>
             <div class="form-col">
               <label>Unit <span class="req">*</span></label>
-              <select name="unit" class="field" required>
-                <option value="">Select</option>
-                <option value="PCS">PCS</option>
-                <option value="ROLL">ROLL</option>
-                <option value="CONE">CONE</option>
-                <option value="GROSS">GROSS</option>
-              </select>
+              <input list="unitsList" name="unit" class="field" required placeholder="Select or type a unit"
+                     autocomplete="off" oninput="this.value=this.value.toUpperCase()">
+              <datalist id="unitsList">
+                <% (units || []).forEach(function(u){ %><option value="<%= u %>"></option><% }); %>
+              </datalist>
             </div>
             <div class="form-col">
               <label>Size</label>


### PR DESCRIPTION
## What & why
On `/indent/manage` → **New Item Type**, the **Unit** field was a hardcoded dropdown (`PCS`, `ROLL`, `CONE`, `GROSS`) — a store manager couldn't add a unit not in that list. This makes it a **creatable combobox**: pick an existing unit or type a new one; new units persist and reflect thereafter.

## Changes
- **New `units` master table** (self-bootstrapping in `utils/unitsMaster.js` → `ensureUnitsTable`), seeded with `PCS/ROLL/CONE/GROSS/MTR` + backfilled from existing `goods_inventory.unit` values.
- **`utils/unitsMaster.js`**: `normalizeUnit` (UPPER+TRIM, dedupe), `getUnits`, `ensureUnit`, `ensureUnitsTable` — unit-tested.
- **`routes/indentRoutes.js`** & **`routes/storeAdminRoutes.js`**: render the units list; persist a typed-new unit via `ensureUnit()` on item create.
- **Views**: hardcoded `<select name="unit">` → `<input list>` + `<datalist>` combobox on both the indent and store-admin item forms.
- Fabric roll unit (METER/KG, `fabricInvoiceRolls.ejs`) intentionally **excluded** — different domain tied to weight logic.

## Test plan
- [x] `npm test` — 18/18 pass (incl. new unitsMaster tests)
- [x] Both views compile; both route modules load
- [ ] After deploy: `/indent/manage` New Item Type → type `BOX` → Create → reload → `BOX` in the list; lowercase `box` collapses to `BOX` (no dupe); same on `/store-admin/dashboard`; existing items/GROSS weight section unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)