### PR TITLE
Search & show lots by manual lot number across all new stages

### DIFF
--- a/routes/finishingRoutes.js
+++ b/routes/finishingRoutes.js
@@ -667,13 +667,13 @@ router.get('/event/search', isAuthenticated, isFinishingMaster, async (req, res)
     if (!q) return res.json({ lots: [] });
     const like = `%${q}%`;
     const [lots] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
               u.username AS cutting_master, u.is_denim_cutter
        FROM cutting_lots cl JOIN users u ON u.id = cl.user_id
-       WHERE cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ?
+       WHERE cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?
        ORDER BY cl.created_at DESC
        LIMIT 25`,
-      [like, like, like]
+      [like, like, like, like]
     );
     res.json({ lots });
   } catch (err) {
@@ -688,7 +688,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isFinishingMaster,
     if (!Number.isFinite(lotId) || lotId <= 0) return res.status(400).json({ error: 'Invalid cutting_lot_id' });
 
     const [[lot]] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
               u.username AS cutting_master, u.is_denim_cutter
        FROM cutting_lots cl JOIN users u ON u.id = cl.user_id WHERE cl.id = ?`,
       [lotId]
@@ -949,12 +949,14 @@ router.get('/list-entries', isAuthenticated, isFinishingMaster, async (req, res)
     const likeStr = `%${searchTerm}%`;
     // Fixed: Replace SELECT * with specific columns
     const [rows] = await pool.query(
-      `SELECT id, user_id, lot_no, sku, total_pieces, created_at
-         FROM finishing_data
-        WHERE user_id = ? AND (lot_no LIKE ? OR sku LIKE ?)
-        ORDER BY created_at DESC
+      `SELECT fd.id, fd.user_id, fd.lot_no, cl.manual_lot_number, fd.sku, fd.total_pieces, fd.created_at,
+              cl.remark AS cutting_remark
+         FROM finishing_data fd
+         LEFT JOIN cutting_lots cl ON cl.lot_no = fd.lot_no
+        WHERE fd.user_id = ? AND (fd.lot_no LIKE ? OR fd.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
+        ORDER BY fd.created_at DESC
         LIMIT ? OFFSET ?`,
-      [userId, likeStr, likeStr, limit, offset]
+      [userId, likeStr, likeStr, likeStr, likeStr, limit, offset]
     );
     if (!rows.length) return res.json({ data: [], hasMore: false });
 
@@ -984,9 +986,10 @@ router.get('/list-entries', isAuthenticated, isFinishingMaster, async (req, res)
     });
     const [[{ totalCount }]] = await pool.query(`
       SELECT COUNT(*) AS totalCount
-      FROM finishing_data
-      WHERE user_id = ? AND (lot_no LIKE ? OR sku LIKE ?)
-    `, [userId, likeStr, likeStr]);
+      FROM finishing_data fd
+      LEFT JOIN cutting_lots cl ON cl.lot_no = fd.lot_no
+      WHERE fd.user_id = ? AND (fd.lot_no LIKE ? OR fd.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
+    `, [userId, likeStr, likeStr, likeStr, likeStr]);
     const hasMore = offset + rows.length < totalCount;
     return res.json({ data: dataOut, hasMore });
   } catch (err) {
@@ -1851,6 +1854,7 @@ router.get('/available-lots', isAuthenticated, isFinishingMaster, async (req, re
       SELECT
         sd.id,
         sd.lot_no,
+        cl.manual_lot_number,
         sd.sku,
         sd.total_pieces,
         sd.created_at,
@@ -1866,7 +1870,7 @@ router.get('/available-lots', isAuthenticated, isFinishingMaster, async (req, re
       FROM stitching_data sd
       JOIN users u ON sd.user_id = u.id
       LEFT JOIN cutting_lots cl ON cl.lot_no = sd.lot_no
-      WHERE (sd.lot_no LIKE ? OR sd.sku LIKE ? OR cl.remark LIKE ?)
+      WHERE (sd.lot_no LIKE ? OR sd.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
         AND (
           cl.flow_type = 'hosiery'
           OR (cl.flow_type IS NULL AND NOT EXISTS (
@@ -1878,13 +1882,14 @@ router.get('/available-lots', isAuthenticated, isFinishingMaster, async (req, re
       HAVING remaining_pieces > 0
       ORDER BY sd.created_at DESC
       LIMIT 25
-    `, [search, search, search]);
+    `, [search, search, search, search]);
 
     // Denim lots: from washing_in_data where flow_type is denim and not yet in finishing
     const [denimRows] = await pool.query(`
       SELECT
         wid.id,
         wid.lot_no,
+        cl.manual_lot_number,
         wid.sku,
         wid.total_pieces,
         wid.created_at,
@@ -1900,7 +1905,7 @@ router.get('/available-lots', isAuthenticated, isFinishingMaster, async (req, re
       FROM washing_in_data wid
       JOIN users u ON wid.user_id = u.id
       LEFT JOIN cutting_lots cl ON cl.lot_no = wid.lot_no
-      WHERE (wid.lot_no LIKE ? OR wid.sku LIKE ? OR cl.remark LIKE ?)
+      WHERE (wid.lot_no LIKE ? OR wid.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
         AND (
           cl.flow_type = 'denim'
           OR EXISTS (
@@ -1912,7 +1917,7 @@ router.get('/available-lots', isAuthenticated, isFinishingMaster, async (req, re
       HAVING remaining_pieces > 0
       ORDER BY wid.created_at DESC
       LIMIT 25
-    `, [search, search, search]);
+    `, [search, search, search, search]);
 
     const allRows = [...hosieryRows, ...denimRows].sort((a, b) =>
       new Date(b.created_at) - new Date(a.created_at)

--- a/routes/indentRoutes.js
+++ b/routes/indentRoutes.js
@@ -727,13 +727,13 @@ router.get('/api/my-approved-lots', isAuthenticated, canCreateStageIndent, async
       // Lots this stitching master has approved (taken in) — sourced from
       // stitching_events. Distinct lots, ordered by most-recent approve.
       const [r] = await pool.query(
-        `SELECT c.lot_no, c.sku, c.total_pieces, c.lot_type, c.fabric_type,
+        `SELECT c.lot_no, c.manual_lot_number, c.sku, c.total_pieces, c.lot_type, c.fabric_type,
                 MAX(se.created_at) AS approved_on
            FROM stitching_events se
            JOIN cutting_lots c ON c.id = se.cutting_lot_id
           WHERE se.operator_id = ? AND se.event_type = 'approve'
             ${lotType ? 'AND c.lot_type = ?' : ''}
-          GROUP BY c.id, c.lot_no, c.sku, c.total_pieces, c.lot_type, c.fabric_type
+          GROUP BY c.id, c.lot_no, c.manual_lot_number, c.sku, c.total_pieces, c.lot_type, c.fabric_type
           ORDER BY approved_on DESC
           LIMIT 200`,
         lotType ? [userId, lotType] : [userId]
@@ -741,7 +741,7 @@ router.get('/api/my-approved-lots', isAuthenticated, canCreateStageIndent, async
       rows = r;
     } else if (userRole === 'cutting_master') {
       const [r] = await pool.query(
-        `SELECT lot_no, sku, total_pieces, lot_type, fabric_type
+        `SELECT lot_no, manual_lot_number, sku, total_pieces, lot_type, fabric_type
            FROM cutting_lots
           WHERE user_id = ?
             ${lotType ? 'AND lot_type = ?' : ''}
@@ -760,7 +760,7 @@ router.get('/api/my-approved-lots', isAuthenticated, canCreateStageIndent, async
       const t = stageTables[userRole];
       if (t) {
         const [r] = await pool.query(
-          `SELECT DISTINCT c.lot_no, c.sku, c.total_pieces, c.lot_type, c.fabric_type
+          `SELECT DISTINCT c.lot_no, c.manual_lot_number, c.sku, c.total_pieces, c.lot_type, c.fabric_type
              FROM ${t} s
              JOIN cutting_lots c ON c.lot_no = s.lot_no
             WHERE ${userRole === 'operator' ? '1=1' : 's.user_id = ?'}
@@ -1211,66 +1211,79 @@ router.get('/recent-lots', isAuthenticated, canCreateStageIndent, async (req, re
 
   try {
     let recentLots = [];
+    const mapLots = rows => rows.map(l => ({ lot_no: l.lot_no, manual_lot_number: l.manual_lot_number }));
 
-    // Get lots based on user's stage
+    // Get lots based on user's stage. Each query also surfaces the manual lot
+    // number (joining cutting_lots for stage-data tables) so the picker can be
+    // searched/displayed by manual lot, not just the system lot_no.
     if (userRole === 'stitching_master') {
       const [lots] = await pool.query(
-        `SELECT DISTINCT lot_no
-           FROM stitching_data
-          WHERE user_id = ?
-          ORDER BY created_at DESC
+        `SELECT s.lot_no, MAX(cl.manual_lot_number) AS manual_lot_number
+           FROM stitching_data s
+           LEFT JOIN cutting_lots cl ON cl.lot_no = s.lot_no
+          WHERE s.user_id = ?
+          GROUP BY s.lot_no
+          ORDER BY MAX(s.created_at) DESC
           LIMIT 20`,
         [userId]
       );
-      recentLots = lots.map(l => l.lot_no);
+      recentLots = mapLots(lots);
     } else if (userRole === 'finishing_master') {
       const [lots] = await pool.query(
-        `SELECT DISTINCT lot_no
-           FROM finishing_data
-          WHERE user_id = ?
-          ORDER BY created_at DESC
+        `SELECT f.lot_no, MAX(cl.manual_lot_number) AS manual_lot_number
+           FROM finishing_data f
+           LEFT JOIN cutting_lots cl ON cl.lot_no = f.lot_no
+          WHERE f.user_id = ?
+          GROUP BY f.lot_no
+          ORDER BY MAX(f.created_at) DESC
           LIMIT 20`,
         [userId]
       );
-      recentLots = lots.map(l => l.lot_no);
+      recentLots = mapLots(lots);
     } else if (userRole === 'cutting_master') {
       const [lots] = await pool.query(
-        `SELECT DISTINCT lot_no
+        `SELECT DISTINCT lot_no, manual_lot_number
            FROM cutting_lots
           WHERE user_id = ?
           ORDER BY created_at DESC
           LIMIT 20`,
         [userId]
       );
-      recentLots = lots.map(l => l.lot_no);
+      recentLots = mapLots(lots);
     } else if (userRole === 'jeans_assembly_master') {
       const [lots] = await pool.query(
-        `SELECT DISTINCT lot_no
-           FROM jeans_assembly_data
-          WHERE user_id = ?
-          ORDER BY created_at DESC
+        `SELECT j.lot_no, MAX(cl.manual_lot_number) AS manual_lot_number
+           FROM jeans_assembly_data j
+           LEFT JOIN cutting_lots cl ON cl.lot_no = j.lot_no
+          WHERE j.user_id = ?
+          GROUP BY j.lot_no
+          ORDER BY MAX(j.created_at) DESC
           LIMIT 20`,
         [userId]
       );
-      recentLots = lots.map(l => l.lot_no);
+      recentLots = mapLots(lots);
     } else if (userRole === 'operator') {
       const [lots] = await pool.query(
-        `SELECT DISTINCT lot_no
-           FROM stitching_data
-          ORDER BY created_at DESC
+        `SELECT s.lot_no, MAX(cl.manual_lot_number) AS manual_lot_number
+           FROM stitching_data s
+           LEFT JOIN cutting_lots cl ON cl.lot_no = s.lot_no
+          GROUP BY s.lot_no
+          ORDER BY MAX(s.created_at) DESC
           LIMIT 20`
       );
-      recentLots = lots.map(l => l.lot_no);
+      recentLots = mapLots(lots);
     } else if (userRole === 'washing_in_master') {
       const [lots] = await pool.query(
-        `SELECT DISTINCT lot_no
-           FROM washing_in_data
-          WHERE user_id = ?
-          ORDER BY created_at DESC
+        `SELECT w.lot_no, MAX(cl.manual_lot_number) AS manual_lot_number
+           FROM washing_in_data w
+           LEFT JOIN cutting_lots cl ON cl.lot_no = w.lot_no
+          WHERE w.user_id = ?
+          GROUP BY w.lot_no
+          ORDER BY MAX(w.created_at) DESC
           LIMIT 20`,
         [userId]
       );
-      recentLots = lots.map(l => l.lot_no);
+      recentLots = mapLots(lots);
     }
 
     res.json({ success: true, lots: recentLots });

--- a/routes/jeansAssemblyRoutes.js
+++ b/routes/jeansAssemblyRoutes.js
@@ -1183,18 +1183,18 @@ router.get('/event/search', isAuthenticated, isJeansAssemblyMaster, async (req, 
     const like = `%${q}%`;
     // Restrict to denim — assembly is denim-only
     const [lots] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark AS cutting_remark,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.remark AS cutting_remark,
               cl.flow_type,
               u.username AS cutting_master, u.is_denim_cutter
        FROM cutting_lots cl
        JOIN users u ON u.id = cl.user_id
-       WHERE (cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ?)
+       WHERE (cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
          AND (cl.flow_type = 'denim' OR (cl.flow_type IS NULL AND u.is_denim_cutter = 1)
               OR (cl.flow_type IS NULL AND u.is_denim_cutter IS NULL
                   AND (cl.lot_no LIKE 'AK%' OR cl.lot_no LIKE 'UM%')))
        ORDER BY cl.created_at DESC
        LIMIT 25`,
-      [like, like, like]
+      [like, like, like, like]
     );
     res.json({ lots });
   } catch (err) {
@@ -1212,7 +1212,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isJeansAssemblyMas
     }
 
     const [[lot]] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
               u.username AS cutting_master, u.is_denim_cutter
        FROM cutting_lots cl
        JOIN users u ON u.id = cl.user_id
@@ -1529,15 +1529,18 @@ router.get('/list-entries', isAuthenticated, isJeansAssemblyMaster, async (req, 
 
     const [rows] = await pool.query(`
       SELECT ja_data.*,
+             cl.manual_lot_number,
+             cl.remark AS cutting_remark,
              (SELECT JSON_ARRAYAGG(JSON_OBJECT('size_label', jas.size_label, 'pieces', jas.pieces))
               FROM jeans_assembly_data_sizes jas
               WHERE jas.jeans_assembly_data_id = ja_data.id) AS sizes
       FROM jeans_assembly_data ja_data
+      LEFT JOIN cutting_lots cl ON cl.lot_no = ja_data.lot_no
       WHERE ja_data.user_id = ?
-        AND (ja_data.lot_no LIKE ? OR ja_data.sku LIKE ?)
+        AND (ja_data.lot_no LIKE ? OR ja_data.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
       ORDER BY ja_data.created_at DESC
       LIMIT ?, ?
-    `, [userId, search, search, offset, limit]);
+    `, [userId, search, search, search, search, offset, limit]);
 
     const hasMore = rows.length === limit;
     return res.json({ data: rows, hasMore });
@@ -1571,6 +1574,7 @@ router.get('/available-lots', isAuthenticated, isJeansAssemblyMaster, async (req
       SELECT
         sd.id AS stitching_data_id,
         sd.lot_no,
+        cl.manual_lot_number,
         sd.sku,
         sd.total_pieces AS stitched_total,
         sd.created_at AS stitch_date,
@@ -1580,7 +1584,7 @@ router.get('/available-lots', isAuthenticated, isJeansAssemblyMaster, async (req
       JOIN cutting_lots cl ON cl.lot_no = sd.lot_no
       JOIN users u ON sd.user_id = u.id
       JOIN users cu ON cl.user_id = cu.id
-      WHERE (sd.lot_no LIKE ? OR cl.remark LIKE ?)
+      WHERE (sd.lot_no LIKE ? OR sd.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
         AND (cl.flow_type = 'denim' OR (cl.flow_type IS NULL AND cu.is_denim_cutter = 1) OR (cl.flow_type IS NULL AND cu.is_denim_cutter IS NULL AND (sd.lot_no LIKE 'AK%' OR sd.lot_no LIKE 'UM%')))
         AND EXISTS (
           SELECT 1 FROM stitching_data_sizes sds
@@ -1593,7 +1597,7 @@ router.get('/available-lots', isAuthenticated, isJeansAssemblyMaster, async (req
         )
       ORDER BY sd.created_at DESC
       LIMIT 10
-    `, [searchLike, searchLike]);
+    `, [searchLike, searchLike, searchLike, searchLike]);
 
     // For each lot, get size details
     for (const lot of lots) {

--- a/routes/stitchingRoutes.js
+++ b/routes/stitchingRoutes.js
@@ -162,7 +162,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isStitchingMaster,
     }
 
     const [[lot]] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
               u.username AS cutting_master, u.is_denim_cutter
        FROM cutting_lots cl
        JOIN users u ON u.id = cl.user_id
@@ -810,15 +810,15 @@ router.get('/event/search', isAuthenticated, isStitchingMaster, async (req, res)
     if (!q) return res.json({ lots: [] });
     const like = `%${q}%`;
     const [lots] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark AS cutting_remark,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.remark AS cutting_remark,
               cl.flow_type,
               u.username AS cutting_master, u.is_denim_cutter
        FROM cutting_lots cl
        JOIN users u ON u.id = cl.user_id
-       WHERE cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ?
+       WHERE cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?
        ORDER BY cl.created_at DESC
        LIMIT 25`,
-      [like, like, like]
+      [like, like, like, like]
     );
     res.json({ lots });
   } catch (err) {
@@ -875,13 +875,15 @@ router.get('/list-entries', isAuthenticated, isStitchingMaster, async (req, res)
 
     // Fixed: Replace SELECT * with specific columns
     const [rows] = await pool.query(`
-      SELECT id, user_id, lot_no, sku, total_pieces, created_at
-      FROM stitching_data
-      WHERE user_id = ?
-        AND (lot_no LIKE ? OR sku LIKE ?)
-      ORDER BY created_at DESC
+      SELECT sd.id, sd.user_id, sd.lot_no, cl.manual_lot_number, sd.sku, sd.total_pieces, sd.created_at,
+             cl.remark AS cutting_remark
+      FROM stitching_data sd
+      LEFT JOIN cutting_lots cl ON cl.lot_no = sd.lot_no
+      WHERE sd.user_id = ?
+        AND (sd.lot_no LIKE ? OR sd.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
+      ORDER BY sd.created_at DESC
       LIMIT ? OFFSET ?
-    `, [userId, searchLike, searchLike, limit, offset]);
+    `, [userId, searchLike, searchLike, searchLike, searchLike, limit, offset]);
 
     if (!rows.length) {
       return res.json({ data: [], hasMore: false });
@@ -908,10 +910,11 @@ router.get('/list-entries', isAuthenticated, isStitchingMaster, async (req, res)
 
     const [[{ totalCount }]] = await pool.query(`
       SELECT COUNT(*) AS totalCount
-      FROM stitching_data
-      WHERE user_id = ?
-        AND (lot_no LIKE ? OR sku LIKE ?)
-    `, [userId, searchLike, searchLike]);
+      FROM stitching_data sd
+      LEFT JOIN cutting_lots cl ON cl.lot_no = sd.lot_no
+      WHERE sd.user_id = ?
+        AND (sd.lot_no LIKE ? OR sd.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
+    `, [userId, searchLike, searchLike, searchLike, searchLike]);
 
     const hasMore = offset + rows.length < totalCount;
 
@@ -1906,6 +1909,7 @@ router.get('/available-lots', isAuthenticated, isStitchingMaster, async (req, re
       SELECT
         cl.id AS cutting_lot_id,
         cl.lot_no,
+        cl.manual_lot_number,
         cl.sku,
         cl.remark AS cutting_remark,
         cl.total_pieces AS cut_total,
@@ -1914,14 +1918,14 @@ router.get('/available-lots', isAuthenticated, isStitchingMaster, async (req, re
         u.is_denim_cutter
       FROM cutting_lots cl
       JOIN users u ON u.id = cl.user_id
-      WHERE (cl.lot_no LIKE ? OR cl.remark LIKE ?)
+      WHERE (cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
         AND EXISTS (
           SELECT 1 FROM v_lot_available_sizes vas
           WHERE vas.cutting_lot_id = cl.id AND vas.available_qty > 0
         )
       ORDER BY cl.created_at DESC
       LIMIT 10
-    `, [searchLike, searchLike]);
+    `, [searchLike, searchLike, searchLike, searchLike]);
 
     // For each lot, get size details with who took what
     for (const lot of lots) {

--- a/routes/washingInRoutes.js
+++ b/routes/washingInRoutes.js
@@ -492,17 +492,17 @@ router.get('/event/search', isAuthenticated, isWashingInMaster, async (req, res)
     if (!q) return res.json({ lots: [] });
     const like = `%${q}%`;
     const [lots] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
               u.username AS cutting_master, u.is_denim_cutter
        FROM cutting_lots cl
        JOIN users u ON u.id = cl.user_id
-       WHERE (cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ?)
+       WHERE (cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
          AND (cl.flow_type = 'denim' OR (cl.flow_type IS NULL AND u.is_denim_cutter = 1)
               OR (cl.flow_type IS NULL AND u.is_denim_cutter IS NULL
                   AND (cl.lot_no LIKE 'AK%' OR cl.lot_no LIKE 'UM%')))
        ORDER BY cl.created_at DESC
        LIMIT 25`,
-      [like, like, like]
+      [like, like, like, like]
     );
     res.json({ lots });
   } catch (err) {
@@ -517,7 +517,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isWashingInMaster,
     if (!Number.isFinite(lotId) || lotId <= 0) return res.status(400).json({ error: 'Invalid cutting_lot_id' });
 
     const [[lot]] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
               u.username AS cutting_master, u.is_denim_cutter
        FROM cutting_lots cl JOIN users u ON u.id = cl.user_id
        WHERE cl.id = ?`,
@@ -881,13 +881,15 @@ router.get('/list-entries', isAuthenticated, isWashingInMaster, async (req, res)
 
     // Fixed: Replace SELECT * with specific columns
     const [rows] = await pool.query(`
-      SELECT id, user_id, lot_no, sku, total_pieces, created_at
-      FROM washing_in_data
-      WHERE user_id = ?
-        AND (lot_no LIKE ? OR sku LIKE ?)
-      ORDER BY created_at DESC
+      SELECT wid.id, wid.user_id, wid.lot_no, cl.manual_lot_number, wid.sku, wid.total_pieces, wid.created_at,
+             cl.remark AS cutting_remark
+      FROM washing_in_data wid
+      LEFT JOIN cutting_lots cl ON cl.lot_no = wid.lot_no
+      WHERE wid.user_id = ?
+        AND (wid.lot_no LIKE ? OR wid.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
+      ORDER BY wid.created_at DESC
       LIMIT ? OFFSET ?
-    `, [userId, searchLike, searchLike, limit, offset]);
+    `, [userId, searchLike, searchLike, searchLike, searchLike, limit, offset]);
 
     if (!rows.length) {
       return res.json({ data: [], hasMore: false });
@@ -919,10 +921,11 @@ router.get('/list-entries', isAuthenticated, isWashingInMaster, async (req, res)
     // check total for pagination
     const [[{ totalCount }]] = await pool.query(`
       SELECT COUNT(*) AS totalCount
-      FROM washing_in_data
-      WHERE user_id = ?
-        AND (lot_no LIKE ? OR sku LIKE ?)
-    `, [userId, searchLike, searchLike]);
+      FROM washing_in_data wid
+      LEFT JOIN cutting_lots cl ON cl.lot_no = wid.lot_no
+      WHERE wid.user_id = ?
+        AND (wid.lot_no LIKE ? OR wid.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
+    `, [userId, searchLike, searchLike, searchLike, searchLike]);
     const hasMore = offset + rows.length < totalCount;
 
     return res.json({ data, hasMore });
@@ -1985,6 +1988,7 @@ router.get('/available-lots', isAuthenticated, isWashingInMaster, async (req, re
       SELECT
         wd.id,
         wd.lot_no,
+        cl.manual_lot_number,
         wd.sku,
         wd.total_pieces,
         wd.created_at,
@@ -1998,7 +2002,7 @@ router.get('/available-lots', isAuthenticated, isWashingInMaster, async (req, re
       FROM washing_data wd
       JOIN users u ON wd.user_id = u.id
       LEFT JOIN cutting_lots cl ON cl.lot_no = wd.lot_no
-      WHERE (wd.lot_no LIKE ? OR wd.sku LIKE ? OR cl.remark LIKE ?)
+      WHERE (wd.lot_no LIKE ? OR wd.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
         AND (
           cl.flow_type = 'denim'
           OR EXISTS (
@@ -2010,7 +2014,7 @@ router.get('/available-lots', isAuthenticated, isWashingInMaster, async (req, re
       HAVING remaining_pieces > 0
       ORDER BY wd.created_at DESC
       LIMIT 50
-    `, [search, search, search]);
+    `, [search, search, search, search]);
 
     return res.json({ data: rows });
   } catch (err) {

--- a/routes/washingRoutes.js
+++ b/routes/washingRoutes.js
@@ -1050,18 +1050,18 @@ router.get('/event/search', isAuthenticated, isWashingMaster, async (req, res) =
     if (!q) return res.json({ lots: [] });
     const like = `%${q}%`;
     const [lots] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark AS cutting_remark,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.remark AS cutting_remark,
               cl.flow_type,
               u.username AS cutting_master, u.is_denim_cutter
        FROM cutting_lots cl
        JOIN users u ON u.id = cl.user_id
-       WHERE (cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ?)
+       WHERE (cl.lot_no LIKE ? OR cl.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
          AND (cl.flow_type = 'denim' OR (cl.flow_type IS NULL AND u.is_denim_cutter = 1)
               OR (cl.flow_type IS NULL AND u.is_denim_cutter IS NULL
                   AND (cl.lot_no LIKE 'AK%' OR cl.lot_no LIKE 'UM%')))
        ORDER BY cl.created_at DESC
        LIMIT 25`,
-      [like, like, like]
+      [like, like, like, like]
     );
     res.json({ lots });
   } catch (err) {
@@ -1077,7 +1077,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isWashingMaster, a
       return res.status(400).json({ error: 'Invalid cutting_lot_id' });
     }
     const [[lot]] = await pool.query(
-      `SELECT cl.id, cl.lot_no, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.remark AS cutting_remark, cl.flow_type,
               u.username AS cutting_master, u.is_denim_cutter
        FROM cutting_lots cl
        JOIN users u ON u.id = cl.user_id
@@ -1351,8 +1351,9 @@ router.get('/list-entries', isAuthenticated, isWashingMaster, async (req, res) =
     const limit = 10;
 
     const [rows] = await pool.query(`
-      SELECT 
+      SELECT
         wd.*,
+        cl.manual_lot_number,
         cl.remark AS cutting_remark,
         (
           SELECT JSON_ARRAYAGG(
@@ -1365,10 +1366,10 @@ router.get('/list-entries', isAuthenticated, isWashingMaster, async (req, res) =
       LEFT JOIN cutting_lots cl
         ON cl.lot_no = wd.lot_no
       WHERE wd.user_id = ?
-        AND (wd.lot_no LIKE ? OR wd.sku LIKE ?)
+        AND (wd.lot_no LIKE ? OR wd.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
       ORDER BY wd.created_at DESC
       LIMIT ?, ?
-    `, [userId, search, search, offset, limit]);
+    `, [userId, search, search, search, search, offset, limit]);
 
     const hasMore = rows.length === limit;
     return res.json({ data: rows, hasMore });
@@ -1627,6 +1628,7 @@ router.get('/available-lots', isAuthenticated, isWashingMaster, async (req, res)
       SELECT
         jad.id,
         jad.lot_no,
+        cl.manual_lot_number,
         jad.sku,
         prod.produced AS total_pieces,
         jad.created_at,
@@ -1648,7 +1650,7 @@ router.get('/available-lots', isAuthenticated, isWashingMaster, async (req, res)
       ) prod ON prod.rep_id = jad.id
       LEFT JOIN users u ON jad.user_id = u.id
       LEFT JOIN cutting_lots cl ON cl.lot_no = jad.lot_no
-      WHERE (jad.lot_no LIKE ? OR jad.sku LIKE ? OR cl.remark LIKE ?)
+      WHERE (jad.lot_no LIKE ? OR jad.sku LIKE ? OR cl.remark LIKE ? OR cl.manual_lot_number LIKE ?)
         AND (
           cl.flow_type = 'denim'
           OR EXISTS (
@@ -1660,7 +1662,7 @@ router.get('/available-lots', isAuthenticated, isWashingMaster, async (req, res)
       HAVING remaining_pieces > 0
       ORDER BY jad.created_at DESC
       LIMIT 50
-    `, [search, search, search]);
+    `, [search, search, search, search]);
 
     return res.json({ data: rows });
   } catch (err) {

--- a/views/finishingEvents.ejs
+++ b/views/finishingEvents.ejs
@@ -1162,8 +1162,8 @@ async function runSearch() {
       row.onclick = () => selectLot(lot);
       const isDenim = (lot.flow_type || '').toLowerCase() === 'denim' || (lot.flow_type === null && lot.is_denim_cutter);
       row.innerHTML = `
-        <span class="sx-result-no">${escapeText((lot.lot_no || '').toUpperCase())}</span>
-        <span class="sx-result-meta">${escapeText(lot.sku || '—')} · ${fmt(Number(lot.total_pieces || 0))} pcs cut</span>
+        <span class="sx-result-no">${escapeText((lot.manual_lot_number || lot.lot_no || '').toUpperCase())}</span>
+        <span class="sx-result-meta">${lot.manual_lot_number ? 'Lot ' + escapeText((lot.lot_no || '').toUpperCase()) + ' · ' : ''}${escapeText(lot.sku || '—')} · ${fmt(Number(lot.total_pieces || 0))} pcs cut</span>
         <span class="sx-flow ${isDenim ? 'denim' : 'hosiery'}">${isDenim ? 'denim' : 'hosiery'}</span>
       `;
       wrap.appendChild(row);
@@ -1194,7 +1194,7 @@ function renderState() {
   if (!currentState) return;
   const { lot, stage_aggregates: agg, upstream_sizes, open_approvals: open } = currentState;
 
-  el('lotNo').textContent = (lot.lot_no || '').toUpperCase();
+  el('lotNo').textContent = (lot.manual_lot_number || lot.lot_no || '').toUpperCase();
   el('lotSku').textContent = lot.sku || '—';
   el('lotCutter').textContent = lot.cutting_master || '—';
   const isDenim = (lot.flow_type || '').toLowerCase() === 'denim' || (lot.flow_type === null && lot.is_denim_cutter);

--- a/views/jeansAssemblyEvents.ejs
+++ b/views/jeansAssemblyEvents.ejs
@@ -1156,8 +1156,8 @@ async function runSearch() {
       row.onclick = () => selectLot(lot);
       const isDenim = (lot.flow_type || '').toLowerCase() === 'denim' || (lot.flow_type === null && lot.is_denim_cutter);
       row.innerHTML = `
-        <span class="sx-result-no">${escapeText((lot.lot_no || '').toUpperCase())}</span>
-        <span class="sx-result-meta">${escapeText(lot.sku || '—')} · ${fmt(Number(lot.total_pieces || 0))} pcs cut</span>
+        <span class="sx-result-no">${escapeText((lot.manual_lot_number || lot.lot_no || '').toUpperCase())}</span>
+        <span class="sx-result-meta">${lot.manual_lot_number ? 'Lot ' + escapeText((lot.lot_no || '').toUpperCase()) + ' · ' : ''}${escapeText(lot.sku || '—')} · ${fmt(Number(lot.total_pieces || 0))} pcs cut</span>
         <span class="sx-flow ${isDenim ? 'denim' : 'hosiery'}">${isDenim ? 'denim' : 'hosiery'}</span>
       `;
       wrap.appendChild(row);
@@ -1188,7 +1188,7 @@ function renderState() {
   if (!currentState) return;
   const { lot, stage_aggregates: agg, upstream_sizes, open_approvals: open } = currentState;
 
-  el('lotNo').textContent = (lot.lot_no || '').toUpperCase();
+  el('lotNo').textContent = (lot.manual_lot_number || lot.lot_no || '').toUpperCase();
   el('lotSku').textContent = lot.sku || '—';
   el('lotCutter').textContent = lot.cutting_master || '—';
   const isDenim = (lot.flow_type || '').toLowerCase() === 'denim' || (lot.flow_type === null && lot.is_denim_cutter);

--- a/views/partials/indentWrapper.ejs
+++ b/views/partials/indentWrapper.ejs
@@ -716,7 +716,8 @@
       function refreshPicker() {
         loadLotsForPicker().then(function(lots){
           var options = lots.map(function(l){
-            return { id: l.lot_no, text: (l.lot_no || '').toUpperCase() + ' · ' + (l.sku || '') + ' · ' + (l.total_pieces || 0) + ' pcs (' + (l.lot_type || '-') + ')', _row: l };
+            var manualBit = l.manual_lot_number ? String(l.manual_lot_number).toUpperCase() + ' / ' : '';
+            return { id: l.lot_no, text: manualBit + (l.lot_no || '').toUpperCase() + ' · ' + (l.sku || '') + ' · ' + (l.total_pieces || 0) + ' pcs (' + (l.lot_type || '-') + ')', _row: l };
           });
           $picker.empty().select2({ placeholder: 'Type lot number or SKU…', width: '100%', data: options, multiple: true });
         });
@@ -735,10 +736,19 @@
         var sel = document.getElementById('iwSingleLot');
         if (!sel) return;
         (d.lots || []).forEach(function(l){
+          // recent-lots now returns { lot_no, manual_lot_number } objects;
+          // tolerate the legacy plain-string shape too.
+          var lotNo = (l && typeof l === 'object') ? l.lot_no : l;
+          var manual = (l && typeof l === 'object') ? l.manual_lot_number : null;
           var o = document.createElement('option');
-          o.value = l; o.textContent = String(l).toUpperCase();
+          o.value = lotNo;
+          o.textContent = (manual ? String(manual).toUpperCase() + ' / ' : '') + String(lotNo).toUpperCase();
           sel.appendChild(o);
         });
+        // Make the lot picker type-to-search (by manual lot or system lot).
+        if (window.jQuery && jQuery.fn.select2) {
+          jQuery(sel).select2({ width: '100%', placeholder: 'Type manual or system lot…' });
+        }
       });
       addCustomRow();
     }

--- a/views/stitchingEvents.ejs
+++ b/views/stitchingEvents.ejs
@@ -1162,8 +1162,8 @@ async function runSearch() {
       row.onclick = () => selectLot(lot);
       const isDenim = (lot.flow_type || '').toLowerCase() === 'denim' || (lot.flow_type === null && lot.is_denim_cutter);
       row.innerHTML = `
-        <span class="sx-result-no">${escapeText((lot.lot_no || '').toUpperCase())}</span>
-        <span class="sx-result-meta">${escapeText(lot.sku || '—')} · ${fmt(Number(lot.total_pieces || 0))} pcs cut</span>
+        <span class="sx-result-no">${escapeText((lot.manual_lot_number || lot.lot_no || '').toUpperCase())}</span>
+        <span class="sx-result-meta">${lot.manual_lot_number ? 'Lot ' + escapeText((lot.lot_no || '').toUpperCase()) + ' · ' : ''}${escapeText(lot.sku || '—')} · ${fmt(Number(lot.total_pieces || 0))} pcs cut</span>
         <span class="sx-flow ${isDenim ? 'denim' : 'hosiery'}">${isDenim ? 'denim' : 'hosiery'}</span>
       `;
       wrap.appendChild(row);
@@ -1194,7 +1194,7 @@ function renderState() {
   if (!currentState) return;
   const { lot, stage_aggregates: agg, upstream_sizes, open_approvals: open } = currentState;
 
-  el('lotNo').textContent = (lot.lot_no || '').toUpperCase();
+  el('lotNo').textContent = (lot.manual_lot_number || lot.lot_no || '').toUpperCase();
   el('lotSku').textContent = lot.sku || '—';
   el('lotCutter').textContent = lot.cutting_master || '—';
   const isDenim = (lot.flow_type || '').toLowerCase() === 'denim' || (lot.flow_type === null && lot.is_denim_cutter);

--- a/views/washingEvents.ejs
+++ b/views/washingEvents.ejs
@@ -1156,8 +1156,8 @@ async function runSearch() {
       row.onclick = () => selectLot(lot);
       const isDenim = (lot.flow_type || '').toLowerCase() === 'denim' || (lot.flow_type === null && lot.is_denim_cutter);
       row.innerHTML = `
-        <span class="sx-result-no">${escapeText((lot.lot_no || '').toUpperCase())}</span>
-        <span class="sx-result-meta">${escapeText(lot.sku || '—')} · ${fmt(Number(lot.total_pieces || 0))} pcs cut</span>
+        <span class="sx-result-no">${escapeText((lot.manual_lot_number || lot.lot_no || '').toUpperCase())}</span>
+        <span class="sx-result-meta">${lot.manual_lot_number ? 'Lot ' + escapeText((lot.lot_no || '').toUpperCase()) + ' · ' : ''}${escapeText(lot.sku || '—')} · ${fmt(Number(lot.total_pieces || 0))} pcs cut</span>
         <span class="sx-flow ${isDenim ? 'denim' : 'hosiery'}">${isDenim ? 'denim' : 'hosiery'}</span>
       `;
       wrap.appendChild(row);
@@ -1188,7 +1188,7 @@ function renderState() {
   if (!currentState) return;
   const { lot, stage_aggregates: agg, upstream_sizes, open_approvals: open } = currentState;
 
-  el('lotNo').textContent = (lot.lot_no || '').toUpperCase();
+  el('lotNo').textContent = (lot.manual_lot_number || lot.lot_no || '').toUpperCase();
   el('lotSku').textContent = lot.sku || '—';
   el('lotCutter').textContent = lot.cutting_master || '—';
   const isDenim = (lot.flow_type || '').toLowerCase() === 'denim' || (lot.flow_type === null && lot.is_denim_cutter);

--- a/views/washingInEvents.ejs
+++ b/views/washingInEvents.ejs
@@ -1156,8 +1156,8 @@ async function runSearch() {
       row.onclick = () => selectLot(lot);
       const isDenim = (lot.flow_type || '').toLowerCase() === 'denim' || (lot.flow_type === null && lot.is_denim_cutter);
       row.innerHTML = `
-        <span class="sx-result-no">${escapeText((lot.lot_no || '').toUpperCase())}</span>
-        <span class="sx-result-meta">${escapeText(lot.sku || '—')} · ${fmt(Number(lot.total_pieces || 0))} pcs cut</span>
+        <span class="sx-result-no">${escapeText((lot.manual_lot_number || lot.lot_no || '').toUpperCase())}</span>
+        <span class="sx-result-meta">${lot.manual_lot_number ? 'Lot ' + escapeText((lot.lot_no || '').toUpperCase()) + ' · ' : ''}${escapeText(lot.sku || '—')} · ${fmt(Number(lot.total_pieces || 0))} pcs cut</span>
         <span class="sx-flow ${isDenim ? 'denim' : 'hosiery'}">${isDenim ? 'denim' : 'hosiery'}</span>
       `;
       wrap.appendChild(row);
@@ -1188,7 +1188,7 @@ function renderState() {
   if (!currentState) return;
   const { lot, stage_aggregates: agg, upstream_sizes, open_approvals: open } = currentState;
 
-  el('lotNo').textContent = (lot.lot_no || '').toUpperCase();
+  el('lotNo').textContent = (lot.manual_lot_number || lot.lot_no || '').toUpperCase();
   el('lotSku').textContent = lot.sku || '—';
   el('lotCutter').textContent = lot.cutting_master || '—';
   const isDenim = (lot.flow_type || '').toLowerCase() === 'denim' || (lot.flow_type === null && lot.is_denim_cutter);


### PR DESCRIPTION
## Problem
Lots could only be found by system `lot_no` / `sku` / `remark`. The manual lot number (e.g. `1246km`) was unsearchable in every new stage dashboard **and** the material-indent picker, so users searching by manual lot got no results. The paginated "my lots" lists also didn't search by remark or manual lot.

## Fix
**Search** now matches `lot_no` + `remark` + `manual_lot_number` (+`sku`) in all five stages (stitching, finishing, washing, washing-in, jeans assembly) across all three search paths each: `event/search`, `available-lots`, and `list-entries` (joining `cutting_lots` and fixing the COUNT queries where the join was added).

**Material indent** — searchable across all flows: `/indent/api/my-approved-lots` and `/indent/recent-lots` now return `manual_lot_number`, and both indentWrapper pickers display + type-search by it (system `lot_no` stays the posted key).

**Display** — event-model search results and the selected-lot card show `manual_lot_number || lot_no`, with the system lot kept as secondary meta and as all internal keys/data-attributes; `lot-state` endpoints return the field.

## Verification
- `node --check` passes on all 6 route files
- All 6 modified EJS views compile via `ejs.compile`
- All 19 search clauses reviewed: 4 conditions each with matching params; every `cl.manual_lot_number`/`cl.remark` reference has `cutting_lots` joined
- ⚠️ Not yet run against a live DB (local needs cloud-sql-proxy). Suggested manual test: search `1246km`, its cutting remark, and the system `lot_no` in each stage dashboard + the indent picker — all three should return the same lot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)