### PR TITLE
feat(pm): SKU resolver — pm_sku_resolution + validated upload

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -11,6 +11,7 @@ const ExcelJS = require('exceljs');
 const { pool } = require('../config/db');
 const { isAuthenticated, allowRoles } = require('../middlewares/auth');
 const analytics = require('../utils/easyecomAnalytics');
+const skuResolver = require('../utils/skuResolver');
 let pullWorker = null;
 try { pullWorker = require('../utils/easyecomPullWorker'); } catch (_) { pullWorker = null; }
 
@@ -539,6 +540,82 @@ router.get('/debug-ee', async (req, res) => {
       eeStatus: err.response?.status, eeBody: err.response?.data,
     });
   }
+});
+
+// ─── Resolver: cutting-style -> ecom size-SKU map (pm_sku_resolution) ──
+// Validates filled templates and loads pm_sku_resolution. Per-row validation
+// against distinct ee_suborders; rejects with reasons; partial uploads fine.
+
+function parseResolverSheet(ws, required) {
+  const headers = [];
+  ws.getRow(1).eachCell((cell, col) => {
+    headers.push({ col, k: String(cell.value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '') });
+  });
+  const headerMap = {};
+  for (const key of required) {
+    const h = headers.find((x) => x.k === key) || headers.find((x) => x.k.startsWith(key));
+    if (h) headerMap[key] = h.col;
+  }
+  for (const r of required) if (!headerMap[r]) return { error: `Missing required column: ${r}` };
+  const cellText = (v) => {
+    if (v == null) return '';
+    if (typeof v === 'object') {
+      if ('text' in v) return v.text;
+      if ('result' in v) return v.result;
+      if ('richText' in v) return v.richText.map((t) => t.text).join('');
+    }
+    return v;
+  };
+  const rows = [];
+  for (let i = 2; i <= ws.rowCount; i++) {
+    const row = ws.getRow(i);
+    const obj = {};
+    for (const k of required) obj[k] = String(cellText(row.getCell(headerMap[k]).value)).trim();
+    rows.push(obj);
+  }
+  return { rows };
+}
+
+// POST /pm/resolver/upload-sizes — filled size template (cl_sku, size_label, size_sku)
+router.post('/resolver/upload-sizes', upload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ ok: false, error: 'No file uploaded.' });
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(req.file.buffer);
+    const ws = wb.worksheets[0];
+    if (!ws) return res.status(400).json({ ok: false, error: 'Workbook has no sheets.' });
+    const parsed = parseResolverSheet(ws, ['cl_sku', 'size_label', 'size_sku']);
+    if (parsed.error) return res.status(400).json({ ok: false, error: parsed.error });
+    const result = await skuResolver.loadSizeRows(pool, parsed.rows, req.session?.user?.id || null);
+    res.json({ ok: true, ...result });
+  } catch (err) {
+    console.error('[pm] resolver upload-sizes error', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// POST /pm/resolver/upload-styles — filled style sheet (style, ruling = waist|letter|skip)
+router.post('/resolver/upload-styles', upload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ ok: false, error: 'No file uploaded.' });
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(req.file.buffer);
+    const ws = wb.worksheets[0];
+    if (!ws) return res.status(400).json({ ok: false, error: 'Workbook has no sheets.' });
+    const parsed = parseResolverSheet(ws, ['style', 'ruling']);
+    if (parsed.error) return res.status(400).json({ ok: false, error: parsed.error });
+    const summary = await skuResolver.loadStyleRulings(pool, parsed.rows, req.session?.user?.id || null);
+    res.json({ ok: true, ...summary });
+  } catch (err) {
+    console.error('[pm] resolver upload-styles error', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// GET /pm/resolver/status — counts of resolved/excluded mappings
+router.get('/resolver/status', async (req, res) => {
+  try { res.json({ ok: true, ...(await skuResolver.getResolutionStatus(pool)) }); }
+  catch (err) { res.status(500).json({ ok: false, error: err.message }); }
 });
 
 module.exports = router;

--- a/sql/2026_06_pm_sku_resolution.sql
+++ b/sql/2026_06_pm_sku_resolution.sql
@@ -1,0 +1,22 @@
+-- pm_sku_resolution: the human-authored cutting-style -> ecom size-SKU map (the
+-- "chart"). Frozen, validated rows the auto-binder trusts. Per (cl_sku, size_label).
+--   state='resolved' : size_sku set and verified to exist in ee_suborders.
+--   state='excluded' : a SKIP decision (discontinued/liquidating) — NOT a gap;
+--                      the binder marks these lot-sizes bind_state='excluded'.
+-- Additive, pm_-side only. No production/flow table is touched.
+
+CREATE TABLE IF NOT EXISTS pm_sku_resolution (
+  id          BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  cl_sku      VARCHAR(100) NOT NULL,                    -- cutting style code (cutting_lots.sku)
+  size_label  VARCHAR(40)  NOT NULL,                    -- cutting size (cutting_lot_sizes.size_label)
+  size_sku    VARCHAR(100) NULL,                        -- resolved ecom size-SKU; NULL when excluded
+  state       ENUM('resolved','excluded') NOT NULL,
+  source      ENUM('size_sheet','style_sheet','manual') NOT NULL DEFAULT 'size_sheet',
+  ruling      ENUM('waist','letter','skip') NULL,       -- style-level ruling that produced the row, if any
+  loaded_by   INT NULL,
+  created_at  DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updated_at  DATETIME DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_pair (cl_sku, size_label),            -- one mapping per cut lot-size
+  INDEX idx_size_sku (size_sku),
+  INDEX idx_state (state)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/utils/skuResolver.js
+++ b/utils/skuResolver.js
@@ -1,0 +1,123 @@
+// utils/skuResolver.js
+//
+// Loads the human-authored cutting-style -> ecom size-SKU map into
+// pm_sku_resolution. Two inputs:
+//   - SIZE sheet: explicit (cl_sku, size_label, size_sku) rows.
+//   - STYLE sheet: per-style ruling (waist | letter | skip) expanded to size rows.
+//
+// Rules (locked):
+//   - Every resolved size_sku MUST exist in the distinct ee_suborders SKU set;
+//     rows that fail validation are rejected with a per-row reason, never loaded.
+//   - Loaded rows are frozen mappings the binder trusts (upsert on (cl_sku,size_label)
+//     so a later corrected upload can fix one, but a bad row never lands).
+//   - Partial uploads are fine: only rows present in the sheet are processed.
+//   - SKIP -> state='excluded' (a decision, not a gap).
+
+const U = (s) => String(s == null ? '' : s).toUpperCase().trim();
+
+async function getCanonSkuSet(pool) {
+  const [rows] = await pool.query(
+    'SELECT DISTINCT UPPER(sku) AS sku FROM ee_suborders WHERE sku IS NOT NULL AND sku <> ""'
+  );
+  return new Set(rows.map((r) => r.sku));
+}
+
+async function getStyleSizeLabels(pool, clSkus) {
+  if (!clSkus.length) return new Map();
+  const [rows] = await pool.query(
+    `SELECT cl.sku AS cl_sku, cls.size_label
+     FROM cutting_lots cl JOIN cutting_lot_sizes cls ON cls.cutting_lot_id = cl.id
+     WHERE cl.sku IN (?) AND cls.size_label <> ''
+     GROUP BY cl.sku, cls.size_label`,
+    [clSkus]
+  );
+  const map = new Map();
+  for (const r of rows) {
+    if (!map.has(r.cl_sku)) map.set(r.cl_sku, new Set());
+    map.get(r.cl_sku).add(r.size_label);
+  }
+  return map;
+}
+
+async function upsertRows(pool, rows, loadedBy) {
+  // rows: [cl_sku, size_label, size_sku|null, state, source, ruling|null]
+  for (let i = 0; i < rows.length; i += 500) {
+    const chunk = rows.slice(i, i + 500);
+    await pool.query(
+      `INSERT INTO pm_sku_resolution (cl_sku, size_label, size_sku, state, source, ruling, loaded_by)
+       VALUES ?
+       ON DUPLICATE KEY UPDATE
+         size_sku = VALUES(size_sku), state = VALUES(state), source = VALUES(source),
+         ruling = VALUES(ruling), loaded_by = VALUES(loaded_by), updated_at = CURRENT_TIMESTAMP`,
+      [chunk.map((r) => [...r, loadedBy ?? null])]
+    );
+  }
+}
+
+// SIZE sheet: explicit size_sku per row.
+async function loadSizeRows(pool, inputRows, loadedBy) {
+  const canon = await getCanonSkuSet(pool);
+  const toLoad = [];
+  const rejected = [];
+  let skippedBlank = 0;
+  for (const r of inputRows) {
+    const clSku = String(r.cl_sku || '').trim();
+    const sizeLabel = String(r.size_label || '').trim();
+    const sizeSku = String(r.size_sku || '').trim();
+    if (!clSku || !sizeLabel) continue;
+    if (!sizeSku) { skippedBlank++; continue; }                 // leave unresolved, re-export later
+    if (!canon.has(U(sizeSku))) {
+      rejected.push({ cl_sku: clSku, size_label: sizeLabel, size_sku: sizeSku, reason: 'size_sku not found in ee_suborders' });
+      continue;
+    }
+    toLoad.push([clSku, sizeLabel, U(sizeSku), 'resolved', 'size_sheet', null]);
+  }
+  if (toLoad.length) await upsertRows(pool, toLoad, loadedBy);
+  return { loaded: toLoad.length, rejected, skippedBlank };
+}
+
+// STYLE sheet: per-style ruling expanded to size rows.
+//   skip   -> every size_label excluded.
+//   letter -> concat(cl_sku, size_label) [and _variant]; load if exactly one validates.
+//   waist  -> needs per-size mapping (waist->letter) -> left for the size sheet, reported.
+async function loadStyleRulings(pool, rulings, loadedBy) {
+  const canon = await getCanonSkuSet(pool);
+  const clean = rulings
+    .map((r) => ({ cl_sku: String(r.style || r.cl_sku || '').trim(), ruling: String(r.ruling || '').trim().toLowerCase() }))
+    .filter((r) => r.cl_sku && ['waist', 'letter', 'skip'].includes(r.ruling));
+  const labelMap = await getStyleSizeLabels(pool, [...new Set(clean.map((r) => r.cl_sku))]);
+
+  const toLoad = [];
+  const summary = { excluded: 0, resolved_letter: 0, needs_size_sheet: 0, unresolved_letter: [], unknown_ruling: [] };
+  for (const r of clean) {
+    const labels = [...(labelMap.get(r.cl_sku) || [])];
+    if (r.ruling === 'skip') {
+      for (const lbl of labels) { toLoad.push([r.cl_sku, lbl, null, 'excluded', 'style_sheet', 'skip']); summary.excluded++; }
+    } else if (r.ruling === 'letter') {
+      for (const lbl of labels) {
+        const cands = [...new Set([U(r.cl_sku) + U(lbl), U(r.cl_sku) + '_' + U(lbl)])];
+        const matches = cands.filter((c) => canon.has(c));
+        if (matches.length === 1) { toLoad.push([r.cl_sku, lbl, matches[0], 'resolved', 'style_sheet', 'letter']); summary.resolved_letter++; }
+        else { summary.unresolved_letter.push({ cl_sku: r.cl_sku, size_label: lbl, reason: matches.length ? 'ambiguous letter match' : 'no letter match' }); }
+      }
+    } else if (r.ruling === 'waist') {
+      // waist->letter is a per-size judgement; defer to the size sheet (stays resolver_failed).
+      summary.needs_size_sheet += labels.length;
+    }
+  }
+  if (toLoad.length) await upsertRows(pool, toLoad, loadedBy);
+  return summary;
+}
+
+async function getResolutionStatus(pool) {
+  const [[r]] = await pool.query(
+    `SELECT
+       SUM(state='resolved') AS resolved,
+       SUM(state='excluded') AS excluded,
+       COUNT(*) AS total
+     FROM pm_sku_resolution`
+  );
+  return { resolved: Number(r.resolved) || 0, excluded: Number(r.excluded) || 0, total: Number(r.total) || 0 };
+}
+
+module.exports = { getCanonSkuSet, loadSizeRows, loadStyleRulings, getResolutionStatus };


### PR DESCRIPTION
Builds the human-authored cutting-style → ecom size-SKU map (the resolver "chart") that the auto-binder needs (string auto-resolve only hits ~17%). **Additive, pm-side only — no production/flow tables touched.**

- **`pm_sku_resolution`** table — `(cl_sku, size_label) → size_sku`, `state ∈ {resolved, excluded}`.
- **`utils/skuResolver.js`** — per-row validation against the distinct `ee_suborders` SKU set (rejects with reasons, never loads a bad row), partial-uploads supported, frozen upsert. Handles the **size sheet** (explicit `size_sku`) and the **style sheet** (per-style ruling `waist|letter|skip` expanded to its size rows; `SKIP → excluded`).
- **Routes** — `POST /pm/resolver/upload-sizes`, `POST /pm/resolver/upload-styles`, `GET /pm/resolver/status`.

Needs the migration applied; consumes the size/style templates Mohit is filling. Independent of the demand pipeline (#437).

🤖 Generated with [Claude Code](https://claude.com/claude-code)