### PR TITLE
PIC report: show manual lot number, swap Sort No for Fabric Type

### DIFF
--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -1123,7 +1123,12 @@ function buildEnhancedRow({
     break;
   }
 
-  const { externalLotNo, sortNo } = parseLotRemark(lot.remark);
+  const { externalLotNo: parsedExternalLotNo, sortNo } = parseLotRemark(lot.remark);
+  // Prefer the authoritative, backfilled manual_lot_number column; fall back to
+  // the value parsed live from the remark for any lot not yet backfilled.
+  const externalLotNo = (lot.manual_lot_number && String(lot.manual_lot_number).trim())
+    ? String(lot.manual_lot_number).trim()
+    : parsedExternalLotNo;
   const opName = a => (a && a.opName) ? a.opName : '';
 
   return {
@@ -1131,6 +1136,7 @@ function buildEnhancedRow({
     lotNo: lot.lot_no,
     externalLotNo,
     sortNo,
+    fabricType: lot.fabric_type || '',
     sku: lot.sku,
     lotType: isDenim ? 'Denim' : 'Hosiery',
     createdAt: lot.created_at
@@ -1215,8 +1221,8 @@ function buildEnhancedRow({
 
 const PIC_REPORT_V2_COLUMNS = [
   { header: 'Lot No',              key: 'lotNo',             width: 14 },
-  { header: 'External Lot No',     key: 'externalLotNo',     width: 14 },
-  { header: 'Sort No',             key: 'sortNo',            width: 14 },
+  { header: 'Manual Lot No',       key: 'externalLotNo',     width: 14 },
+  { header: 'Fabric Type',         key: 'fabricType',        width: 14 },
   { header: 'SKU',                 key: 'sku',               width: 22 },
   { header: 'Lot Type',            key: 'lotType',           width: 9  },
   { header: 'Created At',          key: 'createdAt',         width: 12 },
@@ -1983,7 +1989,7 @@ router.get("/dashboard/pic-report", isAuthenticated, isOperator, async (req, res
 
     // 2) Fetch all lots (ONE QUERY)
     const baseQuery = `
-      SELECT cl.lot_no, cl.sku, cl.total_pieces, cl.created_at, cl.remark, cl.flow_type,
+      SELECT cl.lot_no, cl.manual_lot_number, cl.sku, cl.fabric_type, cl.total_pieces, cl.created_at, cl.remark, cl.flow_type,
              u.username AS created_by, u.is_denim_cutter
         FROM cutting_lots cl
         JOIN users u ON cl.user_id = u.id
@@ -2242,7 +2248,7 @@ router.get("/dashboard/pic-size-report", isAuthenticated, isOperator, async (req
 
     // 2) Fetch lot/size rows (with LIMIT for performance)
     const baseQuery = `
-      SELECT cl.lot_no, cl.sku, cls.size_label, cls.total_pieces, cl.created_at, cl.remark, cl.flow_type,
+      SELECT cl.lot_no, cl.manual_lot_number, cl.sku, cl.fabric_type, cls.size_label, cls.total_pieces, cl.created_at, cl.remark, cl.flow_type,
              u.username AS created_by, u.is_denim_cutter
         FROM cutting_lots cl
         JOIN cutting_lot_sizes cls ON cls.cutting_lot_id = cl.id
@@ -2402,7 +2408,9 @@ router.get("/dashboard/pic-size-report", isAuthenticated, isOperator, async (req
 
       const lotForBuilder = {
         lot_no: lotNo,
+        manual_lot_number: row.manual_lot_number,
         sku: row.sku,
+        fabric_type: row.fabric_type,
         remark: row.remark,
         created_at: row.created_at
       };
@@ -2434,8 +2442,8 @@ router.get("/dashboard/pic-size-report", isAuthenticated, isOperator, async (req
       // Size-aware column set: same shape as PIC v2 + Size + dispatch columns
       const sizeCols = [
         { header: 'Lot No',              key: 'lotNo',             width: 14 },
-        { header: 'External Lot No',     key: 'externalLotNo',     width: 14 },
-        { header: 'Sort No',             key: 'sortNo',            width: 14 },
+        { header: 'Manual Lot No',       key: 'externalLotNo',     width: 14 },
+        { header: 'Fabric Type',         key: 'fabricType',        width: 14 },
         { header: 'SKU',                 key: 'sku',               width: 22 },
         { header: 'Size',                key: 'size',              width: 8  },
         { header: 'SKU_Size',            key: 'sku_size',          width: 24 },

--- a/views/operatorPICReport.ejs
+++ b/views/operatorPICReport.ejs
@@ -126,8 +126,8 @@
                 <tr>
                   <th style="width:28px;"></th>
                   <th>Lot No</th>
-                  <th>Ext Lot</th>
-                  <th>Sort</th>
+                  <th>Manual Lot</th>
+                  <th>Fabric</th>
                   <th>SKU</th>
                   <th>Type</th>
                   <th>Cut</th>
@@ -151,7 +151,7 @@
                   <td><button type="button" class="lse-toggle" aria-expanded="false" aria-label="Show size breakdown"><span class="lse-chevron">&#9654;</span></button></td>
                   <td><strong style="color: var(--terracotta);"><%= row.lotNo %></strong></td>
                   <td><%= row.externalLotNo || '—' %></td>
-                  <td><%= row.sortNo || '—' %></td>
+                  <td><%= row.fabricType || '—' %></td>
                   <td style="max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;" title="<%= row.sku %>"><%= row.sku %></td>
                   <td>
                     <span class="badge <%= row.lotType === 'Denim' ? 'badge-primary' : 'badge-info' %>">

--- a/views/operatorSizeReport.ejs
+++ b/views/operatorSizeReport.ejs
@@ -121,8 +121,8 @@
           <thead>
             <tr>
               <th>Lot No</th>
-              <th>Ext Lot</th>
-              <th>Sort</th>
+              <th>Manual Lot</th>
+              <th>Fabric</th>
               <th>SKU_Size</th>
               <th>Type</th>
               <th>Cut</th>
@@ -142,7 +142,7 @@
             <tr>
               <td><strong><%= row.lotNo %></strong></td>
               <td><%= row.externalLotNo || '—' %></td>
-              <td><%= row.sortNo || '—' %></td>
+              <td><%= row.fabricType || '—' %></td>
               <td><code class="text-muted"><%= row.sku_size %></code></td>
               <td><span class="badge <%= row.lotType === 'Denim' ? 'badge-primary' : 'badge-info' %>"><%= row.lotType %></span></td>
               <td><%= row.totalCut %></td>


### PR DESCRIPTION
Follow-up to #445 (which is merged). That PR covered 8 reports but not the **PIC report**, which is where the user looked.

## What
- **Manual Lot No now shows real data in the PIC report + PIC size report.** The old "External Lot No" column was parsed live from the free-text remark with a weak regex that missed the `NB`/bare/glued lot families and ignored the backfilled `manual_lot_number` column. It now sources `cl.manual_lot_number` directly (falling back to the live-parsed value only for lots not yet backfilled), and the column is renamed **Manual Lot No** on screen and in both Excel exports.
- **Removed the Sort No column; added Fabric Type** (`cl.fabric_type`) in its place, across both reports (views + Excel).

## Files
- `routes/operatorRoutes.js` — `buildEnhancedRow` prefers `manual_lot_number`; both PIC queries select `fabric_type`; column defs updated.
- `views/operatorPICReport.ejs`, `views/operatorSizeReport.ejs` — headers + cells.

Syntax-checked. No data changes (the remark→manual_lot_number backfill already ran via #445's scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)