### PR TITLE
feat(pm): derive real fabric consumption per style from cutting history

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -12,6 +12,7 @@ const { pool } = require('../config/db');
 const { isAuthenticated, allowRoles } = require('../middlewares/auth');
 const analytics = require('../utils/easyecomAnalytics');
 const skuResolver = require('../utils/skuResolver');
+const { aggregateStyleConsumption } = require('../utils/styleConsumption');
 let pullWorker = null;
 try { pullWorker = require('../utils/easyecomPullWorker'); } catch (_) { pullWorker = null; }
 
@@ -179,6 +180,37 @@ router.get('/api/dead-stock', async (req, res) => {
     res.json({ ok: true, items: rows || [] });
   } catch (err) {
     if (err.code === 'ANALYTICS_MISSING') {
+      return res.json({ ok: false, items: [], warning: err.message });
+    }
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// Real fabric consumption (meters/piece) per style, derived from cutting history.
+// A lot's blended consumption = table_length * SUM(layers) / total_pieces; dirty rows
+// are filtered and styles aggregated by median (see utils/styleConsumption.js).
+async function loadStyleConsumption(dbPool, windowDays) {
+  const days = Number.isFinite(windowDays) ? windowDays : 120;
+  const [rows] = await dbPool.query(
+    `SELECT cl.sku, cl.table_length, cl.total_pieces, COALESCE(SUM(clr.layers), 0) AS layers
+     FROM cutting_lots cl
+     LEFT JOIN cutting_lot_rolls clr ON clr.cutting_lot_id = cl.id
+     WHERE cl.created_at >= CURDATE() - INTERVAL ? DAY AND cl.sku IS NOT NULL
+     GROUP BY cl.id`,
+    [days]
+  );
+  return aggregateStyleConsumption(rows);
+}
+
+// GET /pm/api/consumption — per-style real consumption, most-measured styles first.
+router.get('/api/consumption', async (req, res) => {
+  try {
+    const days = parseInt(req.query.days, 10) || 120;
+    const items = await loadStyleConsumption(pool, days);
+    items.sort((a, b) => b.cleanLots - a.cleanLots);
+    res.json({ ok: true, windowDays: days, count: items.length, items });
+  } catch (err) {
+    if (err.code === 'ER_NO_SUCH_TABLE') {
       return res.json({ ok: false, items: [], warning: err.message });
     }
     res.status(500).json({ ok: false, error: err.message });

--- a/test/styleConsumption.test.js
+++ b/test/styleConsumption.test.js
@@ -1,0 +1,101 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  lotMetersPerPiece,
+  isCleanLot,
+  aggregateStyleConsumption,
+  varianceVsStandard,
+} = require('../utils/styleConsumption.js');
+
+test('lotMetersPerPiece = table_length * layers / total_pieces', () => {
+  // 5.25 m marker, 166 layers, 913 pieces -> ~0.955 m/piece (real KTTWOMENSPANT261 lot)
+  const mpp = lotMetersPerPiece({ table_length: 5.25, layers: 166, total_pieces: 913 });
+  assert.ok(Math.abs(mpp - 0.9545) < 0.001, `expected ~0.955, got ${mpp}`);
+});
+
+test('lotMetersPerPiece returns null on missing/zero inputs', () => {
+  assert.strictEqual(lotMetersPerPiece({ table_length: 5.25, layers: 0, total_pieces: 900 }), null);
+  assert.strictEqual(lotMetersPerPiece({ table_length: null, layers: 10, total_pieces: 900 }), null);
+  assert.strictEqual(lotMetersPerPiece({ table_length: 5, layers: 10, total_pieces: 0 }), null);
+});
+
+test('isCleanLot accepts a normal lot', () => {
+  assert.strictEqual(isCleanLot({ table_length: 5.25, layers: 166, total_pieces: 913 }), true);
+});
+
+test('isCleanLot rejects garbage table_length (data-entry error)', () => {
+  // a real outlier seen in prod: table_length 3914
+  assert.strictEqual(isCleanLot({ table_length: 3914, layers: 5, total_pieces: 100 }), false);
+  // sub-meter marker is implausible
+  assert.strictEqual(isCleanLot({ table_length: 0.2, layers: 5, total_pieces: 100 }), false);
+});
+
+test('isCleanLot rejects implausible meters-per-piece (too low / too high)', () => {
+  // 6 m * 1 layer / 1000 pieces = 0.006 m/pc -> impossible
+  assert.strictEqual(isCleanLot({ table_length: 6, layers: 1, total_pieces: 1000 }), false);
+  // 6 m * 100 layers / 50 pieces = 12 m/pc -> impossible
+  assert.strictEqual(isCleanLot({ table_length: 6, layers: 100, total_pieces: 50 }), false);
+});
+
+test('isCleanLot rejects a lot with no usable consumption', () => {
+  assert.strictEqual(isCleanLot({ table_length: null, layers: 10, total_pieces: 900 }), false);
+});
+
+test('aggregateStyleConsumption groups by style and uses the median of clean lots', () => {
+  const rows = [
+    { sku: 'KTTWOMENSPANT261', table_length: 5.25, layers: 100, total_pieces: 550 }, // 0.954
+    { sku: 'KTTWOMENSPANT261', table_length: 5.25, layers: 166, total_pieces: 913 }, // 0.954
+    { sku: 'KTTWOMENSPANT261', table_length: 6, layers: 100, total_pieces: 500 },    // 1.20
+    { sku: 'KTTLADIESJEANS823', table_length: 6, layers: 100, total_pieces: 600 },   // 1.00
+  ];
+  const out = aggregateStyleConsumption(rows);
+  const pant = out.find((r) => r.style === 'KTTWOMENSPANT261');
+  const jean = out.find((r) => r.style === 'KTTLADIESJEANS823');
+  assert.strictEqual(pant.cleanLots, 3);
+  assert.ok(Math.abs(pant.realMetersPerPiece - 0.954) < 0.01, `median ~0.954, got ${pant.realMetersPerPiece}`);
+  assert.ok(Math.abs(jean.realMetersPerPiece - 1.0) < 0.001);
+});
+
+test('aggregateStyleConsumption excludes outlier lots from the figure', () => {
+  const rows = [
+    { sku: 'S1', table_length: 5, layers: 100, total_pieces: 500 },   // 1.0 clean
+    { sku: 'S1', table_length: 3914, layers: 5, total_pieces: 100 },  // garbage, excluded
+  ];
+  const out = aggregateStyleConsumption(rows);
+  const s1 = out.find((r) => r.style === 'S1');
+  assert.strictEqual(s1.totalLots, 2);
+  assert.strictEqual(s1.cleanLots, 1);
+  assert.ok(Math.abs(s1.realMetersPerPiece - 1.0) < 0.001);
+});
+
+test('aggregateStyleConsumption returns null consumption when a style has no clean lots', () => {
+  const rows = [{ sku: 'BAD', table_length: 3914, layers: 5, total_pieces: 100 }];
+  const out = aggregateStyleConsumption(rows);
+  const bad = out.find((r) => r.style === 'BAD');
+  assert.strictEqual(bad.realMetersPerPiece, null);
+  assert.strictEqual(bad.cleanLots, 0);
+  assert.strictEqual(bad.totalLots, 1);
+});
+
+test('varianceVsStandard: real below standard = under (good), positive when over', () => {
+  // real 0.955 vs standard 1.01 -> ~ -5.4% (consuming LESS than standard)
+  const v = varianceVsStandard(0.955, 1.01);
+  assert.ok(Math.abs(v.variancePct - -5.45) < 0.1, `expected ~-5.45, got ${v.variancePct}`);
+  assert.strictEqual(v.status, 'under');
+
+  // real 1.10 vs standard 1.00 -> +10% over standard (wasting fabric)
+  const over = varianceVsStandard(1.1, 1.0);
+  assert.ok(Math.abs(over.variancePct - 10) < 0.001);
+  assert.strictEqual(over.status, 'over');
+});
+
+test('varianceVsStandard: within tolerance is on_target', () => {
+  const v = varianceVsStandard(1.01, 1.0); // +1%, inside default 3% band
+  assert.strictEqual(v.status, 'on_target');
+});
+
+test('varianceVsStandard: missing real or standard yields unknown status, null pct', () => {
+  assert.deepStrictEqual(varianceVsStandard(null, 1.0), { variancePct: null, status: 'unknown' });
+  assert.deepStrictEqual(varianceVsStandard(1.0, null), { variancePct: null, status: 'unknown' });
+  assert.deepStrictEqual(varianceVsStandard(1.0, 0), { variancePct: null, status: 'unknown' });
+});

--- a/utils/styleConsumption.js
+++ b/utils/styleConsumption.js
@@ -1,0 +1,91 @@
+// Derive REAL fabric consumption (meters per piece) per style from cutting history,
+// and compare it against the theoretical/standard consumption to surface wastage.
+//
+// History rows come from SQL: per cutting lot we have the marker length
+// (cutting_lots.table_length, in meters), the total layers spread
+// (SUM(cutting_lot_rolls.layers)), and the pieces cut (cutting_lots.total_pieces).
+// A lot's blended consumption = table_length * layers / total_pieces.
+
+// Real meters of fabric consumed per garment for a single lot.
+// Returns null when inputs are missing/invalid.
+function lotMetersPerPiece(lot) {
+  const tl = Number(lot && lot.table_length);
+  const layers = Number(lot && lot.layers);
+  const pieces = Number(lot && lot.total_pieces);
+  if (!isFinite(tl) || !isFinite(layers) || !isFinite(pieces)) return null;
+  if (tl <= 0 || layers <= 0 || pieces <= 0) return null;
+  return (tl * layers) / pieces;
+}
+
+// Plausibility bounds for a cutting lot, tuned against real prod data. Lots outside
+// these are data-entry errors (e.g. table_length 3914) and are excluded from the
+// derived consumption so they can't poison a style's figure.
+const CLEAN_BOUNDS = {
+  minTableLength: 1,    // meters
+  maxTableLength: 20,   // meters
+  minMetersPerPiece: 0.3,
+  maxMetersPerPiece: 5,
+};
+
+// Is this lot trustworthy enough to count toward a style's real consumption?
+function isCleanLot(lot, bounds = CLEAN_BOUNDS) {
+  const tl = Number(lot && lot.table_length);
+  if (!isFinite(tl) || tl < bounds.minTableLength || tl > bounds.maxTableLength) return false;
+  const mpp = lotMetersPerPiece(lot);
+  if (mpp === null) return false;
+  if (mpp < bounds.minMetersPerPiece || mpp > bounds.maxMetersPerPiece) return false;
+  return true;
+}
+
+function median(nums) {
+  if (!nums.length) return null;
+  const s = [...nums].sort((a, b) => a - b);
+  const mid = Math.floor(s.length / 2);
+  return s.length % 2 ? s[mid] : (s[mid - 1] + s[mid]) / 2;
+}
+
+// Per-style real consumption from cutting history. A lot's style is cutting_lots.sku
+// (the factory style code, no size). Uses the MEDIAN of clean lots so a few bad rows
+// can't skew the figure. Styles with no clean lots get realMetersPerPiece = null.
+// rows: [{ sku, table_length, layers, total_pieces }]
+function aggregateStyleConsumption(rows, bounds = CLEAN_BOUNDS) {
+  const byStyle = new Map();
+  for (const r of rows || []) {
+    const style = r.sku;
+    if (!byStyle.has(style)) byStyle.set(style, { style, totalLots: 0, clean: [] });
+    const g = byStyle.get(style);
+    g.totalLots += 1;
+    if (isCleanLot(r, bounds)) g.clean.push(lotMetersPerPiece(r));
+  }
+  return [...byStyle.values()].map((g) => ({
+    style: g.style,
+    realMetersPerPiece: median(g.clean),
+    cleanLots: g.clean.length,
+    totalLots: g.totalLots,
+  }));
+}
+
+// Compare real derived consumption to the theoretical/standard. Positive variance = the
+// floor consumes MORE than standard (fabric waste to investigate); negative = under.
+// Within +/- tolerancePct it's 'on_target'. Returns 'unknown' if either side is missing.
+function varianceVsStandard(realMetersPerPiece, standardMetersPerPiece, tolerancePct = 3) {
+  const real = Number(realMetersPerPiece);
+  const std = Number(standardMetersPerPiece);
+  if (!isFinite(real) || !isFinite(std) || std <= 0 || realMetersPerPiece == null || standardMetersPerPiece == null) {
+    return { variancePct: null, status: 'unknown' };
+  }
+  const variancePct = ((real - std) / std) * 100;
+  let status = 'on_target';
+  if (variancePct > tolerancePct) status = 'over';
+  else if (variancePct < -tolerancePct) status = 'under';
+  return { variancePct, status };
+}
+
+module.exports = {
+  lotMetersPerPiece,
+  isCleanLot,
+  aggregateStyleConsumption,
+  varianceVsStandard,
+  median,
+  CLEAN_BOUNDS,
+};


### PR DESCRIPTION
## What

First step toward the fabric/wastage engine: turn your **cutting history** into **real fabric consumption (meters/piece) per style**, cleaned of data-entry garbage. The theoretical sheet stays the *planning standard*; this surfaces where actual cutting drifts from it (the wastage to fix).

## How

New pure module `utils/styleConsumption.js` (TDD, 12 tests):
- `lotMetersPerPiece` — a lot's real consumption = `table_length × SUM(layers) ÷ total_pieces`
- `isCleanLot` — rejects implausible rows (e.g. `table_length=3914`, or m/pc outside 0.3–5) so they can't poison a style
- `aggregateStyleConsumption` — per-style figure via **median** (robust to remaining dirt); styles with no clean lots return `null`
- `varianceVsStandard` — real vs theoretical → `over` / `under` / `on_target` (wired live once the standard sheet lands in the next PR)

New endpoint `GET /pm/api/consumption` (role-gated PM/admin, read-only): per-style real consumption, most-measured styles first. `?days=` window (default 120).

## Validation (against prod, read-only)

- `KTTWOMENSPANT261` = **0.9545 m/pc** (24/26 lots clean — the 2 outliers correctly dropped) — matches the manual figure exactly.
- **437 / 447** styles get a clean figure over the last 120 days.
- Full test suite: **47 passing**, no regressions.

## Notes

- Read-only and additive — no behavior change to `/pm` suggestions, so no feature flag.
- Next: PB — upload the theoretical per-size sheet into `pm_sku_fabric` to turn on live standard-vs-actual variance + feed the marker/wastage engine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)