### PR TITLE
feat(pm): real per-size demand pipeline — THE /pm fix (orphaned from merged #437)

### DIFF
--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -586,6 +586,16 @@ async function getDohForSku(pool, { sku }) {
   };
 }
 
+// Strip the trailing size token from an ecom size-SKU to get the style/base code
+// for dashboard grouping: KTTLADIESJEANS823M -> KTTLADIESJEANS823,
+// KTTLADIESJEANS1003_3XL -> KTTLADIESJEANS1003, KTTMENSJEANS381_28 -> KTTMENSJEANS381.
+function deriveStyle(sku) {
+  const s = String(sku || '').toUpperCase();
+  // _3XL.._6XL and _<waist> require the underscore (so ...823 + XL isn't read as 3XL);
+  // XXL/XL/XS/S/M/L attach directly. Longest alternatives first.
+  return s.replace(/(?:_(?:3XL|4XL|5XL|6XL)|_\d{2,3}|XXL|XL|XS|S|M|L)$/, '') || s;
+}
+
 // Clean-day demand metrics per size-SKU, company-wide. Gap/dup-safe.
 // A day counts as a clean in-stock day only if it was in stock the WHOLE day:
 // current snapshot qty>0 AND the most-recent-PRIOR present snapshot qty>0
@@ -601,10 +611,9 @@ async function computeCleanDayMetrics(pool, windowStart) {
     `SELECT s.sku, DATE_FORMAT(s.snapshot_date, '%Y-%m-%d') AS d, SUM(s.qty) AS qty
      FROM ee_inventory_daily_snapshot s
      INNER JOIN (
-       SELECT DISTINCT es.sku
-       FROM ee_suborders es
-       INNER JOIN ee_orders eo ON es.order_id = eo.order_id
-       WHERE eo.order_date >= ?
+       SELECT DISTINCT sku
+       FROM ee_sales_daily
+       WHERE sale_date >= ? AND source = 'mini_sales_report'
      ) sold ON sold.sku = s.sku
      WHERE s.snapshot_date >= ?
      GROUP BY s.sku, d
@@ -613,11 +622,10 @@ async function computeCleanDayMetrics(pool, windowStart) {
   );
   // Daily sales by SKU on order_date.
   const [saleRows] = await pool.query(
-    `SELECT es.sku, DATE_FORMAT(eo.order_date, '%Y-%m-%d') AS d, SUM(es.quantity) AS qty
-     FROM ee_suborders es
-     INNER JOIN ee_orders eo ON es.order_id = eo.order_id
-     WHERE eo.order_date >= ?
-     GROUP BY es.sku, d`,
+    `SELECT sku, DATE_FORMAT(sale_date, '%Y-%m-%d') AS d, SUM(qty) AS qty
+     FROM ee_sales_daily
+     WHERE sale_date >= ? AND source = 'mini_sales_report'
+     GROUP BY sku, d`,
     [windowStart]
   );
   const salesBySku = new Map();
@@ -687,19 +695,18 @@ async function getCuttingRecommendations(pool, { periodKey = '30d', shadow = fal
   // Company-wide aggregation per SKU
   const [rows] = await pool.query(
     `SELECT
-        es.sku,
-        COALESCE(SUM(es.quantity), 0) AS order_count,
+        s.sku,
+        COALESCE(SUM(s.qty), 0) AS order_count,
         COALESCE(MAX(sd.selling_days), 0) AS selling_days
-     FROM ee_suborders es
-     INNER JOIN ee_orders eo ON es.order_id = eo.order_id
+     FROM ee_sales_daily s
      LEFT JOIN (
        SELECT sku, COUNT(DISTINCT snapshot_date) AS selling_days
        FROM ee_inventory_daily_snapshot
        WHERE snapshot_date >= ? AND qty > 0
        GROUP BY sku
-     ) sd ON sd.sku = es.sku
-     WHERE eo.order_date >= ?
-     GROUP BY es.sku`,
+     ) sd ON sd.sku = s.sku
+     WHERE s.sale_date >= ? AND s.source = 'mini_sales_report'
+     GROUP BY s.sku`,
     [snapshotStart, snapshotStart]
   );
 
@@ -769,10 +776,40 @@ async function getCuttingRecommendations(pool, { periodKey = '30d', shadow = fal
   // Keep the clean-day series OFF the live /pm path. Compute it only when it
   // drives output (cutover mode) or when a shadow diff is explicitly requested.
   const includeCleanDay = DRR_MODE === 'cleanday' || shadow === true;
+  // GUARD (shadow diff): clean-day DRR is meaningless if sales don't cover the
+  // snapshot window. Refuse the diff below 90% coverage and print it — this is
+  // the lesson from the half-backfilled-orders incident, made permanent.
+  if (shadow === true) {
+    const [[cov]] = await pool.query(
+      `SELECT
+         (SELECT COUNT(DISTINCT snapshot_date) FROM ee_inventory_daily_snapshot WHERE snapshot_date >= ?) AS snap_days,
+         (SELECT COUNT(DISTINCT sale_date) FROM ee_sales_daily WHERE sale_date >= ? AND source = 'mini_sales_report') AS sale_days`,
+      [snapshotStart, snapshotStart]
+    );
+    const snapDays = Number(cov.snap_days) || 0;
+    const saleDays = Number(cov.sale_days) || 0;
+    const coverage = snapDays > 0 ? saleDays / snapDays : 0;
+    if (coverage < 0.9) {
+      throw new Error(
+        `[shadow-diff guard] sales cover only ${(coverage * 100).toFixed(0)}% of the snapshot window ` +
+        `(sales_days=${saleDays}, snapshot_days=${snapDays}; need >=90%). Backfill orders to the snapshot window first.`
+      );
+    }
+  }
   const cleanMetrics = includeCleanDay ? await computeCleanDayMetrics(pool, snapshotStart) : new Map();
+
+  // SKUs actually tracked in inventory (have a snapshot). Sold-but-untracked SKUs
+  // — 2-piece sets / bundles / virtual SKUs — have no cuttable lot, so exclude them
+  // (they otherwise dominate the recs with 0-stock noise and a bogus '(unknown)' style).
+  const [snapPresentRows] = await pool.query(
+    `SELECT DISTINCT sku FROM ee_inventory_daily_snapshot WHERE snapshot_date >= ?`,
+    [snapshotStart]
+  );
+  const snapPresent = new Set(snapPresentRows.map((r) => r.sku));
 
   const results = [];
   for (const sku of allSkus) {
+    if (!snapPresent.has(sku)) continue; // untracked/bundle SKU — not a cuttable lot
     const row = rowMap.get(sku) || { order_count: 0, selling_days: 0 };
     const orderCount = Number(row.order_count) || 0;
     const sellingDays = Number(row.selling_days) || 0;
@@ -800,13 +837,18 @@ async function getCuttingRecommendations(pool, { periodKey = '30d', shadow = fal
     );
 
     const doh = drr > 0 ? soh / drr : null;
+    // Thin-sample SKUs (clean_days < 7) aren't trustworthy cut targets in cleanday mode.
+    const lowConfidence = DRR_MODE === 'cleanday' && cd && (cd.data_quality === 'low_sample' || cd.data_quality === 'no_clean_days');
     let trigger = 'green';
     if (doh !== null && doh <= lt.lead_time) trigger = 'red';
     else if (doh !== null && doh <= horizon) trigger = 'orange';
+    if (lowConfidence && trigger === 'red') trigger = 'orange'; // demote noisy thin-sample reds
 
     const drrDiffPct = legacyDrr > 0 ? ((cleandayDrr - legacyDrr) / legacyDrr) * 100 : (cleandayDrr > 0 ? Infinity : 0);
     results.push({
       sku,
+      style: deriveStyle(sku),
+      low_confidence: !!lowConfidence,
       soh,
       drr,
       doh,

--- a/utils/easyecomPullWorker.js
+++ b/utils/easyecomPullWorker.js
@@ -23,6 +23,7 @@ const {
 const { recomputeAllHealth } = require('./easyecomAnalytics');
 
 const EASYECOM_API_BASE = global.env?.EASYECOM_API_BASE || process.env.EASYECOM_API_BASE || 'https://api.easyecom.io';
+const EASYECOM_API_KEY = global.env?.EASYECOM_API_KEY || process.env.EASYECOM_API_KEY || '';
 
 // EasyEcom c_id (warehouse) → credential key in easyecomReturnsClient.
 const WAREHOUSE_KEY_BY_ID = {
@@ -253,7 +254,7 @@ async function pullOrdersForWarehouse(pool, warehouseKey, warehouseId, startStr,
 
   const api = axios.create({
     baseURL: EASYECOM_API_BASE,
-    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}`, ...(EASYECOM_API_KEY ? { 'x-api-key': EASYECOM_API_KEY } : {}) },
     timeout: 120000,
   });
 
@@ -354,47 +355,65 @@ async function persistOrderBatch(pool, orders, fallbackWarehouseId) {
 // Step 3 — MINI_SALES_REPORT  (per-day per-SKU sales for cross-check)
 // ────────────────────────────────────────────────────────────────────
 
+// Aggregate one downloaded mini-sales report (per suborder LINE) to (sku, sale_date)
+// rows for ee_sales_daily, dropping cancellations. Kept as a helper so each 7-day
+// chunk is parsed, reduced, and released before the next — bounds memory.
+function aggregateMiniSales(rows, warehouseId) {
+  const agg = new Map();
+  for (const r of rows) {
+    const status = String(pickField(r, ['Order Status', 'order_status']) || '');
+    if (/cancel/i.test(status)) continue;
+    const sku = pickField(r, ['SKU', 'sku', 'Product Code']);
+    const dateStr = pickField(r, ['Order Date', 'order_date', 'Invoice Date', 'invoice_date', 'date']);
+    if (!sku || !dateStr) continue;
+    const qty = Number(pickField(r, ['Item Quantity', 'Suborder Quantity', 'quantity', 'qty', 'Quantity'])) || 0;
+    const rev = Number(pickField(r, ['Selling Price', 'total_amount', 'amount', 'Revenue'])) || 0;
+    const saleDate = String(dateStr).slice(0, 10);
+    const key = String(sku).toUpperCase() + '|' + saleDate;
+    const cur = agg.get(key) || { sku: String(sku).toUpperCase(), saleDate, qty: 0, rev: 0 };
+    cur.qty += qty; cur.rev += rev;
+    agg.set(key, cur);
+  }
+  return [...agg.values()].map((a) => [a.sku, warehouseId, a.saleDate, a.qty, a.rev || null, 'mini_sales_report']);
+}
+
 async function pullMiniSalesReport(pool, runStartedAt, windowDays) {
   const stepStart = Date.now();
-  const end = new Date();
-  const start = new Date(end.getTime() - windowDays * 24 * 60 * 60 * 1000);
-  const startDate = ymd(start);
-  const endDate = ymd(end);
-
+  const CHUNK_DAYS = 7; // one ~7-day report (~35k lines) in memory at a time — avoids OOM on a 30d pull
+  const MS_DAY = 24 * 60 * 60 * 1000;
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - windowDays * MS_DAY);
   let totalRows = 0;
+
   for (const [warehouseIdStr, warehouseKey] of Object.entries(WAREHOUSE_KEY_BY_ID)) {
     const warehouseId = Number(warehouseIdStr);
     try {
-      const rows = await fetchMiniSalesReport({ startDate, endDate }, warehouseKey);
-      const upsert = [];
-      for (const r of rows) {
-        const sku = pickField(r, ['sku', 'SKU', 'Product Code']);
-        const dateStr = pickField(r, ['order_date', 'Order Date', 'invoice_date', 'Invoice Date', 'date']);
-        const qty = Number(pickField(r, ['quantity', 'qty', 'Quantity', 'Order Quantity'])) || 0;
-        const revenue = Number(pickField(r, ['total_amount', 'amount', 'Revenue', 'Selling Price'])) || null;
-        if (!sku || !dateStr) continue;
-        const saleDate = String(dateStr).slice(0, 10);
-        upsert.push([String(sku).toUpperCase(), warehouseId, saleDate, qty, revenue, 'mini_sales_report']);
-      }
-      if (upsert.length) {
+      let cursor = new Date(windowStart);
+      while (cursor <= now) {
+        const chunkEnd = new Date(Math.min(cursor.getTime() + (CHUNK_DAYS - 1) * MS_DAY, now.getTime()));
+        const startDate = ymd(cursor);
+        const endDate = ymd(chunkEnd);
+        let rows = await fetchMiniSalesReport({ startDate, endDate }, warehouseKey);
+        const upsert = aggregateMiniSales(rows, warehouseId);
+        rows = null; // release the parsed report before the next chunk
         for (let i = 0; i < upsert.length; i += 1000) {
-          const chunk = upsert.slice(i, i + 1000);
           await pool.query(
             `INSERT INTO ee_sales_daily (sku, warehouse_id, sale_date, qty, revenue, source)
              VALUES ?
              ON DUPLICATE KEY UPDATE qty = VALUES(qty), revenue = VALUES(revenue), synced_at = CURRENT_TIMESTAMP`,
-            [chunk]
+            [upsert.slice(i, i + 1000)]
           );
         }
+        totalRows += upsert.length;
+        cursor = new Date(chunkEnd.getTime() + MS_DAY); // next day after this chunk — no overlap
       }
-      totalRows += upsert.length;
     } catch (err) {
       console.error(`[pullWorker] mini sales report failed for ${warehouseKey}:`, err.message);
       await logStep(pool, runStartedAt, `mini_sales:${warehouseKey}`, 'error', err.message, Date.now() - stepStart);
     }
   }
   await logStep(pool, runStartedAt, 'mini_sales', 'ok',
-    `window=${windowDays}d rows=${totalRows} ${startDate}..${endDate}`, Date.now() - stepStart);
+    `window=${windowDays}d chunk=${CHUNK_DAYS}d rows=${totalRows}`, Date.now() - stepStart);
 }
 
 // ────────────────────────────────────────────────────────────────────
@@ -685,4 +704,4 @@ function triggerNow(pool, opts = {}) {
   return Promise.resolve().then(() => runPullWorker(pool, opts));
 }
 
-module.exports = { runPullWorker, triggerNow, pullSnapshotsFromPrimary };
+module.exports = { runPullWorker, triggerNow, pullSnapshotsFromPrimary, pullOrders, pullMiniSalesReport };

--- a/utils/easyecomReturnsClient.js
+++ b/utils/easyecomReturnsClient.js
@@ -4,6 +4,7 @@
  */
 
 const axios = require('axios');
+const JSZip = require('jszip');
 
 // Configuration from environment
 // Uses global.env from secure-env (loaded in app.js) with fallback to process.env
@@ -76,7 +77,7 @@ async function authenticateWithCredentials(warehouse = 'faridabad') {
       password: creds.password,
       location_key: creds.location_key,
     }, {
-      headers: { 'Content-Type': 'application/json' },
+      headers: { 'Content-Type': 'application/json', ...(EASYECOM_API_KEY ? { 'x-api-key': EASYECOM_API_KEY } : {}) },
       timeout: 30000
     });
 
@@ -787,7 +788,7 @@ function ensureAxiosForWarehouse(warehouseKey, timeoutMs = 60000) {
     if (!jwt) throw new Error(`EasyEcom not configured for warehouse: ${warehouseKey}`);
     return axios.create({
       baseURL: EASYECOM_API_BASE,
-      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${jwt}` },
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${jwt}`, ...(EASYECOM_API_KEY ? { 'x-api-key': EASYECOM_API_KEY } : {}) },
       timeout: timeoutMs,
     });
   })();
@@ -903,19 +904,27 @@ async function waitForAndDownloadReport(reportId, warehouse = 'faridabad', { pol
     await new Promise(r => setTimeout(r, pollIntervalMs));
   }
   if (!ready) throw new Error(`Report ${reportId} timed out after ${maxWaitMs}ms`);
-  // /reports/download returns either raw CSV, or a JSON envelope
-  // { data: { reportStatus, downloadUrl } } pointing at a pre-signed S3 CSV. Handle both.
-  const dl = await api.get('/reports/download', { params: { reportId }, responseType: 'text' });
-  let csvText = typeof dl.data === 'string' ? dl.data : JSON.stringify(dl.data);
-  if (csvText && csvText.trimStart().startsWith('{')) {
+  // Download. EasyEcom returns the report as raw CSV, a ZIP (PK magic), or a JSON
+  // envelope { data: { downloadUrl } } pointing at an S3 file (usually a ZIP).
+  const dl = await api.get('/reports/download', { params: { reportId }, responseType: 'arraybuffer' });
+  let buf = Buffer.from(dl.data);
+  if (buf.slice(0, 1).toString() === '{') {
     try {
-      const env = JSON.parse(csvText);
+      const env = JSON.parse(buf.toString('utf8'));
       const url = env?.data?.downloadUrl || env?.downloadUrl;
       if (url) {
-        const s3 = await axios.get(url, { timeout: 600000, responseType: 'text' });
-        csvText = typeof s3.data === 'string' ? s3.data : JSON.stringify(s3.data);
+        const s3 = await axios.get(url, { responseType: 'arraybuffer', timeout: 600000 });
+        buf = Buffer.from(s3.data);
       }
-    } catch (_) { /* treat as raw CSV */ }
+    } catch (_) { /* treat buf as the file itself */ }
+  }
+  let csvText;
+  if (buf.slice(0, 2).toString() === 'PK') {
+    const zip = await JSZip.loadAsync(buf);
+    const name = Object.keys(zip.files).find((n) => n.toLowerCase().endsWith('.csv')) || Object.keys(zip.files)[0];
+    csvText = name ? await zip.files[name].async('string') : '';
+  } else {
+    csvText = buf.toString('utf8');
   }
   return parseCsv(csvText);
 }


### PR DESCRIPTION
**This is the commit that actually makes `/pm` show real per-style cutting.** It was pushed to the #437 branch *after* #437 was already merged, so it got orphaned — `main` never got it. This PR brings it in.

Makes `/pm` real (validated on prod data: ~2.9s, 8,798 real styles, no `(unknown)`, top sellers real DRR):
- **EasyEcom client**: `x-api-key` on auth + data calls (keyed tier — no-key is Forbidden-blocked); report download handles JSON-envelope→S3→**ZIP unzip** (was read as text → garbage).
- **Pull worker**: `pullMiniSalesReport` chunked into 7-day windows (fixes OOM on 30d), aggregated per (sku,date) using `Item Quantity`, drops cancellations → `ee_sales_daily`.
- **Analytics**: DRR (legacy + clean-day) reads `ee_sales_daily` (the orders endpoint 504s on history); shadow-diff coverage guard; `deriveStyle()` (fixes the single `(unknown)` row); exclude untracked/bundle SKUs; thin-sample `low_confidence` gating.

**Prereq already done:** `EASYECOM_API_KEY` is set on Cloud Run; `ee_sales_daily` is backfilled (30d). Merge → deploy → `/pm` is real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)