### PR TITLE
feat(pm): EasyEcom /access/token auth + primary-location snapshot pull + DRR order_date fix

### DIFF
--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -69,7 +69,7 @@ async function getOrderAggregates(pool, { periodKey = '1d', marketplaceId, wareh
       WHERE snapshot_date >= ? AND qty > 0
       GROUP BY sku
     ) sd ON sd.sku = es.sku
-    WHERE eo.import_date >= ?
+    WHERE eo.order_date >= ?
       AND EXISTS (
         SELECT 1 FROM ee_replenishment_rules r
         WHERE r.sku = es.sku
@@ -609,7 +609,7 @@ async function getCuttingRecommendations(pool, { periodKey = '30d' } = {}) {
        WHERE snapshot_date >= ? AND qty > 0
        GROUP BY sku
      ) sd ON sd.sku = es.sku
-     WHERE eo.import_date >= ?
+     WHERE eo.order_date >= ?
      GROUP BY es.sku`,
     [snapshotStart, snapshotStart]
   );

--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -640,37 +640,55 @@ async function getCuttingRecommendations(pool, { periodKey = '30d' } = {}) {
     ...sohRows.map((r) => r.sku),
   ]);
 
+  // Bulk-load every per-SKU input ONCE. Previously the loop below issued a
+  // lead-time + open-lot + PO query per SKU — an N+1 explosion that was cheap at
+  // ~2k SKUs but turns into ~100k sequential queries once the snapshot pull
+  // populates ee_inventory_health with ~25k SKUs. These four queries replace it.
+  const rowMap = new Map(rows.map((r) => [r.sku, r]));
+  const [ltRows] = await pool.query(
+    `SELECT key_value, default_lead_time_days, fabric_lead_time_days, safety_days, override_drr
+     FROM pm_style_lead_times WHERE scope = 'sku'`
+  );
+  const ltMap = new Map(ltRows.map((r) => [r.key_value, r]));
+  const [openLotRows] = await pool.query(
+    `SELECT sku, COALESCE(SUM(qty), 0) AS qty FROM pm_open_cutting_lots
+     WHERE closed_at IS NULL GROUP BY sku`
+  );
+  const openLotMap = new Map(openLotRows.map((r) => [r.sku, Number(r.qty) || 0]));
+  const [poRows] = await pool.query(
+    `SELECT sku, DATEDIFF(required_by_date, CURDATE()) AS days_out, COALESCE(SUM(qty), 0) AS qty
+     FROM pm_marketplace_po_lines WHERE required_by_date >= CURDATE() GROUP BY sku, days_out`
+  );
+  const poMap = new Map();
+  for (const r of poRows) {
+    if (!poMap.has(r.sku)) poMap.set(r.sku, []);
+    poMap.get(r.sku).push({ daysOut: Number(r.days_out), qty: Number(r.qty) || 0 });
+  }
+  const resolveLeadTime = (cfg) => cfg ? {
+    lead_time: Number(cfg.default_lead_time_days ?? DEFAULT_LEAD_TIME),
+    fabric_lead_time: Number(cfg.fabric_lead_time_days ?? 0),
+    safety_days: Number(cfg.safety_days ?? DEFAULT_SAFETY_DAYS),
+    override_drr: cfg.override_drr != null ? Number(cfg.override_drr) : null,
+  } : { lead_time: DEFAULT_LEAD_TIME, fabric_lead_time: 0, safety_days: DEFAULT_SAFETY_DAYS, override_drr: null };
+
   const results = [];
   for (const sku of allSkus) {
-    const row = rows.find((r) => r.sku === sku) || { order_count: 0, selling_days: 0 };
+    const row = rowMap.get(sku) || { order_count: 0, selling_days: 0 };
     const orderCount = Number(row.order_count) || 0;
     const sellingDays = Number(row.selling_days) || 0;
     const warming = sellingDays < 7;
     const denom = warming ? windowDays : sellingDays;
     let drr = denom > 0 ? orderCount / denom : 0;
 
-    const lt = await getLeadTimeForSku(pool, sku, null);
+    const lt = resolveLeadTime(ltMap.get(sku));
     if (lt.override_drr !== null) drr = lt.override_drr;
 
     const soh = sohMap.get(sku) || 0;
-
-    const [[openLot]] = await pool.query(
-      `SELECT COALESCE(SUM(qty), 0) AS qty
-       FROM pm_open_cutting_lots
-       WHERE sku = ? AND closed_at IS NULL`,
-      [sku]
-    );
-    const openLotQty = Number(openLot?.qty) || 0;
+    const openLotQty = openLotMap.get(sku) || 0;
 
     const horizon = lt.lead_time + lt.safety_days;
-    const [[poRow]] = await pool.query(
-      `SELECT COALESCE(SUM(qty), 0) AS qty
-       FROM pm_marketplace_po_lines
-       WHERE sku = ?
-         AND required_by_date BETWEEN CURDATE() AND DATE_ADD(CURDATE(), INTERVAL ? DAY)`,
-      [sku, horizon]
-    );
-    const upcomingPoQty = Number(poRow?.qty) || 0;
+    const upcomingPoQty = (poMap.get(sku) || [])
+      .reduce((s, p) => s + (p.daysOut <= horizon ? p.qty : 0), 0);
 
     const suggested = Math.max(
       0,

--- a/utils/easyecomPullWorker.js
+++ b/utils/easyecomPullWorker.js
@@ -73,117 +73,133 @@ async function listDistinctWarehouses(pool) {
 }
 
 // ────────────────────────────────────────────────────────────────────
-// Step 1 — Snapshot CSV ingestion (per warehouse)
+// Step 1 — Inventory snapshot ingestion (PRIMARY-location, account-wide)
 // ────────────────────────────────────────────────────────────────────
+//
+// EasyEcom's Inventory Snapshot is an ACCOUNT-LEVEL report owned by the PRIMARY
+// location ("Kotty Lifestyle", c_id 173969). A single daily CSV covers every
+// warehouse; each row carries a `Company Token` (= a secondary location_key) that
+// we map back to our warehouse_id. Authenticating against a secondary warehouse
+// returns an empty snapshot, so this MUST run against the primary location.
 
-async function pullSnapshotsForWarehouse(pool, warehouseId, runStartedAt, windowDays) {
+const PRIMARY_SNAPSHOT_C_ID = 173969; // bookkeeping marker for ee_snapshot_files
+const WAREHOUSE_ID_BY_LOCATION_KEY = {
+  ee30270084289: 173983, // Faridabad
+  en31088037124: 176318, // Delhi
+};
+
+// EasyEcom guards text cells with a leading backtick (Excel-injection guard); some
+// values also carry a trailing comma. Strip both before using the SKU.
+function cleanCsvSku(v) {
+  return String(v == null ? '' : v).replace(/`/g, '').replace(/,+\s*$/, '').trim().toUpperCase();
+}
+
+async function pullSnapshotsFromPrimary(pool, runStartedAt, windowDays) {
   const stepStart = Date.now();
-  const warehouseKey = WAREHOUSE_KEY_BY_ID[warehouseId];
-  if (!warehouseKey) {
-    await logStep(pool, runStartedAt, `snapshot:${warehouseId}`, 'error',
-      `No credential mapping for warehouse_id ${warehouseId}`, Date.now() - stepStart);
-    return;
-  }
-
   const end = new Date();
   const start = new Date(end.getTime() - windowDays * 24 * 60 * 60 * 1000);
   const startStr = `${ymd(start)} 00:00:00`;
   const endStr = `${ymd(end)} 23:59:59`;
 
+  let files;
   try {
-    const files = await listInventorySnapshots({ startDate: startStr, endDate: endStr }, warehouseKey);
-    if (!files.length) {
-      await logStep(pool, runStartedAt, `snapshot:${warehouseId}`, 'partial',
-        `No CSV files returned for ${startStr}..${endStr}`, Date.now() - stepStart);
-      return;
-    }
-
-    // Skip files we've already ingested.
-    const [existing] = await pool.query(
-      `SELECT entry_date FROM ee_snapshot_files WHERE warehouse_id = ?`, [warehouseId]
-    );
-    const have = new Set(existing.map(r => new Date(r.entry_date).toISOString().slice(0, 19)));
-
-    let newFiles = 0;
-    let totalRows = 0;
-    let latestDate = null;
-    let latestRows = [];
-
-    for (const f of files) {
-      const entryDateStr = String(f.entry_date).slice(0, 19).replace('T', ' ');
-      const isoKey = new Date(entryDateStr).toISOString().slice(0, 19);
-      if (have.has(isoKey)) continue;
-
-      let csvText;
-      try {
-        csvText = await downloadSnapshotCsv(f.file_url);
-      } catch (err) {
-        console.error(`[pullWorker] snapshot CSV download failed (${entryDateStr}):`, err.message);
-        continue;
-      }
-      const rows = parseCsv(csvText);
-      const snapshotDate = entryDateStr.slice(0, 10);
-      const upsertRows = [];
-      for (const r of rows) {
-        const sku = pickField(r, ['sku', 'SKU', 'Product Code', 'productCode', 'product_code']);
-        const qtyRaw = pickField(r, ['available', 'availableInventory', 'Available Quantity', 'Available', 'qty', 'Inventory', 'inventoryCount', 'inventory_count', 'Quantity']);
-        if (!sku) continue;
-        const qty = Number(qtyRaw) || 0;
-        upsertRows.push([String(sku).toUpperCase(), warehouseId, snapshotDate, qty]);
-      }
-
-      if (upsertRows.length) {
-        // Chunk inserts of 1000 to keep packet size sane.
-        for (let i = 0; i < upsertRows.length; i += 1000) {
-          const chunk = upsertRows.slice(i, i + 1000);
-          await pool.query(
-            `INSERT INTO ee_inventory_daily_snapshot (sku, warehouse_id, snapshot_date, qty)
-             VALUES ?
-             ON DUPLICATE KEY UPDATE qty = VALUES(qty)`,
-            [chunk]
-          );
-        }
-      }
-
-      await pool.query(
-        `INSERT INTO ee_snapshot_files (warehouse_id, entry_date, file_url, row_count)
-         VALUES (?, ?, ?, ?)
-         ON DUPLICATE KEY UPDATE row_count = VALUES(row_count), ingested_at = CURRENT_TIMESTAMP`,
-        [warehouseId, entryDateStr, f.file_url, upsertRows.length]
-      );
-
-      newFiles++;
-      totalRows += upsertRows.length;
-      if (!latestDate || entryDateStr > latestDate) {
-        latestDate = entryDateStr;
-        latestRows = upsertRows;
-      }
-    }
-
-    // Push the latest snapshot into ee_inventory_health.inventory so the
-    // dashboard's "current SOH" matches the most recent close-of-business.
-    if (latestRows.length) {
-      for (let i = 0; i < latestRows.length; i += 500) {
-        const chunk = latestRows.slice(i, i + 500);
-        const placeholders = chunk.map(() => '(?, ?, ?, ?)').join(',');
-        const values = [];
-        for (const [sku, wh, , qty] of chunk) values.push(sku, wh, qty, 'green');
-        await pool.query(
-          `INSERT INTO ee_inventory_health (sku, warehouse_id, inventory, status)
-           VALUES ${placeholders}
-           ON DUPLICATE KEY UPDATE inventory = VALUES(inventory), updated_at = CURRENT_TIMESTAMP`,
-          values
-        );
-      }
-    }
-
-    await logStep(pool, runStartedAt, `snapshot:${warehouseId}`, 'ok',
-      `files_new=${newFiles}/${files.length} rows=${totalRows} latest=${latestDate || 'n/a'}`,
-      Date.now() - stepStart);
+    files = await listInventorySnapshots({ startDate: startStr, endDate: endStr }, 'primary');
   } catch (err) {
-    console.error(`[pullWorker] snapshot pull failed for ${warehouseKey}:`, err.message);
-    await logStep(pool, runStartedAt, `snapshot:${warehouseId}`, 'error', err.message, Date.now() - stepStart);
+    console.error('[pullWorker] snapshot list (primary) failed:', err.message);
+    await logStep(pool, runStartedAt, 'snapshot', 'error', `list: ${err.message}`, Date.now() - stepStart);
+    return;
   }
+  if (!files.length) {
+    await logStep(pool, runStartedAt, 'snapshot', 'partial',
+      `No snapshot files for ${startStr}..${endStr}`, Date.now() - stepStart);
+    return;
+  }
+
+  // Skip files we've already ingested (tracked under the primary c_id).
+  const [existing] = await pool.query(
+    `SELECT entry_date FROM ee_snapshot_files WHERE warehouse_id = ?`, [PRIMARY_SNAPSHOT_C_ID]
+  );
+  const have = new Set(existing.map(r => new Date(r.entry_date).toISOString().slice(0, 19)));
+
+  let newFiles = 0;
+  let totalRows = 0;
+  let skippedRows = 0;
+  let latestDate = null;
+  let latestHealth = [];
+
+  for (const f of files) {
+    const entryDateStr = String(f.entry_date).slice(0, 19).replace('T', ' ');
+    const isoKey = new Date(entryDateStr).toISOString().slice(0, 19);
+    if (have.has(isoKey)) continue;
+    const snapshotDate = entryDateStr.slice(0, 10);
+
+    let csvText;
+    try {
+      csvText = await downloadSnapshotCsv(f.file_url);
+    } catch (err) {
+      console.error(`[pullWorker] snapshot CSV download failed (${entryDateStr}):`, err.message);
+      continue;
+    }
+    const rows = parseCsv(csvText);
+    const upsertRows = [];
+    const healthRows = [];
+    for (const r of rows) {
+      const locKey = String(pickField(r, ['Company Token', 'company_token', 'companytoken']) || '').trim();
+      const warehouseId = WAREHOUSE_ID_BY_LOCATION_KEY[locKey];
+      if (!warehouseId) { skippedRows++; continue; } // not one of our two warehouses
+      const sku = cleanCsvSku(pickField(r, ['SKU', 'sku', 'Product Code']));
+      if (!sku) continue;
+      const qty = Number(pickField(r, ['Available Quantity', 'available', 'Available', 'availableInventory'])) || 0;
+      upsertRows.push([sku, warehouseId, snapshotDate, qty]);
+      healthRows.push([sku, warehouseId, qty]);
+    }
+
+    // Chunk inserts of 1000 to keep packet size sane.
+    for (let i = 0; i < upsertRows.length; i += 1000) {
+      const chunk = upsertRows.slice(i, i + 1000);
+      await pool.query(
+        `INSERT INTO ee_inventory_daily_snapshot (sku, warehouse_id, snapshot_date, qty)
+         VALUES ?
+         ON DUPLICATE KEY UPDATE qty = VALUES(qty)`,
+        [chunk]
+      );
+    }
+
+    await pool.query(
+      `INSERT INTO ee_snapshot_files (warehouse_id, entry_date, file_url, row_count)
+       VALUES (?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE row_count = VALUES(row_count), ingested_at = CURRENT_TIMESTAMP`,
+      [PRIMARY_SNAPSHOT_C_ID, entryDateStr, f.file_url, upsertRows.length]
+    );
+
+    newFiles++;
+    totalRows += upsertRows.length;
+    if (!latestDate || entryDateStr > latestDate) {
+      latestDate = entryDateStr;
+      latestHealth = healthRows;
+    }
+  }
+
+  // Push the latest snapshot into ee_inventory_health.inventory so the dashboard's
+  // "current SOH" matches the most recent close-of-business.
+  if (latestHealth.length) {
+    for (let i = 0; i < latestHealth.length; i += 500) {
+      const chunk = latestHealth.slice(i, i + 500);
+      const placeholders = chunk.map(() => '(?, ?, ?, ?)').join(',');
+      const values = [];
+      for (const [sku, wh, qty] of chunk) values.push(sku, wh, qty, 'green');
+      await pool.query(
+        `INSERT INTO ee_inventory_health (sku, warehouse_id, inventory, status)
+         VALUES ${placeholders}
+         ON DUPLICATE KEY UPDATE inventory = VALUES(inventory), updated_at = CURRENT_TIMESTAMP`,
+        values
+      );
+    }
+  }
+
+  await logStep(pool, runStartedAt, 'snapshot', 'ok',
+    `files_new=${newFiles}/${files.length} rows=${totalRows} skipped=${skippedRows} latest=${latestDate || 'n/a'}`,
+    Date.now() - stepStart);
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -611,16 +627,13 @@ async function runPullWorker(pool, { bootstrap = 'auto', includeProducts } = {})
   }
   const windowDays = bootstrapMode ? 30 : 3;
 
-  // Inventory snapshots
+  // Inventory snapshots — account-wide, from the PRIMARY location. Bootstrap pulls a
+  // deeper window so selling-days DRR has real history immediately (configurable).
+  const snapshotWindowDays = bootstrapMode
+    ? Number(process.env.EASYECOM_SNAPSHOT_BACKFILL_DAYS || global.env?.EASYECOM_SNAPSHOT_BACKFILL_DAYS || 60)
+    : Math.max(windowDays, 3);
   try {
-    const warehouses = await listDistinctWarehouses(pool);
-    if (!warehouses.length) {
-      await logStep(pool, runStartedAt, 'snapshot', 'partial', 'No warehouses in ee_user_warehouses', 0);
-    } else {
-      for (const wh of warehouses) {
-        await pullSnapshotsForWarehouse(pool, wh, runStartedAt, windowDays);
-      }
-    }
+    await pullSnapshotsFromPrimary(pool, runStartedAt, snapshotWindowDays);
   } catch (err) {
     await logStep(pool, runStartedAt, 'snapshot', 'error', err.message, 0);
   }
@@ -672,4 +685,4 @@ function triggerNow(pool, opts = {}) {
   return Promise.resolve().then(() => runPullWorker(pool, opts));
 }
 
-module.exports = { runPullWorker, triggerNow };
+module.exports = { runPullWorker, triggerNow, pullSnapshotsFromPrimary };

--- a/utils/easyecomReturnsClient.js
+++ b/utils/easyecomReturnsClient.js
@@ -19,16 +19,29 @@ const EASYECOM_PASSWORD = global.env?.EASYECOM_PASSWORD || process.env.EASYECOM_
 const EASYECOM_DELHI_EMAIL = global.env?.EASYECOM_DELHI_EMAIL || process.env.EASYECOM_DELHI_EMAIL || '';
 const EASYECOM_DELHI_PASSWORD = global.env?.EASYECOM_DELHI_PASSWORD || process.env.EASYECOM_DELHI_PASSWORD || '';
 
+// Location keys (Seller IDs) — MANDATORY for the V2.1 `/access/token` auth.
+// Defaults are the resolved Seller IDs for our two warehouses (from ee_orders /
+// ee_inventory_snapshots); override via env only if EasyEcom changes them.
+const EASYECOM_LOCATION_KEY = global.env?.EASYECOM_LOCATION_KEY || process.env.EASYECOM_LOCATION_KEY || 'ee30270084289';
+const EASYECOM_DELHI_LOCATION_KEY = global.env?.EASYECOM_DELHI_LOCATION_KEY || process.env.EASYECOM_DELHI_LOCATION_KEY || 'en31088037124';
+// Primary/parent location ("Kotty Lifestyle", c_id 173969). Account-level reports
+// (inventory snapshot, getAllLocation) are PRIMARY-only; the two warehouses above are
+// SECONDARY locations and return empty for those endpoints. Used by the PM snapshot pull.
+const EASYECOM_PRIMARY_LOCATION_KEY = global.env?.EASYECOM_PRIMARY_LOCATION_KEY || process.env.EASYECOM_PRIMARY_LOCATION_KEY || 'ne30265212961';
+
 // Warehouse credentials mapping
 const WAREHOUSE_CREDENTIALS = {
-  faridabad: { email: EASYECOM_EMAIL, password: EASYECOM_PASSWORD, c_id: 173983 },
-  delhi: { email: EASYECOM_DELHI_EMAIL, password: EASYECOM_DELHI_PASSWORD, c_id: 176318 },
+  faridabad: { email: EASYECOM_EMAIL, password: EASYECOM_PASSWORD, c_id: 173983, location_key: EASYECOM_LOCATION_KEY },
+  delhi: { email: EASYECOM_DELHI_EMAIL, password: EASYECOM_DELHI_PASSWORD, c_id: 176318, location_key: EASYECOM_DELHI_LOCATION_KEY },
+  // Authenticated with the all-location API user (Faridabad creds), which can access the primary.
+  primary: { email: EASYECOM_EMAIL, password: EASYECOM_PASSWORD, c_id: 173969, location_key: EASYECOM_PRIMARY_LOCATION_KEY },
 };
 
 // Cached JWT tokens per warehouse
 const cachedTokens = {
   faridabad: { token: null, expiry: null },
   delhi: { token: null, expiry: null },
+  primary: { token: null, expiry: null },
 };
 
 /**
@@ -54,17 +67,23 @@ async function authenticateWithCredentials(warehouse = 'faridabad') {
   try {
     console.log(`Authenticating with EasyEcom for ${warehouse}...`);
 
-    const response = await axios.post(`${EASYECOM_API_BASE}/getApiToken`, {
+    // V2.1 auth: POST /access/token with the warehouse location_key (Seller ID).
+    // The deprecated /getApiToken path now returns 403 for this account, and the
+    // V2.1 data endpoints (snapshot, orders V2, reports) only accept a token minted
+    // here. No x-api-key header is required for this account.
+    const response = await axios.post(`${EASYECOM_API_BASE}/access/token`, {
       email: creds.email,
-      password: creds.password
+      password: creds.password,
+      location_key: creds.location_key,
     }, {
       headers: { 'Content-Type': 'application/json' },
       timeout: 30000
     });
 
-    // Extract token from response
+    // Extract token. V2.1 /access/token nests it at data.token.jwt_token;
+    // keep legacy fallbacks for safety.
     const data = response.data;
-    const token = data.data?.jwt_token || data.jwt_token || data.token || data.access_token;
+    const token = data.data?.token?.jwt_token || data.data?.jwt_token || data.jwt_token || data.token || data.access_token;
 
     if (token) {
       cache.token = token;
@@ -875,7 +894,8 @@ async function waitForAndDownloadReport(reportId, warehouse = 'faridabad', { pol
         String(r.reportId || r.id || r.report_id) === String(reportId)
       );
     } catch (_) {}
-    const status = (entry?.status || entry?.report_status || '').toString().toLowerCase();
+    // EasyEcom returns status under `reportStatus` (e.g. "COMPLETED").
+    const status = (entry?.reportStatus || entry?.report_status || entry?.status || '').toString().toLowerCase();
     if (status.includes('complete') || status.includes('ready') || status === 'done') { ready = true; break; }
     if (status.includes('fail') || status.includes('error')) {
       throw new Error(`Report ${reportId} failed: ${JSON.stringify(entry).slice(0,200)}`);
@@ -883,17 +903,31 @@ async function waitForAndDownloadReport(reportId, warehouse = 'faridabad', { pol
     await new Promise(r => setTimeout(r, pollIntervalMs));
   }
   if (!ready) throw new Error(`Report ${reportId} timed out after ${maxWaitMs}ms`);
+  // /reports/download returns either raw CSV, or a JSON envelope
+  // { data: { reportStatus, downloadUrl } } pointing at a pre-signed S3 CSV. Handle both.
   const dl = await api.get('/reports/download', { params: { reportId }, responseType: 'text' });
-  const text = typeof dl.data === 'string' ? dl.data : JSON.stringify(dl.data);
-  return parseCsv(text);
+  let csvText = typeof dl.data === 'string' ? dl.data : JSON.stringify(dl.data);
+  if (csvText && csvText.trimStart().startsWith('{')) {
+    try {
+      const env = JSON.parse(csvText);
+      const url = env?.data?.downloadUrl || env?.downloadUrl;
+      if (url) {
+        const s3 = await axios.get(url, { timeout: 600000, responseType: 'text' });
+        csvText = typeof s3.data === 'string' ? s3.data : JSON.stringify(s3.data);
+      }
+    } catch (_) { /* treat as raw CSV */ }
+  }
+  return parseCsv(csvText);
 }
 
 // Convenience wrappers — queue + poll + download for the reports we care about.
 async function fetchMiniSalesReport({ startDate, endDate, warehouseIds, invoiceType = 'ALL', dateType = 'ORDER_DATE' }, warehouse = 'faridabad') {
-  // EasyEcom rejects empty/missing warehouseIds with a 400 — only pass the
-  // param when caller supplied a non-empty location-key list.
+  // warehouseIds is the location_key (Seller ID) and is effectively required —
+  // default to this warehouse's Seller ID when the caller didn't supply one.
+  const creds = WAREHOUSE_CREDENTIALS[(warehouse || 'faridabad').toLowerCase()] || WAREHOUSE_CREDENTIALS.faridabad;
+  const whIds = (warehouseIds && String(warehouseIds).trim()) ? warehouseIds : creds.location_key;
   const params = { invoiceType, dateType, startDate, endDate };
-  if (warehouseIds && String(warehouseIds).trim()) params.warehouseIds = warehouseIds;
+  if (whIds) params.warehouseIds = whIds;
   const reportId = await queueReport('MINI_SALES_REPORT', params, warehouse);
   return waitForAndDownloadReport(reportId, warehouse);
 }


### PR DESCRIPTION
Gets the production-planning demand pipeline working against EasyEcom's real API behaviour. Validated with live calls and a 60-day backfill (1,640,589 rows / 25,738 SKUs / 49 days, both warehouses). **No auto-merge — for review.**

## What's in scope
**1. Auth migration** (`easyecomReturnsClient.js`) — `/getApiToken` now returns **403** for this account (dead). Migrate to `POST /access/token` with the warehouse `location_key` (no `x-api-key` needed). Adds the **primary** location (`ne30265212961`, c_id 173969) because the inventory-snapshot + `getAllLocation` endpoints are **primary-only**. Also fixes report polling (`reportStatus` field + S3 `downloadUrl` follow) and defaults mini-sales `warehouseIds`. **Vinay's live-inventory (`getInventoryDetailsV3`) verified still working** on the new token.

**2. Primary-location snapshot pull** (`easyecomPullWorker.js`) — snapshot is an **account-wide** report; `pullSnapshotsFromPrimary` lists account CSVs, splits rows by `Company Token` → warehouse, cleans the backtick/comma SKU guard, upserts `Available Quantity` into `ee_inventory_daily_snapshot`. Gap/dup-safe via PK `(sku, warehouse_id, snapshot_date)`.

**3. DRR demand-window fix** (`easyecomAnalytics.js`) — window on `eo.order_date` (sell date), not `eo.import_date` (import lag), at **both** sites (`getOrderAggregates`, `getCuttingRecommendations`).

## Behavioural notes for review
- **Auth endpoint change is unavoidable** — old path is dead; this also keeps returns/live-inventory alive.
- The 60-day backfill was already run manually into prod; **this PR makes the nightly 02:30 cron produce it going forward** (gated by `PM_PULL_ENABLED=1`, already set).
- EasyEcom skips ~18% of calendar days — downstream clean-day DRR must be gap-safe (separate workstream).
- **Out of scope / not included:** the unrelated `routes/accountsChallanRoutes.js` working-tree edit and untracked files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)