### PR TITLE
Repair cross-stage qty corruption + operator approval-correction tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ nul
 
 # Claude Code local settings (may contain secrets)
 .claude/settings.local.json
+
+# one-off data-repair pre-image backups (local audit only)
+scripts/repair-backups/

--- a/app.js
+++ b/app.js
@@ -235,6 +235,7 @@ app.use('/accounts/payments', accountsPaymentRoutes);
 app.use('/cutting-analysis', cuttingAnalysisRoutes);
 app.use("/operator", editCuttingLotRoutes);
 app.use('/operator', editWashingAssignmentsRoutes);
+app.use('/operator', require('./routes/correctStageApproval'));
 app.use('/operator', departmentMgmtRoutes);
 app.use('/operator', operatorEmployeeRoutes);
 app.use('/', bulkUploadRoutes);

--- a/routes/correctStageApproval.js
+++ b/routes/correctStageApproval.js
@@ -1,0 +1,200 @@
+/**
+ * Operator-driven approval correction.
+ *
+ * The create→approve flow lost its "assign" step, so anyone can approve a lot
+ * onto themselves (e.g. lot UM416 was meant for Salman but Salim approved it).
+ * A floor supervisor (role `operator`) uses this tool to reattribute a lot at
+ * a stage from the wrong operator to the right one. The fix cascades across
+ * the THREE places an operator is recorded so production AND pay both follow:
+ *   1. <stage>_events.operator_id   (approve/complete/reject — the ledger)
+ *   2. legacy <stage>_data.user_id  (payee source + downstream dashboards)
+ *   3. stage_payments.user_id/username (incl. already-PAID rows)
+ * Every correction is written to stage_approval_corrections for accountants.
+ *
+ * Mounted under /operator (isOperator). Masters cannot reach it, so the
+ * "approve onto myself" mistake can be undone but not freely re-done.
+ */
+
+const express = require('express');
+const router = express.Router();
+const multer = require('multer');
+const upload = multer();
+const { pool } = require('../config/db');
+const { isAuthenticated, isOperator } = require('../middlewares/auth');
+const { STAGE_DEFS, applyCorrection } = require('../utils/approvalCorrection');
+
+// Resolve a lot by its lot_no OR manual_lot_number (case-insensitive).
+async function resolveLot(conn, lotStr) {
+  const q = String(lotStr || '').trim();
+  if (!q) return null;
+  const [[row]] = await conn.query(
+    `SELECT id, lot_no, manual_lot_number, sku
+       FROM cutting_lots
+      WHERE lot_no = ? OR manual_lot_number = ?
+      ORDER BY (lot_no = ?) DESC
+      LIMIT 1`,
+    [q, q, q]
+  );
+  return row || null;
+}
+
+// Active users who hold the role for a stage (candidate target operators).
+async function operatorsForRole(conn, roleName) {
+  const [rows] = await conn.query(
+    `SELECT u.id, u.username
+       FROM users u JOIN roles r ON r.id = u.role_id
+      WHERE r.name = ? AND u.is_active = 1
+      ORDER BY u.username`,
+    [roleName]
+  );
+  return rows;
+}
+
+// GET /operator/correct-approval
+router.get('/correct-approval', isAuthenticated, isOperator, (req, res) => {
+  res.render('correctStageApproval', {
+    user: req.session.user,
+    stages: Object.entries(STAGE_DEFS).map(([key, d]) => ({ key, label: d.label })),
+  });
+});
+
+// GET /operator/correct-approval/lookup?stage=&lot=
+// Returns the lot, the operator(s) currently attributed at the stage (with
+// piece counts), and the list of valid target operators for the stage.
+router.get('/correct-approval/lookup', isAuthenticated, isOperator, async (req, res) => {
+  const stage = String(req.query.stage || '');
+  const def = STAGE_DEFS[stage];
+  if (!def) return res.status(400).json({ error: 'Invalid stage' });
+  let conn;
+  try {
+    conn = await pool.getConnection();
+    const lot = await resolveLot(conn, req.query.lot);
+    if (!lot) return res.status(404).json({ error: 'Lot not found' });
+
+    // Operators attributed via the event ledger (completed pieces).
+    const [evOps] = await conn.query(
+      `SELECT e.operator_id AS user_id, u.username,
+              COALESCE(SUM(CASE WHEN e.event_type='complete' THEN e.pieces END),0) AS completed,
+              COALESCE(SUM(CASE WHEN e.event_type='approve'  THEN e.pieces END),0) AS approved
+         FROM ${def.ev} e JOIN users u ON u.id = e.operator_id
+        WHERE e.cutting_lot_id = ?
+        GROUP BY e.operator_id, u.username`,
+      [lot.id]
+    );
+    // Operators attributed via the legacy data rows.
+    const [dataOps] = await conn.query(
+      `SELECT d.user_id, u.username, COALESCE(SUM(d.total_pieces),0) AS data_pieces, COUNT(*) AS rows_n
+         FROM ${def.data} d JOIN users u ON u.id = d.user_id
+        WHERE d.lot_no = ?
+        GROUP BY d.user_id, u.username`,
+      [lot.lot_no]
+    );
+    // Merge the two views by user.
+    const merged = new Map();
+    for (const r of evOps) merged.set(r.user_id, { user_id: r.user_id, username: r.username, completed: Number(r.completed), approved: Number(r.approved), data_pieces: 0, data_rows: 0 });
+    for (const r of dataOps) {
+      const m = merged.get(r.user_id) || { user_id: r.user_id, username: r.username, completed: 0, approved: 0 };
+      m.data_pieces = Number(r.data_pieces); m.data_rows = Number(r.rows_n);
+      merged.set(r.user_id, m);
+    }
+
+    // Payments currently attributed to each of those users for this lot.
+    const userIds = [...merged.keys()];
+    if (userIds.length) {
+      const [pays] = await conn.query(
+        `SELECT user_id,
+                COUNT(*) AS n,
+                SUM(status='paid') AS paid_n,
+                COALESCE(SUM(total_amount),0) AS amount
+           FROM stage_payments WHERE lot_no = ? AND user_id IN (?)
+          GROUP BY user_id`,
+        [lot.lot_no, userIds]
+      );
+      const pmap = new Map(pays.map(p => [p.user_id, p]));
+      for (const [uid, m] of merged) {
+        const p = pmap.get(uid);
+        m.payments = p ? Number(p.n) : 0;
+        m.paid_payments = p ? Number(p.paid_n) : 0;
+        m.payment_amount = p ? Number(p.amount) : 0;
+      }
+    }
+
+    const targets = await operatorsForRole(conn, def.role);
+    res.json({
+      lot: { cutting_lot_id: lot.id, lot_no: lot.lot_no, display_lot: lot.manual_lot_number || lot.lot_no, sku: lot.sku },
+      stage, stage_label: def.label, role: def.role,
+      current: [...merged.values()],
+      targets,
+    });
+  } catch (err) {
+    console.error('[ERROR] GET /operator/correct-approval/lookup =>', err);
+    res.status(500).json({ error: err.message });
+  } finally {
+    if (conn) conn.release();
+  }
+});
+
+// POST /operator/correct-approval/update
+// Body: { stage, cutting_lot_id, from_user_id, to_user_id }
+router.post('/correct-approval/update', isAuthenticated, isOperator, upload.none(), async (req, res) => {
+  const stage = String(req.body.stage || '');
+  const def = STAGE_DEFS[stage];
+  const cuttingLotId = parseInt(req.body.cutting_lot_id, 10);
+  const fromUserId = parseInt(req.body.from_user_id, 10);
+  const toUserId = parseInt(req.body.to_user_id, 10);
+  const correctedBy = req.session.user.id;
+
+  if (!def) return res.status(400).json({ error: 'Invalid stage' });
+  if (!Number.isFinite(cuttingLotId) || !Number.isFinite(fromUserId) || !Number.isFinite(toUserId)) {
+    return res.status(400).json({ error: 'Missing or invalid parameters' });
+  }
+  if (fromUserId === toUserId) return res.status(400).json({ error: 'From and To operator are the same' });
+
+  let conn;
+  try {
+    conn = await pool.getConnection();
+    await conn.beginTransaction();
+
+    const [[lot]] = await conn.query(`SELECT id, lot_no FROM cutting_lots WHERE id = ? FOR UPDATE`, [cuttingLotId]);
+    if (!lot) { await conn.rollback(); return res.status(404).json({ error: 'Lot not found' }); }
+
+    // Validate the target operator holds the correct role for this stage.
+    const [[toUser]] = await conn.query(
+      `SELECT u.id, u.username, r.name AS role
+         FROM users u JOIN roles r ON r.id = u.role_id
+        WHERE u.id = ? AND u.is_active = 1`,
+      [toUserId]
+    );
+    if (!toUser) { await conn.rollback(); return res.status(400).json({ error: 'Target operator not found or inactive' }); }
+    if (toUser.role !== def.role) {
+      await conn.rollback();
+      return res.status(400).json({ error: `Target operator is a '${toUser.role}', not a '${def.role}' — cannot own a ${def.label} lot` });
+    }
+
+    const moved = await applyCorrection(conn, {
+      stage, cuttingLotId, lotNo: lot.lot_no,
+      fromUserId, toUserId, toUsername: toUser.username, correctedBy,
+    });
+
+    if (moved.eventsMoved + moved.dataMoved + moved.paymentsMoved === 0) {
+      await conn.rollback();
+      return res.status(400).json({ error: 'Nothing to correct: that operator has no events, data, or payments for this lot at this stage.' });
+    }
+
+    await conn.commit();
+    res.json({
+      success: true,
+      lot_no: lot.lot_no,
+      moved: { events: moved.eventsMoved, data_rows: moved.dataMoved, payments: moved.paymentsMoved, paid_payments: moved.paidMoved },
+      to_username: toUser.username,
+    });
+  } catch (err) {
+    if (conn) try { await conn.rollback(); } catch (_) {}
+    console.error('[ERROR] POST /operator/correct-approval/update =>', err);
+    res.status(500).json({ error: err.message });
+  } finally {
+    if (conn) conn.release();
+  }
+});
+
+module.exports = router;

--- a/routes/washingRoutes.js
+++ b/routes/washingRoutes.js
@@ -1620,21 +1620,32 @@ router.get('/available-lots', isAuthenticated, isWashingMaster, async (req, res)
     // Find jeans_assembly_data records where:
     // 1. flow_type is denim (or cutter is_denim_cutter = 1)
     // 2. Has remaining pieces not yet washed
+    // Single source of truth for "produced at assembly": SUM of the assembly
+    // size rows (not the denormalized jad.total_pieces, which duplicate jad
+    // rows would double-count). One row per lot via the representative jad.id.
     const [rows] = await pool.query(`
       SELECT
         jad.id,
         jad.lot_no,
         jad.sku,
-        jad.total_pieces,
+        prod.produced AS total_pieces,
         jad.created_at,
         cl.remark AS cutting_remark,
-        jad.total_pieces - COALESCE((
-          SELECT SUM(wd.total_pieces)
-          FROM washing_data wd
+        prod.produced - COALESCE((
+          SELECT SUM(wds.pieces)
+          FROM washing_data_sizes wds
+          JOIN washing_data wd ON wd.id = wds.washing_data_id
           WHERE wd.lot_no = jad.lot_no
         ), 0) AS remaining_pieces,
         u.username AS assembly_master
       FROM jeans_assembly_data jad
+      JOIN (
+        SELECT d.lot_no, MAX(d.id) AS rep_id,
+               SUM(s.pieces) AS produced
+        FROM jeans_assembly_data d
+        JOIN jeans_assembly_data_sizes s ON s.jeans_assembly_data_id = d.id
+        GROUP BY d.lot_no
+      ) prod ON prod.rep_id = jad.id
       LEFT JOIN users u ON jad.user_id = u.id
       LEFT JOIN cutting_lots cl ON cl.lot_no = jad.lot_no
       WHERE (jad.lot_no LIKE ? OR jad.sku LIKE ? OR cl.remark LIKE ?)

--- a/scripts/repairStageQuantities.js
+++ b/scripts/repairStageQuantities.js
@@ -1,0 +1,343 @@
+#!/usr/bin/env node
+/**
+ * repairStageQuantities.js — one-off, idempotent repair for the
+ * "cutting = 10 but stitching = 20" class of data corruption.
+ *
+ * Confirmed mechanisms (see sql/diagnostics/stage_qty_reconciliation.sql):
+ *   A) uniform inflation — every size row is a constant multiple (x2/x4/x10)
+ *      of the cutting breakdown, in BOTH the legacy *_data rows and the
+ *      *_events ledger (carried in by the stage-events backfill, which did
+ *      not re-validate against cutting).
+ *   B) exact-duplicate rows — a double/triple submit wrote byte-identical
+ *      *_data rows AND identical events.
+ *   C) malformed "extra batch" rows — e.g. a washing_in row whose size
+ *      labels are 0,1,2,3,4 (cutting labels are 26,28,30,...). Junk.
+ *
+ * Unified, deterministic repair, per affected lot:
+ *   1. drop JUNK rows/events  (size labels entirely disjoint from cutting)
+ *   2. dedupe EXACT-duplicate *_data rows, and exact-duplicate events of the
+ *      same type (keep the lowest id)
+ *   3. for the legacy *_data breakdown and for each event_type in
+ *      {approve, complete}: if it still sums to MORE than the cutting
+ *      ceiling, proportionally scale its size rows down to the ceiling
+ *      (largest-remainder rounding so the integer total is exact) and keep
+ *      each row's total_pieces / event.pieces in sync
+ *   4. clamp any stage_payments.qty for the lot that exceeds the ceiling and
+ *      recompute total_amount from the configured rate
+ *
+ * Reject events are never scaled (rejected pieces are a separate ledger).
+ * Re-running after a successful repair finds zero offenders and is a no-op.
+ *
+ * Usage:
+ *   DB_PASSWORD=... node scripts/repairStageQuantities.js            # DRY RUN
+ *   DB_PASSWORD=... node scripts/repairStageQuantities.js --apply    # WRITE
+ *   ... --lot=ak3159            # restrict to one lot
+ * Connection defaults target a cloud-sql-proxy on 127.0.0.1:3307; override
+ * with DB_HOST / DB_PORT / DB_USER / DB_NAME.
+ */
+
+const mysql = require('mysql2/promise');
+const fs = require('fs');
+const path = require('path');
+
+const APPLY = process.argv.includes('--apply');
+const LOT_FILTER = (process.argv.find(a => a.startsWith('--lot=')) || '').split('=')[1] || null;
+
+const norm = (s) => String(s == null ? '' : s).trim().toUpperCase();
+
+// production stage -> table names
+const STAGES = [
+  { key: 'stitching',  data: 'stitching_data',       dsz: 'stitching_data_sizes',       fk: 'stitching_data_id',       ev: 'stitching_events',       evsz: 'stitching_event_sizes' },
+  { key: 'assembly',   data: 'jeans_assembly_data',  dsz: 'jeans_assembly_data_sizes',  fk: 'jeans_assembly_data_id',  ev: 'jeans_assembly_events',  evsz: 'jeans_assembly_event_sizes' },
+  { key: 'washing',    data: 'washing_data',         dsz: 'washing_data_sizes',         fk: 'washing_data_id',         ev: 'washing_events',         evsz: 'washing_event_sizes' },
+  { key: 'washing_in', data: 'washing_in_data',      dsz: 'washing_in_data_sizes',      fk: 'washing_in_data_id',      ev: 'washing_in_events',      evsz: 'washing_in_event_sizes' },
+  { key: 'finishing',  data: 'finishing_data',       dsz: 'finishing_data_sizes',       fk: 'finishing_data_id',       ev: 'finishing_events',       evsz: 'finishing_event_sizes' },
+];
+
+/**
+ * Largest-remainder scale of a list of {key, pieces} down to `target`.
+ * Returns a map key->newPieces with an exact integer sum === target.
+ * Only call when current sum > target.
+ */
+function scaleToTarget(items, target) {
+  const S = items.reduce((a, r) => a + r.pieces, 0);
+  if (S <= target) return null;
+  const raw = items.map(r => (r.pieces * target) / S);
+  const out = raw.map(Math.floor);
+  let rem = target - out.reduce((a, b) => a + b, 0);
+  const order = raw.map((x, i) => ({ i, frac: x - Math.floor(x) })).sort((a, b) => b.frac - a.frac);
+  for (let k = 0; k < rem && k < order.length; k++) out[order[k].i]++;
+  const m = new Map();
+  items.forEach((r, i) => m.set(r.key, out[i]));
+  return m;
+}
+
+async function main() {
+  const conn = await mysql.createConnection({
+    host: process.env.DB_HOST || '127.0.0.1',
+    port: parseInt(process.env.DB_PORT || '3307', 10),
+    user: process.env.DB_USER || 'kotty_user',
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME || 'kotty_db',
+    multipleStatements: false,
+  });
+
+  const backup = { startedAt: new Date().toISOString(), apply: APPLY, lots: [] };
+  const log = [];
+
+  // ── Identify affected lots via the diagnostic reconciliation (one query),
+  //    then process ONLY those lots (keeps the run fast + connection alive). ──
+  const offenderLotNos = await offenderLots(conn);
+  const lotList = LOT_FILTER ? offenderLotNos.filter(l => l === LOT_FILTER) : offenderLotNos;
+  const [cutLots] = lotList.length
+    ? await conn.query(
+        `SELECT cl.id, cl.lot_no,
+                COALESCE((SELECT SUM(total_pieces) FROM cutting_lot_sizes WHERE cutting_lot_id=cl.id),0) AS cut
+         FROM cutting_lots cl WHERE cl.lot_no IN (?)`, [lotList])
+    : [[]];
+  console.log(`Offender lots from diagnostic: ${offenderLotNos.length}${LOT_FILTER ? ` (filtered to ${lotList.length})` : ''}`);
+
+  let affected = 0;
+  for (const lot of cutLots) {
+    const cut = Math.round(Number(lot.cut));
+    if (cut <= 0) continue;
+    const cutLabels = new Set();
+    const [cs] = await conn.query(`SELECT size_label FROM cutting_lot_sizes WHERE cutting_lot_id=?`, [lot.id]);
+    cs.forEach(r => cutLabels.add(norm(r.size_label)));
+
+    const lotBackup = { lot_no: lot.lot_no, cutting_lot_id: lot.id, cut, ops: [] };
+    let lotTouched = false;
+
+    for (const st of STAGES) {
+      // legacy rows + sizes
+      const [drows] = await conn.query(
+        `SELECT d.id, d.total_pieces FROM ${st.data} d WHERE d.lot_no=? ORDER BY d.id`, [lot.lot_no]
+      );
+      if (!drows.length) continue;
+      const dIds = drows.map(r => r.id);
+      const [dsizes] = await conn.query(
+        `SELECT id, ${st.fk} AS pid, size_label, pieces FROM ${st.dsz} WHERE ${st.fk} IN (?)`, [dIds]
+      );
+      // events + sizes
+      const [erows] = await conn.query(
+        `SELECT id, event_type, pieces FROM ${st.ev} WHERE cutting_lot_id=? ORDER BY id`, [lot.id]
+      );
+      const eIds = erows.map(r => r.id);
+      const [esizes] = eIds.length
+        ? await conn.query(`SELECT event_id, size_label, pieces FROM ${st.evsz} WHERE event_id IN (?)`, [eIds])
+        : [[]];
+
+      const ops = await repairStage(conn, st, lot, cut, cutLabels, drows, dsizes, erows, esizes);
+      if (ops.length) {
+        lotTouched = true;
+        lotBackup.ops.push({ stage: st.key, ops });
+        for (const op of ops) log.push(`${lot.lot_no} [${st.key}] ${op.summary}`);
+      }
+    }
+
+    // payments: clamp qty>cut once per lot
+    const payOps = await repairPayments(conn, lot, cut);
+    if (payOps.length) {
+      lotTouched = true;
+      lotBackup.ops.push({ stage: 'payments', ops: payOps });
+      for (const op of payOps) log.push(`${lot.lot_no} [payment] ${op.summary}`);
+    }
+
+    if (lotTouched) { affected++; backup.lots.push(lotBackup); }
+  }
+
+  // ── write backup + apply ──
+  if (backup.lots.length) {
+    const dir = path.join(__dirname, 'repair-backups');
+    fs.mkdirSync(dir, { recursive: true });
+    const fname = path.join(dir, `repair-backup-${backup.startedAt.replace(/[:.]/g, '-')}.json`);
+    fs.writeFileSync(fname, JSON.stringify(backup, null, 2));
+    console.log(`\nBackup (pre-images + planned ops) written to: ${fname}`);
+  }
+
+  console.log(`\n${'='.repeat(70)}`);
+  console.log(`${APPLY ? 'APPLIED' : 'DRY RUN'} — ${affected} lot(s) affected, ${log.length} operation(s).`);
+  console.log('='.repeat(70));
+  log.forEach(l => console.log('  ' + l));
+
+  if (APPLY && backup.lots.length) {
+    console.log('\nExecuting writes (one transaction per lot)…');
+    for (const lb of backup.lots) {
+      await conn.beginTransaction();
+      try {
+        for (const stageOps of lb.ops) for (const op of stageOps.ops) {
+          for (const sql of op.sql) await conn.query(sql.q, sql.p);
+        }
+        await conn.commit();
+        console.log(`  committed ${lb.lot_no}`);
+      } catch (e) {
+        await conn.rollback();
+        console.error(`  ROLLED BACK ${lb.lot_no}: ${e.message}`);
+      }
+    }
+    // verify
+    console.log('\nRe-checking for remaining offenders…');
+    const remaining = await countOffenders(conn, LOT_FILTER);
+    console.log(`  remaining cross-stage offenders: ${remaining}`);
+  } else if (!APPLY) {
+    console.log('\n(dry run — re-run with --apply to write)');
+  }
+
+  await conn.end();
+}
+
+/**
+ * Build (but do not execute) the repair ops for one (lot, stage).
+ * Returns [{summary, sql:[{q,p}], before}] — sql executed later in a txn.
+ */
+async function repairStage(conn, st, lot, cut, cutLabels, drows, dsizes, erows, esizes) {
+  const ops = [];
+
+  // group sizes
+  const dsByRow = new Map(); drows.forEach(r => dsByRow.set(r.id, []));
+  dsizes.forEach(s => { if (dsByRow.has(s.pid)) dsByRow.get(s.pid).push(s); });
+  const esByEvt = new Map(); erows.forEach(r => esByEvt.set(r.id, []));
+  esizes.forEach(s => { if (esByEvt.has(s.event_id)) esByEvt.get(s.event_id).push(s); });
+
+  const sig = (sizes) => sizes.map(s => `${norm(s.size_label)}:${s.pieces}`).sort().join('|');
+  const labelsDisjoint = (sizes) => sizes.length > 0 && sizes.every(s => !cutLabels.has(norm(s.size_label)));
+
+  // VOID, don't DELETE: drop the size rows (no inbound FKs) and zero the
+  // scalar, but keep the parent *_data / *_events row so child events
+  // (parent_event_id) and finishing_dispatches references stay valid.
+  const voidLegacy = (r) => [
+    { q: `DELETE FROM ${st.dsz} WHERE ${st.fk}=?`, p: [r.id] },
+    { q: `UPDATE ${st.data} SET total_pieces=0 WHERE id=?`, p: [r.id] },
+  ];
+  const voidEvent = (r) => [
+    { q: `DELETE FROM ${st.evsz} WHERE event_id=?`, p: [r.id] },
+    { q: `UPDATE ${st.ev} SET pieces=0 WHERE id=?`, p: [r.id] },
+  ];
+
+  // ---- 1) JUNK legacy rows ----
+  const keptD = [];
+  for (const r of drows) {
+    const sizes = dsByRow.get(r.id) || [];
+    if (labelsDisjoint(sizes)) {
+      ops.push({
+        summary: `void JUNK ${st.data}#${r.id} (labels ${sizes.map(s => s.size_label).join(',')})`,
+        before: { row: r, sizes }, sql: voidLegacy(r),
+      });
+    } else keptD.push(r);
+  }
+  // ---- 1) JUNK events ----
+  const keptE = [];
+  for (const r of erows) {
+    const sizes = esByEvt.get(r.id) || [];
+    if (labelsDisjoint(sizes)) {
+      ops.push({
+        summary: `void JUNK ${st.ev}#${r.id} (${r.event_type}, labels ${sizes.map(s => s.size_label).join(',')})`,
+        before: { row: r, sizes }, sql: voidEvent(r),
+      });
+    } else keptE.push(r);
+  }
+
+  // ---- 2) dedupe identical legacy rows ----
+  const seenD = new Map();
+  const keptD2 = [];
+  for (const r of keptD) {
+    const k = sig(dsByRow.get(r.id) || []);
+    if (seenD.has(k)) {
+      ops.push({
+        summary: `void DUP ${st.data}#${r.id} (identical to #${seenD.get(k)})`,
+        before: { row: r, sizes: dsByRow.get(r.id) }, sql: voidLegacy(r),
+      });
+    } else { seenD.set(k, r.id); keptD2.push(r); }
+  }
+  // ---- 2) dedupe identical events of the same type ----
+  const seenE = new Map();
+  const keptE2 = [];
+  for (const r of keptE) {
+    const k = r.event_type + '::' + sig(esByEvt.get(r.id) || []);
+    if (seenE.has(k)) {
+      ops.push({
+        summary: `void DUP ${st.ev}#${r.id} (${r.event_type}, identical to #${seenE.get(k)})`,
+        before: { row: r, sizes: esByEvt.get(r.id) }, sql: voidEvent(r),
+      });
+    } else { seenE.set(k, r.id); keptE2.push(r); }
+  }
+
+  // ---- 3) scale legacy breakdown to ceiling ----
+  const legSizeItems = [];
+  keptD2.forEach(r => (dsByRow.get(r.id) || []).forEach(s => legSizeItems.push({ key: s.id, pieces: Number(s.pieces), rowId: r.id })));
+  const legTotal = legSizeItems.reduce((a, s) => a + s.pieces, 0);
+  if (legTotal > cut) {
+    const m = scaleToTarget(legSizeItems, cut);
+    const sql = [];
+    const newRowTotals = new Map(keptD2.map(r => [r.id, 0]));
+    for (const it of legSizeItems) {
+      const nv = m.get(it.key);
+      newRowTotals.set(it.rowId, newRowTotals.get(it.rowId) + nv);
+      if (nv === 0) sql.push({ q: `DELETE FROM ${st.dsz} WHERE id=?`, p: [it.key] });
+      else if (nv !== it.pieces) sql.push({ q: `UPDATE ${st.dsz} SET pieces=? WHERE id=?`, p: [nv, it.key] });
+    }
+    for (const r of keptD2) sql.push({ q: `UPDATE ${st.data} SET total_pieces=? WHERE id=?`, p: [newRowTotals.get(r.id), r.id] });
+    ops.push({ summary: `scale ${st.data} sizes ${legTotal}→${cut}`, before: { sizes: legSizeItems }, sql });
+  }
+
+  // ---- 3) scale each event_type (approve, complete) to ceiling ----
+  for (const etype of ['approve', 'complete']) {
+    const evs = keptE2.filter(r => r.event_type === etype);
+    if (!evs.length) continue;
+    const items = [];
+    evs.forEach(r => (esByEvt.get(r.id) || []).forEach(s => items.push({ key: `${r.id}::${norm(s.size_label)}`, pieces: Number(s.pieces), evId: r.id, label: s.size_label })));
+    const total = items.reduce((a, s) => a + s.pieces, 0);
+    if (total > cut) {
+      const m = scaleToTarget(items, cut);
+      const sql = [];
+      const newEvTotals = new Map(evs.map(r => [r.id, 0]));
+      for (const it of items) {
+        const nv = m.get(it.key);
+        newEvTotals.set(it.evId, newEvTotals.get(it.evId) + nv);
+        if (nv === 0) sql.push({ q: `DELETE FROM ${st.evsz} WHERE event_id=? AND size_label=?`, p: [it.evId, it.label] });
+        else if (nv !== it.pieces) sql.push({ q: `UPDATE ${st.evsz} SET pieces=? WHERE event_id=? AND size_label=?`, p: [nv, it.evId, it.label] });
+      }
+      for (const r of evs) sql.push({ q: `UPDATE ${st.ev} SET pieces=? WHERE id=?`, p: [newEvTotals.get(r.id), r.id] });
+      ops.push({ summary: `scale ${st.ev} ${etype} sizes ${total}→${cut}`, before: { sizes: items }, sql });
+    }
+  }
+
+  return ops;
+}
+
+async function repairPayments(conn, lot, cut) {
+  const [pays] = await conn.query(
+    `SELECT id, stage, qty, base_rate, extra_amount, rate_configured, status, total_amount
+     FROM stage_payments WHERE lot_no=? AND qty > ?`, [lot.lot_no, cut]
+  );
+  const ops = [];
+  for (const p of pays) {
+    // recompute amount: base_rate*cut + (per-piece extra)*cut, preserving rate flag
+    const perPieceExtra = p.qty > 0 ? Number(p.extra_amount) / Number(p.qty) : 0;
+    const newExtra = +(perPieceExtra * cut).toFixed(2);
+    const newTotal = p.rate_configured ? +((Number(p.base_rate) * cut) + newExtra).toFixed(2) : 0;
+    ops.push({
+      summary: `clamp stage_payments#${p.id} (${p.stage}, ${p.status}) qty ${p.qty}→${cut}, amt ${p.total_amount}→${newTotal}`,
+      before: { payment: p },
+      sql: [{ q: `UPDATE stage_payments SET qty=?, extra_amount=?, total_amount=?, updated_at=NOW() WHERE id=?`, p: [cut, newExtra, newTotal, p.id] }],
+    });
+  }
+  return ops;
+}
+
+// Run Query 1 of the diagnostic SQL file; return the offender lot_no list.
+async function offenderLots(conn) {
+  const file = path.join(__dirname, '..', 'sql', 'diagnostics', 'stage_qty_reconciliation.sql');
+  const full = fs.readFileSync(file, 'utf8');
+  const q1 = full.split(/;\s*\n/)[0]
+    .split('\n').filter(l => !l.trim().startsWith('--')).join('\n');
+  const [rows] = await conn.query(q1);
+  return rows.map(r => r.lot_no);
+}
+
+async function countOffenders(conn, lotFilter) {
+  const lots = await offenderLots(conn);
+  return lotFilter ? lots.filter(l => l === lotFilter).length : lots.length;
+}
+
+main().catch(e => { console.error(e); process.exit(1); });

--- a/sql/diagnostics/stage_qty_reconciliation.sql
+++ b/sql/diagnostics/stage_qty_reconciliation.sql
@@ -1,0 +1,68 @@
+-- ─────────────────────────────────────────────────────────────────────
+-- Stage Quantity Reconciliation (READ-ONLY diagnostic)
+--
+-- Confirms the "cutting = 10 but stitching = 20" class of bug: a lot whose
+-- piece total at a DOWNSTREAM stage exceeds the cutting ceiling.
+--
+-- Canonical total per (lot, stage):
+--   = SUM(<stage>_event_sizes.pieces) for event_type='complete'  (preferred)
+--   = SUM(<stage>_data_sizes.pieces)                             (legacy fallback)
+-- Cutting baseline = SUM(cutting_lot_sizes.total_pieces).
+--
+-- Query 1 — cross-stage offenders (a stage total > cutting ceiling).
+-- Query 2 — denormalized drift  (*_data.total_pieces != SUM(*_data_sizes)).
+-- Query 3 — duplicate legacy rows (same lot, identical size breakdown twice).
+--
+-- Pure SELECTs. Safe to run on prod. Requires MySQL 8 (CTEs).
+-- ─────────────────────────────────────────────────────────────────────
+
+-- ─── Query 1: cross-stage offenders ──────────────────────────────────
+WITH cut AS (
+  SELECT cl.id AS cutting_lot_id, cl.lot_no, cl.lot_type,
+         COALESCE((SELECT SUM(cls.total_pieces) FROM cutting_lot_sizes cls
+                   WHERE cls.cutting_lot_id = cl.id), 0) AS cut_pcs
+  FROM cutting_lots cl
+),
+st_leg AS (SELECT d.lot_no, SUM(s.pieces) sz FROM stitching_data d JOIN stitching_data_sizes s ON s.stitching_data_id=d.id GROUP BY d.lot_no),
+st_ev  AS (SELECT cl.lot_no, SUM(es.pieces) sz FROM stitching_event_sizes es JOIN stitching_events e ON e.id=es.event_id JOIN cutting_lots cl ON cl.id=e.cutting_lot_id WHERE e.event_type='complete' GROUP BY cl.lot_no),
+as_leg AS (SELECT d.lot_no, SUM(s.pieces) sz FROM jeans_assembly_data d JOIN jeans_assembly_data_sizes s ON s.jeans_assembly_data_id=d.id GROUP BY d.lot_no),
+as_ev  AS (SELECT cl.lot_no, SUM(es.pieces) sz FROM jeans_assembly_event_sizes es JOIN jeans_assembly_events e ON e.id=es.event_id JOIN cutting_lots cl ON cl.id=e.cutting_lot_id WHERE e.event_type='complete' GROUP BY cl.lot_no),
+wa_leg AS (SELECT d.lot_no, SUM(s.pieces) sz FROM washing_data d JOIN washing_data_sizes s ON s.washing_data_id=d.id GROUP BY d.lot_no),
+wa_ev  AS (SELECT cl.lot_no, SUM(es.pieces) sz FROM washing_event_sizes es JOIN washing_events e ON e.id=es.event_id JOIN cutting_lots cl ON cl.id=e.cutting_lot_id WHERE e.event_type='complete' GROUP BY cl.lot_no),
+wi_leg AS (SELECT d.lot_no, SUM(s.pieces) sz FROM washing_in_data d JOIN washing_in_data_sizes s ON s.washing_in_data_id=d.id GROUP BY d.lot_no),
+wi_ev  AS (SELECT cl.lot_no, SUM(es.pieces) sz FROM washing_in_event_sizes es JOIN washing_in_events e ON e.id=es.event_id JOIN cutting_lots cl ON cl.id=e.cutting_lot_id WHERE e.event_type='complete' GROUP BY cl.lot_no),
+fi_leg AS (SELECT d.lot_no, SUM(s.pieces) sz FROM finishing_data d JOIN finishing_data_sizes s ON s.finishing_data_id=d.id GROUP BY d.lot_no),
+fi_ev  AS (SELECT cl.lot_no, SUM(es.pieces) sz FROM finishing_event_sizes es JOIN finishing_events e ON e.id=es.event_id JOIN cutting_lots cl ON cl.id=e.cutting_lot_id WHERE e.event_type='complete' GROUP BY cl.lot_no)
+SELECT c.lot_no, c.lot_type, c.cut_pcs,
+       COALESCE(st_ev.sz, st_leg.sz) AS stitch_pcs,
+       COALESCE(as_ev.sz, as_leg.sz) AS assembly_pcs,
+       COALESCE(wa_ev.sz, wa_leg.sz) AS washing_pcs,
+       COALESCE(wi_ev.sz, wi_leg.sz) AS washing_in_pcs,
+       COALESCE(fi_ev.sz, fi_leg.sz) AS finishing_pcs
+FROM cut c
+LEFT JOIN st_leg ON st_leg.lot_no=c.lot_no LEFT JOIN st_ev ON st_ev.lot_no=c.lot_no
+LEFT JOIN as_leg ON as_leg.lot_no=c.lot_no LEFT JOIN as_ev ON as_ev.lot_no=c.lot_no
+LEFT JOIN wa_leg ON wa_leg.lot_no=c.lot_no LEFT JOIN wa_ev ON wa_ev.lot_no=c.lot_no
+LEFT JOIN wi_leg ON wi_leg.lot_no=c.lot_no LEFT JOIN wi_ev ON wi_ev.lot_no=c.lot_no
+LEFT JOIN fi_leg ON fi_leg.lot_no=c.lot_no LEFT JOIN fi_ev ON fi_ev.lot_no=c.lot_no
+WHERE c.cut_pcs > 0
+  AND ( COALESCE(st_ev.sz, st_leg.sz) > c.cut_pcs + 0.5
+     OR COALESCE(as_ev.sz, as_leg.sz) > c.cut_pcs + 0.5
+     OR COALESCE(wa_ev.sz, wa_leg.sz) > c.cut_pcs + 0.5
+     OR COALESCE(wi_ev.sz, wi_leg.sz) > c.cut_pcs + 0.5
+     OR COALESCE(fi_ev.sz, fi_leg.sz) > c.cut_pcs + 0.5 )
+ORDER BY GREATEST(
+   COALESCE(st_ev.sz, st_leg.sz, 0), COALESCE(as_ev.sz, as_leg.sz, 0),
+   COALESCE(wa_ev.sz, wa_leg.sz, 0), COALESCE(wi_ev.sz, wi_leg.sz, 0),
+   COALESCE(fi_ev.sz, fi_leg.sz, 0)) - c.cut_pcs DESC;
+
+-- ─── Query 2: denormalized drift (total_pieces != SUM of size rows) ───
+-- Run per stage; example for stitching (repeat for the other *_data tables):
+-- SELECT d.id, d.lot_no, d.user_id, d.total_pieces,
+--        (SELECT SUM(pieces) FROM stitching_data_sizes WHERE stitching_data_id=d.id) AS sizes_sum
+-- FROM stitching_data d
+-- HAVING ABS(d.total_pieces - sizes_sum) > 0.5;
+
+-- ─── Query 3: duplicate legacy rows (same lot, identical breakdown) ───
+-- SELECT lot_no, COUNT(*) n_rows, GROUP_CONCAT(id) ids, SUM(total_pieces) tot
+-- FROM stitching_data GROUP BY lot_no HAVING n_rows > 1;

--- a/sql/stage_approval_corrections.sql
+++ b/sql/stage_approval_corrections.sql
@@ -1,0 +1,26 @@
+-- ─────────────────────────────────────────────────────────────────────
+-- Stage Approval Corrections — audit log for operator-driven fixes of a
+-- wrong-operator approval (e.g. lot UM416 was approved by Salim but should
+-- have been Salman). A floor supervisor (role `operator`) reattributes the
+-- lot at a stage; every move is recorded here, including already-PAID
+-- payment rows, so accountants can see exactly what changed.
+--
+-- Idempotent: safe to re-run.
+-- ─────────────────────────────────────────────────────────────────────
+CREATE TABLE IF NOT EXISTS stage_approval_corrections (
+  id                  INT AUTO_INCREMENT PRIMARY KEY,
+  stage               VARCHAR(20)  NOT NULL,   -- stitching|assembly|washing|washing_in|finishing
+  cutting_lot_id      INT          NOT NULL,
+  lot_no              VARCHAR(50)  NOT NULL,
+  from_user_id        INT          NOT NULL,   -- operator the lot was wrongly attributed to
+  to_user_id          INT          NOT NULL,   -- operator it should belong to
+  corrected_by        INT          NOT NULL,   -- supervisor (operator role) who made the fix
+  events_moved        INT NOT NULL DEFAULT 0,  -- *_events rows reattributed
+  data_rows_moved     INT NOT NULL DEFAULT 0,  -- legacy *_data rows reattributed
+  payments_moved      INT NOT NULL DEFAULT 0,  -- stage_payments rows reattributed (all)
+  paid_payments_moved INT NOT NULL DEFAULT 0,  -- subset of the above already marked 'paid'
+  created_at          DATETIME     NOT NULL,
+  INDEX idx_lot (lot_no),
+  INDEX idx_stage (stage),
+  INDEX idx_created_at (created_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/test/approvalCorrection.test.js
+++ b/test/approvalCorrection.test.js
@@ -1,0 +1,85 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { STAGE_DEFS, applyCorrection } = require('../utils/approvalCorrection.js');
+
+// Stub a mysql2 connection that records every query and dispatches by SQL
+// shape. Models the UM416 scenario: Salim (id 51) wrongly owns the lot at
+// stitching; we move it to Salman (id 50). 2 events, 1 data row, and 2
+// payments (one already PAID) are attributed to Salim.
+function stubConn() {
+  const queries = [];
+  return {
+    queries,
+    async query(sql, params) {
+      queries.push({ sql: sql.replace(/\s+/g, ' ').trim(), params });
+      if (/^UPDATE stitching_events SET operator_id/.test(sql.trim())) return [{ affectedRows: 2 }];
+      if (/^UPDATE stitching_data SET user_id/.test(sql.trim())) return [{ affectedRows: 1 }];
+      if (/SELECT COUNT\(\*\) AS n, SUM\(status='paid'\) AS paid_n/.test(sql)) return [[{ n: 2, paid_n: 1 }]];
+      if (/^UPDATE stage_payments SET user_id/.test(sql.trim())) return [{ affectedRows: 2 }];
+      if (/INSERT INTO stage_approval_corrections/.test(sql)) return [{ insertId: 99 }];
+      throw new Error('unexpected query: ' + sql);
+    },
+  };
+}
+
+test('applyCorrection (UM416): moves events, data, and payments incl. paid, and audits', async () => {
+  const conn = stubConn();
+  const moved = await applyCorrection(conn, {
+    stage: 'stitching', cuttingLotId: 4921, lotNo: 'um416',
+    fromUserId: 51, toUserId: 50, toUsername: 'salman', correctedBy: 7,
+  });
+
+  assert.deepStrictEqual(moved, { eventsMoved: 2, dataMoved: 1, paymentsMoved: 2, paidMoved: 1 });
+
+  // event ledger reattributed to Salman, scoped to the lot + wrong operator
+  const ev = conn.queries.find(q => /UPDATE stitching_events SET operator_id/.test(q.sql));
+  assert.deepStrictEqual(ev.params, [50, 4921, 51]);
+
+  // legacy data row reattributed by lot_no + wrong operator
+  const data = conn.queries.find(q => /UPDATE stitching_data SET user_id/.test(q.sql));
+  assert.deepStrictEqual(data.params, [50, 'um416', 51]);
+
+  // payments moved with BOTH user_id and username (so payee follows)
+  const pay = conn.queries.find(q => /UPDATE stage_payments SET user_id/.test(q.sql));
+  assert.deepStrictEqual(pay.params, [50, 'salman', 'um416', 51]);
+
+  // audit row carries the move counts incl. the paid subset
+  const audit = conn.queries.find(q => /INSERT INTO stage_approval_corrections/.test(q.sql));
+  assert.ok(audit, 'audit row inserted');
+  assert.deepStrictEqual(audit.params,
+    ['stitching', 4921, 'um416', 51, 50, 7, /*events*/2, /*data*/1, /*payments*/2, /*paid*/1]);
+});
+
+test('applyCorrection: no audit row when nothing matched', async () => {
+  const conn = {
+    queries: [],
+    async query(sql) {
+      this.queries.push(sql.replace(/\s+/g, ' ').trim());
+      if (/^UPDATE \w+ SET (operator_id|user_id)/.test(sql.trim())) return [{ affectedRows: 0 }];
+      if (/SELECT COUNT/.test(sql)) return [[{ n: 0, paid_n: null }]];
+      if (/^UPDATE stage_payments/.test(sql.trim())) return [{ affectedRows: 0 }];
+      if (/INSERT INTO stage_approval_corrections/.test(sql)) throw new Error('should not audit a no-op');
+      throw new Error('unexpected query: ' + sql);
+    },
+  };
+  const moved = await applyCorrection(conn, {
+    stage: 'washing', cuttingLotId: 1, lotNo: 'zzz', fromUserId: 1, toUserId: 2, toUsername: 'x', correctedBy: 9,
+  });
+  assert.deepStrictEqual(moved, { eventsMoved: 0, dataMoved: 0, paymentsMoved: 0, paidMoved: 0 });
+  assert.ok(!conn.queries.some(s => /INSERT INTO stage_approval_corrections/.test(s)));
+});
+
+test('STAGE_DEFS maps every stage to its tables + role', () => {
+  assert.deepStrictEqual(Object.keys(STAGE_DEFS).sort(),
+    ['assembly', 'finishing', 'stitching', 'washing', 'washing_in']);
+  assert.strictEqual(STAGE_DEFS.stitching.role, 'stitching_master');
+  assert.strictEqual(STAGE_DEFS.assembly.role, 'jeans_assembly');
+  assert.strictEqual(STAGE_DEFS.finishing.ev, 'finishing_events');
+});
+
+test('applyCorrection: rejects an unknown stage', async () => {
+  await assert.rejects(
+    () => applyCorrection({ async query() { return [{}]; } }, { stage: 'nope', cuttingLotId: 1, lotNo: 'a', fromUserId: 1, toUserId: 2, toUsername: 'x', correctedBy: 1 }),
+    /Invalid stage/
+  );
+});

--- a/test/stageEvents.test.js
+++ b/test/stageEvents.test.js
@@ -77,3 +77,45 @@ test('getOpenApprovals: reject also consumes the approved pool', async () => {
   const result = await getOpenApprovals(conn, 'washing', 3);
   assert.strictEqual(result.length, 0);
 });
+
+// ── Part B guardrail: recordEvent rejects labels not in the cutting breakdown ──
+const { recordEvent } = require('../utils/stageEvents.js');
+
+function recordStub(cutLabels) {
+  const q = [];
+  return {
+    q,
+    async query(sql, params) {
+      q.push({ sql: sql.replace(/\s+/g, ' ').trim(), params });
+      if (/FROM cutting_lot_sizes WHERE cutting_lot_id/.test(sql)) {
+        return [cutLabels.map(l => ({ size_label: l }))];
+      }
+      if (/^INSERT INTO \w+_events/.test(sql.trim())) return [{ insertId: 123 }];
+      if (/^INSERT INTO \w+_event_sizes/.test(sql.trim())) return [{}];
+      throw new Error('unexpected query: ' + sql);
+    },
+  };
+}
+
+test('recordEvent: rejects size labels not in the cutting breakdown (blocks junk like 0,1,2)', async () => {
+  const conn = recordStub(['26', '28', '30', '32', '34']);
+  await assert.rejects(
+    () => recordEvent(conn, {
+      stage: 'washing_in', cuttingLotId: 7744, eventType: 'approve', operatorId: 9,
+      sizes: [{ size_label: '0', pieces: 26 }, { size_label: '1', pieces: 28 }],
+    }),
+    /Invalid size label/
+  );
+  // no event row should have been inserted
+  assert.ok(!conn.q.some(x => /INSERT INTO \w+_events/.test(x.sql)));
+});
+
+test('recordEvent: accepts labels that match the cutting breakdown', async () => {
+  const conn = recordStub(['26', '28', '30', '32', '34']);
+  const id = await recordEvent(conn, {
+    stage: 'stitching', cuttingLotId: 1, eventType: 'approve', operatorId: 9,
+    sizes: [{ size_label: '26', pieces: 132 }, { size_label: '28', pieces: 132 }],
+  });
+  assert.strictEqual(id, 123);
+  assert.ok(conn.q.some(x => /INSERT INTO \w+_event_sizes/.test(x.sql)));
+});

--- a/utils/approvalCorrection.js
+++ b/utils/approvalCorrection.js
@@ -1,0 +1,69 @@
+/**
+ * Approval-correction cascade.
+ *
+ * Reattributes a lot at a stage from the wrong operator to the right one
+ * across the three places an operator is recorded, then writes an audit row.
+ * Pure data logic (takes a mysql2 connection) so it can be unit-tested with a
+ * stubbed connection and reused by routes/correctStageApproval.js.
+ */
+
+// production stage -> tables + the role allowed to operate it
+const STAGE_DEFS = {
+  stitching:  { label: 'Stitching',      data: 'stitching_data',      ev: 'stitching_events',      evsz: 'stitching_event_sizes',      fk: 'stitching_data_id',      role: 'stitching_master' },
+  assembly:   { label: 'Jeans Assembly', data: 'jeans_assembly_data', ev: 'jeans_assembly_events', evsz: 'jeans_assembly_event_sizes', fk: 'jeans_assembly_data_id', role: 'jeans_assembly' },
+  washing:    { label: 'Washing',        data: 'washing_data',        ev: 'washing_events',        evsz: 'washing_event_sizes',        fk: 'washing_data_id',        role: 'washing' },
+  washing_in: { label: 'Washing In',     data: 'washing_in_data',     ev: 'washing_in_events',     evsz: 'washing_in_event_sizes',     fk: 'washing_in_data_id',     role: 'washing_in' },
+  finishing:  { label: 'Finishing',      data: 'finishing_data',      ev: 'finishing_events',      evsz: 'finishing_event_sizes',      fk: 'finishing_data_id',      role: 'finishing' },
+};
+
+/**
+ * Apply the cascade inside an already-open transaction.
+ * @returns {Promise<{eventsMoved:number,dataMoved:number,paymentsMoved:number,paidMoved:number}>}
+ */
+async function applyCorrection(conn, { stage, cuttingLotId, lotNo, fromUserId, toUserId, toUsername, correctedBy }) {
+  const def = STAGE_DEFS[stage];
+  if (!def) throw new Error('Invalid stage');
+
+  // 1) event ledger (approve / complete / reject for this lot at this stage)
+  const [evRes] = await conn.query(
+    `UPDATE ${def.ev} SET operator_id = ? WHERE cutting_lot_id = ? AND operator_id = ?`,
+    [toUserId, cuttingLotId, fromUserId]
+  );
+  // 2) legacy data rows (payee source + downstream dashboards)
+  const [dataRes] = await conn.query(
+    `UPDATE ${def.data} SET user_id = ? WHERE lot_no = ? AND user_id = ?`,
+    [toUserId, lotNo, fromUserId]
+  );
+  // 3) payments — count the already-paid subset first, then move everything
+  const [[payCount]] = await conn.query(
+    `SELECT COUNT(*) AS n, SUM(status='paid') AS paid_n
+       FROM stage_payments WHERE lot_no = ? AND user_id = ?`,
+    [lotNo, fromUserId]
+  );
+  const [payRes] = await conn.query(
+    `UPDATE stage_payments SET user_id = ?, username = ?, updated_at = NOW()
+      WHERE lot_no = ? AND user_id = ?`,
+    [toUserId, toUsername, lotNo, fromUserId]
+  );
+
+  const eventsMoved = evRes.affectedRows || 0;
+  const dataMoved = dataRes.affectedRows || 0;
+  const paymentsMoved = payRes.affectedRows || 0;
+  const paidMoved = Number(payCount && payCount.paid_n) || 0;
+
+  // 4) audit — only when something actually moved
+  if (eventsMoved + dataMoved + paymentsMoved > 0) {
+    await conn.query(
+      `INSERT INTO stage_approval_corrections
+         (stage, cutting_lot_id, lot_no, from_user_id, to_user_id, corrected_by,
+          events_moved, data_rows_moved, payments_moved, paid_payments_moved, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NOW())`,
+      [stage, cuttingLotId, lotNo, fromUserId, toUserId, correctedBy,
+       eventsMoved, dataMoved, paymentsMoved, paidMoved]
+    );
+  }
+
+  return { eventsMoved, dataMoved, paymentsMoved, paidMoved };
+}
+
+module.exports = { STAGE_DEFS, applyCorrection };

--- a/utils/stageEvents.js
+++ b/utils/stageEvents.js
@@ -282,6 +282,25 @@ async function recordEvent(conn, {
   // reject events MAY be parentless: that's an "upstream reject" — pieces
   // refused at handover before they entered this stage's pool.
 
+  // Guardrail: every size_label must belong to this lot's cutting breakdown.
+  // Blocks malformed submissions (e.g. array-index labels '0','1','2'… that
+  // historically produced phantom "+150" rows) and typo labels from ever
+  // entering the event ledger — the single chokepoint for all stage events.
+  const [cutRows] = await conn.query(
+    `SELECT size_label FROM cutting_lot_sizes WHERE cutting_lot_id = ?`,
+    [cuttingLotId]
+  );
+  if (cutRows.length) {
+    const allowed = new Set(cutRows.map(r => normalizeSizeLabel(r.size_label)));
+    const bad = [...new Set(sizes.map(s => normalizeSizeLabel(s.size_label)))]
+      .filter(l => l && !allowed.has(l));
+    if (bad.length) {
+      throw new Error(
+        `Invalid size label(s) [${bad.join(', ')}] not in cutting breakdown for lot ${cuttingLotId}`
+      );
+    }
+  }
+
   const [result] = await conn.query(
     `
       INSERT INTO ${events}

--- a/views/correctStageApproval.ejs
+++ b/views/correctStageApproval.ejs
@@ -1,0 +1,150 @@
+<%- include('partials/header', { pageTitle: 'Correct Stage Approval' }) %>
+<%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+
+<style>
+  .page-wrapper { padding-top: var(--navbar-height); min-height: 100vh; background: var(--bg-page); }
+  .page-container { max-width: 860px; margin: 0 auto; padding: 32px 24px; }
+  .page-header { margin-bottom: 28px; }
+  .page-title { font-family: var(--font-display); font-size: var(--text-3xl); color: var(--text-primary); margin-bottom: 8px; }
+  .page-subtitle { font-size: var(--text-base); color: var(--text-secondary); }
+  .kotty-card { background: var(--bg-card); border: 1px solid var(--border-light); border-radius: var(--radius-lg); box-shadow: var(--shadow-sm); margin-bottom: 24px; }
+  .kotty-card-header { padding: 16px 22px; border-bottom: 1px solid var(--border-light); display: flex; align-items: center; gap: 12px; }
+  .kotty-card-header h2 { font-family: var(--font-display); font-size: var(--text-lg); color: var(--text-primary); margin: 0; flex: 1; }
+  .kotty-card-header i { color: var(--terracotta); font-size: 20px; }
+  .kotty-card-body { padding: 22px; }
+  .form-label { font-size: var(--text-sm); font-weight: 500; color: var(--text-primary); margin-bottom: 8px; display: block; }
+  .form-select, .form-input { width: 100%; padding: 12px 16px; font-size: var(--text-base); color: var(--text-primary); background: var(--bg-card); border: 1px solid var(--border-medium); border-radius: var(--radius-md); }
+  .form-select:focus, .form-input:focus { outline: none; border-color: var(--terracotta); box-shadow: 0 0 0 3px var(--terracotta-bg); }
+  .row-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+  .btn-primary { background: var(--terracotta); color: #fff; border: none; padding: 12px 22px; border-radius: var(--radius-md); cursor: pointer; font-size: var(--text-base); }
+  .btn-primary:disabled { opacity: .5; cursor: not-allowed; }
+  table.kt { width: 100%; border-collapse: collapse; }
+  table.kt th, table.kt td { padding: 10px 12px; border-bottom: 1px solid var(--border-light); text-align: left; font-size: var(--text-sm); }
+  table.kt th { color: var(--text-secondary); font-weight: 600; }
+  .badge { display: inline-block; padding: 2px 8px; border-radius: 999px; font-size: 12px; background: var(--gray-100); }
+  .badge.paid { background: var(--danger-light); color: var(--danger); }
+  .alert { border-radius: var(--radius-md); padding: 14px 18px; margin-top: 14px; display: flex; gap: 10px; align-items: center; }
+  .alert-danger { background: var(--danger-light); color: var(--danger); }
+  .alert-success { background: #e6f4ea; color: #1a7f37; }
+  .muted { color: var(--text-secondary); font-size: var(--text-sm); }
+  .hidden { display: none; }
+</style>
+
+<div class="page-wrapper">
+  <div class="page-container">
+    <div class="page-header">
+      <h1 class="page-title">Correct Stage Approval</h1>
+      <p class="page-subtitle">Reattribute a lot at a stage from the wrong operator to the right one. Moves the event ledger, the production data, and the payments (including already-paid).</p>
+    </div>
+
+    <div class="kotty-card">
+      <div class="kotty-card-header"><i class="bi bi-search"></i><h2>Find a lot</h2></div>
+      <div class="kotty-card-body">
+        <div class="row-2">
+          <div>
+            <label class="form-label" for="stageSel">Stage</label>
+            <select id="stageSel" class="form-select">
+              <% stages.forEach(function(s){ %><option value="<%= s.key %>"><%= s.label %></option><% }) %>
+            </select>
+          </div>
+          <div>
+            <label class="form-label" for="lotInput">Lot number (lot_no or manual)</label>
+            <input id="lotInput" class="form-input" placeholder="e.g. UM416" />
+          </div>
+        </div>
+        <div style="margin-top:16px"><button id="lookupBtn" class="btn-primary"><i class="bi bi-search"></i> Look up</button></div>
+        <div id="lookupAlert"></div>
+      </div>
+    </div>
+
+    <div id="resultCard" class="kotty-card hidden">
+      <div class="kotty-card-header"><i class="bi bi-people"></i><h2 id="resultTitle">Current attribution</h2></div>
+      <div class="kotty-card-body">
+        <table class="kt">
+          <thead><tr><th>Operator</th><th>Approved</th><th>Completed</th><th>Data rows</th><th>Payments</th></tr></thead>
+          <tbody id="currentBody"></tbody>
+        </table>
+
+        <hr style="margin:20px 0; border:none; border-top:1px solid var(--border-light)">
+
+        <div class="row-2">
+          <div>
+            <label class="form-label" for="fromSel">From (wrong operator)</label>
+            <select id="fromSel" class="form-select"></select>
+          </div>
+          <div>
+            <label class="form-label" for="toSel">To (correct operator)</label>
+            <select id="toSel" class="form-select"></select>
+          </div>
+        </div>
+        <p class="muted" style="margin-top:10px">This moves every event, data row and payment for this lot at this stage from the wrong operator to the correct one, and writes an audit record.</p>
+        <div style="margin-top:14px"><button id="applyBtn" class="btn-primary"><i class="bi bi-arrow-left-right"></i> Apply correction</button></div>
+        <div id="applyAlert"></div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+document.addEventListener('DOMContentLoaded', function () {
+  const $ = (id) => document.getElementById(id);
+  let state = { lot: null, stage: null, current: [], targets: [] };
+
+  function alertHTML(box, type, msg) { box.innerHTML = '<div class="alert alert-' + type + '"><i class="bi bi-' + (type === 'danger' ? 'exclamation-triangle-fill' : 'check-circle-fill') + '"></i><span>' + msg + '</span></div>'; }
+  function esc(s) { return String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c])); }
+
+  $('lookupBtn').addEventListener('click', function () {
+    const stage = $('stageSel').value, lot = $('lotInput').value.trim();
+    $('lookupAlert').innerHTML = ''; $('resultCard').classList.add('hidden');
+    if (!lot) { alertHTML($('lookupAlert'), 'danger', 'Enter a lot number.'); return; }
+    fetch('/operator/correct-approval/lookup?stage=' + encodeURIComponent(stage) + '&lot=' + encodeURIComponent(lot))
+      .then(r => r.json().then(j => ({ ok: r.ok, j })))
+      .then(({ ok, j }) => {
+        if (!ok) { alertHTML($('lookupAlert'), 'danger', esc(j.error || 'Lookup failed')); return; }
+        state = { lot: j.lot, stage: j.stage, current: j.current || [], targets: j.targets || [] };
+        renderResult(j);
+      })
+      .catch(e => alertHTML($('lookupAlert'), 'danger', 'Network error: ' + esc(e.message)));
+  });
+
+  function renderResult(j) {
+    $('resultTitle').textContent = j.stage_label + ' — ' + j.lot.display_lot + ' (' + esc(j.lot.sku || '') + ')';
+    const body = $('currentBody');
+    if (!j.current.length) {
+      body.innerHTML = '<tr><td colspan="5" class="muted">No operator is attributed at this stage for this lot.</td></tr>';
+    } else {
+      body.innerHTML = j.current.map(c => {
+        const pay = c.payments ? (c.payments + (c.paid_payments ? ' <span class="badge paid">' + c.paid_payments + ' paid</span>' : '')) : '0';
+        return '<tr><td>' + esc(c.username) + '</td><td>' + (c.approved || 0) + '</td><td>' + (c.completed || 0) + '</td><td>' + (c.data_rows || 0) + '</td><td>' + pay + '</td></tr>';
+      }).join('');
+    }
+    // From = operators currently attributed; To = valid role holders
+    $('fromSel').innerHTML = j.current.map(c => '<option value="' + c.user_id + '">' + esc(c.username) + '</option>').join('') || '<option value="">(none)</option>';
+    $('toSel').innerHTML = j.targets.map(t => '<option value="' + t.id + '">' + esc(t.username) + '</option>').join('');
+    $('applyAlert').innerHTML = '';
+    $('resultCard').classList.remove('hidden');
+  }
+
+  $('applyBtn').addEventListener('click', function () {
+    const fromId = $('fromSel').value, toId = $('toSel').value;
+    $('applyAlert').innerHTML = '';
+    if (!fromId || !toId) { alertHTML($('applyAlert'), 'danger', 'Pick both operators.'); return; }
+    if (fromId === toId) { alertHTML($('applyAlert'), 'danger', 'From and To are the same operator.'); return; }
+    const fd = new FormData();
+    fd.append('stage', state.stage); fd.append('cutting_lot_id', state.lot.cutting_lot_id);
+    fd.append('from_user_id', fromId); fd.append('to_user_id', toId);
+    $('applyBtn').disabled = true;
+    fetch('/operator/correct-approval/update', { method: 'POST', body: fd })
+      .then(r => r.json().then(j => ({ ok: r.ok, j })))
+      .then(({ ok, j }) => {
+        $('applyBtn').disabled = false;
+        if (!ok || !j.success) { alertHTML($('applyAlert'), 'danger', esc(j.error || 'Correction failed')); return; }
+        alertHTML($('applyAlert'), 'success', 'Done. Moved to ' + esc(j.to_username) + ' — ' + j.moved.events + ' events, ' + j.moved.data_rows + ' data rows, ' + j.moved.payments + ' payments (' + j.moved.paid_payments + ' paid). Re-running lookup…');
+        setTimeout(() => $('lookupBtn').click(), 700);
+      })
+      .catch(e => { $('applyBtn').disabled = false; alertHTML($('applyAlert'), 'danger', 'Network error: ' + esc(e.message)); });
+  });
+});
+</script>
+
+<%- include('partials/footer') %>

--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -785,6 +785,10 @@
           <i class="bi bi-pencil-square"></i>
           <span class="action-card-title">Edit Wash</span>
         </a>
+        <a href="/operator/correct-approval" class="action-card">
+          <i class="bi bi-arrow-left-right"></i>
+          <span class="action-card-title">Fix Approval</span>
+        </a>
         <a href="/operator/dashboard/washing-summary/download" class="action-card">
           <i class="bi bi-calendar-range"></i>
           <span class="action-card-title">Wash Monthly</span>


### PR DESCRIPTION
## Summary
Two linked production-data fixes for the multi-stage flow (cutting → stitching → assembly → washing → washing-in → finishing).

### 1. Cross-stage quantity corruption ("cutting 10 → stitching 20")
- **Diagnosed** with `sql/diagnostics/stage_qty_reconciliation.sql` (read-only): canonical stage total = events-complete size-sum (else legacy `*_data` size-sum) vs cutting ceiling. Found **37 offender lots** on prod.
- **Causes** (all confirmed from data): uniform size-row inflation (×2/×4/×10, e.g. `ak2168` 11280 vs cut 1128), exact-duplicate rows from double-submit, and malformed "junk" rows whose `size_label`s are array indices `0,1,2,3,4`. Root cause: `backfill_stage_events*.sql` copied legacy size rows into the event tables without re-validating against cutting.
- **Repaired** with `scripts/repairStageQuantities.js` (dry-run default, `--apply`, JSON backups). FK-safe: voids dup/junk rows (deletes size rows + zeros scalar, keeps parent rows), proportionally scales over-cut breakdowns to the cutting ceiling, clamps over-cut payments. **Already applied on prod → 0 remaining offenders.** Idempotent.
- **Guardrails:** `recordEvent` rejects size labels not in the lot's cutting breakdown (blocks the junk-label class at the single event chokepoint); washing `/available-lots` now uses assembly size-sum + per-lot dedupe instead of denormalized `total_pieces`.

### 2. Operator-driven approval correction
The create→approve flow lost its "assign" step, so anyone can approve a lot onto themselves (and the payee follows the approver). New **`/operator/correct-approval`** (floor-supervisor `isOperator` only — masters can't self-correct). Reattributing a lot moves all three places an operator is recorded — `*_events.operator_id` + legacy `*_data.user_id` + `stage_payments` (incl. already-paid) — and writes a `stage_approval_corrections` audit row.

**UM416 example (real, live):** at stitching it's approved by `Salimsambhal` (id 164); should be `salmansambhal` (id 161). Proved end-to-end against the real prod row in a rolled-back transaction; left for the operator to fix via the new "Fix Approval" card.

## Tests
`node --test` → 35 pass (approval cascade incl. paid payments + UM416 case; recordEvent label guard).

## Deploy notes
- The `stage_approval_corrections` table was already created on prod and the 37-lot repair already applied — but this **code is new**. The migration is `CREATE IF NOT EXISTS`; the repair is a no-op on re-run.
- Run `sql/stage_approval_corrections.sql` before/with the code deploy on any non-prod env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)