### PR TITLE
fix(deploy): persist PM_CRON_SECRET across deploys

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -44,7 +44,7 @@ steps:
       - '--max-instances'
       - '${_MAX_INSTANCES}'
       - '--set-secrets'
-      - 'DB_PASSWORD=db-password:latest,SESSION_SECRET=session-secret:latest'
+      - 'DB_PASSWORD=db-password:latest,SESSION_SECRET=session-secret:latest,PM_CRON_SECRET=pm-cron-secret:latest'
       # Use --update-env-vars to PRESERVE existing env vars (like Zoho, AWS credentials)
       # Only update the base vars needed for the app to run
       - '--update-env-vars'


### PR DESCRIPTION
## Why
Follow-up to #442. The Cloud Build deploy step uses `--set-secrets`, which **replaces** the entire secret list each deploy. So the `PM_CRON_SECRET` I set by hand (via `--update-secrets`) was **wiped on the very next deploy** — confirmed: revision `00357` came up *without* it, and `POST /internal/run-pull` returned `403` because the secret was `undefined`. (The env var `SERVICE_BASE_URL` survived because the deploy uses `--update-env-vars`, which preserves.)

## Fix
Add `PM_CRON_SECRET=pm-cron-secret:latest` to the declared `--set-secrets` list in `cloudbuild.yaml`, next to `DB_PASSWORD` and `SESSION_SECRET`, so it's reapplied on every deploy.

Prereqs (already done): `pm-cron-secret` exists in Secret Manager; the Cloud Run runtime SA has `secretAccessor` on it.

## Verify after merge
New revision has `PM_CRON_SECRET` set; `curl -X POST .../internal/run-pull -H "x-cron-secret: <secret>"` is accepted (not 403).

🤖 Generated with [Claude Code](https://claude.com/claude-code)