### PR TITLE
feat(pm): CAD per-size consumption + fabric-aware cut plan

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -13,6 +13,8 @@ const { isAuthenticated, allowRoles } = require('../middlewares/auth');
 const analytics = require('../utils/easyecomAnalytics');
 const skuResolver = require('../utils/skuResolver');
 const { aggregateStyleConsumption } = require('../utils/styleConsumption');
+const { parseConsumptionSheet } = require('../utils/cadConsumption');
+const { planCut } = require('../utils/cutPlanner');
 let pullWorker = null;
 try { pullWorker = require('../utils/easyecomPullWorker'); } catch (_) { pullWorker = null; }
 
@@ -212,6 +214,110 @@ router.get('/api/consumption', async (req, res) => {
   } catch (err) {
     if (err.code === 'ER_NO_SUCH_TABLE') {
       return res.json({ ok: false, items: [], warning: err.message });
+    }
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// Read a worksheet into row objects keyed by a known column set (some optional). Headers
+// are slugified (lowercase, non-alphanumeric -> _); unmatched optional columns are skipped.
+function readSheetRows(ws, columns) {
+  const headers = [];
+  ws.getRow(1).eachCell((cell, col) => {
+    headers.push({ col, k: String(cell.value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_|_$/g, '') });
+  });
+  const map = {};
+  for (const key of columns) {
+    const h = headers.find((x) => x.k === key) || headers.find((x) => x.k.startsWith(key));
+    if (h) map[key] = h.col;
+  }
+  const cellText = (v) => {
+    if (v == null) return '';
+    if (typeof v === 'object') {
+      if ('text' in v) return v.text;
+      if ('result' in v) return v.result;
+      if ('richText' in v) return v.richText.map((t) => t.text).join('');
+    }
+    return v;
+  };
+  const rows = [];
+  for (let i = 2; i <= ws.rowCount; i++) {
+    const row = ws.getRow(i);
+    const obj = {};
+    for (const key of columns) obj[key] = map[key] ? String(cellText(row.getCell(map[key]).value)).trim() : '';
+    if (Object.values(obj).some((v) => v !== '')) rows.push(obj);
+  }
+  return { rows, map };
+}
+
+// POST /pm/consumption/upload — load CAD per-size consumption (style, fabric_type, size,
+// consumption, [unit]) into pm_style_consumption. CAD is the fabric truth (owner ruling).
+router.post('/consumption/upload', upload.single('file'), async (req, res) => {
+  try {
+    if (!req.file) return res.status(400).json({ ok: false, error: 'No file uploaded.' });
+    const wb = new ExcelJS.Workbook();
+    await wb.xlsx.load(req.file.buffer);
+    const ws = wb.worksheets[0];
+    if (!ws) return res.status(400).json({ ok: false, error: 'Workbook has no sheets.' });
+    const { rows: rawRows, map } = readSheetRows(ws, ['style', 'fabric_type', 'size', 'consumption', 'unit']);
+    if (!map.style || !map.size || !map.consumption) {
+      return res.status(400).json({ ok: false, error: 'Need columns: style, size, consumption (fabric_type, unit optional).' });
+    }
+    const { rows, errors } = parseConsumptionSheet(rawRows);
+    let saved = 0;
+    for (const r of rows) {
+      await pool.query(
+        `INSERT INTO pm_style_consumption (style, size_label, fabric_type, consumption_per_piece, consumption_unit, source, loaded_by)
+         VALUES (?, ?, ?, ?, ?, 'cad', ?)
+         ON DUPLICATE KEY UPDATE fabric_type=VALUES(fabric_type), consumption_per_piece=VALUES(consumption_per_piece),
+           consumption_unit=VALUES(consumption_unit), loaded_by=VALUES(loaded_by)`,
+        [r.style, r.size_label, r.fabric_type, r.consumption_per_piece, r.consumption_unit, req.session?.user?.id || null]
+      );
+      saved += 1;
+    }
+    res.json({ ok: true, saved, skipped: errors.length, errors: errors.slice(0, 20) });
+  } catch (err) {
+    console.error('[pm] consumption upload error', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// GET /pm/api/cut-plan?style=... — turn a style's suggested cut into capped lots with the
+// fabric to issue per lot from CAD consumption. CAD makes the marker; we plan quantities+lots.
+router.get('/api/cut-plan', async (req, res) => {
+  try {
+    const style = String(req.query.style || '').trim();
+    if (!style) return res.status(400).json({ ok: false, error: 'style is required' });
+
+    const recs = await safeCall('getCuttingRecommendations', pool, { periodKey: '30d' });
+    const demand = {};
+    for (const r of (recs || [])) {
+      if (r.style !== style) continue;
+      const qty = Number(r.suggested_cut_qty) || 0;
+      if (qty > 0 && r.size) demand[r.size] = (demand[r.size] || 0) + qty;
+    }
+
+    const [consRows] = await pool.query(
+      'SELECT size_label, consumption_per_piece, consumption_unit, fabric_type FROM pm_style_consumption WHERE style = ?',
+      [style]
+    );
+    const consumptionBySize = {};
+    let fabricType = null;
+    let unit = 'METER';
+    for (const c of consRows) {
+      consumptionBySize[c.size_label] = Number(c.consumption_per_piece);
+      fabricType = fabricType || c.fabric_type;
+      unit = c.consumption_unit || unit;
+    }
+
+    const plan = planCut(demand, { consumptionBySize });
+    res.json({
+      ok: true, style, fabric_type: fabricType, fabric_unit: unit,
+      demand, has_cad: consRows.length > 0, ...plan,
+    });
+  } catch (err) {
+    if (err.code === 'ANALYTICS_MISSING' || err.code === 'ER_NO_SUCH_TABLE') {
+      return res.json({ ok: false, warning: err.message });
     }
     res.status(500).json({ ok: false, error: err.message });
   }

--- a/sql/2026_06_pm_style_consumption.sql
+++ b/sql/2026_06_pm_style_consumption.sql
@@ -1,0 +1,25 @@
+-- CAD per-size fabric consumption per style.
+--
+-- Owner ruling (2026-06-18): CAD is the fabric truth. fabric = sum(size_qty * consumption).
+-- CAD generates the marker; our system only produces quantities + lots and uses these
+-- numbers to compute the fabric to issue. Populated by upload (utils/cadConsumption.js)
+-- for the few styles that have CAD data today; grows over time.
+--
+-- One row per (style, size_label). size_label is the ecom letter size (S/M/L/XL/XXL/...),
+-- extracted from combined CAD labels like "S / 26".
+--
+-- Idempotent: safe to re-run.
+
+CREATE TABLE IF NOT EXISTS pm_style_consumption (
+  id                    INT AUTO_INCREMENT PRIMARY KEY,
+  style                 VARCHAR(100) NOT NULL,
+  size_label            VARCHAR(20)  NOT NULL,
+  fabric_type           VARCHAR(100) NULL,
+  consumption_per_piece DECIMAL(7,3) NOT NULL,           -- meters (or kg) of fabric per piece
+  consumption_unit      ENUM('METER','KG') NOT NULL DEFAULT 'METER',
+  source                ENUM('cad','manual') NOT NULL DEFAULT 'cad',
+  loaded_by             INT NULL,
+  updated_at            TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uq_style_size (style, size_label),
+  INDEX idx_style (style)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/test/cadConsumption.test.js
+++ b/test/cadConsumption.test.js
@@ -1,0 +1,48 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { normalizeSize, parseConsumptionSheet } = require('../utils/cadConsumption.js');
+
+test('normalizeSize extracts the letter size from a combined "S / 26" label', () => {
+  assert.strictEqual(normalizeSize('S / 26'), 'S');
+  assert.strictEqual(normalizeSize('XL / 32'), 'XL');
+  assert.strictEqual(normalizeSize(' xxl '), 'XXL');
+  assert.strictEqual(normalizeSize('3XL'), '3XL');
+});
+
+test('normalizeSize falls back to the raw token when no letter size present', () => {
+  assert.strictEqual(normalizeSize('26'), '26');
+  assert.strictEqual(normalizeSize(''), '');
+});
+
+test('parseConsumptionSheet normalizes valid CAD rows', () => {
+  const rows = [
+    { style: 'KTTWOMENSPANT261', fabric_type: 'Valentino', size: 'S / 26', consumption: '0.9' },
+    { style: 'KTTWOMENSPANT261', fabric_type: 'Valentino', size: 'M / 28', consumption: 1.02 },
+  ];
+  const { rows: out, errors } = parseConsumptionSheet(rows);
+  assert.strictEqual(errors.length, 0);
+  assert.deepStrictEqual(out[0], {
+    style: 'KTTWOMENSPANT261', fabric_type: 'Valentino', size_label: 'S',
+    consumption_per_piece: 0.9, consumption_unit: 'METER',
+  });
+  assert.strictEqual(out[1].size_label, 'M');
+  assert.strictEqual(out[1].consumption_per_piece, 1.02);
+});
+
+test('parseConsumptionSheet rejects rows missing style/size or with bad consumption', () => {
+  const rows = [
+    { style: '', size: 'S', consumption: '0.9' },
+    { style: 'X', size: '', consumption: '0.9' },
+    { style: 'X', size: 'S', consumption: 'abc' },
+    { style: 'X', size: 'M', consumption: '0' },
+  ];
+  const { rows: out, errors } = parseConsumptionSheet(rows);
+  assert.strictEqual(out.length, 0);
+  assert.strictEqual(errors.length, 4);
+});
+
+test('parseConsumptionSheet honours an explicit KG unit', () => {
+  const rows = [{ style: 'X', size: 'S', consumption: '0.4', unit: 'kg' }];
+  const { rows: out } = parseConsumptionSheet(rows);
+  assert.strictEqual(out[0].consumption_unit, 'KG');
+});

--- a/test/cutPlanner.test.js
+++ b/test/cutPlanner.test.js
@@ -1,0 +1,78 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { fabricForCut, splitIntoLots, planCut } = require('../utils/cutPlanner.js');
+
+// Owner ruling 2026-06-18: CAD per-size consumption is the fabric truth.
+// fabric = sum(size_qty * CAD consumption). CAD owns the marker; we only do quantities+lots.
+
+test('fabricForCut sums size_qty * CAD consumption per size', () => {
+  const r = fabricForCut({ M: 200, L: 100 }, { M: 1.02, L: 1.05 });
+  assert.ok(Math.abs(r.perSize.M - 204) < 1e-9);
+  assert.ok(Math.abs(r.perSize.L - 105) < 1e-9);
+  assert.ok(Math.abs(r.total - 309) < 1e-9);
+  assert.deepStrictEqual(r.missingSizes, []);
+  assert.strictEqual(r.complete, true);
+});
+
+test('fabricForCut flags sizes with no CAD consumption and excludes them from the total', () => {
+  const r = fabricForCut({ M: 100, XXL: 50 }, { M: 1.02 }); // no CAD for XXL
+  assert.ok(Math.abs(r.total - 102) < 1e-9); // only the M counted
+  assert.deepStrictEqual(r.missingSizes, ['XXL']);
+  assert.strictEqual(r.complete, false);
+});
+
+test('fabricForCut returns zero/complete for empty demand', () => {
+  const r = fabricForCut({}, { M: 1.02 });
+  assert.strictEqual(r.total, 0);
+  assert.deepStrictEqual(r.missingSizes, []);
+  assert.strictEqual(r.complete, true);
+});
+
+test('splitIntoLots caps at 1500, sizes proportional, never above the cap', () => {
+  const lots = splitIntoLots({ M: 1300, L: 900, XL: 400, XXL: 200 }); // 2800 -> 2x1400
+  assert.strictEqual(lots.length, 2);
+  for (const lot of lots) assert.ok(lot.total <= 1500);
+  assert.deepStrictEqual(lots[0].sizes, { M: 650, L: 450, XL: 200, XXL: 100 });
+  assert.strictEqual(lots[0].total + lots[1].total, 2800);
+});
+
+test('splitIntoLots may dip below 1200 but never exceeds 1500', () => {
+  const lots = splitIntoLots({ M: 1000, L: 600, XL: 310 }); // 1910 -> 2x955
+  assert.strictEqual(lots.length, 2);
+  for (const lot of lots) assert.ok(lot.total <= 1500);
+});
+
+test('splitIntoLots: empty/zero demand -> no lots', () => {
+  assert.deepStrictEqual(splitIntoLots({}), []);
+  assert.deepStrictEqual(splitIntoLots({ M: 0 }), []);
+});
+
+test('planCut: lots + per-lot fabric from CAD consumption', () => {
+  const plan = planCut(
+    { M: 1304, L: 344, XS: 272 }, // total 1920 -> 2 lots
+    { consumptionBySize: { M: 1.02, L: 1.05, XS: 0.9 } }
+  );
+  assert.strictEqual(plan.lotCount, 2);
+  assert.strictEqual(plan.totalPieces, 1920);
+  for (const lot of plan.lots) {
+    assert.ok(lot.total <= 1500);
+    // fabric of a lot = sum(size_qty * CAD consumption)
+    const expect = lot.sizes.M * 1.02 + lot.sizes.L * 1.05 + lot.sizes.XS * 0.9;
+    assert.ok(Math.abs(lot.fabricMeters - expect) < 1e-6);
+  }
+  assert.strictEqual(plan.fabricComplete, true);
+});
+
+test('planCut flags missing CAD sizes and still plans quantities', () => {
+  const plan = planCut({ M: 800, XXL: 700 }, { consumptionBySize: { M: 1.02 } }); // no XXL
+  assert.strictEqual(plan.fabricComplete, false);
+  assert.deepStrictEqual(plan.missingSizes, ['XXL']);
+  assert.ok(plan.totalPieces === 1500);
+});
+
+test('planCut with no CAD data: fabric null, quantities still planned', () => {
+  const plan = planCut({ M: 700, L: 800 }, {});
+  assert.ok(plan.lotCount >= 1);
+  assert.strictEqual(plan.totalFabricMeters, null);
+  assert.strictEqual(plan.fabricComplete, false);
+});

--- a/utils/cadConsumption.js
+++ b/utils/cadConsumption.js
@@ -1,0 +1,50 @@
+// Parse an uploaded CAD per-size consumption sheet into normalized rows for
+// pm_style_consumption. CAD per-size consumption is the fabric truth (owner, 2026-06-18).
+//
+// Expected (already header-normalized) row keys: style, fabric_type, size, consumption, unit.
+// `size` may be a combined CAD label like "S / 26" — we keep the letter size (ecom space).
+
+const LETTER_SIZES = ['XXXL', '4XL', '3XL', 'XXL', 'XS', 'XL', 'S', 'M', 'L'];
+
+// Pull the canonical letter size out of a raw CAD label ("S / 26" -> "S"); if there's no
+// recognizable letter size, fall back to the trimmed raw token.
+function normalizeSize(raw) {
+  const s = String(raw == null ? '' : raw).trim();
+  if (!s) return '';
+  const tokens = s.split(/[\/,|]/).map((t) => t.trim().toUpperCase()).filter(Boolean);
+  for (const t of tokens) {
+    if (LETTER_SIZES.includes(t)) return t;
+  }
+  // single token already a letter size?
+  const up = s.toUpperCase();
+  if (LETTER_SIZES.includes(up)) return up;
+  return tokens[0] || up;
+}
+
+function parseConsumptionSheet(rawRows) {
+  const rows = [];
+  const errors = [];
+  (rawRows || []).forEach((r, i) => {
+    const style = String(r.style == null ? '' : r.style).trim();
+    const size_label = normalizeSize(r.size);
+    const consumption_per_piece = Number(r.consumption);
+    const unit = String(r.unit == null ? '' : r.unit).trim().toUpperCase();
+    const consumption_unit = unit === 'KG' ? 'KG' : 'METER';
+    if (!style) { errors.push({ row: i + 1, error: 'missing style' }); return; }
+    if (!size_label) { errors.push({ row: i + 1, error: 'missing size' }); return; }
+    if (!isFinite(consumption_per_piece) || consumption_per_piece <= 0) {
+      errors.push({ row: i + 1, error: 'invalid consumption' });
+      return;
+    }
+    rows.push({
+      style,
+      fabric_type: String(r.fabric_type == null ? '' : r.fabric_type).trim() || null,
+      size_label,
+      consumption_per_piece,
+      consumption_unit,
+    });
+  });
+  return { rows, errors };
+}
+
+module.exports = { normalizeSize, parseConsumptionSheet, LETTER_SIZES };

--- a/utils/cutPlanner.js
+++ b/utils/cutPlanner.js
@@ -1,0 +1,85 @@
+// Cut planner: turn a per-size cut demand into cutting lots and the fabric to issue.
+//
+// Owner rulings (2026-06-18):
+//  - CAD owns the marker (size ratio + layers). We produce QUANTITIES + LOTS only.
+//  - CAD per-size consumption is the fabric truth: fabric = sum(size_qty * CAD consumption).
+//    A size with no CAD figure is flagged, not guessed.
+//  - A lot caps at 1,500 pieces (hard); split via n = ceil(total / 1500), sizes proportional.
+
+// Fabric (meters) needed for a set of per-size quantities, using CAD per-size consumption.
+// Sizes without a CAD figure are listed in missingSizes and left out of the total.
+function fabricForCut(sizesQty, consumptionBySize) {
+  const cons = consumptionBySize || {};
+  const perSize = {};
+  const missingSizes = [];
+  let total = 0;
+  for (const [size, rawQty] of Object.entries(sizesQty || {})) {
+    const qty = Number(rawQty) || 0;
+    if (qty <= 0) continue;
+    const c = Number(cons[size]);
+    if (!isFinite(c) || cons[size] == null) {
+      missingSizes.push(size);
+      continue;
+    }
+    perSize[size] = qty * c;
+    total += perSize[size];
+  }
+  return { perSize, total, missingSizes, complete: missingSizes.length === 0 };
+}
+
+const MAX_LOT = 1500;
+
+function sumSizes(sizes) {
+  return Object.values(sizes || {}).reduce((s, q) => s + (Number(q) || 0), 0);
+}
+
+// Split per-size demand into lots, each total <= maxLot, sizes PROPORTIONAL in every lot.
+// n = ceil(total / maxLot); 1,500 is a hard cap (never above), a lot may dip below 1,200.
+// Rounding remainders go to the earliest lots so per-size totals are exactly conserved.
+function splitIntoLots(demandBySize, opts = {}) {
+  const maxLot = opts.maxLot || MAX_LOT;
+  const total = sumSizes(demandBySize);
+  if (total <= 0) return [];
+  const n = Math.ceil(total / maxLot);
+  const lots = Array.from({ length: n }, () => ({ sizes: {}, total: 0 }));
+  for (const [size, rawQty] of Object.entries(demandBySize)) {
+    const qty = Number(rawQty) || 0;
+    if (qty <= 0) continue;
+    const base = Math.floor(qty / n);
+    let remainder = qty - base * n;
+    for (let i = 0; i < n; i++) {
+      const give = base + (remainder > 0 ? 1 : 0);
+      if (remainder > 0) remainder -= 1;
+      if (give > 0) { lots[i].sizes[size] = (lots[i].sizes[size] || 0) + give; lots[i].total += give; }
+    }
+  }
+  return lots;
+}
+
+// Full cut plan: split a style's suggested cut into capped lots and attach the fabric to
+// issue per lot from CAD per-size consumption (opts.consumptionBySize). CAD makes the marker
+// for each lot's quantities — we do not. Fabric is null/incomplete when CAD data is missing.
+function planCut(demandBySize, opts = {}) {
+  const cons = opts.consumptionBySize || {};
+  const rawLots = splitIntoLots(demandBySize, opts);
+  const missing = new Set();
+  const lots = rawLots.map((lot) => {
+    const f = fabricForCut(lot.sizes, cons);
+    f.missingSizes.forEach((s) => missing.add(s));
+    return { sizes: lot.sizes, total: lot.total, fabricMeters: f.complete || f.total > 0 ? f.total : null, fabricComplete: f.complete };
+  });
+  const totalPieces = lots.reduce((s, l) => s + l.total, 0);
+  const haveAnyCad = Object.keys(cons).length > 0 && lots.some((l) => l.fabricMeters != null && l.fabricMeters > 0);
+  const fabricComplete = lots.length > 0 && lots.every((l) => l.fabricComplete);
+  const totalFabricMeters = haveAnyCad ? lots.reduce((s, l) => s + (l.fabricMeters || 0), 0) : null;
+  return {
+    lots,
+    lotCount: lots.length,
+    totalPieces,
+    totalFabricMeters,
+    fabricComplete,
+    missingSizes: [...missing],
+  };
+}
+
+module.exports = { fabricForCut, splitIntoLots, planCut, sumSizes, MAX_LOT };


### PR DESCRIPTION
## What

Implements the owner ruling (2026-06-18): **CAD generates the marker**, and **CAD per-size consumption is the fabric truth**. Our system's job is the *cut order* — turn a style's suggested cut into capped, proportional **lots** and compute the **fabric to issue** straight from CAD numbers. We do **not** compute markers (CAD owns that), and we never guess consumption — a size with no CAD figure is flagged.

## Pieces

- **`sql/2026_06_pm_style_consumption.sql`** — per-`(style, size_label)` CAD consumption (meters/kg per piece), fabric type, source. Idempotent. *(apply manually in Cloud SQL — no auto-runner)*
- **`utils/cadConsumption.js`** (TDD, 5 tests) — parses the CAD upload; `normalizeSize` pulls the ecom letter out of combined CAD labels (`"S / 26"` → `S`).
- **`utils/cutPlanner.js`** (TDD, 9 tests):
  - `splitIntoLots` — lots capped at **1,500 (hard)**, `n = ceil(total/1500)`, sizes proportional in every lot (may dip below 1,200, never above 1,500)
  - `fabricForCut` — `Σ(size_qty × CAD consumption)`, lists `missingSizes`
  - `planCut` — lots + per-lot fabric; plans quantities even when CAD data is partial/absent
- **`POST /pm/consumption/upload`** — load the CAD sheet (`style, size, consumption`; `fabric_type, unit` optional). Upserts; reports saved/skipped.
- **`GET /pm/api/cut-plan?style=…`** — a style's suggested cut → capped lots with fabric to issue per lot from CAD; flags sizes lacking CAD data.

## Validation

On the real `KTTWOMENSPANT261` CAD example (S 0.9 / M 1.02 / L 1.05 / XL 1.07):
- suggested cut 1,920 → **2 lots of 960** (≤1,500 ✓), proportional
- fabric **845.64 m/lot** = `652×1.02 + 172×1.05` from CAD
- **XS correctly flagged "no CAD yet"** (not guessed), `complete: false`
- Full suite: **61 passing**

## Notes

- CAD data exists for only a few styles today; the plan degrades gracefully (flags missing sizes) and grows as more CAD sheets are uploaded.
- The history-derived consumption (PR #450) is retained only as an **audit cross-check**, not the planning input. The earlier marker-ratio optimizer is shelved (CAD owns the marker).
- Deploy: merge to `main`, then apply `sql/2026_06_pm_style_consumption.sql` in Cloud SQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)