### PR TITLE
feat(cutting): batch add multiple missed rolls

### DIFF
--- a/docs/superpowers/specs/2026-06-09-batch-add-missed-rolls-design.md
+++ b/docs/superpowers/specs/2026-06-09-batch-add-missed-rolls-design.md
@@ -1,0 +1,109 @@
+# Batch "Add Missed Rolls" on Edit Cutting Lots
+
+**Date:** 2026-06-09
+**Page:** `/operator/editcuttinglots` → Edit lot → Sizes & Rolls tab → "Add a missed roll"
+
+## Context
+
+The "Add a missed roll" feature currently adds **one** roll at a time. After a successful add it re-fetches and re-renders the whole edit-form modal, which also bounces the operator back to the first tab ("Lot Details"). When an operator needs to add several missed rolls to a lot, this is tedious: fill → add → full reload → re-navigate to Sizes & Rolls → scroll down → repeat.
+
+This spec replaces the single-row add UI with a **multi-row batch entry** form: the operator stacks several roll rows and submits them all at once, committed **all-or-nothing** in a single DB transaction.
+
+The backend single-roll endpoint (`POST /editcuttinglots/add-roll`, [routes/editcuttinglots.js:781-894](../../../routes/editcuttinglots.js#L781-L894)) is already correct and handles inventory depletion, duplicate guarding, and totals recompute. This feature generalizes that logic to a batch.
+
+**Note on a prior bug:** the add-roll client wiring must live in the parent page's `attachFormListeners()` in `views/editcuttinglots.ejs`, NOT in a `<script>` inside the server-rendered fragment — fragments are injected via `innerHTML`, and browsers never execute `<script>` tags inserted that way. The fragment passes data through an inert `<script type="application/json" id="addRollConfig">` block. This design preserves that pattern.
+
+## Goals
+
+- Operator can enter N roll rows and add them in one action.
+- All-or-nothing commit: if any row is invalid, nothing is saved; the error names the offending row/roll; typed rows remain on screen to fix and resubmit.
+- Per-row weight computation matches existing rules (denim vs hosiery).
+- Inventory depletion, duplicate guarding, and piece-total recompute remain correct.
+
+## Non-Goals
+
+- No change to the normal "Update Lot" submit flow.
+- No change to the single-roll `add-roll` endpoint (left in place, unused by the UI after this change — kept to minimize risk).
+- No bulk paste/import; rows are entered one at a time via "+ Add another row".
+
+## Design
+
+### 1. UI — edit-form fragment (`routes/editcuttinglots.js`, the `add a missed roll` block ~lines 411-460)
+
+Replace the single static input row with a **row repeater**:
+
+- A container `#addRollRows` holding one or more roll rows. Each row carries the same fields as today:
+  - **Roll Number** — text input with the shared `<datalist id="addRollNoOptions">` (autocomplete from inventory for the lot's `fabric_type`).
+  - **Layers** — number.
+  - **Full Weight** — number (auto-filled + locked when the roll is found in inventory).
+  - **Weight Used** — readonly, auto-computed.
+  - **Remaining** — readonly for denim (auto), editable default 0 for hosiery.
+  - **✕ Remove** button (hidden/disabled when only one row remains).
+  - A per-row availability hint element (the `addRollAvail` equivalent).
+- A hidden **row template** (e.g. a `<template id="addRollRowTemplate">` or a JS-built string) used to clone new rows.
+- **"+ Add another row"** button (`#addRollAddRow`).
+- One **"Add N rolls to lot"** submit button (`#addRollBtn`), disabled for denim lots missing `table_length` (same guard as today).
+- A shared error area `#addRollError`.
+
+The inert `#addRollConfig` JSON block (rollInventory, isDenim, allowAdhoc, tableLength, managerId, lotId) stays as-is.
+
+### 2. Frontend wiring — `views/editcuttinglots.ejs`, inside `attachFormListeners()`
+
+Extend the existing `wireAddRoll()` block (added when the single-roll bug was fixed):
+
+- Read `#addRollConfig` once (rollInventory, isDenim, allowAdhoc, tableLength).
+- `attachRowListeners(row)` — wires one row's listeners:
+  - Roll-number `change`: look up inventory; if found, set+lock Full Weight and show "Available in inventory: …"; else unlock + "New roll (manual entry…)"; then recompute that row.
+  - `recomputeRowWeights(row)`: denim → `used = tableLength × layers`, `remaining = full − used`; hosiery → `used = full − remaining`. Toggle `text-danger` when `used > full`. (Same math as the current `recomputeAddRollWeights`, scoped to the row.)
+  - Full Weight `input` always recomputes; Layers (denim) or Remaining (hosiery) `input` recomputes.
+- `#addRollAddRow` click: clone the template, append to `#addRollRows`, call `attachRowListeners` on the new row, focus its Roll Number field, show Remove buttons.
+- ✕ Remove click: remove that row (guard: never remove the last remaining row).
+- `#addRollBtn` click:
+  1. Collect all rows; skip fully-empty rows.
+  2. Client-side validate each non-empty row (roll# present; if `!allowAdhoc`, roll must be in inventory; layers > 0; full > 0; used ≥ 0; used ≤ full). On failure, show "Row K: …" and abort.
+  3. Client-side duplicate check across rows (same roll_no twice) → "Row K duplicates row J (roll …)".
+  4. POST `FormData` with parallel arrays `roll_no[]`, `layers[]`, `full_weight[]`, `weight_used[]` to `/operator/editcuttinglots/add-rolls?managerId=…&lotId=…`.
+  5. On `{success:true}`: alert "Added N rolls. Total pieces is now …", then `loadEditForm(managerId, lotId)` once.
+  6. On `{success:false}`: `showErr(data.error)`; leave rows on screen.
+
+### 3. Backend — new `POST /editcuttinglots/add-rolls` (plural)
+
+Mirrors the single `add-roll` logic, looped inside ONE transaction:
+
+- Parse arrays (normalize single values to length-1 arrays, like the `update` handler does).
+- Open transaction; `SELECT … FOR UPDATE` the lot (confirm `user_id = managerId`); load `fabric_type`, `table_length`.
+- Load `allowAdhoc` once.
+- Build a `Set` of existing roll_nos in the lot (one query) for duplicate detection, plus an in-batch `Set` to catch duplicates within the submission.
+- For each row:
+  - Validate `layers > 0`, `full_weight > 0`, `weight_used ≥ 0`, `weight_used ≤ full_weight` → else `throw` naming the row.
+  - Duplicate (existing lot or earlier in batch) → throw.
+  - Inventory lookup (`fabric_invoice_rolls` JOIN `fabric_invoices` on `fabric_type` FOR UPDATE). If found: `resolvedFullWeight = per_roll_weight`, guard `weight_used ≤ available`, deplete with `UPDATE … WHERE roll_no=? AND per_roll_weight >= ?` (throw if `affectedRows === 0`). If not found and `!allowAdhoc` → throw.
+  - `remaining_weight = max(resolvedFullWeight − weight_used, 0)`.
+  - Add roll_no to the in-batch and existing sets.
+  - Stage the INSERT values.
+- Compute `sumPatterns` once; each row's `total_pieces = layers × sumPatterns`.
+- Bulk INSERT all rows into `cutting_lot_rolls`.
+- Increment each size: `UPDATE cutting_lot_sizes SET total_pieces = total_pieces + (pattern_count * ?)` with the **sum of all batched layers**, in one statement.
+- Recompute lot total = `SUM(cutting_lot_sizes.total_pieces)`; update `cutting_lots.total_pieces`.
+- `COMMIT`; return `{ success, added: N, total_pieces, sum_layers, sum_patterns }`.
+- Any throw → `ROLLBACK`, return `{ success:false, error }`.
+
+Use `upload.none()` middleware (FormData parsing), consistent with the other endpoints.
+
+## Error Handling
+
+All-or-nothing. The first invalid row aborts the whole transaction; the error message identifies the row (1-based index) and roll number. The client keeps all typed rows so the operator corrects the flagged row and resubmits.
+
+## Testing / Verification
+
+Run locally (`npm start`), open the page, edit a lot, Sizes & Rolls tab:
+
+1. **1-row parity:** add a single roll → behaves like before (row appears, totals bump).
+2. **N rows:** add 3 rolls in one submit → all appear, inventory depleted for each, lot/size totals correct.
+3. **Duplicate in batch:** two rows same roll# → rejected, nothing saved.
+4. **Duplicate vs existing:** a row whose roll# already exists in the lot → rejected.
+5. **Over-inventory:** a row with weight_used > available → rejected, error names the row, nothing saved.
+6. **Denim math:** Weight Used = table_length × layers per row, Remaining auto.
+7. **Hosiery math:** enter Remaining, Weight Used = full − remaining.
+8. **DB checks:** new `cutting_lot_rolls` rows present; `fabric_invoice_rolls.per_roll_weight` depleted; `cutting_lots.total_pieces` and per-size totals consistent.
+9. **Regression:** normal "Update Lot" submit still fires once and saves size/layer edits.

--- a/routes/editcuttinglots.js
+++ b/routes/editcuttinglots.js
@@ -311,6 +311,37 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
     // Has any downstream stage seen this lot?
     const downstreamHits = downstream.filter(d => d.c > 0).map(d => d.stage);
 
+    // Markup for a single add-roll row. Shared by the initial row and the
+    // <template> the client clones for "Add another row". Uses classes (not ids)
+    // since the form now holds many of these rows.
+    const addRollRowMarkup = `
+      <div class="add-roll-row row g-2 align-items-end mb-2">
+        <div class="col-md-3">
+          <label class="form-label">Roll Number</label>
+          <input type="text" class="form-control arr-roll-no" list="addRollNoOptions" placeholder="Pick or type roll #" autocomplete="off">
+          <div class="form-text arr-avail" style="font-size:0.75rem;color:#6b7280;"></div>
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">Layers</label>
+          <input type="number" min="1" step="1" class="form-control arr-layers" placeholder="Layers">
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">Full Weight</label>
+          <input type="number" step="0.01" min="0" class="form-control arr-full" placeholder="Full">
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">Weight Used</label>
+          <input type="number" step="0.01" min="0" class="form-control arr-used" readonly placeholder="Weight used (auto)">
+        </div>
+        <div class="col-md-2">
+          <label class="form-label">Remaining</label>
+          <input type="number" step="0.01" min="0" class="form-control arr-rem" ${isDenim ? 'readonly' : 'value="0"'} placeholder="${isDenim ? 'Auto' : 'Remaining (default 0)'}">
+        </div>
+        <div class="col-md-1">
+          <button type="button" class="btn btn-outline-danger btn-sm arr-remove" title="Remove this row"><i class="bi bi-x-lg"></i></button>
+        </div>
+      </div>`;
+
     // Build the combined edit form HTML.
     let html = `
       <div id="editFormWrapper">
@@ -412,7 +443,7 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
                   <div class="mt-4 p-3 border rounded" style="background:#f8fafc;">
                     <h5 class="mb-2"><i class="bi bi-plus-circle"></i> Add a missed roll</h5>
                     <p class="text-muted small mb-2">
-                      Inserts a new roll into this lot, recomputes total pieces, and (if the roll exists in inventory) deducts the used weight from <code>fabric_invoice_rolls</code>.
+                      Inserts one or more rolls into this lot, recomputes total pieces, and (if a roll exists in inventory) deducts the used weight from <code>fabric_invoice_rolls</code>. All rows are added together — if any row is invalid, nothing is saved.
                       ${isDenim ? 'Weight Used is auto-computed from <strong>table_length × layers</strong>.' : 'Enter <strong>Remaining</strong>; Weight Used is derived automatically.'}
                     </p>
                     ${isDenim && !lot.table_length ? `
@@ -425,36 +456,20 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
                         <strong>Heads-up:</strong> this lot has already moved into <strong>${downstreamHits.join(', ')}</strong>.
                         Adding pieces upstream is allowed (downstream stages track their own qty), but the next-stage master will see more pieces available than before.
                       </div>` : ''}
-                    <div class="row g-2">
-                      <div class="col-md-4">
-                        <label class="form-label">Roll Number</label>
-                        <input type="text" class="form-control" id="addRollNo" list="addRollNoOptions" placeholder="Pick or type roll #" autocomplete="off">
-                        <datalist id="addRollNoOptions">
-                          ${availableRolls.map(r => `<option value="${r.roll_no}" label="Avail ${r.per_roll_weight} ${r.unit || ''}"></option>`).join('')}
-                        </datalist>
-                        <div class="form-text" id="addRollAvail" style="font-size:0.75rem;color:#6b7280;"></div>
-                      </div>
-                      <div class="col-md-2">
-                        <label class="form-label">Layers</label>
-                        <input type="number" min="1" step="1" class="form-control" id="addRollLayers" placeholder="Layers">
-                      </div>
-                      <div class="col-md-2">
-                        <label class="form-label">Full Weight</label>
-                        <input type="number" step="0.01" min="0" class="form-control" id="addRollFullWeight" placeholder="Full">
-                      </div>
-                      <div class="col-md-2">
-                        <label class="form-label">Weight Used</label>
-                        <input type="number" step="0.01" min="0" class="form-control" id="addRollWeightUsed" readonly placeholder="Weight used (auto)">
-                      </div>
-                      <div class="col-md-2">
-                        <label class="form-label">Remaining</label>
-                        <input type="number" step="0.01" min="0" class="form-control" id="addRollRemaining" ${isDenim ? 'readonly' : 'value="0"'} placeholder="${isDenim ? 'Auto' : 'Remaining (default 0)'}">
-                      </div>
+                    <datalist id="addRollNoOptions">
+                      ${availableRolls.map(r => `<option value="${r.roll_no}" label="Avail ${r.per_roll_weight} ${r.unit || ''}"></option>`).join('')}
+                    </datalist>
+                    <div id="addRollRows">${addRollRowMarkup}</div>
+                    <template id="addRollRowTemplate">${addRollRowMarkup}</template>
+                    <div class="mt-2">
+                      <button type="button" class="btn btn-outline-secondary btn-sm" id="addRollAddRow">
+                        <i class="bi bi-plus"></i> Add another row
+                      </button>
                     </div>
                     <div id="addRollError" class="text-danger small mt-2" style="display:none;"></div>
                     <div class="mt-3">
                       <button type="button" class="btn btn-primary btn-sm" id="addRollBtn"${isDenim && !lot.table_length ? ' disabled' : ''}>
-                        <i class="bi bi-plus-circle"></i> Add roll to lot
+                        <i class="bi bi-plus-circle"></i> Add rolls to lot
                       </button>
                     </div>
                   </div>
@@ -770,6 +785,150 @@ router.post('/editcuttinglots/add-roll', isAuthenticated, isOperator, upload.non
     await conn.rollback();
     console.error('Error in POST /operator/editcuttinglots/add-roll:', err);
     res.json({ success: false, error: err.message || 'Failed to add roll.' });
+  } finally {
+    conn.release();
+  }
+});
+
+/**
+ * POST /operator/editcuttinglots/add-rolls?managerId=…&lotId=…
+ * Batch version of add-roll. Accepts parallel arrays roll_no[], layers[],
+ * full_weight[], weight_used[]. All rows are added in ONE transaction
+ * (all-or-nothing): if any row fails validation/duplicate/inventory checks,
+ * nothing is saved and the error names the offending row.
+ */
+router.post('/editcuttinglots/add-rolls', isAuthenticated, isOperator, upload.none(), async (req, res) => {
+  const { managerId, lotId } = req.query;
+  if (!managerId || !lotId) {
+    return res.status(400).json({ success: false, error: 'Manager and Lot IDs required.' });
+  }
+  // Normalize to arrays (a single row arrives as scalars).
+  let { roll_no, layers, full_weight, weight_used } = req.body;
+  if (!Array.isArray(roll_no)) { roll_no = [roll_no]; layers = [layers]; full_weight = [full_weight]; weight_used = [weight_used]; }
+
+  // Parse + drop fully-empty rows.
+  const rows = [];
+  for (let i = 0; i < roll_no.length; i++) {
+    const rn = (roll_no[i] || '').trim();
+    const ly = layers[i], fw = full_weight[i], wu = weight_used[i];
+    const blank = !rn && (ly === undefined || ly === '') && (fw === undefined || fw === '') && (wu === undefined || wu === '');
+    if (blank) continue;
+    rows.push({
+      idx: rows.length + 1, // 1-based for messages
+      roll_no: rn,
+      layers: parseFloat(ly),
+      full_weight: parseFloat(fw),
+      weight_used: parseFloat(wu),
+    });
+  }
+  if (!rows.length) return res.json({ success: false, error: 'Add at least one roll.' });
+
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+
+    // Confirm the lot belongs to this manager + load fabric_type
+    const [[lot]] = await conn.query(
+      `SELECT id, fabric_type, table_length FROM cutting_lots WHERE id = ? AND user_id = ? FOR UPDATE`,
+      [lotId, managerId]
+    );
+    if (!lot) throw new Error('Lot not found for this manager.');
+
+    const allowAdhoc = await allowAdhocCuttingEntry();
+
+    // Roll numbers already in this lot — duplicate guard (vs existing + within batch).
+    const [existingRolls] = await conn.query(
+      `SELECT roll_no FROM cutting_lot_rolls WHERE cutting_lot_id = ?`,
+      [lotId]
+    );
+    const seen = new Set(existingRolls.map(r => r.roll_no));
+
+    // Σ(pattern_count) once — used for every row's total_pieces.
+    const [[patternsRow]] = await conn.query(
+      `SELECT COALESCE(SUM(pattern_count), 0) AS sum_patterns FROM cutting_lot_sizes WHERE cutting_lot_id = ?`,
+      [lotId]
+    );
+    const sumPatterns = Number(patternsRow.sum_patterns) || 0;
+
+    const insertValues = [];
+    let batchLayers = 0;
+    for (const row of rows) {
+      const label = `Row ${row.idx}${row.roll_no ? ` (${row.roll_no})` : ''}`;
+      if (!row.roll_no) throw new Error(`${label}: roll number is required.`);
+      if (!(row.layers > 0)) throw new Error(`${label}: layers must be > 0.`);
+      if (!(row.full_weight > 0)) throw new Error(`${label}: full weight must be > 0.`);
+      if (!(row.weight_used >= 0)) throw new Error(`${label}: weight used must be ≥ 0.`);
+      if (row.weight_used > row.full_weight) throw new Error(`${label}: weight used cannot exceed full weight.`);
+      if (seen.has(row.roll_no)) throw new Error(`${label}: this roll number is already in this lot (or duplicated in the batch).`);
+
+      // Inventory lookup — deplete fabric_invoice_rolls if the roll exists there.
+      const [[inv]] = await conn.query(
+        `SELECT fir.roll_no, fir.per_roll_weight
+           FROM fabric_invoice_rolls fir
+           JOIN fabric_invoices fi ON fi.id = fir.invoice_id
+          WHERE fir.roll_no = ? AND fi.fabric_type = ?
+          FOR UPDATE`,
+        [row.roll_no, lot.fabric_type]
+      );
+      let resolvedFullWeight = row.full_weight;
+      if (inv) {
+        resolvedFullWeight = parseFloat(inv.per_roll_weight);
+        if (row.weight_used > resolvedFullWeight) {
+          throw new Error(`${label}: weight used (${row.weight_used}) exceeds inventory available (${resolvedFullWeight}).`);
+        }
+        const [upd] = await conn.query(
+          `UPDATE fabric_invoice_rolls SET per_roll_weight = per_roll_weight - ?
+            WHERE roll_no = ? AND per_roll_weight >= ?`,
+          [row.weight_used, row.roll_no, row.weight_used]
+        );
+        if (upd.affectedRows === 0) throw new Error(`${label}: insufficient inventory.`);
+      } else if (!allowAdhoc) {
+        throw new Error(`${label}: roll is not in fabric inventory. Ad-hoc entry is disabled.`);
+      }
+      const remaining_weight = Math.max(resolvedFullWeight - row.weight_used, 0);
+      const rollPieces = row.layers * sumPatterns;
+      insertValues.push([lotId, row.roll_no, row.weight_used, row.layers, rollPieces, resolvedFullWeight, remaining_weight]);
+      seen.add(row.roll_no);
+      batchLayers += row.layers;
+    }
+
+    // Bulk insert all rows.
+    const placeholders = insertValues.map(() => '(?, ?, ?, ?, ?, ?, ?, NOW())').join(', ');
+    await conn.query(
+      `INSERT INTO cutting_lot_rolls
+         (cutting_lot_id, roll_no, weight_used, layers, total_pieces, full_weight, remaining_weight, created_at)
+       VALUES ${placeholders}`,
+      insertValues.flat()
+    );
+
+    // Increment each size by the whole batch's layer contribution, then recompute lot total.
+    await conn.query(
+      `UPDATE cutting_lot_sizes SET total_pieces = total_pieces + (pattern_count * ?) WHERE cutting_lot_id = ?`,
+      [batchLayers, lotId]
+    );
+    const [[sizeSumRow]] = await conn.query(
+      `SELECT COALESCE(SUM(total_pieces), 0) AS sum_pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ?`,
+      [lotId]
+    );
+    const newLotPieces = Number(sizeSumRow.sum_pieces) || 0;
+    await conn.query(`UPDATE cutting_lots SET total_pieces = ? WHERE id = ?`, [newLotPieces, lotId]);
+    const [[layersRow]] = await conn.query(
+      `SELECT COALESCE(SUM(layers), 0) AS sum_layers FROM cutting_lot_rolls WHERE cutting_lot_id = ?`,
+      [lotId]
+    );
+
+    await conn.commit();
+    res.json({
+      success: true,
+      added: insertValues.length,
+      total_pieces: newLotPieces,
+      sum_layers: Number(layersRow.sum_layers) || 0,
+      sum_patterns: sumPatterns,
+    });
+  } catch (err) {
+    await conn.rollback();
+    console.error('Error in POST /operator/editcuttinglots/add-rolls:', err);
+    res.json({ success: false, error: err.message || 'Failed to add rolls.' });
   } finally {
     conn.release();
   }

--- a/views/editcuttinglots.ejs
+++ b/views/editcuttinglots.ejs
@@ -392,7 +392,11 @@
       (function wireAddRoll() {
         var cfgEl = modalContainer.querySelector("#addRollConfig");
         var addRollBtn = modalContainer.querySelector("#addRollBtn");
-        if (!cfgEl || !addRollBtn) return;
+        var rowsContainer = modalContainer.querySelector("#addRollRows");
+        var rowTemplate = modalContainer.querySelector("#addRollRowTemplate");
+        var addRowBtn = modalContainer.querySelector("#addRollAddRow");
+        var addRollErr = modalContainer.querySelector("#addRollError");
+        if (!cfgEl || !addRollBtn || !rowsContainer || !rowTemplate) return;
         var cfg;
         try { cfg = JSON.parse(cfgEl.textContent); } catch (e) { return; }
         var ROLL_INVENTORY = cfg.rollInventory || [];
@@ -400,80 +404,125 @@
         var ALLOW_ADHOC = !!cfg.allowAdhoc;
         var TABLE_LENGTH = (cfg.tableLength === null || cfg.tableLength === undefined) ? null : Number(cfg.tableLength);
 
-        var addRollNo    = modalContainer.querySelector("#addRollNo");
-        var addRollLayers = modalContainer.querySelector("#addRollLayers");
-        var addRollFullW = modalContainer.querySelector("#addRollFullWeight");
-        var addRollUsed  = modalContainer.querySelector("#addRollWeightUsed");
-        var addRollRem   = modalContainer.querySelector("#addRollRemaining");
-        var addRollAvail = modalContainer.querySelector("#addRollAvail");
-        var addRollErr   = modalContainer.querySelector("#addRollError");
-
         function showErr(m) { addRollErr.textContent = m; addRollErr.style.display = "block"; addRollBtn.disabled = false; }
+        function clearErr() { addRollErr.style.display = "none"; }
 
-        // Mirrors CuttingWeight.computeRollWeights() in public/js/cuttingWeight.js.
-        function recomputeAddRollWeights() {
-          var full = parseFloat(addRollFullW.value);
+        // Show/hide Remove buttons (hidden when only one row remains).
+        function refreshRemoveButtons() {
+          var rows = rowsContainer.querySelectorAll(".add-roll-row");
+          rows.forEach(function(row) {
+            var btn = row.querySelector(".arr-remove");
+            if (btn) btn.style.visibility = (rows.length > 1) ? "visible" : "hidden";
+          });
+        }
+
+        // Mirrors CuttingWeight.computeRollWeights(), scoped to one row.
+        function recomputeRow(row) {
+          var fullEl = row.querySelector(".arr-full");
+          var usedEl = row.querySelector(".arr-used");
+          var remEl  = row.querySelector(".arr-rem");
+          var full = parseFloat(fullEl.value);
           if (IS_DENIM) {
-            var layers = parseFloat(addRollLayers.value);
-            if (isNaN(layers) || TABLE_LENGTH == null) { addRollUsed.value = ""; addRollRem.value = ""; return; }
+            var layers = parseFloat(row.querySelector(".arr-layers").value);
+            if (isNaN(layers) || TABLE_LENGTH == null) { usedEl.value = ""; remEl.value = ""; return; }
             var used = TABLE_LENGTH * layers;
-            addRollUsed.value = used.toFixed(2);
-            addRollRem.value = isNaN(full) ? "" : Math.max(full - used, 0).toFixed(2);
-            addRollUsed.classList.toggle("text-danger", !isNaN(full) && used > full);
+            usedEl.value = used.toFixed(2);
+            remEl.value = isNaN(full) ? "" : Math.max(full - used, 0).toFixed(2);
+            usedEl.classList.toggle("text-danger", !isNaN(full) && used > full);
           } else {
-            var remaining = addRollRem.value === "" ? 0 : parseFloat(addRollRem.value);
-            if (isNaN(full)) { addRollUsed.value = ""; addRollUsed.classList.remove("text-danger"); return; }
-            addRollUsed.value = Math.max(full - remaining, 0).toFixed(2);
-            addRollUsed.classList.toggle("text-danger", remaining > full);
+            var remaining = remEl.value === "" ? 0 : parseFloat(remEl.value);
+            if (isNaN(full)) { usedEl.value = ""; usedEl.classList.remove("text-danger"); return; }
+            usedEl.value = Math.max(full - remaining, 0).toFixed(2);
+            usedEl.classList.toggle("text-danger", remaining > full);
           }
         }
 
-        addRollNo.addEventListener("change", function() {
-          var val = addRollNo.value.trim();
-          var inv = ROLL_INVENTORY.find(function(r) { return r.roll_no === val; });
-          if (inv) {
-            addRollFullW.value = Number(inv.per_roll_weight).toFixed(2);
-            addRollFullW.readOnly = true;
-            addRollAvail.textContent = "Available in inventory: " + inv.per_roll_weight + " " + (inv.unit || "");
+        function attachRowListeners(row) {
+          var rollNoEl = row.querySelector(".arr-roll-no");
+          var fullEl   = row.querySelector(".arr-full");
+          var availEl  = row.querySelector(".arr-avail");
+
+          rollNoEl.addEventListener("change", function() {
+            var val = rollNoEl.value.trim();
+            var inv = ROLL_INVENTORY.find(function(r) { return r.roll_no === val; });
+            if (inv) {
+              fullEl.value = Number(inv.per_roll_weight).toFixed(2);
+              fullEl.readOnly = true;
+              availEl.textContent = "Available in inventory: " + inv.per_roll_weight + " " + (inv.unit || "");
+            } else {
+              fullEl.readOnly = false;
+              availEl.textContent = "New roll (manual entry — not in inventory)";
+            }
+            recomputeRow(row);
+          });
+          fullEl.addEventListener("input", function() { recomputeRow(row); });
+          if (IS_DENIM) {
+            row.querySelector(".arr-layers").addEventListener("input", function() { recomputeRow(row); });
           } else {
-            addRollFullW.readOnly = false;
-            addRollAvail.textContent = "New roll (manual entry — not in inventory)";
+            row.querySelector(".arr-rem").addEventListener("input", function() { recomputeRow(row); });
           }
-          recomputeAddRollWeights();
-        });
-        addRollFullW.addEventListener("input", recomputeAddRollWeights);
-        if (IS_DENIM) {
-          addRollLayers.addEventListener("input", recomputeAddRollWeights);
-        } else {
-          addRollRem.addEventListener("input", recomputeAddRollWeights);
+          var removeBtn = row.querySelector(".arr-remove");
+          if (removeBtn) removeBtn.addEventListener("click", function() {
+            if (rowsContainer.querySelectorAll(".add-roll-row").length <= 1) return;
+            row.remove();
+            refreshRemoveButtons();
+          });
         }
+
+        // Wire the initial row, then enable adding more.
+        rowsContainer.querySelectorAll(".add-roll-row").forEach(attachRowListeners);
+        refreshRemoveButtons();
+
+        if (addRowBtn) addRowBtn.addEventListener("click", function() {
+          var newRow = rowTemplate.content.firstElementChild.cloneNode(true);
+          rowsContainer.appendChild(newRow);
+          attachRowListeners(newRow);
+          refreshRemoveButtons();
+          var rn = newRow.querySelector(".arr-roll-no");
+          if (rn) rn.focus();
+        });
 
         addRollBtn.addEventListener("click", function() {
-          addRollErr.style.display = "none";
-          var roll_no = (addRollNo.value || "").trim();
-          var layers = parseFloat(addRollLayers.value);
-          var full_weight = parseFloat(addRollFullW.value);
-          var weight_used = parseFloat(addRollUsed.value);
-          if (!roll_no) return showErr("Pick a roll number.");
-          if (!ALLOW_ADHOC && !ROLL_INVENTORY.some(function(r) { return r.roll_no === roll_no; })) {
-            return showErr("Roll is not in fabric inventory; ad-hoc entry is disabled.");
+          clearErr();
+          var rows = Array.prototype.slice.call(rowsContainer.querySelectorAll(".add-roll-row"));
+          var payload = [];
+          var seen = {};
+          for (var i = 0; i < rows.length; i++) {
+            var row = rows[i];
+            var roll_no = (row.querySelector(".arr-roll-no").value || "").trim();
+            var layers = parseFloat(row.querySelector(".arr-layers").value);
+            var full_weight = parseFloat(row.querySelector(".arr-full").value);
+            var weight_used = parseFloat(row.querySelector(".arr-used").value);
+            // Skip fully-empty rows.
+            if (!roll_no && isNaN(layers) && isNaN(full_weight) && isNaN(weight_used)) continue;
+            var label = "Row " + (payload.length + 1);
+            if (!roll_no) return showErr(label + ": pick a roll number.");
+            if (!ALLOW_ADHOC && !ROLL_INVENTORY.some(function(r) { return r.roll_no === roll_no; })) {
+              return showErr(label + " (" + roll_no + "): not in fabric inventory; ad-hoc entry is disabled.");
+            }
+            if (!(layers > 0)) return showErr(label + " (" + roll_no + "): layers must be greater than 0.");
+            if (!(full_weight > 0)) return showErr(label + " (" + roll_no + "): full weight must be greater than 0.");
+            if (!(weight_used >= 0)) return showErr(label + " (" + roll_no + "): enter a valid Weight Used (0 or more).");
+            if (weight_used > full_weight) return showErr(label + " (" + roll_no + "): weight used (" + weight_used.toFixed(2) + ") cannot exceed full weight (" + full_weight.toFixed(2) + ").");
+            if (seen[roll_no]) return showErr(label + " (" + roll_no + "): duplicated in the batch.");
+            seen[roll_no] = true;
+            payload.push({ roll_no: roll_no, layers: layers, full_weight: full_weight, weight_used: weight_used });
           }
-          if (!(layers > 0)) return showErr("Layers must be greater than 0.");
-          if (!(full_weight > 0)) return showErr("Full weight must be greater than 0.");
-          if (!(weight_used >= 0)) return showErr("Enter a valid Weight Used (0 or more).");
-          if (weight_used > full_weight) return showErr("Weight used (" + weight_used.toFixed(2) + ") cannot exceed full weight (" + full_weight.toFixed(2) + ").");
+          if (!payload.length) return showErr("Enter at least one roll.");
 
           addRollBtn.disabled = true;
           var fd = new FormData();
-          fd.append("roll_no", roll_no);
-          fd.append("layers", layers);
-          fd.append("full_weight", full_weight);
-          fd.append("weight_used", weight_used);
-          fetch("/operator/editcuttinglots/add-roll?managerId=" + managerId + "&lotId=" + lotId, { method: "POST", body: fd })
+          payload.forEach(function(p) {
+            fd.append("roll_no[]", p.roll_no);
+            fd.append("layers[]", p.layers);
+            fd.append("full_weight[]", p.full_weight);
+            fd.append("weight_used[]", p.weight_used);
+          });
+          fetch("/operator/editcuttinglots/add-rolls?managerId=" + managerId + "&lotId=" + lotId, { method: "POST", body: fd })
             .then(function(r) { return r.json(); })
             .then(function(data) {
-              if (!data.success) return showErr(data.error || "Failed to add roll.");
-              alert("Roll added. Total pieces is now " + data.total_pieces + ".");
+              if (!data.success) return showErr(data.error || "Failed to add rolls.");
+              alert("Added " + data.added + " roll(s). Total pieces is now " + data.total_pieces + ".");
               loadEditForm(managerId, lotId); // refresh the modal in place
             })
             .catch(function(e) { showErr("Network error: " + e.message); });


### PR DESCRIPTION
## What
The "Add a missed roll" box on `/operator/editcuttinglots` now supports **multiple rows**: **+ Add another row** stacks rows (each with its own roll-pick + weight computation), and **Add rolls to lot** submits them all together.

## Backend
New `POST /editcuttinglots/add-rolls` adds the whole batch in **one transaction** (all-or-nothing): per-row validation, duplicate guard (vs existing lot rolls and within the batch), inventory depletion, bulk insert, single totals recompute. Any failure → `ROLLBACK` + error naming the offending row. The single `add-roll` endpoint is left in place (unused by the UI).

## Frontend
Per-row listeners + batch submit live in the parent page's `attachFormListeners()` (live context) — the fragment ships a row `<template>` + the inert `#addRollConfig` JSON block, since `<script>` in an `innerHTML`-injected fragment never runs.

Design spec: `docs/superpowers/specs/2026-06-09-batch-add-missed-rolls-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)