### PR TITLE
feat(cutting): manual lot number + mapping + challan display

### DIFF
--- a/app.js
+++ b/app.js
@@ -151,6 +151,7 @@ const dashboardRoutes = require('./routes/dashboardRoutes');
 const operatorRoutes = require('./routes/operatorRoutes');
 const fabricManagerRoutes = require('./routes/fabricManagerRoutes'); // Import Fabric Manager Routes
 const cuttingManagerRoutes = require('./routes/cuttingManagerRoutes');
+const manualLotRoutes = require('./routes/manualLotRoutes');
 const departmentRoutes = require('./routes/departmentRoutes');
 const stitchingRoutes = require('./routes/stitchingRoutes');
 const finishingRoutes = require('./routes/finishingRoutes');
@@ -211,6 +212,7 @@ app.use('/dashboard', dashboardRoutes);
 app.use('/operator', operatorRoutes);
 app.use('/fabric-manager', fabricManagerRoutes); // Use Fabric Manager Routes
 app.use('/cutting-manager', cuttingManagerRoutes);
+app.use('/manual-lot', manualLotRoutes);
 app.use('/department', departmentRoutes);
 app.use('/stitchingdashboard', stitchingRoutes);
 app.use('/finishingdashboard', finishingRoutes);

--- a/routes/accountsChallanRoutes.js
+++ b/routes/accountsChallanRoutes.js
@@ -60,15 +60,15 @@ function buildAssignmentsQuery({ search, limit, offset }) {
         const conds = [];
         for (const term of terms) {
           const like = `%${term}%`;
-          conds.push('(c.sku LIKE ? OR c.lot_no LIKE ? OR c.remark LIKE ?)');
-          params.push(like, like, like);
+          conds.push('(c.sku LIKE ? OR c.lot_no LIKE ? OR c.remark LIKE ? OR c.manual_lot_number LIKE ?)');
+          params.push(like, like, like, like);
         }
         whereClause += ` AND (${conds.join(' OR ')})`;
       }
     } else {
       const like = `%${search}%`;
-      whereClause += ' AND (c.sku LIKE ? OR c.lot_no LIKE ? OR c.remark LIKE ?)';
-      params.push(like, like, like);
+      whereClause += ' AND (c.sku LIKE ? OR c.lot_no LIKE ? OR c.remark LIKE ? OR c.manual_lot_number LIKE ?)';
+      params.push(like, like, like, like);
     }
   }
 
@@ -76,6 +76,8 @@ function buildAssignmentsQuery({ search, limit, offset }) {
     SELECT
       c.id AS cutting_id,
       c.lot_no,
+      c.manual_lot_number,
+      COALESCE(NULLIF(c.manual_lot_number, ''), c.lot_no) AS display_lot,
       c.sku,
       c.total_pieces,
       c.remark AS cutting_remark,
@@ -131,6 +133,15 @@ router.get('/search', isAuthenticated, isAccountsAdmin, async (req, res) => {
     console.error('[ERROR] GET /accounts-challan/search:', err);
     res.status(500).json({ error: err.message });
   }
+});
+
+// GET /accounts-challan/generate — the generation form is produced by POSTing
+// selected rows from the dashboard. A GET here means a refresh / Back button /
+// bookmark / direct nav (no selected rows in the body), which would otherwise
+// 404 with "Cannot GET". Send the user back to the dashboard to re-select.
+router.get('/generate', isAuthenticated, isAccountsAdmin, (req, res) => {
+  req.flash('error', 'Please select lots and click "Generate Challan" again.');
+  res.redirect('/accounts-challan');
 });
 
 router.post('/generate', isAuthenticated, isAccountsAdmin, async (req, res) => {
@@ -241,6 +252,7 @@ router.post('/create', isAuthenticated, isAccountsAdmin, async (req, res) => {
     const [assignmentRows] = await conn.query(
       `SELECT
          c.lot_no,
+         c.manual_lot_number,
          c.sku,
          c.total_pieces,
          IFNULL(SUM(dci.issued_pieces), 0) AS issued_pieces
@@ -291,6 +303,7 @@ router.post('/create', isAuthenticated, isAccountsAdmin, async (req, res) => {
           entryType: 'mix',
           washing_id: null,
           lot_no: customLabel,
+          manual_lot_number: null,
           customLabel,
           sku: mixSku,
           total_pieces: requestedPieces,
@@ -341,6 +354,7 @@ router.post('/create', isAuthenticated, isAccountsAdmin, async (req, res) => {
         entryType,
         washing_id: null,
         lot_no: assignment.lot_no,
+        manual_lot_number: assignment.manual_lot_number || null,
         sku: assignment.sku,
         total_pieces: requestedPieces,
         lot_total_pieces: assignment.total_pieces,
@@ -398,6 +412,7 @@ router.post('/create', isAuthenticated, isAccountsAdmin, async (req, res) => {
       challanId,
       item.entryType === 'mix' ? null : item.washing_id,
       item.entryType === 'mix' ? item.customLabel : item.lot_no,
+      item.entryType === 'mix' ? null : (item.manual_lot_number || null),
       item.sku,
       item.entryType === 'mix' ? item.total_pieces : item.lot_total_pieces,
       item.total_pieces,
@@ -408,7 +423,7 @@ router.post('/create', isAuthenticated, isAccountsAdmin, async (req, res) => {
 
     await conn.query(
       `INSERT INTO dc_challan_items
-        (challan_id, washing_id, lot_no, sku, total_pieces, issued_pieces, item_type, custom_label, sku_override)
+        (challan_id, washing_id, lot_no, manual_lot_number, sku, total_pieces, issued_pieces, item_type, custom_label, sku_override)
        VALUES ?`,
       [insertItemValues]
     );
@@ -491,8 +506,9 @@ router.get('/list', isAuthenticated, isAccountsAdmin, async (req, res) => {
         AND (
           challan_no LIKE ?
           OR JSON_SEARCH(items,'one',?,NULL,'$[*].lot_no') IS NOT NULL
+          OR JSON_SEARCH(items,'one',?,NULL,'$[*].manual_lot_number') IS NOT NULL
         )`;
-      params.push(`%${search}%`, search);
+      params.push(`%${search}%`, search, search);
     }
 
     sql += ' ORDER BY created_at DESC LIMIT 200';

--- a/routes/bulkUploadRoutes.js
+++ b/routes/bulkUploadRoutes.js
@@ -58,10 +58,11 @@ router.get('/bulk-upload/template', isAuthenticated, isCuttingManager, async (re
       { header: 'Lot No', key: 'lot_no', width: 15 },
       { header: 'SKU', key: 'sku', width: 15 },
       { header: 'Fabric Type', key: 'fabric_type', width: 15 },
-      { header: 'Remark', key: 'remark', width: 20 }
+      { header: 'Remark', key: 'remark', width: 20 },
+      { header: 'Manual Lot No', key: 'manual_lot_number', width: 18 }
     ];
     // Add an example row
-    lotsSheet.addRow({ lot_no: 'LOT001', sku: 'SKU001', fabric_type: 'Cotton', remark: 'Older lot' });
+    lotsSheet.addRow({ lot_no: 'LOT001', sku: 'SKU001', fabric_type: 'Cotton', remark: 'Older lot', manual_lot_number: 'A-1024' });
 
     // Sheet 2: Sizes
     const sizesSheet = workbook.addWorksheet('Sizes');
@@ -133,9 +134,12 @@ router.post('/bulk-upload/upload-lots', isAuthenticated, isCuttingManager, uploa
       const sku = row.getCell(2).value;
       const fabric_type = row.getCell(3).value;
       const remark = row.getCell(4).value;
-      console.log(`Row ${rowNumber} - Lot No: ${lot_no}, SKU: ${sku}, Fabric Type: ${fabric_type}, Remark: ${remark}`);
+      // Manual lot number is optional here so historical sheets keep working;
+      // it is required on the single create-lot form going forward.
+      const manual_lot_number = row.getCell(5).value;
+      console.log(`Row ${rowNumber} - Lot No: ${lot_no}, SKU: ${sku}, Fabric Type: ${fabric_type}, Remark: ${remark}, Manual Lot No: ${manual_lot_number}`);
       if (lot_no && sku && fabric_type) {
-        lotsData.push({ lot_no, sku, fabric_type, remark });
+        lotsData.push({ lot_no, sku, fabric_type, remark, manual_lot_number });
       }
     });
     console.log('Lots data extracted:', lotsData.length);
@@ -206,10 +210,13 @@ router.post('/bulk-upload/upload-lots', isAuthenticated, isCuttingManager, uploa
         throw new Error(`Fabric type "${lot.fabric_type}" for lot ${lot.lot_no} is not in the fabric database. Ad-hoc entry is disabled.`);
       }
 
+      const manualLotNo = lot.manual_lot_number
+        ? lot.manual_lot_number.toString().trim() || null
+        : null;
       const [result] = await conn.query(
-        `INSERT INTO cutting_lots (lot_no, sku, fabric_type, remark, user_id, total_pieces)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-        [lot.lot_no, lot.sku, lot.fabric_type, lot.remark || null, req.session.user.id, totalPieces]
+        `INSERT INTO cutting_lots (lot_no, manual_lot_number, sku, fabric_type, remark, user_id, total_pieces)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        [lot.lot_no, manualLotNo, lot.sku, lot.fabric_type, lot.remark || null, req.session.user.id, totalPieces]
       );
       const cuttingLotId = result.insertId;
 

--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -84,9 +84,10 @@ router.get('/dashboard', isAuthenticated, isCuttingManager, async (req, res) => 
     // Fetch all cutting lots created by this cutting manager
     const [cuttingLots] = await pool.query(
       `
-      SELECT 
+      SELECT
         l.id,
         l.lot_no,
+        l.manual_lot_number,
         l.sku,
         l.fabric_type,
         l.remark,
@@ -209,6 +210,7 @@ router.post(
   async (req, res) => {
     const {
       lot_no,
+      manual_lot_number,
       sku,
       fabric_type,
       remark,
@@ -224,8 +226,8 @@ router.post(
     const image = req.file;
 
     // Input validation
-    if (!lot_no || !sku || !fabric_type) {
-      req.flash('error', 'Lot No., SKU and Fabric Type are required.');
+    if (!lot_no || !sku || !fabric_type || !manual_lot_number || !manual_lot_number.trim()) {
+      req.flash('error', 'Lot No., SKU, Fabric Type and Manual Lot Number are required.');
       return res.redirect('/cutting-manager/dashboard');
     }
 
@@ -260,12 +262,13 @@ router.post(
         const [result] = await conn.query(
           `
           INSERT INTO cutting_lots
-            (lot_no, sku, fabric_type, remark, table_length, image_url, user_id, total_pieces, flow_type)
+            (lot_no, manual_lot_number, sku, fabric_type, remark, table_length, image_url, user_id, total_pieces, flow_type)
           VALUES
-            (?, ?, ?, ?, ?, ?, ?, 0, ?)
+            (?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
         `,
           [
             lot_no,
+            manual_lot_number.trim(),
             sku,
             fabric_type,
             remark || null,

--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -561,7 +561,7 @@ router.get('/lot-details/:lotId', isAuthenticated, isCuttingManager, async (req,
     // Fetch lot, sizes and rolls concurrently
     const [[lotRows], [sizes], [rolls]] = await Promise.all([
       pool.query(
-        `SELECT l.id, l.lot_no, l.sku, l.fabric_type, l.remark, l.table_length, l.image_url, l.total_pieces, l.is_confirmed, l.created_at, u.username AS created_by
+        `SELECT l.id, l.lot_no, l.manual_lot_number, l.sku, l.fabric_type, l.remark, l.table_length, l.image_url, l.total_pieces, l.is_confirmed, l.created_at, u.username AS created_by
          FROM cutting_lots l
          JOIN users u ON l.user_id = u.id
          WHERE l.id = ?`,

--- a/routes/finishingRoutes.js
+++ b/routes/finishingRoutes.js
@@ -1347,7 +1347,7 @@ router.get('/challan/:id', isAuthenticated, isFinishingMaster, async (req, res) 
     const userId = req.session.user.id;
     const entryId = req.params.id;
     const [[row]] = await pool.query(`
-      SELECT fd.*, cl.remark AS cutting_remark
+      SELECT fd.*, cl.remark AS cutting_remark, cl.manual_lot_number
       FROM finishing_data fd
       LEFT JOIN cutting_lots cl ON cl.lot_no = fd.lot_no
       WHERE fd.id = ? AND fd.user_id = ?

--- a/routes/jeansAssemblyRoutes.js
+++ b/routes/jeansAssemblyRoutes.js
@@ -545,9 +545,10 @@ router.get('/challan/:id', isAuthenticated, isJeansAssemblyMaster, async (req, r
 
     // 1) Jeans assembly record
     const [[entry]] = await pool.query(`
-      SELECT *
-      FROM jeans_assembly_data
-      WHERE id = ? AND user_id = ?
+      SELECT jad.*, cl.manual_lot_number
+      FROM jeans_assembly_data jad
+      LEFT JOIN cutting_lots cl ON cl.lot_no = jad.lot_no
+      WHERE jad.id = ? AND jad.user_id = ?
     `, [entryId, userId]);
     if (!entry) {
       req.flash('error', 'Challan not found or no permission.');

--- a/routes/manualLotRoutes.js
+++ b/routes/manualLotRoutes.js
@@ -1,0 +1,202 @@
+// routes/manualLotRoutes.js
+//
+// Map a manual (handwritten / physical) lot number onto existing cutting lots.
+// Two ways in:
+//   - inline search-and-edit page (one lot at a time)
+//   - bulk Excel upload (system lot_no -> manual lot number)
+//
+// The system cutting_lots.lot_no is never touched here; we only set
+// manual_lot_number, which is a display label.
+
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const path = require('path');
+const ExcelJS = require('exceljs');
+const { pool } = require('../config/db');
+const { isAuthenticated, isCuttingManager } = require('../middlewares/auth');
+
+// Reuse the same disk-upload setup as bulk lot upload.
+const storage = multer.diskStorage({
+  destination: function (req, file, cb) {
+    cb(null, 'uploads/');
+  },
+  filename: function (req, file, cb) {
+    cb(null, Date.now() + path.extname(file.originalname));
+  }
+});
+const upload = multer({
+  storage: storage,
+  limits: { fileSize: 50 * 1024 * 1024 }
+});
+
+async function fetchLots(search) {
+  if (search) {
+    const like = `%${search}%`;
+    const [rows] = await pool.query(
+      `SELECT id, lot_no, manual_lot_number, sku, remark, created_at
+         FROM cutting_lots
+        WHERE lot_no LIKE ? OR sku LIKE ? OR remark LIKE ? OR manual_lot_number LIKE ?
+        ORDER BY created_at DESC
+        LIMIT 200`,
+      [like, like, like, like]
+    );
+    return rows;
+  }
+  const [rows] = await pool.query(
+    `SELECT id, lot_no, manual_lot_number, sku, remark, created_at
+       FROM cutting_lots
+      ORDER BY created_at DESC
+      LIMIT 200`
+  );
+  return rows;
+}
+
+// GET /manual-lot  — inline mapping page (with optional ?search=)
+router.get('/', isAuthenticated, isCuttingManager, async (req, res) => {
+  try {
+    const search = (req.query.search || '').trim();
+    const lots = await fetchLots(search);
+    res.render('manualLotMapping', {
+      user: req.session.user,
+      lots,
+      search,
+      uploadResult: null,
+      error: req.flash('error'),
+      success: req.flash('success')
+    });
+  } catch (err) {
+    console.error('[ERROR] GET /manual-lot:', err);
+    req.flash('error', 'Could not load manual lot mapping.');
+    res.redirect('/cutting-manager/dashboard');
+  }
+});
+
+// POST /manual-lot/update — set/clear manual_lot_number for one lot (by id)
+router.post('/update', isAuthenticated, isCuttingManager, async (req, res) => {
+  const search = (req.body.search || '').trim();
+  const back = `/manual-lot${search ? `?search=${encodeURIComponent(search)}` : ''}`;
+  try {
+    const id = parseInt(req.body.id, 10);
+    const manualLotNumber = (req.body.manual_lot_number || '').trim();
+    if (!id) {
+      req.flash('error', 'Invalid lot.');
+      return res.redirect(back);
+    }
+    await pool.query(
+      'UPDATE cutting_lots SET manual_lot_number = ? WHERE id = ?',
+      [manualLotNumber || null, id]
+    );
+    req.flash('success', `Manual lot number ${manualLotNumber ? 'saved' : 'cleared'}.`);
+    res.redirect(back);
+  } catch (err) {
+    console.error('[ERROR] POST /manual-lot/update:', err);
+    req.flash('error', 'Failed to update manual lot number.');
+    res.redirect(back);
+  }
+});
+
+// GET /manual-lot/template — download the bulk mapping Excel template
+router.get('/template', isAuthenticated, isCuttingManager, async (req, res) => {
+  try {
+    const workbook = new ExcelJS.Workbook();
+    const sheet = workbook.addWorksheet('Mapping');
+    sheet.columns = [
+      { header: 'System Lot No', key: 'lot_no', width: 20 },
+      { header: 'Manual Lot Number', key: 'manual_lot_number', width: 22 }
+    ];
+    sheet.addRow({ lot_no: 'jo1', manual_lot_number: 'A-1024' });
+
+    res.setHeader(
+      'Content-Type',
+      'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+    );
+    res.setHeader(
+      'Content-Disposition',
+      'attachment; filename=ManualLotMappingTemplate.xlsx'
+    );
+    await workbook.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error('[ERROR] GET /manual-lot/template:', err);
+    req.flash('error', 'Could not generate template.');
+    res.redirect('/manual-lot');
+  }
+});
+
+// POST /manual-lot/upload — bulk map by system lot_no
+router.post('/upload', isAuthenticated, isCuttingManager, upload.single('excelFile'), async (req, res) => {
+  const file = req.file;
+  if (!file) {
+    req.flash('error', 'No file uploaded.');
+    return res.redirect('/manual-lot');
+  }
+
+  let conn;
+  try {
+    const workbook = new ExcelJS.Workbook();
+    await workbook.xlsx.readFile(file.path);
+    const sheet = workbook.getWorksheet('Mapping') || workbook.worksheets[0];
+    if (!sheet) {
+      throw new Error('No worksheet found in the uploaded file.');
+    }
+
+    const rows = [];
+    sheet.eachRow({ includeEmpty: false }, (row, rowNumber) => {
+      if (rowNumber === 1) return; // header
+      const lotNo = row.getCell(1).value;
+      const manual = row.getCell(2).value;
+      rows.push({
+        lot_no: lotNo == null ? '' : lotNo.toString().trim(),
+        manual_lot_number: manual == null ? '' : manual.toString().trim()
+      });
+    });
+
+    conn = await pool.getConnection();
+    await conn.beginTransaction();
+
+    let matched = 0;
+    let skipped = 0;
+    const unmatched = [];
+
+    for (const r of rows) {
+      if (!r.lot_no || !r.manual_lot_number) {
+        skipped += 1;
+        continue;
+      }
+      const [result] = await conn.query(
+        'UPDATE cutting_lots SET manual_lot_number = ? WHERE lot_no = ?',
+        [r.manual_lot_number, r.lot_no]
+      );
+      if (result.affectedRows >= 1) {
+        matched += 1;
+      } else {
+        unmatched.push(r.lot_no);
+      }
+    }
+
+    await conn.commit();
+    conn.release();
+
+    const search = '';
+    const lots = await fetchLots(search);
+    res.render('manualLotMapping', {
+      user: req.session.user,
+      lots,
+      search,
+      uploadResult: { matched, skipped, unmatched },
+      error: req.flash('error'),
+      success: req.flash('success')
+    });
+  } catch (err) {
+    if (conn) {
+      await conn.rollback();
+      conn.release();
+    }
+    console.error('[ERROR] POST /manual-lot/upload:', err);
+    req.flash('error', `Upload failed: ${err.message}`);
+    res.redirect('/manual-lot');
+  }
+});
+
+module.exports = router;

--- a/routes/myLotsRoutes.js
+++ b/routes/myLotsRoutes.js
@@ -77,7 +77,7 @@ async function loadUserLots(userId) {
 
     // 2) Load lot metadata.
     const [lots] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.flow_type, cl.created_at,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.flow_type, cl.created_at,
               cl.remark, cl.user_id AS cutter_id, cu.username AS cutter_name
          FROM cutting_lots cl
     LEFT JOIN users cu ON cu.id = cl.user_id
@@ -93,6 +93,8 @@ async function loadUserLots(userId) {
       lotById[l.id] = {
         lot_id: l.id,
         lot_no: l.lot_no,
+        manual_lot_number: l.manual_lot_number || null,
+        display_lot: l.manual_lot_number || l.lot_no,
         sku: l.sku,
         remark: l.remark || '',
         pieces: Number(l.total_pieces) || 0,

--- a/routes/stitchingRoutes.js
+++ b/routes/stitchingRoutes.js
@@ -1368,10 +1368,11 @@ router.get('/challan/:id', isAuthenticated, isStitchingMaster, async (req, res) 
 
     // 1) Verify the user owns this stitching_data record
     const [[row]] = await pool.query(`
-      SELECT *
-      FROM stitching_data
-      WHERE id = ?
-        AND user_id = ?
+      SELECT sd.*, cl.manual_lot_number
+      FROM stitching_data sd
+      LEFT JOIN cutting_lots cl ON cl.lot_no = sd.lot_no
+      WHERE sd.id = ?
+        AND sd.user_id = ?
     `, [entryId, userId]);
     if (!row) {
       req.flash('error', 'Challan not found or no permission.');

--- a/routes/washingInRoutes.js
+++ b/routes/washingInRoutes.js
@@ -1383,10 +1383,11 @@ router.get('/challan/:id', isAuthenticated, isWashingInMaster, async (req, res) 
     const entryId = req.params.id;
 
     const [[row]] = await pool.query(`
-      SELECT *
-      FROM washing_in_data
-      WHERE id = ?
-        AND user_id = ?
+      SELECT wid.*, cl.manual_lot_number
+      FROM washing_in_data wid
+      LEFT JOIN cutting_lots cl ON cl.lot_no = wid.lot_no
+      WHERE wid.id = ?
+        AND wid.user_id = ?
     `, [entryId, userId]);
     if (!row) {
       req.flash('error', 'Challan not found or no permission.');

--- a/routes/washingRoutes.js
+++ b/routes/washingRoutes.js
@@ -423,10 +423,11 @@ router.get('/challan/:id', isAuthenticated, isWashingMaster, async (req, res) =>
     const userId = req.session.user.id;
     const entryId = req.params.id;
     const [[row]] = await pool.query(`
-      SELECT *
-      FROM washing_data
-      WHERE id = ?
-        AND user_id = ?
+      SELECT wd.*, cl.manual_lot_number
+      FROM washing_data wd
+      LEFT JOIN cutting_lots cl ON cl.lot_no = wd.lot_no
+      WHERE wd.id = ?
+        AND wd.user_id = ?
     `, [entryId, userId]);
     if (!row) {
       req.flash('error', 'Challan not found or no permission.');

--- a/sql/manual_lot_number_migration.sql
+++ b/sql/manual_lot_number_migration.sql
@@ -1,0 +1,19 @@
+-- Manual (handwritten / physical) lot number on cutting lots.
+--
+-- The system-generated cutting_lots.lot_no (e.g. "jo1") remains the IMMUTABLE
+-- internal key used by every downstream join and all piece-tracking math.
+-- manual_lot_number is a DISPLAY label only: it replaces lot_no in what users
+-- see, falling back to lot_no for lots that have not been mapped yet.
+--
+-- Run manually (this repo has no migration runner).
+
+ALTER TABLE cutting_lots
+  ADD COLUMN manual_lot_number VARCHAR(64) NULL AFTER lot_no;
+
+CREATE INDEX idx_cutting_lots_manual_lot ON cutting_lots (manual_lot_number);
+
+-- Snapshot the manual number onto each challan line at issue time, for
+-- display / printing / search. lot_no STAYS the real system key that the
+-- issued/remaining computation (LEFT JOIN dci.lot_no = c.lot_no) depends on.
+ALTER TABLE dc_challan_items
+  ADD COLUMN manual_lot_number VARCHAR(64) NULL AFTER lot_no;

--- a/views/accountsChallanDashboard.ejs
+++ b/views/accountsChallanDashboard.ejs
@@ -139,6 +139,7 @@
                 <tr
                   data-id="<%= a.cutting_id %>"
                   data-lot="<%= a.lot_no %>"
+                  data-manual="<%= a.manual_lot_number || '' %>"
                   data-sku="<%= a.sku %>"
                   data-total="<%= a.total_pieces %>"
                   data-remaining="<%= a.remaining_pieces %>"
@@ -147,7 +148,7 @@
                     <input type="checkbox" class="rowCheckbox" style="width: 18px; height: 18px; accent-color: var(--terracotta);">
                   </td>
                   <td><span style="font-family: var(--font-mono); font-size: var(--text-sm);"><%= a.cutting_id %></span></td>
-                  <td><strong><%= a.lot_no %></strong></td>
+                  <td><strong><%= a.display_lot %></strong></td>
                   <td><%= a.sku %></td>
                   <td><%= a.total_pieces %></td>
                   <td><%= a.issued_pieces %></td>
@@ -247,6 +248,7 @@
       const row = document.createElement('tr');
       row.dataset.id = a.cutting_id;
       row.dataset.lot = a.lot_no;
+      row.dataset.manual = a.manual_lot_number || '';
       row.dataset.sku = a.sku;
       row.dataset.total = a.total_pieces;
       row.dataset.remaining = a.remaining_pieces;
@@ -255,7 +257,7 @@
           <input type="checkbox" class="rowCheckbox" style="width: 18px; height: 18px; accent-color: var(--terracotta);">
         </td>
         <td><span style="font-family: var(--font-mono); font-size: var(--text-sm);">${a.cutting_id}</span></td>
-        <td><strong>${a.lot_no}</strong></td>
+        <td><strong>${a.display_lot || a.lot_no}</strong></td>
         <td>${a.sku}</td>
         <td>${a.total_pieces}</td>
         <td>${a.issued_pieces}</td>
@@ -339,6 +341,7 @@
       selected.push({
         cutting_id: row.dataset.id,
         lot_no: row.dataset.lot,
+        manual_lot_number: row.dataset.manual || '',
         sku: row.dataset.sku,
         total_pieces: row.dataset.total,
         challan_pieces: qty,

--- a/views/accountsChallanGeneration.ejs
+++ b/views/accountsChallanGeneration.ejs
@@ -519,10 +519,10 @@
       td1.appendChild(indexBadge);
       tr.appendChild(td1);
 
-      // Cell 2: Lot No
+      // Cell 2: Lot No (manual number replaces the system number for display)
       const td2 = document.createElement('td');
       const lotStrong = document.createElement('strong');
-      lotStrong.textContent = row.lot_no || '';
+      lotStrong.textContent = row.manual_lot_number || row.lot_no || '';
       td2.appendChild(lotStrong);
       tr.appendChild(td2);
 

--- a/views/challan.ejs
+++ b/views/challan.ejs
@@ -303,7 +303,7 @@
         </tr>
         <tr>
           <td class="label">Lot No:</td>
-          <td class="value"><%= entry.lot_no %></td>
+          <td class="value"><%= entry.manual_lot_number || entry.lot_no %></td>
         </tr>
         <tr>
           <td class="label">SKU Number:</td>

--- a/views/challanCreation.ejs
+++ b/views/challanCreation.ejs
@@ -398,9 +398,10 @@ HARYANA, Haryana 121009
           <% challan.items.forEach((item, index) => { %>
             <%
               const typeLabel = (item.entryType || '').toUpperCase() || 'NORMAL';
+              const displayLot = item.manual_lot_number || item.lot_no || '-';
               const itemLabel = item.entryType === 'mix'
                 ? (item.customLabel || item.lot_no || 'Mix Item')
-                : `Lot: ${item.lot_no || '-'}`;
+                : `Lot: ${displayLot}`;
               const skuLabel = item.sku || item.sku_override || '';
               const qtyVal = parseFloat(item.total_pieces || 0);
               const rateVal = parseFloat(item.rate || 200);

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -326,6 +326,9 @@
       <button class="kotty-tab" id="indent-tab" data-bs-toggle="tab" data-bs-target="#indent-panel" type="button" role="tab" aria-controls="indent-panel" aria-selected="false">
         <i class="bi bi-box-seam"></i><span>Raise Indent</span>
       </button>
+      <a class="kotty-tab" href="/manual-lot">
+        <i class="bi bi-pencil-square"></i><span>Manual Lot Mapping</span>
+      </a>
     </div>
 
     <div class="tab-content" id="dashboardTabsContent">
@@ -342,6 +345,7 @@
                     <th style="width:28px;"></th>
                     <th data-i18n="idLabel">ID</th>
                     <th data-i18n="lotNumberLabel">Lot Number</th>
+                    <th data-i18n="manualLotNumber">Manual Lot No</th>
                     <th data-i18n="skuLabel">SKU</th>
                     <th data-i18n="fabricTypeLabel">Fabric Type</th>
                     <th data-i18n="tableLengthLabel">Table Length</th>
@@ -356,13 +360,14 @@
                 </thead>
                 <tbody>
                   <% if (cuttingLots.length === 0) { %>
-                    <tr><td colspan="13" class="text-center" style="padding: 40px;" data-i18n="noCuttingLotsAvailable">No cutting lots available.</td></tr>
+                    <tr><td colspan="14" class="text-center" style="padding: 40px;" data-i18n="noCuttingLotsAvailable">No cutting lots available.</td></tr>
                   <% } else { %>
                     <% cuttingLots.forEach(lot => { %>
                       <tr data-lot-no="<%= lot.lot_no %>">
                         <td><button type="button" class="lse-toggle" aria-expanded="false" aria-label="Show size breakdown"><span class="lse-chevron">&#9654;</span></button></td>
                         <td><%= lot.id %></td>
                         <td><strong><%= lot.lot_no %></strong></td>
+                        <td><%= lot.manual_lot_number || 'N/A' %></td>
                         <td><%= lot.sku %></td>
                         <td><%= lot.fabric_type %></td>
                         <td><%= lot.table_length ?? 'N/A' %></td>
@@ -406,6 +411,10 @@
                 <div class="col-md-4">
                   <label for="lot_no" class="kotty-form-label"><i class="bi bi-hash"></i><span data-i18n="lotNumberGenerated">Lot Number (Generated)</span></label>
                   <input type="text" class="kotty-input" id="lot_no" name="lot_no" value="<%= generatedLotNumber %>" readonly />
+                </div>
+                <div class="col-md-4">
+                  <label for="manual_lot_number" class="kotty-form-label"><i class="bi bi-pencil-square"></i><span data-i18n="manualLotNumber">Manual Lot Number</span></label>
+                  <input type="text" class="kotty-input" id="manual_lot_number" name="manual_lot_number" required placeholder="Handwritten / physical lot number" />
                 </div>
                 <!-- SKU Builder -->
                 <div class="col-md-8">

--- a/views/finishingChallan.ejs
+++ b/views/finishingChallan.ejs
@@ -229,7 +229,7 @@
       </tr>
       <tr>
         <td>Lot No:</td>
-        <td><%= entry.lot_no %></td>
+        <td><%= entry.manual_lot_number || entry.lot_no %></td>
         <td>SKU:</td>
         <td><%= entry.sku %></td>
       </tr>

--- a/views/jeansAssemblyChallan.ejs
+++ b/views/jeansAssemblyChallan.ejs
@@ -73,7 +73,7 @@
             <div class="col-md-4">
               <div class="detail-item">
                 <span class="detail-label">Lot No</span>
-                <span class="detail-value"><%= entry.lot_no %></span>
+                <span class="detail-value"><%= entry.manual_lot_number || entry.lot_no %></span>
               </div>
             </div>
             <div class="col-md-4">

--- a/views/lotDetails.ejs
+++ b/views/lotDetails.ejs
@@ -17,8 +17,8 @@
     <div class="page-header">
       <div class="d-flex align-items-center justify-content-between flex-wrap gap-3">
         <div>
-          <h1 class="page-title">Lot <%= lot.lot_no %></h1>
-          <p class="page-subtitle">Complete lot information and breakdown</p>
+          <h1 class="page-title">Lot <%= lot.manual_lot_number || lot.lot_no %></h1>
+          <p class="page-subtitle">Complete lot information and breakdown<% if (lot.manual_lot_number) { %> · System lot: <%= lot.lot_no %><% } %></p>
         </div>
         <a href="/cutting-manager/dashboard" class="btn btn-secondary">
           <i class="bi bi-arrow-left"></i>

--- a/views/manualLotMapping.ejs
+++ b/views/manualLotMapping.ejs
@@ -1,0 +1,131 @@
+<%- include('partials/header', { pageTitle: 'Manual Lot Number Mapping' }) %>
+<%- include('partials/navbar', { user: user, dashboardUrl: '/cutting-manager/dashboard' }) %>
+
+<main class="main-content" style="margin-left: 0;">
+  <div class="container-fluid" style="max-width: var(--content-max-width);">
+    <!-- Alerts -->
+    <% if (error && error.length) { %>
+      <div class="alert alert-danger" role="alert">
+        <i class="bi bi-exclamation-triangle me-2"></i>
+        <div><% error.forEach(msg => { %><div><%= msg %></div><% }); %></div>
+      </div>
+    <% } %>
+    <% if (success && success.length) { %>
+      <div class="alert alert-success" role="alert">
+        <i class="bi bi-check-circle me-2"></i>
+        <div><% success.forEach(msg => { %><div><%= msg %></div><% }); %></div>
+      </div>
+    <% } %>
+
+    <!-- Page Header -->
+    <div class="page-header">
+      <h1 class="page-title">
+        <i class="bi bi-pencil-square me-2" style="color: var(--terracotta);"></i>Manual Lot Number Mapping
+      </h1>
+      <p class="page-subtitle">Assign a manual (handwritten / physical) lot number to existing cutting lots. The system lot number is never changed.</p>
+    </div>
+
+    <!-- Bulk Excel Upload -->
+    <div class="card mb-4">
+      <div class="card-header">
+        <h5 class="card-title"><i class="bi bi-file-earmark-spreadsheet me-2" style="color: var(--terracotta);"></i>Bulk Map via Excel</h5>
+      </div>
+      <div class="card-body">
+        <div class="d-flex flex-wrap gap-3 align-items-center">
+          <a href="/manual-lot/template" class="btn btn-secondary">
+            <i class="bi bi-download me-1"></i> Download Template
+          </a>
+          <form action="/manual-lot/upload" method="POST" enctype="multipart/form-data" class="d-flex flex-wrap gap-2 align-items-center">
+            <input type="file" name="excelFile" class="form-input" accept=".xlsx" required />
+            <button type="submit" class="btn btn-primary">
+              <i class="bi bi-upload me-1"></i> Upload &amp; Map
+            </button>
+          </form>
+        </div>
+        <small class="text-muted d-block mt-2">Columns: <strong>System Lot No</strong>, <strong>Manual Lot Number</strong>. Rows are matched by the system lot number.</small>
+
+        <% if (uploadResult) { %>
+          <div class="alert alert-info mt-3" role="alert">
+            <div><strong>Upload result:</strong> <%= uploadResult.matched %> mapped, <%= uploadResult.skipped %> skipped (blank), <%= uploadResult.unmatched.length %> unmatched.</div>
+            <% if (uploadResult.unmatched.length) { %>
+              <div class="mt-1"><strong>Unmatched system lot numbers:</strong> <%= uploadResult.unmatched.join(', ') %></div>
+            <% } %>
+          </div>
+        <% } %>
+      </div>
+    </div>
+
+    <!-- Search -->
+    <div class="card mb-4">
+      <div class="card-body">
+        <form action="/manual-lot" method="GET" class="row align-items-end g-3">
+          <div class="col-md-8">
+            <label class="form-label" style="font-weight: 500;">
+              <i class="bi bi-search me-2" style="color: var(--terracotta);"></i>Search Lots
+            </label>
+            <input type="text" name="search" class="form-input" placeholder="Search by System Lot No, SKU, Remark, or Manual Lot No..." value="<%= search %>" />
+          </div>
+          <div class="col-md-4">
+            <button class="btn btn-primary btn-lg w-100" type="submit">
+              <i class="bi bi-search me-2"></i> Search
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <!-- Lots Table -->
+    <div class="table-container">
+      <div class="card-header">
+        <h5 class="card-title"><i class="bi bi-box-seam me-2" style="color: var(--terracotta);"></i>Cutting Lots</h5>
+      </div>
+      <div class="table-responsive">
+        <table class="table">
+          <thead>
+            <tr>
+              <th><i class="bi bi-hash me-1"></i>ID</th>
+              <th><i class="bi bi-tag me-1"></i>System Lot No</th>
+              <th><i class="bi bi-upc me-1"></i>SKU</th>
+              <th><i class="bi bi-scissors me-1"></i>Remark</th>
+              <th><i class="bi bi-pencil-square me-1"></i>Manual Lot Number</th>
+              <th><i class="bi bi-clock me-1"></i>Created On</th>
+            </tr>
+          </thead>
+          <tbody>
+            <% if (lots && lots.length) { %>
+              <% lots.forEach(lot => { %>
+                <tr>
+                  <td><span style="font-family: var(--font-mono); font-size: var(--text-sm);"><%= lot.id %></span></td>
+                  <td><strong><%= lot.lot_no %></strong></td>
+                  <td><%= lot.sku %></td>
+                  <td style="font-size: var(--text-sm); color: var(--text-secondary);"><%= lot.remark || '' %></td>
+                  <td>
+                    <form action="/manual-lot/update" method="POST" class="d-flex gap-2 align-items-center">
+                      <input type="hidden" name="id" value="<%= lot.id %>" />
+                      <input type="hidden" name="search" value="<%= search %>" />
+                      <input type="text" name="manual_lot_number" class="form-input" value="<%= lot.manual_lot_number || '' %>" placeholder="Manual lot no" style="width: 160px; padding: 6px 10px; font-size: var(--text-sm);" />
+                      <button type="submit" class="btn btn-sm btn-success"><i class="bi bi-check-lg"></i> Save</button>
+                    </form>
+                  </td>
+                  <td style="font-size: var(--text-sm); color: var(--text-secondary);"><%= lot.created_at ? new Date(lot.created_at).toLocaleString() : '' %></td>
+                </tr>
+              <% }); %>
+            <% } else { %>
+              <tr>
+                <td colspan="6" class="text-center" style="padding: 48px 24px;">
+                  <div class="empty-state">
+                    <i class="bi bi-inbox empty-state-icon" style="font-size: 48px; color: var(--text-muted);"></i>
+                    <h5 class="empty-state-title mt-3">No Lots Found</h5>
+                    <p class="empty-state-text">Try a different search.</p>
+                  </div>
+                </td>
+              </tr>
+            <% } %>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</main>
+
+<%- include('partials/footer') %>

--- a/views/myLots.ejs
+++ b/views/myLots.ejs
@@ -198,7 +198,7 @@
     return `<div class="lot-card">
       <div class="lot-head">
         <div>
-          <span class="lot-no">${lot.lot_no}</span>
+          <span class="lot-no">${lot.display_lot || lot.lot_no}</span>
           <span class="dept-chip ${lot.flow_type}">${lot.flow_type}</span>
           <span class="lot-meta">· ${lot.sku} · ${lot.pieces.toLocaleString()} pcs</span>
           ${remarkHtml}
@@ -246,6 +246,7 @@
     if (q) {
       items = items.filter(l =>
         (l.lot_no || '').toLowerCase().includes(q) ||
+        (l.manual_lot_number || '').toLowerCase().includes(q) ||
         (l.sku || '').toLowerCase().includes(q) ||
         (l.remark || '').toLowerCase().includes(q)
       );

--- a/views/washingChallan.ejs
+++ b/views/washingChallan.ejs
@@ -243,7 +243,7 @@
         </tr>
         <tr>
           <td><strong>Lot No:</strong></td>
-          <td><%= entry.lot_no %></td>
+          <td><%= entry.manual_lot_number || entry.lot_no %></td>
           <td><strong>SKU:</strong></td>
           <td><%= entry.sku %></td>
         </tr>

--- a/views/washingInChallan.ejs
+++ b/views/washingInChallan.ejs
@@ -65,7 +65,7 @@
           <div class="col-md-3 col-6">
             <div class="detail-item">
               <span class="detail-label">Lot No</span>
-              <span class="detail-value"><%= entry.lot_no %></span>
+              <span class="detail-value"><%= entry.manual_lot_number || entry.lot_no %></span>
             </div>
           </div>
           <div class="col-md-3 col-6">


### PR DESCRIPTION
## What
Replaces the "manual challan number written in the cutting remark" workaround with a proper `manual_lot_number` field on cutting lots, surfaced across the challan-making flow.

## Key invariant
The system `cutting_lots.lot_no` stays the immutable internal key (all joins + issued/remaining math unchanged). `manual_lot_number` is a **display label**, shown with a `COALESCE` fallback to `lot_no` for lots not yet mapped.

## Changes
- **DB migration** `sql/manual_lot_number_migration.sql`: `cutting_lots.manual_lot_number` (indexed) + snapshot column on `dc_challan_items`. Additive, NULLable.
- **Cutting create**: required manual lot number on the form; bulk Excel upload gets an optional `Manual Lot No` column.
- **`/manual-lot` mapping page** (cutting managers): inline search-and-edit + bulk Excel upload (template + matched/skipped/unmatched summary) to backfill older lots.
- **Accounts DC challan**: dashboard/generation show & search the manual number; it's snapshotted onto each challan line, **printed as the lot identifier**, and matched by challan-list search.
- **All 5 stage challan printouts** (stitching/washing/washing-in/finishing/jeans-assembly) + operator my-lots and lot details show the manual number with fallback.

## ⚠️ Deploy ordering
Run `sql/manual_lot_number_migration.sql` on the prod DB **before** merging — the new code references the columns. The migration is backward-compatible, so it can be run against the currently-live code first.

## Still TODO (separate pass)
Internal monitoring/report screens (operator dashboard datatables, stage payments/debits/invoices, TAT/analysis/completion/pendency reports, approve/event/assign screens) still show the raw system lot number; they're mostly client-fed datatables needing a DB-verified pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)