### PR TITLE
feat(operator): single-screen lot journey through all stages to dispatch

### DIFF
--- a/app.js
+++ b/app.js
@@ -214,6 +214,7 @@ app.use('/', authRoutes);
 app.use('/', launcherRoutes);                       // /launcher + /switch-role
 app.use('/my-lots', require('./routes/myLotsRoutes'));
 app.use('/operator/lot-tat', require('./routes/operatorLotTatRoutes'));
+app.use('/operator/lot-journey', require('./routes/lotJourneyRoutes'));
 app.use('/admin/user-roles', adminUserRolesRoutes); // mohitOperator-only
 app.use('/return-challan', returnChallanRoutes);    // returnchallan role
 app.use('/admin', adminRoutes);

--- a/routes/lotJourneyRoutes.js
+++ b/routes/lotJourneyRoutes.js
@@ -1,0 +1,163 @@
+/**
+ * Lot Journey — one lot's status through EVERY production stage, ending at finishing
+ * dispatch, on a single screen. Search by lot no / manual lot no / SKU.
+ *
+ * Timing/master come from *_events (the truth source), piece tallies from
+ * utils/stageEvents.getStageAggregates, and the final step from finishing_dispatches.
+ * Pure ordering/status/dispatch math lives in utils/lotJourney.js (unit-tested).
+ */
+
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isOperator } = require('../middlewares/auth');
+const stageEvents = require('../utils/stageEvents');
+const {
+  orderedStages, deriveStageStatus, dispatchSummary, currentStage,
+} = require('../utils/lotJourney');
+
+const TAT_DAYS = { cutting: 3, stitching: 7, jeans_assembly: 7, washing: 15, washing_in: 7, finishing: 7 };
+const STAGE_LABEL = {
+  cutting: 'Cutting', stitching: 'Stitching', jeans_assembly: 'Jeans Assembly',
+  washing: 'Washing', washing_in: 'Washing-In', finishing: 'Finishing',
+};
+
+router.get('/', isAuthenticated, isOperator, (req, res) => res.render('lotJourney'));
+
+// Resolve the best-matching lot for a free-text query: exact lot_no / manual_lot_number
+// win, otherwise the most recent LIKE match across lot_no / manual_lot_number / sku.
+async function resolveLot(q) {
+  const exact = q.trim();
+  const like = `%${exact}%`;
+  const [rows] = await pool.query(
+    `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.flow_type,
+            cl.remark, cl.created_at, cl.user_id AS cutter_id, u.username AS cutter_name
+       FROM cutting_lots cl
+  LEFT JOIN users u ON u.id = cl.user_id
+      WHERE cl.lot_no = ? OR cl.manual_lot_number = ?
+            OR cl.lot_no LIKE ? OR cl.manual_lot_number LIKE ? OR cl.sku LIKE ?
+   ORDER BY (cl.lot_no = ?) DESC, (cl.manual_lot_number = ?) DESC, cl.created_at DESC
+      LIMIT 25`,
+    [exact, exact, like, like, like, exact, exact]
+  );
+  return rows;
+}
+
+// Timing + accountable master for one stage from its events table.
+async function stageTiming(table, lotId) {
+  const [rows] = await pool.query(
+    `SELECT e.event_type, e.created_at, u.username
+       FROM \`${table}\` e LEFT JOIN users u ON u.id = e.operator_id
+      WHERE e.cutting_lot_id = ? ORDER BY e.created_at`,
+    [lotId]
+  );
+  let entered = null; let completedAt = null; let master = null;
+  for (const r of rows) {
+    if (!entered) entered = r.created_at;
+    if (r.event_type === 'complete' && (!completedAt || new Date(r.created_at) > new Date(completedAt))) {
+      completedAt = r.created_at;
+    }
+    if (r.event_type === 'approve' && !master) master = r.username;
+  }
+  return { entered, completedAt, master, hasRows: rows.length > 0 };
+}
+
+const EVENT_TABLE = {
+  stitching: 'stitching_events', jeans_assembly: 'jeans_assembly_events',
+  washing: 'washing_events', washing_in: 'washing_in_events', finishing: 'finishing_events',
+};
+
+async function buildJourney(lot) {
+  const stages = orderedStages(lot.flow_type);
+  const now = Date.now();
+
+  // Gather raw per-stage data (timing + piece tallies) for the non-cutting stages.
+  const raw = {};
+  for (const stage of stages) {
+    if (stage === 'cutting') continue;
+    const [timing, aggregates] = await Promise.all([
+      stageTiming(EVENT_TABLE[stage], lot.id),
+      stageEvents.getStageAggregates(pool, stage, lot.id),
+    ]);
+    raw[stage] = { timing, aggregates };
+  }
+
+  const timeline = [];
+  for (let i = 0; i < stages.length; i++) {
+    const stage = stages[i];
+    const next = stages[i + 1];
+    let entered; let master; let pieces; let completedAt = null;
+    if (stage === 'cutting') {
+      entered = lot.created_at;
+      master = lot.cutter_name;
+      pieces = { approved: lot.total_pieces, completed: lot.total_pieces, rejected: 0, inline: 0 };
+    } else {
+      entered = raw[stage].timing.entered;
+      master = raw[stage].timing.master;
+      completedAt = raw[stage].timing.completedAt;
+      pieces = raw[stage].aggregates;
+    }
+    const exit = next ? (next === 'cutting' ? null : (raw[next] && raw[next].timing.entered)) : completedAt;
+    let { status, days } = deriveStageStatus({ entered, exited: exit }, now);
+    if (stage === 'cutting') status = 'done'; // the cut itself is a completed act
+    timeline.push({
+      stage, label: STAGE_LABEL[stage] || stage,
+      entered: entered || null, exited: exit || null,
+      days, tat: TAT_DAYS[stage], overdue: days != null && days > TAT_DAYS[stage],
+      status, master: master || null, pieces,
+    });
+  }
+
+  // Finishing dispatch: finished (finishing completed per size) vs dispatched (by lot_no).
+  const finishedBySize = {};
+  if (stages.includes('finishing')) {
+    const sz = await stageEvents.getStageSizeAggregates(pool, 'finishing', lot.id);
+    for (const [s, v] of Object.entries(sz)) finishedBySize[s] = v.completed || 0;
+  }
+  const [dispRows] = await pool.query(
+    `SELECT size_label, SUM(quantity) AS qty, GROUP_CONCAT(DISTINCT COALESCE(NULLIF(custom_destination,''), destination)) AS dests
+       FROM finishing_dispatches WHERE lot_no = ? GROUP BY size_label`,
+    [lot.lot_no]
+  );
+  const dispatchedBySize = {};
+  const destinations = new Set();
+  for (const r of dispRows) {
+    dispatchedBySize[String(r.size_label || '').trim().toUpperCase()] = Number(r.qty) || 0;
+    if (r.dests) r.dests.split(',').forEach((d) => d && destinations.add(d.trim()));
+  }
+  const dispatch = dispatchSummary(finishedBySize, dispatchedBySize);
+  dispatch.destinations = [...destinations];
+
+  return {
+    lot: {
+      id: lot.id, lot_no: lot.lot_no, manual_lot_number: lot.manual_lot_number || '',
+      sku: lot.sku, flow_type: lot.flow_type || 'unknown', total_pieces: lot.total_pieces,
+      remark: lot.remark || '', created_at: lot.created_at, cutter: lot.cutter_name || '',
+    },
+    timeline,
+    current_stage: dispatch.complete ? 'Dispatched' : currentStage(timeline),
+    dispatch,
+  };
+}
+
+router.get('/data', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const q = String(req.query.q || '').trim();
+    if (!q) return res.json({ ok: true, matches: [], journey: null });
+    const matches = await resolveLot(q);
+    if (!matches.length) return res.json({ ok: true, matches: [], journey: null });
+    const journey = await buildJourney(matches[0]);
+    res.json({
+      ok: true,
+      journey,
+      matches: matches.map((m) => ({
+        id: m.id, lot_no: m.lot_no, manual_lot_number: m.manual_lot_number || '', sku: m.sku,
+      })),
+    });
+  } catch (err) {
+    console.error('GET /operator/lot-journey/data error:', err);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+module.exports = router;

--- a/test/lotJourney.test.js
+++ b/test/lotJourney.test.js
@@ -1,0 +1,77 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  orderedStages, deriveStageStatus, dispatchSummary, currentStage,
+} = require('../utils/lotJourney.js');
+
+const DAY = 86400000;
+
+test('orderedStages: denim runs the full chain, hosiery the short chain', () => {
+  assert.deepStrictEqual(orderedStages('denim'),
+    ['cutting', 'stitching', 'jeans_assembly', 'washing', 'washing_in', 'finishing']);
+  assert.deepStrictEqual(orderedStages('hosiery'), ['cutting', 'stitching', 'finishing']);
+});
+
+test('orderedStages: unknown/null flow defaults to the hosiery chain', () => {
+  assert.deepStrictEqual(orderedStages(null), ['cutting', 'stitching', 'finishing']);
+  assert.deepStrictEqual(orderedStages('weird'), ['cutting', 'stitching', 'finishing']);
+});
+
+test('deriveStageStatus: not started when never entered', () => {
+  const r = deriveStageStatus({ entered: null, exited: null }, 0);
+  assert.strictEqual(r.status, 'not_started');
+  assert.strictEqual(r.days, null);
+});
+
+test('deriveStageStatus: in progress when entered but not exited', () => {
+  const entered = new Date('2026-06-10T00:00:00Z');
+  const now = entered.getTime() + 3 * DAY;
+  const r = deriveStageStatus({ entered, exited: null }, now);
+  assert.strictEqual(r.status, 'in_progress');
+  assert.strictEqual(r.days, 3);
+});
+
+test('deriveStageStatus: done when entered and exited, days = span', () => {
+  const entered = new Date('2026-06-10T00:00:00Z');
+  const exited = new Date('2026-06-15T00:00:00Z');
+  const r = deriveStageStatus({ entered, exited }, Date.now());
+  assert.strictEqual(r.status, 'done');
+  assert.strictEqual(r.days, 5);
+});
+
+test('dispatchSummary: totals, remaining, and per-size breakdown', () => {
+  const r = dispatchSummary({ M: 200, L: 100 }, { M: 120, L: 100 });
+  assert.strictEqual(r.totalFinished, 300);
+  assert.strictEqual(r.totalDispatched, 220);
+  assert.strictEqual(r.remaining, 80);
+  assert.strictEqual(r.complete, false);
+  assert.deepStrictEqual(r.bySize.M, { finished: 200, dispatched: 120, remaining: 80 });
+  assert.deepStrictEqual(r.bySize.L, { finished: 100, dispatched: 100, remaining: 0 });
+});
+
+test('dispatchSummary: fully dispatched is complete', () => {
+  const r = dispatchSummary({ M: 50 }, { M: 50 });
+  assert.strictEqual(r.remaining, 0);
+  assert.strictEqual(r.complete, true);
+});
+
+test('dispatchSummary: nothing finished is not complete', () => {
+  const r = dispatchSummary({}, {});
+  assert.strictEqual(r.totalFinished, 0);
+  assert.strictEqual(r.complete, false);
+});
+
+test('currentStage: first in-progress or not-started stage; Done when all finished', () => {
+  const tl1 = [
+    { stage: 'cutting', status: 'done' },
+    { stage: 'stitching', status: 'in_progress' },
+    { stage: 'finishing', status: 'not_started' },
+  ];
+  assert.strictEqual(currentStage(tl1), 'stitching');
+  const tl2 = [
+    { stage: 'cutting', status: 'done' },
+    { stage: 'stitching', status: 'done' },
+    { stage: 'finishing', status: 'done' },
+  ];
+  assert.strictEqual(currentStage(tl2), 'Done');
+});

--- a/utils/lotJourney.js
+++ b/utils/lotJourney.js
@@ -1,0 +1,77 @@
+// Assemble a single lot's journey through every production stage, ending at finishing
+// dispatch. Pure helpers (no DB) so the ordering/status/dispatch math is unit-tested; the
+// route (routes/lotJourneyRoutes.js) supplies the raw per-stage data from *_events via
+// utils/stageEvents.getStageAggregates and a finishing_dispatches query.
+//
+// Stage names match utils/stageEvents.STAGES (plus 'cutting' at the front, which has no
+// events table — cutting_lots.created_at is its entry point).
+
+const DAY_MS = 86400000;
+
+const STAGES_BY_FLOW = {
+  denim:   ['cutting', 'stitching', 'jeans_assembly', 'washing', 'washing_in', 'finishing'],
+  hosiery: ['cutting', 'stitching', 'finishing'],
+};
+
+// The ordered stage chain for a lot. Unknown/null flow falls back to the hosiery chain
+// (mirrors operatorLotTatRoutes, which treats anything non-denim as the short chain).
+function orderedStages(flowType) {
+  return flowType === 'denim' ? STAGES_BY_FLOW.denim : STAGES_BY_FLOW.hosiery;
+}
+
+// Status + elapsed days for one stage given its entry/exit timestamps.
+//   not_started: never entered. in_progress: entered, no exit (days counted to `nowMs`).
+//   done: entered and exited (days = the span).
+function deriveStageStatus({ entered, exited }, nowMs) {
+  if (!entered) return { status: 'not_started', days: null };
+  const startMs = new Date(entered).getTime();
+  if (!exited) {
+    return { status: 'in_progress', days: Math.max(0, Math.round((nowMs - startMs) / DAY_MS)) };
+  }
+  const endMs = new Date(exited).getTime();
+  return { status: 'done', days: Math.max(0, Math.round((endMs - startMs) / DAY_MS)) };
+}
+
+// Compare finished pieces (per size) to dispatched pieces (per size) so the journey ends
+// with how much of the lot has actually left for the warehouse.
+function dispatchSummary(finishedBySize, dispatchedBySize) {
+  const fin = finishedBySize || {};
+  const disp = dispatchedBySize || {};
+  const sizes = new Set([...Object.keys(fin), ...Object.keys(disp)]);
+  const bySize = {};
+  let totalFinished = 0;
+  let totalDispatched = 0;
+  for (const s of sizes) {
+    const finished = Number(fin[s]) || 0;
+    const dispatched = Number(disp[s]) || 0;
+    bySize[s] = { finished, dispatched, remaining: finished - dispatched };
+    totalFinished += finished;
+    totalDispatched += dispatched;
+  }
+  const remaining = totalFinished - totalDispatched;
+  return {
+    bySize,
+    totalFinished,
+    totalDispatched,
+    remaining,
+    complete: totalFinished > 0 && remaining <= 0,
+  };
+}
+
+// The stage the lot is sitting at: the first one in progress or not yet started.
+// 'Done' when every stage is finished.
+function currentStage(timeline) {
+  for (const t of timeline || []) {
+    if (t.status === 'in_progress' || t.status === 'not_started') return t.stage;
+  }
+  return 'Done';
+}
+
+module.exports = {
+  STAGES_BY_FLOW,
+  orderedStages,
+  deriveStageStatus,
+  dispatchSummary,
+  currentStage,
+  DAY_MS,
+};

--- a/views/lotJourney.ejs
+++ b/views/lotJourney.ejs
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Lot Journey</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+  <style>
+    body { background:#f6f7fb; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }
+    .page-head { background:linear-gradient(135deg,#0f172a,#1e293b); color:#fff; padding:22px 24px; margin-bottom:18px; border-radius:0 0 14px 14px; }
+    .page-head h1 { font-size:1.35rem; font-weight:600; margin:0; }
+    .page-head .sub { color:#94a3b8; font-size:.9rem; margin-top:4px; }
+    .search-box { display:flex; gap:10px; margin-top:14px; max-width:520px; }
+    .search-box input { flex:1; border:0; padding:9px 12px; border-radius:8px; font-size:.95rem; }
+    .lot-head { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:16px 18px; margin-bottom:16px; }
+    .lot-head .lot-no { font-size:1.3rem; font-weight:700; color:#0f172a; }
+    .lot-head .meta { color:#64748b; font-size:.85rem; margin-top:4px; }
+    .badge-flow { text-transform:uppercase; font-size:.7rem; letter-spacing:.4px; }
+    .stage { display:flex; gap:14px; }
+    .stage .rail { display:flex; flex-direction:column; align-items:center; }
+    .stage .dot { width:18px; height:18px; border-radius:50%; border:3px solid #cbd5e1; background:#fff; margin-top:4px; }
+    .stage .dot.done { border-color:#16a34a; background:#16a34a; }
+    .stage .dot.in_progress { border-color:#f59e0b; background:#fde68a; }
+    .stage .dot.not_started { border-color:#cbd5e1; background:#fff; }
+    .stage .line { flex:1; width:3px; background:#e5e7eb; margin:4px 0; min-height:18px; }
+    .stage .body { flex:1; background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:12px 16px; margin-bottom:12px; }
+    .stage .body.overdue { border-color:#fca5a5; box-shadow:0 0 0 1px #fca5a5; }
+    .stage .body .title { font-weight:600; color:#0f172a; display:flex; align-items:center; gap:8px; justify-content:space-between; }
+    .stage .body .sub { color:#64748b; font-size:.82rem; margin-top:3px; }
+    .pieces { display:flex; gap:14px; flex-wrap:wrap; margin-top:8px; font-size:.82rem; }
+    .pieces .p strong { font-size:1.05rem; color:#0f172a; }
+    .pieces .p span { color:#64748b; display:block; font-size:.7rem; text-transform:uppercase; letter-spacing:.3px; }
+    .st-pill { font-size:.7rem; padding:2px 9px; border-radius:999px; font-weight:600; }
+    .st-pill.done { background:#dcfce7; color:#166534; }
+    .st-pill.in_progress { background:#fef3c7; color:#92400e; }
+    .st-pill.not_started { background:#f1f5f9; color:#64748b; }
+    .dispatch-card { background:#0f172a; color:#fff; border-radius:12px; padding:16px 18px; margin-top:6px; }
+    .dispatch-card h5 { margin:0 0 10px; font-size:1rem; }
+    .dispatch-card .num { font-size:1.5rem; font-weight:700; }
+    .dispatch-card .lbl { font-size:.72rem; color:#94a3b8; text-transform:uppercase; }
+    .size-table td, .size-table th { padding:4px 10px; font-size:.82rem; }
+    .muted { color:#94a3b8; }
+  </style>
+</head>
+<body>
+  <div class="page-head">
+    <h1><i class="bi bi-signpost-split"></i> Lot Journey</h1>
+    <div class="sub">Track one lot through every stage — cutting to finishing dispatch.</div>
+    <div class="search-box">
+      <input id="q" type="text" placeholder="Lot no, manual lot no, or SKU…" autofocus>
+      <button class="btn btn-light" onclick="go()"><i class="bi bi-search"></i> Track</button>
+    </div>
+  </div>
+
+  <div class="container-fluid" style="max-width:820px;">
+    <div id="status" class="muted mb-3" style="display:none;"></div>
+    <div id="picker" class="mb-3"></div>
+    <div id="out"></div>
+  </div>
+
+<script>
+const fmtDate = d => d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short',year:'numeric',timeZone:'Asia/Kolkata'}) : '—';
+const esc = s => String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+
+async function go(){
+  const q = document.getElementById('q').value.trim();
+  const status = document.getElementById('status');
+  const out = document.getElementById('out');
+  const picker = document.getElementById('picker');
+  out.innerHTML=''; picker.innerHTML='';
+  if(!q){ return; }
+  status.style.display='block'; status.textContent='Searching…';
+  try{
+    const r = await fetch('/operator/lot-journey/data?q='+encodeURIComponent(q));
+    const data = await r.json();
+    if(!data.ok){ status.textContent='Error: '+(data.error||'failed'); return; }
+    if(!data.journey){ status.textContent='No lot found for "'+q+'".'; return; }
+    status.style.display='none';
+    if(data.matches.length>1){
+      picker.innerHTML = '<div class="muted small mb-1">'+data.matches.length+' lots matched — showing the first. Pick another:</div>'+
+        data.matches.map(m=>'<button class="btn btn-sm btn-outline-secondary me-1 mb-1" onclick="pick(\''+esc(m.lot_no)+'\')">'+
+          esc(m.lot_no)+(m.manual_lot_number?(' / '+esc(m.manual_lot_number)):'')+' · '+esc(m.sku)+'</button>').join('');
+    }
+    out.innerHTML = render(data.journey);
+  }catch(e){ status.textContent='Error: '+e.message; }
+}
+function pick(lotNo){ document.getElementById('q').value=lotNo; go(); }
+
+function render(j){
+  const L=j.lot;
+  let h = '<div class="lot-head"><div class="d-flex justify-content-between align-items-start">'+
+    '<div><div class="lot-no">'+esc(L.lot_no)+(L.manual_lot_number?(' <span class="text-muted fs-6">/ '+esc(L.manual_lot_number)+'</span>'):'')+'</div>'+
+    '<div class="meta">'+esc(L.sku)+' · '+L.total_pieces+' pcs · cut '+fmtDate(L.created_at)+' by '+esc(L.cutter||'—')+(L.remark?(' · '+esc(L.remark)):'')+'</div></div>'+
+    '<div class="text-end"><span class="badge bg-secondary badge-flow">'+esc(L.flow_type)+'</span>'+
+    '<div class="mt-2"><span class="muted small">Now at</span><br><strong>'+esc(j.current_stage)+'</strong></div></div>'+
+    '</div></div>';
+
+  h += j.timeline.map((t,i)=>{
+    const last = i===j.timeline.length-1;
+    const p=t.pieces||{};
+    return '<div class="stage"><div class="rail"><div class="dot '+t.status+'"></div>'+(last?'':'<div class="line"></div>')+'</div>'+
+      '<div class="body '+(t.overdue?'overdue':'')+'">'+
+      '<div class="title"><span>'+esc(t.label)+'</span><span class="st-pill '+t.status+'">'+t.status.replace('_',' ')+'</span></div>'+
+      '<div class="sub">'+(t.master?('by '+esc(t.master)+' · '):'')+
+        (t.entered?('entered '+fmtDate(t.entered)):'not started')+
+        (t.days!=null?(' · '+t.days+'d'+(t.overdue?(' (TAT '+t.tat+'d ⚠)'):'')):'')+'</div>'+
+      ((p.approved||p.completed||p.rejected)?
+        '<div class="pieces">'+
+          '<div class="p"><strong>'+(p.approved||0)+'</strong><span>approved</span></div>'+
+          '<div class="p"><strong>'+(p.completed||0)+'</strong><span>completed</span></div>'+
+          ((p.inline)?'<div class="p"><strong>'+p.inline+'</strong><span>in hand</span></div>':'')+
+          ((p.rejected)?'<div class="p"><strong>'+p.rejected+'</strong><span>rejected</span></div>':'')+
+        '</div>':'')+
+      '</div></div>';
+  }).join('');
+
+  const d=j.dispatch;
+  h += '<div class="dispatch-card"><h5><i class="bi bi-truck"></i> Finishing Dispatch</h5>'+
+    '<div class="d-flex gap-4 mb-2">'+
+      '<div><div class="num">'+d.totalFinished+'</div><div class="lbl">finished</div></div>'+
+      '<div><div class="num">'+d.totalDispatched+'</div><div class="lbl">dispatched</div></div>'+
+      '<div><div class="num">'+d.remaining+'</div><div class="lbl">in stock</div></div>'+
+      '<div><div class="num">'+(d.complete?'<i class="bi bi-check-circle"></i>':'<i class="bi bi-hourglass-split"></i>')+'</div><div class="lbl">'+(d.complete?'all sent':'pending')+'</div></div>'+
+    '</div>'+
+    (d.destinations&&d.destinations.length?('<div class="small muted mb-2">To: '+d.destinations.map(esc).join(', ')+'</div>'):'')+
+    (Object.keys(d.bySize||{}).length?
+      '<table class="table table-dark table-sm size-table mb-0"><thead><tr><th>Size</th><th>Finished</th><th>Dispatched</th><th>In stock</th></tr></thead><tbody>'+
+      Object.entries(d.bySize).map(([s,v])=>'<tr><td>'+esc(s)+'</td><td>'+v.finished+'</td><td>'+v.dispatched+'</td><td>'+v.remaining+'</td></tr>').join('')+
+      '</tbody></table>':'<div class="muted small">No finishing/dispatch records yet.</div>')+
+    '</div>';
+  return h;
+}
+
+document.getElementById('q').addEventListener('keydown',e=>{ if(e.key==='Enter') go(); });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

A new **`/operator/lot-journey`** screen tracks **one lot's full status through every production stage on a single screen** — not just cutting and dispatch. Search by **lot no / manual lot no / SKU** and see the lot move:

`Cutting → Stitching → (Jeans Assembly → Washing → Washing-In for denim) → Finishing → Finishing Dispatch`

For each stage it shows: **status** (not started / in progress / done), **pieces** (approved / completed / in-hand / rejected), the **accountable master**, **days vs TAT** (overdue flagged), and a final **dispatch card** with per-size **finished / dispatched / in-stock**.

## How

- **`utils/lotJourney.js`** (pure, TDD, 9 tests): `orderedStages` (denim vs hosiery chain), `deriveStageStatus` (status + elapsed days), `dispatchSummary` (finished vs dispatched per size), `currentStage`.
- **`routes/lotJourneyRoutes.js`**: resolves the best-matching lot, assembles the timeline from the `*_events` truth source via `stageEvents.getStageAggregates` + a per-stage timing/master scan, and the dispatch step from `finishing_dispatches`. Reuses the proven `operatorLotTat` timing pattern; no new tables.
- **`views/lotJourney.ejs`**: a vertical timeline (status dots, piece tallies, masters, TAT) ending in a dispatch summary card.
- Mounted at `/operator/lot-journey` (auth: operator), next to `/operator/lot-tat`.

## Validation (real prod lots, read-only)

- **ak5164** — cutting → stitching (20d) → finishing → **Dispatched** (1,176 finished = 1,176 dispatched, 0 in stock ✓)
- **sw488** (`KTTWOMENSPANT261`) — cutting done, stitching in progress, finishing not started → "now at: stitching"
- Full test suite: **70 passing**.

## Notes

- Legacy lots with no `flow_type` fall back to the short (hosiery) chain — same behaviour as the existing lot-TAT screen.
- Read-only and additive; no schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)