### PR TITLE
feat(tasks): Linear-like v2 rebuild (+ mohitteam launcher & CC brand fixes)

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -76,6 +76,7 @@ function getDashboardForRole(roleName) {
     'checking': '/department/dashboard',
     'quality_assurance': '/department/dashboard',
     'challan_dashboard': '/challandashboard',
+    'mohitteam': '/tasks',
     'productviewer': '/product-links',
     'wishlinkops': '/inventory-ops/logs',
     'videofinder': '/video-finder',

--- a/routes/launcherRoutes.js
+++ b/routes/launcherRoutes.js
@@ -50,6 +50,7 @@ const ROLE_META = {
   checking:             { label: 'Checking',               icon: 'clipboard-check', desc: 'QA checking' },
   quality_assurance:    { label: 'Quality Assurance',      icon: 'patch-check',    desc: 'QA dashboard' },
   challan_dashboard:    { label: 'Challan',                icon: 'receipt',        desc: 'Challan dashboard' },
+  mohitteam:            { label: 'Tasks',                  icon: 'check2-square',  desc: 'Personal to-dos + team tasks' },
   productviewer:        { label: 'Product Links',          icon: 'link-45deg',     desc: 'View product links' },
   wishlinkops:          { label: 'Wishlink Ops',           icon: 'plug',           desc: 'Inventory hooks + Wishlink ops' },
   videofinder:          { label: 'Video Finder',           icon: 'camera-video',   desc: 'CCTV by AWB / keyword' },

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -417,6 +417,7 @@
                         <option value="KTT" selected>KTT</option>
                         <option value="KOTTY">KOTTY</option>
                         <option value="NW">NW</option>
+                        <option value="CC">CC</option>
                       </select>
                     </div>
                     <div style="flex: 1; min-width: 100px;">


### PR DESCRIPTION
Bundles three changes on this branch (deploys together on merge):

## 1. Tasks v2 — full-screen, dark, Linear-like rebuild (replaces v1)
- **Backend:** new status set (todo/in_progress/done/blocked), priority none..urgent, **projects** (`task_projects` + `project_id`), **tags** (`user_task_tags`), free-form status model. Endpoints for list (w/ tags+project+assignee), create/update, set-status, reassign, `/api/projects`, `/api/tags`.
- **Frontend:** full-screen dark takeover (no app chrome), Geist font, collapsible sidebar (All / My tasks / By project), toolbar with search + status/priority filters + List|Board toggle, grouped compact rows (status glyph, priority bars, tags, project chip, due, assignee avatar), hover actions, blocked-row distinct, skeleton + empty states, **⌘K** palette, **j/k** nav, create/edit dialog. Board tab is a placeholder (next).

### ⚠️ Deploy ordering (important)
`sql/2026_06_user_tasks_v2.sql` is a **breaking schema change for v1**. Recommended: **let this deploy go live, then apply the migration immediately** (v1 keeps working during the build; the only outage window is between the new revision going live and the migration running — keep the SQL ready). Once migrated, rollback to v1 is not viable (fix-forward).

## 2. Launcher fix
`getDashboardForRole` now maps `mohitteam` → `/tasks` (+ launcher card), fixing "can't enter the mohitteam role".

## 3. Cutting dashboard
Added `CC` to the SKU-builder Brand dropdown (KTT / KOTTY / NW / CC).

## Verify after deploy
- Apply `sql/2026_06_user_tasks_v2.sql`, then `/tasks` as a mohitteam user: list groups by status, ⌘K, j/k, create with project/tags/priority, set status, blocked-row styling.
- Launcher → Tasks card lands on `/tasks`. Cutting → Brand shows CC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)