### PR TITLE
feat(pm): PM approve-and-assign a cut to a specific cutting master

### DIFF
--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -753,4 +753,44 @@ router.post('/api/sku-categories', isAuthenticated, isCuttingManager, async (req
   }
 });
 
+// GET /cutting-manager/assigned-cuts — cuts the PM has approved and assigned to THIS master.
+// Shows what to cut (per size) + suggested lots + fabric; links to the lot once cut.
+router.get('/assigned-cuts', isAuthenticated, isCuttingManager, async (req, res) => {
+  try {
+    const masterId = req.session.user.id;
+    let assignments = [];
+    try {
+      const [rows] = await pool.query(
+        `SELECT a.id, a.style, a.fabric_type, a.total_pieces, a.lot_count, a.total_fabric_meters,
+                a.fabric_complete, a.status, a.cutting_lot_id, a.note, a.created_at,
+                cl.lot_no
+           FROM pm_cut_assignment a
+      LEFT JOIN cutting_lots cl ON cl.id = a.cutting_lot_id
+          WHERE a.assigned_master_id = ? AND a.status <> 'cancelled'
+       ORDER BY (a.status = 'assigned') DESC, a.created_at DESC
+          LIMIT 100`,
+        [masterId]
+      );
+      assignments = rows;
+      if (assignments.length) {
+        const ids = assignments.map((a) => a.id);
+        const [sizeRows] = await pool.query(
+          `SELECT assignment_id, size_label, qty FROM pm_cut_assignment_sizes
+            WHERE assignment_id IN (?) ORDER BY qty DESC`,
+          [ids]
+        );
+        const byId = {};
+        for (const s of sizeRows) (byId[s.assignment_id] = byId[s.assignment_id] || []).push(s);
+        assignments.forEach((a) => { a.sizes = byId[a.id] || []; });
+      }
+    } catch (e) {
+      if (e.code !== 'ER_NO_SUCH_TABLE') throw e; // table not migrated yet -> empty list
+    }
+    res.render('assignedCuts', { user: req.session.user, assignments });
+  } catch (err) {
+    console.error('GET /cutting-manager/assigned-cuts error:', err);
+    res.status(500).send('Failed to load assigned cuts');
+  }
+});
+
 module.exports = router;

--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -15,6 +15,7 @@ const skuResolver = require('../utils/skuResolver');
 const { aggregateStyleConsumption } = require('../utils/styleConsumption');
 const { parseConsumptionSheet } = require('../utils/cadConsumption');
 const { planCut } = require('../utils/cutPlanner');
+const { buildAssignmentPayload } = require('../utils/cutAssignment');
 let pullWorker = null;
 try { pullWorker = require('../utils/easyecomPullWorker'); } catch (_) { pullWorker = null; }
 
@@ -139,6 +140,11 @@ router.get('/style/:style', async (req, res) => {
     userRole: req.session.user.roleName,
     style: req.params.style,
   });
+});
+
+// PM approve-and-assign screen: review a style's suggested cut, pick a cutting master, assign.
+router.get('/cut-planning', (req, res) => {
+  res.render('cutPlanning', { user: req.session.user, prefillStyle: String(req.query.style || '').trim() });
 });
 
 // ─── Cutting recommendations ─────────────────────────────────────────
@@ -282,43 +288,117 @@ router.post('/consumption/upload', upload.single('file'), async (req, res) => {
   }
 });
 
+// A style's suggested cut -> capped lots + fabric to issue from CAD. Shared by the
+// cut-plan view and the approve-and-assign action.
+async function computeStyleCutPlan(style) {
+  const recs = await safeCall('getCuttingRecommendations', pool, { periodKey: '30d' });
+  const demand = {};
+  for (const r of (recs || [])) {
+    if (r.style !== style) continue;
+    const qty = Number(r.suggested_cut_qty) || 0;
+    if (qty > 0 && r.size) demand[r.size] = (demand[r.size] || 0) + qty;
+  }
+  const [consRows] = await pool.query(
+    'SELECT size_label, consumption_per_piece, consumption_unit, fabric_type FROM pm_style_consumption WHERE style = ?',
+    [style]
+  );
+  const consumptionBySize = {};
+  let fabricType = null;
+  let unit = 'METER';
+  for (const c of consRows) {
+    consumptionBySize[c.size_label] = Number(c.consumption_per_piece);
+    fabricType = fabricType || c.fabric_type;
+    unit = c.consumption_unit || unit;
+  }
+  const plan = planCut(demand, { consumptionBySize });
+  return { demand, plan, fabricType, unit, hasCad: consRows.length > 0 };
+}
+
 // GET /pm/api/cut-plan?style=... — turn a style's suggested cut into capped lots with the
 // fabric to issue per lot from CAD consumption. CAD makes the marker; we plan quantities+lots.
 router.get('/api/cut-plan', async (req, res) => {
   try {
     const style = String(req.query.style || '').trim();
     if (!style) return res.status(400).json({ ok: false, error: 'style is required' });
-
-    const recs = await safeCall('getCuttingRecommendations', pool, { periodKey: '30d' });
-    const demand = {};
-    for (const r of (recs || [])) {
-      if (r.style !== style) continue;
-      const qty = Number(r.suggested_cut_qty) || 0;
-      if (qty > 0 && r.size) demand[r.size] = (demand[r.size] || 0) + qty;
-    }
-
-    const [consRows] = await pool.query(
-      'SELECT size_label, consumption_per_piece, consumption_unit, fabric_type FROM pm_style_consumption WHERE style = ?',
-      [style]
-    );
-    const consumptionBySize = {};
-    let fabricType = null;
-    let unit = 'METER';
-    for (const c of consRows) {
-      consumptionBySize[c.size_label] = Number(c.consumption_per_piece);
-      fabricType = fabricType || c.fabric_type;
-      unit = c.consumption_unit || unit;
-    }
-
-    const plan = planCut(demand, { consumptionBySize });
-    res.json({
-      ok: true, style, fabric_type: fabricType, fabric_unit: unit,
-      demand, has_cad: consRows.length > 0, ...plan,
-    });
+    const { demand, plan, fabricType, unit, hasCad } = await computeStyleCutPlan(style);
+    res.json({ ok: true, style, fabric_type: fabricType, fabric_unit: unit, demand, has_cad: hasCad, ...plan });
   } catch (err) {
     if (err.code === 'ANALYTICS_MISSING' || err.code === 'ER_NO_SUCH_TABLE') {
       return res.json({ ok: false, warning: err.message });
     }
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// GET /pm/api/cut-masters — the cutting masters a cut can be assigned to.
+router.get('/api/cut-masters', async (req, res) => {
+  try {
+    const [rows] = await pool.query(
+      `SELECT u.id, u.username FROM users u JOIN roles r ON u.role_id = r.id
+        WHERE r.name = 'cutting_manager' AND u.is_active = TRUE ORDER BY u.username`
+    );
+    res.json({ ok: true, masters: rows });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// POST /pm/api/cut-plan/assign { style, master_id } — PM approves a style's suggested cut
+// and assigns it to a specific cutting master. Persists a pm_cut_assignment + size lines.
+router.post('/api/cut-plan/assign', async (req, res) => {
+  try {
+    const style = String(req.body.style || '').trim();
+    const masterId = parseInt(req.body.master_id, 10);
+    if (!style) return res.status(400).json({ ok: false, error: 'style is required' });
+    if (!masterId) return res.status(400).json({ ok: false, error: 'master_id is required' });
+
+    const [[master]] = await pool.query(
+      `SELECT u.id, u.username FROM users u JOIN roles r ON u.role_id = r.id
+        WHERE u.id = ? AND r.name = 'cutting_manager' AND u.is_active = TRUE`,
+      [masterId]
+    );
+    if (!master) return res.status(400).json({ ok: false, error: 'Not a valid cutting master.' });
+
+    const { demand, plan, fabricType } = await computeStyleCutPlan(style);
+    const { header, sizes } = buildAssignmentPayload({
+      style, fabricType, masterId: master.id, masterName: master.username,
+      demand, plan, createdBy: req.session?.user?.id || null,
+    });
+
+    const [result] = await pool.query(
+      `INSERT INTO pm_cut_assignment
+         (style, fabric_type, total_pieces, lot_count, total_fabric_meters, fabric_complete,
+          assigned_master_id, assigned_master_name, status, created_by)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'assigned', ?)`,
+      [header.style, header.fabric_type, header.total_pieces, header.lot_count,
+       header.total_fabric_meters, header.fabric_complete ? 1 : 0,
+       header.assigned_master_id, header.assigned_master_name, header.created_by]
+    );
+    const assignmentId = result.insertId;
+    if (sizes.length) {
+      await pool.query(
+        `INSERT INTO pm_cut_assignment_sizes (assignment_id, size_label, qty) VALUES ?`,
+        [sizes.map((s) => [assignmentId, s.size_label, s.qty])]
+      );
+    }
+    res.json({ ok: true, assignment_id: assignmentId, assigned_to: master.username, ...header });
+  } catch (err) {
+    if (err.code === 'ER_NO_SUCH_TABLE') return res.status(400).json({ ok: false, error: 'Run the cut-assignment migration first.' });
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// GET /pm/api/cut-assignments — recent assignments (PM visibility into what's been routed).
+router.get('/api/cut-assignments', async (req, res) => {
+  try {
+    const [rows] = await pool.query(
+      `SELECT id, style, fabric_type, total_pieces, lot_count, total_fabric_meters,
+              assigned_master_name, status, cutting_lot_id, created_at
+         FROM pm_cut_assignment ORDER BY created_at DESC LIMIT 100`
+    );
+    res.json({ ok: true, items: rows });
+  } catch (err) {
+    if (err.code === 'ER_NO_SUCH_TABLE') return res.json({ ok: true, items: [] });
     res.status(500).json({ ok: false, error: err.message });
   }
 });

--- a/sql/2026_06_pm_cut_assignment.sql
+++ b/sql/2026_06_pm_cut_assignment.sql
@@ -1,0 +1,38 @@
+-- PM-approved cut assignments routed to a specific cutting master.
+--
+-- Flow: the PM views a style's suggested cut (utils/cutPlanner.planCut), picks a cutting
+-- master, and approves. That creates one pm_cut_assignment (header) + pm_cut_assignment_sizes
+-- (what to cut, per size). The chosen master sees it in their "Assigned Cuts" list and cuts
+-- to those quantities (CAD makes the marker). When the master creates the cutting lot from
+-- it, cutting_lot_id links back and status moves to 'cut'.
+--
+-- Idempotent: safe to re-run.
+
+CREATE TABLE IF NOT EXISTS pm_cut_assignment (
+  id                   INT AUTO_INCREMENT PRIMARY KEY,
+  style                VARCHAR(100) NOT NULL,
+  fabric_type          VARCHAR(100) NULL,
+  total_pieces         INT NOT NULL,
+  lot_count            INT NOT NULL DEFAULT 0,        -- suggested number of lots (<=1500 each)
+  total_fabric_meters  DECIMAL(12,2) NULL,            -- from CAD; NULL if CAD data incomplete
+  fabric_complete      TINYINT(1) NOT NULL DEFAULT 0,
+  assigned_master_id   INT NOT NULL,                  -- users.id of the cutting master
+  assigned_master_name VARCHAR(100) NULL,
+  status               ENUM('assigned','cut','cancelled') NOT NULL DEFAULT 'assigned',
+  created_by           INT NULL,                      -- users.id of the PM who approved
+  cutting_lot_id       INT NULL,                      -- set when the master cuts it
+  note                 VARCHAR(255) NULL,
+  created_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at           TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  INDEX idx_master_status (assigned_master_id, status),
+  INDEX idx_style (style),
+  INDEX idx_status (status)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS pm_cut_assignment_sizes (
+  id            INT AUTO_INCREMENT PRIMARY KEY,
+  assignment_id INT NOT NULL,
+  size_label    VARCHAR(20) NOT NULL,
+  qty           INT NOT NULL,
+  INDEX idx_assignment (assignment_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/test/cutAssignment.test.js
+++ b/test/cutAssignment.test.js
@@ -1,0 +1,55 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { buildAssignmentPayload } = require('../utils/cutAssignment.js');
+
+const plan = {
+  lotCount: 2,
+  totalPieces: 1920,
+  totalFabricMeters: 1691.28,
+  fabricComplete: false,
+  missingSizes: ['XS'],
+};
+
+test('buildAssignmentPayload assembles header + size lines from demand and plan', () => {
+  const out = buildAssignmentPayload({
+    style: 'KTTWOMENSPANT261', fabricType: 'Valentino',
+    masterId: 42, masterName: 'Ramesh',
+    demand: { M: 1304, L: 344, XS: 272 }, plan, createdBy: 7,
+  });
+  assert.strictEqual(out.header.style, 'KTTWOMENSPANT261');
+  assert.strictEqual(out.header.assigned_master_id, 42);
+  assert.strictEqual(out.header.assigned_master_name, 'Ramesh');
+  assert.strictEqual(out.header.total_pieces, 1920);
+  assert.strictEqual(out.header.lot_count, 2);
+  assert.ok(Math.abs(out.header.total_fabric_meters - 1691.28) < 1e-6);
+  assert.strictEqual(out.header.fabric_complete, false);
+  assert.strictEqual(out.header.status, 'assigned');
+  assert.strictEqual(out.header.created_by, 7);
+  // size lines, largest first, summing to total_pieces
+  assert.deepStrictEqual(out.sizes, [
+    { size_label: 'M', qty: 1304 },
+    { size_label: 'L', qty: 344 },
+    { size_label: 'XS', qty: 272 },
+  ]);
+  assert.strictEqual(out.sizes.reduce((s, x) => s + x.qty, 0), out.header.total_pieces);
+});
+
+test('buildAssignmentPayload keeps fabric null when the plan could not price it', () => {
+  const out = buildAssignmentPayload({
+    style: 'X', fabricType: null, masterId: 1, masterName: 'A',
+    demand: { M: 100 }, plan: { lotCount: 1, totalPieces: 100, totalFabricMeters: null }, createdBy: 1,
+  });
+  assert.strictEqual(out.header.total_fabric_meters, null);
+});
+
+test('buildAssignmentPayload rejects a missing master', () => {
+  assert.throws(() => buildAssignmentPayload({
+    style: 'X', demand: { M: 10 }, plan, createdBy: 1,
+  }), /master/i);
+});
+
+test('buildAssignmentPayload rejects empty demand', () => {
+  assert.throws(() => buildAssignmentPayload({
+    style: 'X', masterId: 1, masterName: 'A', demand: {}, plan, createdBy: 1,
+  }), /demand|nothing/i);
+});

--- a/utils/cutAssignment.js
+++ b/utils/cutAssignment.js
@@ -1,0 +1,35 @@
+// Build the record for a PM-approved cut assigned to a specific cutting master.
+//
+// Flow: PM views a style's suggested cut (utils/cutPlanner.planCut) -> picks a cutting
+// master -> approves. This turns the demand + plan into a pm_cut_assignment header plus
+// per-size lines the master will cut. CAD owns the marker; the master just cuts to these
+// quantities. Pure (no DB) so the assembly/validation is unit-tested.
+
+function buildAssignmentPayload({ style, fabricType, masterId, masterName, demand, plan, createdBy }) {
+  if (!masterId) throw new Error('A cutting master must be selected (master required).');
+  const sizes = Object.entries(demand || {})
+    .map(([size_label, qty]) => ({ size_label, qty: Number(qty) || 0 }))
+    .filter((s) => s.qty > 0)
+    .sort((a, b) => b.qty - a.qty);
+  if (!sizes.length) throw new Error('Nothing to cut — demand is empty.');
+
+  const totalPieces = sizes.reduce((s, x) => s + x.qty, 0);
+  const p = plan || {};
+  return {
+    header: {
+      style: String(style || '').trim(),
+      fabric_type: fabricType || null,
+      assigned_master_id: masterId,
+      assigned_master_name: masterName || null,
+      total_pieces: totalPieces,
+      lot_count: Number(p.lotCount) || 0,
+      total_fabric_meters: p.totalFabricMeters == null ? null : Number(p.totalFabricMeters),
+      fabric_complete: !!p.fabricComplete,
+      created_by: createdBy || null,
+      status: 'assigned',
+    },
+    sizes,
+  };
+}
+
+module.exports = { buildAssignmentPayload };

--- a/views/assignedCuts.ejs
+++ b/views/assignedCuts.ejs
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Assigned Cuts</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+  <style>
+    body { background:#f6f7fb; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }
+    .page-head { background:linear-gradient(135deg,#0f172a,#1e293b); color:#fff; padding:22px 24px; margin-bottom:18px; border-radius:0 0 14px 14px; }
+    .page-head h1 { font-size:1.35rem; font-weight:600; margin:0; }
+    .page-head .sub { color:#94a3b8; font-size:.9rem; margin-top:4px; }
+    .cut-card { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:16px 18px; margin-bottom:14px; }
+    .cut-card.assigned { border-left:4px solid #f59e0b; }
+    .cut-card.cut { border-left:4px solid #16a34a; }
+    .cut-card .style { font-size:1.15rem; font-weight:700; color:#0f172a; }
+    .cut-card .meta { color:#64748b; font-size:.84rem; margin-top:2px; }
+    .sizes { display:flex; gap:10px; flex-wrap:wrap; margin-top:10px; }
+    .sizes .s { background:#f1f5f9; border-radius:8px; padding:6px 12px; text-align:center; min-width:64px; }
+    .sizes .s strong { display:block; font-size:1.1rem; color:#0f172a; }
+    .sizes .s span { font-size:.7rem; color:#64748b; text-transform:uppercase; letter-spacing:.3px; }
+    .st-pill { font-size:.72rem; padding:3px 10px; border-radius:999px; font-weight:600; }
+    .st-pill.assigned { background:#fef3c7; color:#92400e; }
+    .st-pill.cut { background:#dcfce7; color:#166534; }
+    .fabric { font-size:.85rem; color:#0f172a; margin-top:10px; }
+    .empty { background:#fff; border:1px dashed #cbd5e1; border-radius:12px; padding:40px; text-align:center; color:#94a3b8; }
+  </style>
+</head>
+<body>
+  <div class="page-head">
+    <h1><i class="bi bi-scissors"></i> Assigned Cuts</h1>
+    <div class="sub">Cuts the production manager has approved and assigned to you. Cut to these quantities — CAD makes the marker.</div>
+  </div>
+
+  <div class="container-fluid" style="max-width:820px;">
+    <% if (!assignments || assignments.length === 0) { %>
+      <div class="empty"><i class="bi bi-inbox" style="font-size:2rem;"></i><div class="mt-2">No cuts assigned to you yet.</div></div>
+    <% } else { %>
+      <% assignments.forEach(function(a){ %>
+        <div class="cut-card <%= a.status %>">
+          <div class="d-flex justify-content-between align-items-start">
+            <div>
+              <div class="style"><%= a.style %></div>
+              <div class="meta">
+                <%= a.fabric_type || 'fabric n/a' %> ·
+                <%= a.total_pieces %> pcs ·
+                <%= a.lot_count %> lot<%= a.lot_count === 1 ? '' : 's' %> (≤1500 each) ·
+                assigned <%= new Date(a.created_at).toLocaleDateString('en-IN',{day:'2-digit',month:'short',year:'numeric'}) %>
+              </div>
+            </div>
+            <span class="st-pill <%= a.status %>"><%= a.status === 'cut' ? 'CUT' : 'TO CUT' %></span>
+          </div>
+
+          <div class="sizes">
+            <% (a.sizes || []).forEach(function(s){ %>
+              <div class="s"><strong><%= s.qty %></strong><span><%= s.size_label %></span></div>
+            <% }) %>
+          </div>
+
+          <div class="fabric">
+            <i class="bi bi-rulers"></i>
+            <% if (a.total_fabric_meters != null) { %>
+              Issue ~<strong><%= Number(a.total_fabric_meters).toFixed(1) %> m</strong> of <%= a.fabric_type || 'fabric' %>
+              <% if (!a.fabric_complete) { %><span class="text-warning">(some sizes have no CAD figure yet)</span><% } %>
+            <% } else { %>
+              <span class="text-muted">Fabric: no CAD consumption for this style yet.</span>
+            <% } %>
+          </div>
+
+          <% if (a.cutting_lot_id && a.lot_no) { %>
+            <div class="mt-2"><i class="bi bi-check2-circle text-success"></i> Cut as lot <strong><%= a.lot_no %></strong>
+              — <a href="/cutting-manager/lot-details/<%= a.cutting_lot_id %>">view lot</a></div>
+          <% } %>
+        </div>
+      <% }) %>
+    <% } %>
+  </div>
+</body>
+</html>

--- a/views/cutPlanning.ejs
+++ b/views/cutPlanning.ejs
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cut Planning — Approve &amp; Assign</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
+  <style>
+    body { background:#f6f7fb; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }
+    .page-head { background:linear-gradient(135deg,#0f172a,#1e293b); color:#fff; padding:22px 24px; margin-bottom:18px; border-radius:0 0 14px 14px; }
+    .page-head h1 { font-size:1.35rem; font-weight:600; margin:0; }
+    .page-head .sub { color:#94a3b8; font-size:.9rem; margin-top:4px; }
+    .search-box { display:flex; gap:10px; margin-top:14px; max-width:560px; }
+    .search-box input { flex:1; border:0; padding:9px 12px; border-radius:8px; font-size:.95rem; }
+    .card-box { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:16px 18px; margin-bottom:14px; }
+    .sizes { display:flex; gap:10px; flex-wrap:wrap; margin-top:8px; }
+    .sizes .s { background:#f1f5f9; border-radius:8px; padding:6px 12px; text-align:center; min-width:62px; }
+    .sizes .s strong { display:block; font-size:1.05rem; color:#0f172a; }
+    .sizes .s span { font-size:.7rem; color:#64748b; text-transform:uppercase; }
+    .lot-row { display:flex; gap:8px; flex-wrap:wrap; font-size:.82rem; color:#334155; margin-top:6px; }
+    .lot-chip { background:#eef2ff; border-radius:8px; padding:4px 10px; }
+    .assign-bar { display:flex; gap:10px; align-items:center; margin-top:14px; flex-wrap:wrap; }
+    .muted { color:#94a3b8; }
+    table.asg td, table.asg th { font-size:.84rem; padding:6px 10px; }
+  </style>
+</head>
+<body>
+  <div class="page-head">
+    <h1><i class="bi bi-clipboard2-check"></i> Cut Planning — Approve &amp; Assign</h1>
+    <div class="sub">Review a style's suggested cut, then assign it to a cutting master. CAD makes the marker; the master cuts to these quantities.</div>
+    <div class="search-box">
+      <input id="style" type="text" placeholder="Style code, e.g. KTTWOMENSPANT261" value="<%= prefillStyle %>">
+      <button class="btn btn-light" onclick="loadPlan()"><i class="bi bi-search"></i> Load plan</button>
+    </div>
+  </div>
+
+  <div class="container-fluid" style="max-width:820px;">
+    <div id="status" class="muted mb-2" style="display:none;"></div>
+    <div id="plan"></div>
+    <h6 class="mt-4 mb-2 text-muted">Recently assigned</h6>
+    <div id="assignments" class="card-box"><div class="muted">Loading…</div></div>
+  </div>
+
+<script>
+let MASTERS = [];
+const esc = s => String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const fmtDate = d => d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short'}) : '';
+
+async function loadMasters(){
+  const r = await fetch('/pm/api/cut-masters'); const d = await r.json();
+  MASTERS = (d.ok && d.masters) ? d.masters : [];
+}
+async function loadAssignments(){
+  const r = await fetch('/pm/api/cut-assignments'); const d = await r.json();
+  const box = document.getElementById('assignments');
+  if(!d.ok || !d.items.length){ box.innerHTML = '<div class="muted">No assignments yet.</div>'; return; }
+  box.innerHTML = '<table class="table asg table-sm mb-0"><thead><tr><th>Style</th><th>Pcs</th><th>Master</th><th>Status</th><th>When</th></tr></thead><tbody>'+
+    d.items.map(a=>'<tr><td>'+esc(a.style)+'</td><td>'+a.total_pieces+'</td><td>'+esc(a.assigned_master_name||'')+'</td><td>'+
+      (a.status==='cut'?'<span class="text-success">cut</span>':'assigned')+'</td><td>'+fmtDate(a.created_at)+'</td></tr>').join('')+
+    '</tbody></table>';
+}
+
+async function loadPlan(){
+  const style = document.getElementById('style').value.trim();
+  const status = document.getElementById('status'); const out = document.getElementById('plan');
+  out.innerHTML=''; if(!style) return;
+  status.style.display='block'; status.textContent='Loading…';
+  const r = await fetch('/pm/api/cut-plan?style='+encodeURIComponent(style));
+  const j = await r.json();
+  if(!j.ok){ status.textContent = j.warning || j.error || 'failed'; return; }
+  if(!j.totalPieces){ status.textContent = 'No suggested cut for "'+style+'" right now (stock is covered).'; return; }
+  status.style.display='none';
+  const sizes = Object.entries(j.demand).sort((a,b)=>b[1]-a[1]);
+  const opts = MASTERS.map(m=>'<option value="'+m.id+'">'+esc(m.username)+'</option>').join('');
+  out.innerHTML = '<div class="card-box">'+
+    '<div class="d-flex justify-content-between"><div><div style="font-size:1.15rem;font-weight:700">'+esc(j.style)+'</div>'+
+      '<div class="muted small">'+esc(j.fabric_type||'fabric n/a')+' · '+j.totalPieces+' pcs · '+j.lotCount+' lot(s)</div></div>'+
+      '<div class="text-end">'+(j.totalFabricMeters!=null?('<div style="font-size:1.2rem;font-weight:700">'+Number(j.totalFabricMeters).toFixed(1)+' m</div><div class="muted small">fabric to issue</div>'):'<div class="muted small">no CAD fabric</div>')+'</div></div>'+
+    '<div class="sizes">'+sizes.map(([s,q])=>'<div class="s"><strong>'+q+'</strong><span>'+esc(s)+'</span></div>').join('')+'</div>'+
+    (j.missingSizes&&j.missingSizes.length?('<div class="small text-warning mt-2">No CAD consumption yet for: '+j.missingSizes.map(esc).join(', ')+'</div>'):'')+
+    '<div class="lot-row">'+j.lots.map((l,i)=>'<span class="lot-chip">Lot '+(i+1)+': '+l.total+' pcs'+(l.fabricMeters!=null?(' · '+Number(l.fabricMeters).toFixed(0)+'m'):'')+'</span>').join('')+'</div>'+
+    '<div class="assign-bar"><label class="small text-muted">Assign to cutting master:</label>'+
+      '<select id="masterSel" class="form-select form-select-sm" style="max-width:220px">'+(opts||'<option>no masters</option>')+'</select>'+
+      '<button class="btn btn-primary btn-sm" onclick="assign(\''+esc(j.style)+'\')"><i class="bi bi-send"></i> Approve &amp; Assign</button>'+
+      '<span id="assignMsg" class="small"></span></div>'+
+    '</div>';
+}
+
+async function assign(style){
+  const masterId = document.getElementById('masterSel').value;
+  const msg = document.getElementById('assignMsg');
+  if(!masterId){ msg.textContent='pick a master'; return; }
+  msg.textContent='Assigning…';
+  const r = await fetch('/pm/api/cut-plan/assign',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({style,master_id:masterId})});
+  const d = await r.json();
+  if(d.ok){ msg.innerHTML='<span class="text-success">✓ Assigned to '+esc(d.assigned_to)+'</span>'; loadAssignments(); }
+  else { msg.innerHTML='<span class="text-danger">'+esc(d.error||'failed')+'</span>'; }
+}
+
+(async()=>{ await loadMasters(); loadAssignments(); if(document.getElementById('style').value.trim()) loadPlan(); })();
+document.getElementById('style').addEventListener('keydown',e=>{ if(e.key==='Enter') loadPlan(); });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## What

Closes the **"cutter cuts what they're told"** link. The PM reviews a style's suggested cut, **picks a specific cutting master** (prod has 11), and assigns it. That master sees it in their **Assigned Cuts** list and cuts to the quantities — **CAD makes the marker**.

> ⚠️ **Stacks on #451** (uses `cutPlanner` + `pm_style_consumption`). **Merge #451 first**, then this. Until #451 is in `main`, this PR's diff also shows #451's commits.

## Pieces

- **`sql/2026_06_pm_cut_assignment.sql`** — `pm_cut_assignment` (+ `_sizes`) with `assigned_master_id`, `status` (assigned/cut/cancelled), `cutting_lot_id` link back. Idempotent.
- **`utils/cutAssignment.js`** (TDD, 4 tests) — `buildAssignmentPayload`: demand + cut plan + chosen master → header + per-size lines.
- **PM endpoints** (`productionManagerRoutes`): `GET /api/cut-masters` (the assignable masters), `POST /api/cut-plan/assign`, `GET /api/cut-assignments`. Extracted `computeStyleCutPlan` shared with `/api/cut-plan`.
- **PM screen** `GET /pm/cut-planning` (`views/cutPlanning.ejs`) — load a style's plan, see sizes + lots + CAD fabric, pick a master, **Approve & Assign**.
- **Cutting master** `GET /cutting-manager/assigned-cuts` (`views/assignedCuts.ejs`) — the cuts assigned to the logged-in master, with per-size quantities + fabric, and a link to the lot once cut.

## Validation (prod, round-trip cleaned up)

- **11 cutting masters** detected for the assign dropdown.
- Full assign for `KTTWOMENSPANT261`: 1,920 pcs / 2 lots / 1,691 m Valentino, **XS flagged "no CAD"** — created, read back as the master's list would, then deleted (tables remain).
- Full test suite: **65 passing**.

## Notes / next

- Assignment routing is **PM → specific master** (per your call). Statuses: `assigned` → `cut` (set when the master creates the lot from it) → links `cutting_lot_id`.
- **Next step:** wire the cutting master's "create lot" to consume an assignment (pre-fill + flip status to `cut` + link), and embed the lot journey (#452) on the assigned-cut row so the PM and master track it on the same screen.
- Deploy: merge #451, then this; then apply `sql/2026_06_pm_cut_assignment.sql` (already applied to prod during validation, so it'll be a no-op).

🤖 Generated with [Claude Code](https://claude.com/claude-code)