### PR TITLE
feat(pm): EasyEcom auth circuit-breaker + skip pulls when auth is down

### DIFF
--- a/utils/easyecomPullWorker.js
+++ b/utils/easyecomPullWorker.js
@@ -645,43 +645,61 @@ async function runPullWorker(pool, { bootstrap = 'auto', includeProducts } = {})
     console.error('[pullWorker] bootstrap check failed:', err.message);
   }
   const windowDays = bootstrapMode ? 30 : 3;
+  const isSunday = runStartedAt.getDay() === 0;
 
-  // Inventory snapshots — account-wide, from the PRIMARY location. Bootstrap pulls a
-  // deeper window so selling-days DRR has real history immediately (configurable).
-  const snapshotWindowDays = bootstrapMode
-    ? Number(process.env.EASYECOM_SNAPSHOT_BACKFILL_DAYS || global.env?.EASYECOM_SNAPSHOT_BACKFILL_DAYS || 60)
-    : Math.max(windowDays, 3);
-  try {
-    await pullSnapshotsFromPrimary(pool, runStartedAt, snapshotWindowDays);
-  } catch (err) {
-    await logStep(pool, runStartedAt, 'snapshot', 'error', err.message, 0);
+  // Auth health gate: one upfront /access/token check. If EasyEcom auth is unavailable
+  // (rate-block / outage), skip the EasyEcom pulls this run so we don't re-hammer a
+  // blocked account — the client's circuit breaker backs off, and the DB-only steps
+  // (cross-check, health recompute) still run. 'primary' shares creds with faridabad;
+  // if it can't auth, the others won't either.
+  let authOk = false;
+  try { authOk = !!(await authenticateWithCredentials('primary')); }
+  catch (_) { authOk = false; }
+  if (!authOk) {
+    await logStep(pool, runStartedAt, 'auth', 'error',
+      'easyecom auth unavailable — skipping EasyEcom pulls this run', Date.now() - overallStart);
+    console.warn('[pullWorker] EasyEcom auth unavailable — skipping pulls, DB-only steps only');
   }
 
-  // Orders (per-line detail used for DRR + drill-downs)
-  try { await pullOrders(pool, runStartedAt, bootstrapMode); }
-  catch (err) { await logStep(pool, runStartedAt, 'orders', 'error', err.message, 0); }
+  if (authOk) {
+    // Inventory snapshots — account-wide, from the PRIMARY location. Bootstrap pulls a
+    // deeper window so selling-days DRR has real history immediately (configurable).
+    const snapshotWindowDays = bootstrapMode
+      ? Number(process.env.EASYECOM_SNAPSHOT_BACKFILL_DAYS || global.env?.EASYECOM_SNAPSHOT_BACKFILL_DAYS || 60)
+      : Math.max(windowDays, 3);
+    try {
+      await pullSnapshotsFromPrimary(pool, runStartedAt, snapshotWindowDays);
+    } catch (err) {
+      await logStep(pool, runStartedAt, 'snapshot', 'error', err.message, 0);
+    }
 
-  // MINI_SALES_REPORT (cross-check source)
-  try { await pullMiniSalesReport(pool, runStartedAt, windowDays); }
-  catch (err) { await logStep(pool, runStartedAt, 'mini_sales', 'error', err.message, 0); }
+    // Orders (per-line detail used for DRR + drill-downs)
+    try { await pullOrders(pool, runStartedAt, bootstrapMode); }
+    catch (err) { await logStep(pool, runStartedAt, 'orders', 'error', err.message, 0); }
 
-  // Sales cross-check (orders vs mini sales)
+    // MINI_SALES_REPORT (cross-check source)
+    try { await pullMiniSalesReport(pool, runStartedAt, windowDays); }
+    catch (err) { await logStep(pool, runStartedAt, 'mini_sales', 'error', err.message, 0); }
+  }
+
+  // Sales cross-check (orders vs mini sales) — DB-only, safe to run regardless of auth.
   try { await crossCheckSales(pool, runStartedAt, windowDays); }
   catch (err) { await logStep(pool, runStartedAt, 'sales_cross_check', 'error', err.message, 0); }
 
-  // STATUS_WISE_STOCK_REPORT
-  try { await pullStatusWiseStock(pool, runStartedAt); }
-  catch (err) { await logStep(pool, runStartedAt, 'stock_status', 'error', err.message, 0); }
+  if (authOk) {
+    // STATUS_WISE_STOCK_REPORT
+    try { await pullStatusWiseStock(pool, runStartedAt); }
+    catch (err) { await logStep(pool, runStartedAt, 'stock_status', 'error', err.message, 0); }
 
-  // INVENTORY_AGING_REPORT
-  try { await pullInventoryAging(pool, runStartedAt); }
-  catch (err) { await logStep(pool, runStartedAt, 'aging', 'error', err.message, 0); }
+    // INVENTORY_AGING_REPORT
+    try { await pullInventoryAging(pool, runStartedAt); }
+    catch (err) { await logStep(pool, runStartedAt, 'aging', 'error', err.message, 0); }
 
-  // Product Master — Sundays or when explicitly requested or on bootstrap.
-  const isSunday = runStartedAt.getDay() === 0;
-  if (includeProducts || isSunday || bootstrapMode) {
-    try { await pullProductMaster(pool, runStartedAt); }
-    catch (err) { await logStep(pool, runStartedAt, 'product_master', 'error', err.message, 0); }
+    // Product Master — Sundays or when explicitly requested or on bootstrap.
+    if (includeProducts || isSunday || bootstrapMode) {
+      try { await pullProductMaster(pool, runStartedAt); }
+      catch (err) { await logStep(pool, runStartedAt, 'product_master', 'error', err.message, 0); }
+    }
   }
 
   // Recompute health using fresh data (selling-days DRR + lead-time + open-lots + POs).

--- a/utils/easyecomReturnsClient.js
+++ b/utils/easyecomReturnsClient.js
@@ -38,12 +38,29 @@ const WAREHOUSE_CREDENTIALS = {
   primary: { email: EASYECOM_EMAIL, password: EASYECOM_PASSWORD, c_id: 173969, location_key: EASYECOM_PRIMARY_LOCATION_KEY },
 };
 
-// Cached JWT tokens per warehouse
+// Cached JWT tokens per warehouse. Also carries circuit-breaker state
+// (failCount / failedUntil) so a blocked account isn't re-hammered.
 const cachedTokens = {
   faridabad: { token: null, expiry: null },
   delhi: { token: null, expiry: null },
   primary: { token: null, expiry: null },
 };
+
+// Auth circuit breaker: after a failed /access/token, back off before retrying so a
+// rate-limited / IP-blocked account is not hammered (which keeps the block warm).
+// Escalating cooldown by consecutive failures; a 429 floors the cooldown at 1h.
+function authBackoffMs(failCount, is429) {
+  const STEPS_MIN = [15, 60, 240]; // 15m -> 1h -> 4h (cap)
+  let mins = STEPS_MIN[Math.min(failCount - 1, STEPS_MIN.length - 1)];
+  if (is429) mins = Math.max(mins, 60);
+  return mins * 60 * 1000;
+}
+function recordAuthFailure(cache, warehouse, is429) {
+  cache.failCount = (cache.failCount || 0) + 1;
+  cache.failedUntil = Date.now() + authBackoffMs(cache.failCount, is429);
+  console.warn(`[easyecom] auth failed for ${warehouse} (#${cache.failCount}${is429 ? ' 429' : ''}); ` +
+    `backing off ${Math.round((cache.failedUntil - Date.now()) / 60000)}m`);
+}
 
 /**
  * Authenticate with EasyEcom using email/password to get JWT token
@@ -63,6 +80,14 @@ async function authenticateWithCredentials(warehouse = 'faridabad') {
   // Check if we have a valid cached token
   if (cache.token && cache.expiry && Date.now() < cache.expiry) {
     return cache.token;
+  }
+
+  // Circuit breaker: if a recent auth failed, skip the call until the cooldown elapses
+  // (prevents re-hammering a rate-limited / blocked account).
+  if (cache.failedUntil && Date.now() < cache.failedUntil) {
+    console.warn(`[easyecom] auth for ${warehouse} in cooldown ` +
+      `(${Math.round((cache.failedUntil - Date.now()) / 60000)}m left) — skipping auth call`);
+    return null;
   }
 
   try {
@@ -90,14 +115,19 @@ async function authenticateWithCredentials(warehouse = 'faridabad') {
       cache.token = token;
       // Token typically valid for 24 hours, cache for 23 hours
       cache.expiry = Date.now() + (23 * 60 * 60 * 1000);
+      cache.failCount = 0;       // reset circuit breaker on success
+      cache.failedUntil = null;
       console.log(`EasyEcom ${warehouse} authentication successful, token cached`);
       return token;
     } else {
       console.error('No token in EasyEcom auth response:', JSON.stringify(data).substring(0, 200));
+      recordAuthFailure(cache, warehouse, false);
       return null;
     }
   } catch (error) {
+    const is429 = error.response?.status === 429;
     console.error(`EasyEcom ${warehouse} authentication failed:`, error.response?.data || error.message);
+    recordAuthFailure(cache, warehouse, is429);
     return null;
   }
 }


### PR DESCRIPTION
## Why
On 2026-06-16 the nightly pull was running (the catch-up from #442 works), but **every run failed** with `EasyEcom not configured for warehouse: primary` + `mini_sales rows=0`, and data went stale. Root cause: **EasyEcom rate-blocked our Cloud Run egress IP** after I generated heavy test-pull load — proven by a direct `/access/token` probe with the *same server credentials* returning **HTTP 200 + token** from a different IP. The worker then kept re-hammering auth across all 3 warehouses × every report step, every run, keeping the block warm.

## Fix (pure resilience, no flag)
- **`authenticateWithCredentials` circuit breaker:** on auth failure, record an escalating cooldown per warehouse (15m → 1h → 4h cap; a `429` floors it at 1h). While in cooldown, return `null` **without** calling EasyEcom. Reset on success.
- **`runPullWorker` early-abort:** one upfront `primary` auth check. If it fails, log an `auth` error step and **skip the EasyEcom pulls** (snapshot/orders/mini_sales/stock_status/aging/product_master) for that run; DB-only steps (cross-check, health recompute) still run.

Net effect: a blocked run makes **≤1 auth attempt** (then **0** while in cooldown) instead of dozens — so EasyEcom's block can expire and the next daily run reconnects automatically.

## Verify after merge
While the server IP is still blocked: a run logs an `auth` error step and **no** snapshot/orders/mini_sales attempts (check `pm_pull_runs`). Once the block lifts, the next daily catch-up authenticates and data flows again.

Note: data was refreshed out-of-band via a laptop-run pull (unblocked IP) so `/pm` DRR isn't stale while the block clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)