### PR TITLE
feat(pm): summary cards + production analytics page

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -154,6 +154,93 @@ router.get('/cut-planning', (req, res) => {
 
 const WIP_STAGES = ['stitching', 'jeans_assembly', 'washing', 'washing_in', 'finishing'];
 
+router.get('/analytics', (req, res) => res.render('productionManagerAnalytics', { user: req.session.user }));
+
+// GET /pm/api/analytics — the four analytics sections. Each guarded independently.
+router.get('/api/analytics', async (req, res) => {
+  const out = {};
+
+  // 1. Demand vs supply — daily demand (DRR) vs stock + on-order, and the most under-supplied styles.
+  try {
+    const recs = await safeCall('getCuttingRecommendations', pool, { periodKey: '30d' });
+    let dailyDemand = 0; let soh = 0; let onOrder = 0; let suggested = 0;
+    for (const r of recs || []) {
+      dailyDemand += Number(r.drr) || 0; soh += Number(r.soh) || 0;
+      onOrder += Number(r.open_lot_qty) || 0; suggested += Number(r.suggested_cut_qty) || 0;
+    }
+    const top = aggregateStyles(recs)
+      .filter((s) => s.suggested_cut_qty > 0)
+      .slice(0, 15)
+      .map((s) => ({ style: s.style, suggested: s.suggested_cut_qty, soh: s.total_soh, drr: s.avg_drr, doh: s.worst_size_doh, on_order: s.open_lot_qty, trigger: s.trigger }));
+    out.demand_supply = { dailyDemand, soh, onOrder, suggested, daysCover: dailyDemand > 0 ? soh / dailyDemand : null, top };
+  } catch (_) { out.demand_supply = null; }
+
+  // 2. Throughput & TAT — lots cut/week, dispatched/week, current bottleneck stage (most WIP).
+  try {
+    const [cut] = await pool.query(
+      `SELECT YEARWEEK(created_at,3) wk, MIN(DATE(created_at)) week_start, COUNT(*) lots, COALESCE(SUM(total_pieces),0) pieces
+         FROM cutting_lots WHERE created_at >= CURDATE() - INTERVAL 84 DAY GROUP BY wk ORDER BY wk`
+    );
+    let dispatch = [];
+    try {
+      const [d] = await pool.query(
+        `SELECT YEARWEEK(created_at,3) wk, MIN(DATE(created_at)) week_start, COALESCE(SUM(quantity),0) pieces
+           FROM finishing_dispatches WHERE created_at >= CURDATE() - INTERVAL 84 DAY GROUP BY wk ORDER BY wk`
+      );
+      dispatch = d;
+    } catch (_) {}
+    let bottleneck = null;
+    try {
+      const wipRows = [];
+      for (const stage of WIP_STAGES) {
+        const [[r]] = await pool.query(
+          `SELECT COALESCE(SUM(CASE WHEN e.event_type='approve' THEN e.pieces END),0) approved,
+                  COALESCE(SUM(CASE WHEN e.event_type='complete' THEN e.pieces END),0) completed,
+                  COALESCE(SUM(CASE WHEN e.event_type='reject' AND e.parent_event_id IS NOT NULL THEN e.pieces END),0) inline_rejected
+             FROM \`${stage}_events\` e JOIN cutting_lots cl ON cl.id = e.cutting_lot_id
+            WHERE cl.created_at >= CURDATE() - INTERVAL 120 DAY`
+        );
+        wipRows.push({ stage, ...r });
+      }
+      const w = wipByStage(wipRows);
+      bottleneck = Object.entries(w.byStage).sort((a, b) => b[1] - a[1])[0] || null;
+    } catch (_) {}
+    out.throughput = {
+      cut_per_week: cut.map((r) => ({ week_start: r.week_start, lots: Number(r.lots), pieces: Number(r.pieces) })),
+      dispatch_per_week: dispatch.map((r) => ({ week_start: r.week_start, pieces: Number(r.pieces) })),
+      bottleneck: bottleneck ? { stage: bottleneck[0], wip: bottleneck[1] } : null,
+    };
+  } catch (_) { out.throughput = null; }
+
+  // 3. Fabric usage & variance — real derived consumption vs the CAD standard, per style.
+  try {
+    const derived = await loadStyleConsumption(pool, 120);
+    const [cadRows] = await pool.query('SELECT style, AVG(consumption_per_piece) standard FROM pm_style_consumption GROUP BY style');
+    out.fabric_variance = fabricVarianceRows(derived, cadRows.map((c) => ({ style: c.style, standard: Number(c.standard) }))).slice(0, 25);
+  } catch (_) { out.fabric_variance = null; }
+
+  // 4. Master / cutter output — pieces cut (30d) + assignment counts per master.
+  try {
+    const [lots] = await pool.query(
+      `SELECT cl.user_id master_id, u.username, COUNT(*) lots, COALESCE(SUM(cl.total_pieces),0) pieces
+         FROM cutting_lots cl JOIN users u ON u.id = cl.user_id
+        WHERE cl.created_at >= CURDATE() - INTERVAL 30 DAY GROUP BY cl.user_id, u.username`
+    );
+    let asg = [];
+    try {
+      const [a] = await pool.query(
+        `SELECT assigned_master_id, assigned_master_name username, COUNT(*) assigned,
+                COALESCE(SUM(status='cut'),0) cut
+           FROM pm_cut_assignment GROUP BY assigned_master_id, assigned_master_name`
+      );
+      asg = a;
+    } catch (_) {}
+    out.master_output = masterOutputSummary(lots, asg);
+  } catch (_) { out.master_output = null; }
+
+  res.json({ ok: true, ...out });
+});
+
 // GET /pm/api/summary — the numbers behind the dashboard summary cards. Each card is
 // computed independently and degrades to null on error so one missing table never blanks
 // the whole row.

--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -18,6 +18,7 @@ const { planCut } = require('../utils/cutPlanner');
 const { buildAssignmentPayload } = require('../utils/cutAssignment');
 const stageEvents = require('../utils/stageEvents');
 const { orderedStages, deriveStageStatus, dispatchSummary, currentStage } = require('../utils/lotJourney');
+const { cutPrioritySummary, fabricNeededByType, wipByStage } = require('../utils/pmAnalytics');
 let pullWorker = null;
 try { pullWorker = require('../utils/easyecomPullWorker'); } catch (_) { pullWorker = null; }
 
@@ -150,6 +151,67 @@ router.get('/cut-planning', (req, res) => {
 });
 
 // ─── Cutting recommendations ─────────────────────────────────────────
+
+const WIP_STAGES = ['stitching', 'jeans_assembly', 'washing', 'washing_in', 'finishing'];
+
+// GET /pm/api/summary — the numbers behind the dashboard summary cards. Each card is
+// computed independently and degrades to null on error so one missing table never blanks
+// the whole row.
+router.get('/api/summary', async (req, res) => {
+  const out = {};
+
+  // Cut priority + fabric needed (both off the recommendations).
+  try {
+    const recs = await safeCall('getCuttingRecommendations', pool, { periodKey: '30d' });
+    out.cut_priority = cutPrioritySummary(aggregateStyles(recs));
+    try {
+      const [cons] = await pool.query('SELECT style, size_label, consumption_per_piece, fabric_type FROM pm_style_consumption');
+      out.fabric_needed = fabricNeededByType(recs, cons);
+    } catch (_) { out.fabric_needed = null; }
+  } catch (_) { out.cut_priority = null; out.fabric_needed = null; }
+
+  // WIP currently in hand at each stage (lots from the last 120 days).
+  try {
+    const rows = [];
+    for (const stage of WIP_STAGES) {
+      const [[r]] = await pool.query(
+        `SELECT COALESCE(SUM(CASE WHEN e.event_type='approve' THEN e.pieces END),0) approved,
+                COALESCE(SUM(CASE WHEN e.event_type='complete' THEN e.pieces END),0) completed,
+                COALESCE(SUM(CASE WHEN e.event_type='reject' AND e.parent_event_id IS NOT NULL THEN e.pieces END),0) inline_rejected
+           FROM \`${stage}_events\` e JOIN cutting_lots cl ON cl.id = e.cutting_lot_id
+          WHERE cl.created_at >= CURDATE() - INTERVAL 120 DAY`
+      );
+      rows.push({ stage, ...r });
+    }
+    out.wip = wipByStage(rows);
+  } catch (_) { out.wip = null; }
+
+  // Dead stock (count + units of slow movers).
+  try {
+    const dead = await safeCall('getDeadStock', pool, { days: 45 });
+    out.dead_stock = { count: (dead || []).length, units: (dead || []).reduce((s, d) => s + (Number(d.soh) || 0), 0) };
+  } catch (_) { out.dead_stock = null; }
+
+  // Total inventory on hand (latest snapshot).
+  try {
+    const [[r]] = await pool.query(
+      `SELECT COALESCE(SUM(qty),0) units, MAX(snapshot_date) as_of FROM ee_inventory_daily_snapshot
+        WHERE snapshot_date = (SELECT MAX(snapshot_date) FROM ee_inventory_daily_snapshot)`
+    );
+    out.inventory = { units: Number(r.units) || 0, as_of: r.as_of };
+  } catch (_) { out.inventory = null; }
+
+  // Sales day by day (last 30 days).
+  try {
+    const [rows] = await pool.query(
+      `SELECT sale_date, SUM(qty) qty FROM ee_sales_daily
+        WHERE sale_date >= CURDATE() - INTERVAL 30 DAY GROUP BY sale_date ORDER BY sale_date`
+    );
+    out.sales_by_day = rows.map((r) => ({ date: r.sale_date, qty: Number(r.qty) || 0 }));
+  } catch (_) { out.sales_by_day = null; }
+
+  res.json({ ok: true, ...out });
+});
 
 router.get('/api/styles', async (req, res) => {
   try {

--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -16,6 +16,8 @@ const { aggregateStyleConsumption } = require('../utils/styleConsumption');
 const { parseConsumptionSheet } = require('../utils/cadConsumption');
 const { planCut } = require('../utils/cutPlanner');
 const { buildAssignmentPayload } = require('../utils/cutAssignment');
+const stageEvents = require('../utils/stageEvents');
+const { orderedStages, deriveStageStatus, dispatchSummary, currentStage } = require('../utils/lotJourney');
 let pullWorker = null;
 try { pullWorker = require('../utils/easyecomPullWorker'); } catch (_) { pullWorker = null; }
 
@@ -384,6 +386,88 @@ router.post('/api/cut-plan/assign', async (req, res) => {
     res.json({ ok: true, assignment_id: assignmentId, assigned_to: master.username, ...header });
   } catch (err) {
     if (err.code === 'ER_NO_SUCH_TABLE') return res.status(400).json({ ok: false, error: 'Run the cut-assignment migration first.' });
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// Compact stage journey for one cut lot, reusing the tested lotJourney helpers + stageEvents.
+const STAGE_EVENT_TABLE = {
+  stitching: 'stitching_events', jeans_assembly: 'jeans_assembly_events',
+  washing: 'washing_events', washing_in: 'washing_in_events', finishing: 'finishing_events',
+};
+const STAGE_LABEL = {
+  cutting: 'Cut', stitching: 'Stitch', jeans_assembly: 'Assembly',
+  washing: 'Wash', washing_in: 'Wash-In', finishing: 'Finish',
+};
+
+async function lotJourneyCompact(lot) {
+  const stages = orderedStages(lot.flow_type);
+  const now = Date.now();
+  const raw = {};
+  for (const stage of stages) {
+    if (stage === 'cutting') continue;
+    const [rows] = await pool.query(
+      `SELECT e.event_type, e.created_at, u.username FROM \`${STAGE_EVENT_TABLE[stage]}\` e
+         LEFT JOIN users u ON u.id = e.operator_id WHERE e.cutting_lot_id = ? ORDER BY e.created_at`,
+      [lot.id]
+    );
+    let entered = null; let completedAt = null; let master = null;
+    for (const r of rows) {
+      if (!entered) entered = r.created_at;
+      if (r.event_type === 'complete') completedAt = r.created_at;
+      if (r.event_type === 'approve' && !master) master = r.username;
+    }
+    raw[stage] = { entered, completedAt, master, agg: await stageEvents.getStageAggregates(pool, stage, lot.id) };
+  }
+  const timeline = [];
+  for (let i = 0; i < stages.length; i++) {
+    const stage = stages[i]; const next = stages[i + 1];
+    const entered = stage === 'cutting' ? lot.created_at : raw[stage].entered;
+    const exit = next ? (raw[next] && raw[next].entered) : (stage === 'cutting' ? null : raw[stage].completedAt);
+    let { status, days } = deriveStageStatus({ entered, exited: exit }, now);
+    if (stage === 'cutting') status = 'done';
+    timeline.push({
+      stage, label: STAGE_LABEL[stage] || stage, status, days,
+      completed: stage === 'cutting' ? lot.total_pieces : (raw[stage].agg.completed || 0),
+      master: stage === 'cutting' ? lot.cutter_name : (raw[stage].master || null),
+    });
+  }
+  const finished = {};
+  if (stages.includes('finishing')) {
+    const sz = await stageEvents.getStageSizeAggregates(pool, 'finishing', lot.id);
+    for (const [s, v] of Object.entries(sz)) finished[s] = v.completed || 0;
+  }
+  const [dr] = await pool.query(
+    'SELECT size_label, SUM(quantity) qty FROM finishing_dispatches WHERE lot_no = ? GROUP BY size_label', [lot.lot_no]
+  );
+  const dispatchedBySize = {};
+  for (const r of dr) dispatchedBySize[String(r.size_label || '').trim().toUpperCase()] = Number(r.qty) || 0;
+  const dispatch = dispatchSummary(finished, dispatchedBySize);
+  return {
+    lot_no: lot.lot_no, manual_lot_number: lot.manual_lot_number || '', total_pieces: lot.total_pieces,
+    created_at: lot.created_at, flow_type: lot.flow_type || 'unknown',
+    current_stage: dispatch.complete ? 'Dispatched' : currentStage(timeline),
+    timeline, dispatch: { finished: dispatch.totalFinished, dispatched: dispatch.totalDispatched, in_stock: dispatch.remaining },
+  };
+}
+
+// GET /pm/api/style-lots?style=... — the lots cut for this style and where each one is now,
+// so the PM sees the cut history on the same screen (after assign -> cut).
+router.get('/api/style-lots', async (req, res) => {
+  try {
+    const style = String(req.query.style || '').trim();
+    if (!style) return res.status(400).json({ ok: false, error: 'style is required' });
+    const [lots] = await pool.query(
+      `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.total_pieces, cl.flow_type, cl.created_at,
+              u.username AS cutter_name
+         FROM cutting_lots cl LEFT JOIN users u ON u.id = cl.user_id
+        WHERE cl.sku = ? ORDER BY cl.created_at DESC LIMIT 8`,
+      [style]
+    );
+    const journeys = [];
+    for (const lot of lots) journeys.push(await lotJourneyCompact(lot));
+    res.json({ ok: true, style, lots: journeys });
+  } catch (err) {
     res.status(500).json({ ok: false, error: err.message });
   }
 });

--- a/test/pmAnalytics.test.js
+++ b/test/pmAnalytics.test.js
@@ -1,0 +1,64 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  cutPrioritySummary, fabricNeededByType, wipByStage,
+} = require('../utils/pmAnalytics.js');
+
+test('cutPrioritySummary counts red/amber styles and totals suggested pieces', () => {
+  const aggs = [
+    { trigger: 'red', suggested_cut_qty: 1200 },
+    { trigger: 'amber', suggested_cut_qty: 300 },
+    { trigger: 'red', suggested_cut_qty: 0 },
+    { trigger: 'green', suggested_cut_qty: 0 },
+  ];
+  const s = cutPrioritySummary(aggs);
+  assert.strictEqual(s.red, 2);
+  assert.strictEqual(s.amber, 1);
+  assert.strictEqual(s.totalSuggested, 1500);
+  assert.strictEqual(s.stylesNeedingCut, 2); // only the two with suggested > 0
+});
+
+test('fabricNeededByType prices suggested cuts via CAD, grouped by fabric type', () => {
+  const recs = [
+    { style: 'A', size: 'M', suggested_cut_qty: 100 },
+    { style: 'A', size: 'L', suggested_cut_qty: 50 },
+    { style: 'B', size: 'S', suggested_cut_qty: 200 }, // no CAD -> uncovered
+  ];
+  const cons = [
+    { style: 'A', size_label: 'M', consumption_per_piece: 1.0, fabric_type: 'Denim' },
+    { style: 'A', size_label: 'L', consumption_per_piece: 1.2, fabric_type: 'Denim' },
+  ];
+  const r = fabricNeededByType(recs, cons);
+  assert.strictEqual(r.byType.length, 1);
+  assert.strictEqual(r.byType[0].fabric_type, 'Denim');
+  assert.ok(Math.abs(r.byType[0].meters - (100 * 1.0 + 50 * 1.2)) < 1e-9); // 160
+  assert.strictEqual(r.byType[0].pieces, 150);
+  assert.strictEqual(r.coveredPieces, 150);
+  assert.strictEqual(r.uncoveredPieces, 200);
+  assert.ok(Math.abs(r.totalMeters - 160) < 1e-9);
+});
+
+test('fabricNeededByType ignores zero/negative suggestions', () => {
+  const r = fabricNeededByType(
+    [{ style: 'A', size: 'M', suggested_cut_qty: 0 }],
+    [{ style: 'A', size_label: 'M', consumption_per_piece: 1, fabric_type: 'X' }]
+  );
+  assert.strictEqual(r.totalMeters, 0);
+  assert.strictEqual(r.coveredPieces, 0);
+});
+
+test('wipByStage computes in-hand pieces per stage (approved - completed - inline rejected)', () => {
+  const rows = [
+    { stage: 'stitching', approved: 1000, completed: 600, inline_rejected: 50 },
+    { stage: 'finishing', approved: 400, completed: 400, inline_rejected: 0 },
+  ];
+  const w = wipByStage(rows);
+  assert.strictEqual(w.byStage.stitching, 350);
+  assert.strictEqual(w.byStage.finishing, 0);
+  assert.strictEqual(w.totalInHand, 350);
+});
+
+test('wipByStage never returns negative WIP', () => {
+  const w = wipByStage([{ stage: 'washing', approved: 100, completed: 140, inline_rejected: 0 }]);
+  assert.strictEqual(w.byStage.washing, 0);
+});

--- a/test/pmAnalytics.test.js
+++ b/test/pmAnalytics.test.js
@@ -2,6 +2,7 @@ const { test } = require('node:test');
 const assert = require('node:assert');
 const {
   cutPrioritySummary, fabricNeededByType, wipByStage,
+  masterOutputSummary, fabricVarianceRows,
 } = require('../utils/pmAnalytics.js');
 
 test('cutPrioritySummary counts red/amber styles and totals suggested pieces', () => {
@@ -61,4 +62,47 @@ test('wipByStage computes in-hand pieces per stage (approved - completed - inlin
 test('wipByStage never returns negative WIP', () => {
   const w = wipByStage([{ stage: 'washing', approved: 100, completed: 140, inline_rejected: 0 }]);
   assert.strictEqual(w.byStage.washing, 0);
+});
+
+test('masterOutputSummary merges cut output with assignment counts per master', () => {
+  const lots = [
+    { master_id: 3, username: 'akshay', lots: 12, pieces: 9000 },
+    { master_id: 9, username: 'imran', lots: 4, pieces: 3000 },
+  ];
+  const asg = [
+    { assigned_master_id: 3, assigned: 5, cut: 4 },
+    { assigned_master_id: 17, assigned: 2, cut: 0, username: 'kedar' },
+  ];
+  const out = masterOutputSummary(lots, asg);
+  const ak = out.find(m => m.master_id === 3);
+  assert.strictEqual(ak.pieces, 9000);
+  assert.strictEqual(ak.assigned, 5);
+  assert.strictEqual(ak.cut, 4);
+  // a master with assignments but no cut output this window still shows up
+  const kedar = out.find(m => m.master_id === 17);
+  assert.strictEqual(kedar.username, 'kedar');
+  assert.strictEqual(kedar.pieces, 0);
+  assert.strictEqual(kedar.assigned, 2);
+  // sorted by pieces desc
+  assert.strictEqual(out[0].master_id, 3);
+});
+
+test('fabricVarianceRows compares real derived consumption to the CAD standard', () => {
+  const derived = [
+    { style: 'A', realMetersPerPiece: 0.955 },
+    { style: 'B', realMetersPerPiece: 1.30 },
+    { style: 'C', realMetersPerPiece: 1.00 }, // no CAD -> excluded
+  ];
+  const cad = [
+    { style: 'A', standard: 1.01 },
+    { style: 'B', standard: 1.10 },
+  ];
+  const rows = fabricVarianceRows(derived, cad);
+  assert.strictEqual(rows.length, 2);
+  // B is +18% over standard -> biggest variance, sorted first
+  assert.strictEqual(rows[0].style, 'B');
+  assert.strictEqual(rows[0].status, 'over');
+  const a = rows.find(r => r.style === 'A');
+  assert.strictEqual(a.status, 'under');
+  assert.ok(Math.abs(a.variancePct - -5.45) < 0.1);
 });

--- a/utils/pmAnalytics.js
+++ b/utils/pmAnalytics.js
@@ -1,0 +1,58 @@
+// Pure aggregations behind the Production Manager summary cards + analytics page.
+// DB queries live in routes/productionManagerRoutes.js; these turn the raw rows into the
+// numbers shown on screen, so the logic is unit-tested.
+
+// Cut priority card: how many styles need cutting now (red) / soon (amber), and the total
+// pieces suggested. Input = the per-style aggregates (aggregateStyles output).
+function cutPrioritySummary(styleAggregates) {
+  let red = 0; let amber = 0; let totalSuggested = 0; let stylesNeedingCut = 0;
+  for (const s of styleAggregates || []) {
+    if (s.trigger === 'red') red += 1;
+    else if (s.trigger === 'amber') amber += 1;
+    const sug = Number(s.suggested_cut_qty) || 0;
+    totalSuggested += sug;
+    if (sug > 0) stylesNeedingCut += 1;
+  }
+  return { red, amber, totalSuggested, stylesNeedingCut };
+}
+
+// Fabric-needed card: price the suggested cuts using CAD per-size consumption, grouped by
+// fabric type. Sizes/styles with no CAD figure are counted as "uncovered" (not priced).
+//   recRows: [{ style, size, suggested_cut_qty }]
+//   consumptionRows: [{ style, size_label, consumption_per_piece, fabric_type }]
+function fabricNeededByType(recRows, consumptionRows) {
+  const cons = new Map();
+  for (const c of consumptionRows || []) {
+    cons.set(`${c.style}|${c.size_label}`, { per: Number(c.consumption_per_piece), type: c.fabric_type || '(unknown)' });
+  }
+  const byType = new Map();
+  let totalMeters = 0; let coveredPieces = 0; let uncoveredPieces = 0;
+  for (const r of recRows || []) {
+    const qty = Number(r.suggested_cut_qty) || 0;
+    if (qty <= 0) continue;
+    const hit = cons.get(`${r.style}|${r.size}`);
+    if (!hit || !isFinite(hit.per)) { uncoveredPieces += qty; continue; }
+    const meters = qty * hit.per;
+    const e = byType.get(hit.type) || { fabric_type: hit.type, meters: 0, pieces: 0 };
+    e.meters += meters; e.pieces += qty;
+    byType.set(hit.type, e);
+    totalMeters += meters; coveredPieces += qty;
+  }
+  const types = [...byType.values()].sort((a, b) => b.meters - a.meters);
+  return { byType: types, totalMeters, coveredPieces, uncoveredPieces };
+}
+
+// WIP card: pieces currently held at each stage = approved - completed - inline_rejected
+// (the inline work-in-progress), floored at 0. rows: [{ stage, approved, completed, inline_rejected }]
+function wipByStage(rows) {
+  const byStage = {};
+  let totalInHand = 0;
+  for (const r of rows || []) {
+    const inHand = Math.max(0, (Number(r.approved) || 0) - (Number(r.completed) || 0) - (Number(r.inline_rejected) || 0));
+    byStage[r.stage] = inHand;
+    totalInHand += inHand;
+  }
+  return { byStage, totalInHand };
+}
+
+module.exports = { cutPrioritySummary, fabricNeededByType, wipByStage };

--- a/utils/pmAnalytics.js
+++ b/utils/pmAnalytics.js
@@ -55,4 +55,51 @@ function wipByStage(rows) {
   return { byStage, totalInHand };
 }
 
-module.exports = { cutPrioritySummary, fabricNeededByType, wipByStage };
+const { varianceVsStandard } = require('./styleConsumption');
+
+// Master output: merge each cutting master's recent cut output (lots/pieces) with their
+// assignment counts (assigned vs cut). Masters appear if they're in either source.
+//   lotRows: [{ master_id, username, lots, pieces }]
+//   assignmentRows: [{ assigned_master_id, assigned, cut, username? }]
+function masterOutputSummary(lotRows, assignmentRows) {
+  const byId = new Map();
+  const get = (id) => {
+    if (!byId.has(id)) byId.set(id, { master_id: id, username: null, lots: 0, pieces: 0, assigned: 0, cut: 0 });
+    return byId.get(id);
+  };
+  for (const r of lotRows || []) {
+    const m = get(r.master_id);
+    m.username = r.username || m.username;
+    m.lots = Number(r.lots) || 0;
+    m.pieces = Number(r.pieces) || 0;
+  }
+  for (const r of assignmentRows || []) {
+    const m = get(r.assigned_master_id);
+    if (r.username) m.username = m.username || r.username;
+    m.assigned = Number(r.assigned) || 0;
+    m.cut = Number(r.cut) || 0;
+  }
+  return [...byId.values()].sort((a, b) => b.pieces - a.pieces);
+}
+
+// Fabric variance: real derived consumption (utils/styleConsumption) vs the CAD standard,
+// per style. Only styles present in both are returned, sorted by the biggest gap.
+//   derivedRows: [{ style, realMetersPerPiece }]
+//   cadRows: [{ style, standard }]  (standard = the style's CAD consumption to compare against)
+function fabricVarianceRows(derivedRows, cadRows) {
+  const cad = new Map((cadRows || []).map((c) => [c.style, Number(c.standard)]));
+  const rows = [];
+  for (const d of derivedRows || []) {
+    const standard = cad.get(d.style);
+    if (standard == null || !isFinite(standard)) continue;
+    const real = Number(d.realMetersPerPiece);
+    if (real == null || !isFinite(real)) continue;
+    const v = varianceVsStandard(real, standard);
+    rows.push({ style: d.style, real, standard, variancePct: v.variancePct, status: v.status });
+  }
+  return rows.sort((a, b) => Math.abs(b.variancePct) - Math.abs(a.variancePct));
+}
+
+module.exports = {
+  cutPrioritySummary, fabricNeededByType, wipByStage, masterOutputSummary, fabricVarianceRows,
+};

--- a/views/productionManagerAnalytics.ejs
+++ b/views/productionManagerAnalytics.ejs
@@ -1,0 +1,100 @@
+<%- include('partials/header', { pageTitle: 'PM · Analytics' }) %>
+<%- include('partials/navbar', { user: user, dashboardUrl: '/pm' }) %>
+
+<style>
+  body { background: #f5f7fb; }
+  .pm { --bg:#f5f7fb; --card:#fff; --border:#e5e8ee; --border-2:#eef0f4; --text:#0f172a; --text-2:#475569; --text-3:#94a3b8;
+        --primary:#4f46e5; --success:#16a34a; --success-s:#dcfce7; --warning:#d97706; --warning-s:#fef3c7; --danger:#dc2626; --danger-s:#fee2e2;
+        --shadow:0 1px 3px rgba(15,23,42,0.05); font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif; color:var(--text); }
+  .pm-page { max-width:1300px; margin:0 auto; padding:calc(var(--navbar-height,60px) + 1.5rem) 1rem 4rem; }
+  .pm-head { display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:.75rem; margin-bottom:1rem; }
+  .pm-head h1 { font-size:1.5rem; font-weight:700; margin:0; }
+  .pm-back { color:var(--primary); text-decoration:none; font-weight:600; font-size:.875rem; }
+  .pm-card { background:var(--card); border:1px solid var(--border); border-radius:16px; box-shadow:var(--shadow); margin-bottom:1rem; overflow:hidden; }
+  .pm-card-head { padding:.875rem 1.125rem; border-bottom:1px solid var(--border-2); background:linear-gradient(180deg,#fafbfd,#fff); }
+  .pm-card-head h2 { font-size:1rem; font-weight:700; margin:0; }
+  .pm-card-head .hint { font-size:.78rem; color:var(--text-3); margin-top:2px; }
+  .pm-card-body { padding:1rem 1.125rem; }
+  .metrics { display:flex; gap:2rem; flex-wrap:wrap; margin-bottom:1rem; }
+  .metric .v { font-size:1.6rem; font-weight:800; letter-spacing:-.02em; }
+  .metric .k { font-size:.75rem; text-transform:uppercase; letter-spacing:.04em; color:var(--text-3); }
+  table.t { width:100%; border-collapse:collapse; font-size:.85rem; }
+  table.t thead th { background:#f8fafc; color:var(--text-2); font-size:.7rem; font-weight:700; text-transform:uppercase; letter-spacing:.04em; padding:.5rem .7rem; text-align:left; border-bottom:1px solid var(--border-2); }
+  table.t tbody td { padding:.5rem .7rem; border-bottom:1px solid var(--border-2); }
+  .pill { font-size:.7rem; font-weight:700; padding:.15rem .5rem; border-radius:999px; }
+  .pill.red,.pill.over { background:var(--danger-s); color:var(--danger); }
+  .pill.amber { background:var(--warning-s); color:var(--warning); }
+  .pill.green,.pill.under,.pill.on_target { background:var(--success-s); color:var(--success); }
+  .bars { display:flex; align-items:flex-end; gap:4px; height:90px; }
+  .bars .col { flex:1; display:flex; flex-direction:column; align-items:center; gap:2px; }
+  .bars .bar { width:70%; background:var(--primary); border-radius:3px 3px 0 0; min-height:2px; }
+  .bars .bar.d { background:var(--success); }
+  .bars .lbl { font-size:.62rem; color:var(--text-3); }
+  .empty { padding:1.5rem; text-align:center; color:var(--text-3); }
+</style>
+
+<div class="pm"><div class="pm-page">
+  <div class="pm-head">
+    <div><a class="pm-back" href="/pm">← Dashboard</a><h1 style="margin-top:.4rem;">Production Analytics</h1></div>
+  </div>
+
+  <div class="pm-card"><div class="pm-card-head"><h2>Demand vs supply</h2><div class="hint">how fast we're selling vs what we hold + have on order</div></div><div class="pm-card-body" id="demandSupply"><div class="empty">Loading…</div></div></div>
+  <div class="pm-card"><div class="pm-card-head"><h2>Throughput &amp; TAT</h2><div class="hint">lots cut and dispatched per week · current bottleneck</div></div><div class="pm-card-body" id="throughput"><div class="empty">Loading…</div></div></div>
+  <div class="pm-card"><div class="pm-card-head"><h2>Fabric usage &amp; variance</h2><div class="hint">real consumption vs CAD standard (over = wasting fabric)</div></div><div class="pm-card-body" id="fabricVariance"><div class="empty">Loading…</div></div></div>
+  <div class="pm-card"><div class="pm-card-head"><h2>Master / cutter output</h2><div class="hint">pieces cut (30 days) and assignments per cutting master</div></div><div class="pm-card-body" id="masterOutput"><div class="empty">Loading…</div></div></div>
+</div></div>
+
+<script>
+const esc = s => String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+const cn = n => { n=Number(n)||0; if(n>=1e7)return (n/1e7).toFixed(1)+' Cr'; if(n>=1e5)return (n/1e5).toFixed(1)+' L'; if(n>=1e3)return (n/1e3).toFixed(1)+'k'; return String(Math.round(n)); };
+const fd = d => d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short'}) : '';
+
+(async function(){
+  let a;
+  try { a = await (await fetch('/pm/api/analytics')).json(); } catch(e){ return; }
+  if(!a.ok) return;
+
+  // Demand vs supply
+  const ds = a.demand_supply, dsEl = document.getElementById('demandSupply');
+  if(ds){
+    dsEl.innerHTML = `<div class="metrics">
+      <div class="metric"><div class="v">${cn(ds.dailyDemand)}</div><div class="k">selling / day</div></div>
+      <div class="metric"><div class="v">${cn(ds.soh)}</div><div class="k">in stock</div></div>
+      <div class="metric"><div class="v">${cn(ds.onOrder)}</div><div class="k">on order</div></div>
+      <div class="metric"><div class="v">${ds.daysCover!=null?Math.round(ds.daysCover):'—'}</div><div class="k">days of cover</div></div>
+      <div class="metric"><div class="v">${cn(ds.suggested)}</div><div class="k">suggested cut</div></div>
+    </div>
+    <table class="t"><thead><tr><th>Style (most under-supplied)</th><th>Suggested</th><th>SOH</th><th>DRR</th><th>DOH</th><th>On order</th><th></th></tr></thead><tbody>
+    ${ds.top.map(s=>`<tr><td>${esc(s.style)}</td><td><strong>${cn(s.suggested)}</strong></td><td>${cn(s.soh)}</td><td>${(s.drr||0).toFixed(1)}</td><td>${s.doh==null?'—':Math.round(s.doh)}</td><td>${cn(s.on_order)}</td><td><span class="pill ${esc(s.trigger)}">${esc(s.trigger)}</span></td></tr>`).join('')}
+    </tbody></table>`;
+  } else dsEl.innerHTML = '<div class="empty">Unavailable.</div>';
+
+  // Throughput
+  const tp = a.throughput, tpEl = document.getElementById('throughput');
+  if(tp){
+    const weeks = tp.cut_per_week; const dmap = Object.fromEntries(tp.dispatch_per_week.map(d=>[fd(d.week_start),d.pieces]));
+    const max = Math.max(1, ...weeks.map(w=>w.pieces), ...tp.dispatch_per_week.map(d=>d.pieces));
+    tpEl.innerHTML = `${tp.bottleneck?`<div class="metrics"><div class="metric"><div class="v" style="color:var(--warning)">${esc(tp.bottleneck.stage.replace('_',' '))}</div><div class="k">bottleneck · ${cn(tp.bottleneck.wip)} pcs WIP</div></div></div>`:''}
+      <div class="bars">${weeks.map(w=>{const dp=dmap[fd(w.week_start)]||0;return `<div class="col"><div style="display:flex;gap:2px;align-items:flex-end;height:70px;"><div class="bar" style="height:${Math.round(w.pieces/max*70)}px" title="cut ${w.pieces}"></div><div class="bar d" style="height:${Math.round(dp/max*70)}px" title="dispatched ${dp}"></div></div><div class="lbl">${fd(w.week_start)}</div></div>`;}).join('')}</div>
+      <div style="font-size:.75rem;color:var(--text-3);margin-top:.5rem;"><span style="color:var(--primary)">■</span> cut &nbsp; <span style="color:var(--success)">■</span> dispatched · per week</div>`;
+  } else tpEl.innerHTML = '<div class="empty">Unavailable.</div>';
+
+  // Fabric variance
+  const fv = a.fabric_variance, fvEl = document.getElementById('fabricVariance');
+  if(fv && fv.length){
+    fvEl.innerHTML = `<table class="t"><thead><tr><th>Style</th><th>Actual m/pc</th><th>CAD standard</th><th>Variance</th><th></th></tr></thead><tbody>
+    ${fv.map(r=>`<tr><td>${esc(r.style)}</td><td>${r.real.toFixed(3)}</td><td>${r.standard.toFixed(3)}</td><td>${r.variancePct>0?'+':''}${r.variancePct.toFixed(1)}%</td><td><span class="pill ${esc(r.status)}">${esc(r.status)}</span></td></tr>`).join('')}
+    </tbody></table>`;
+  } else fvEl.innerHTML = '<div class="empty">No styles with both CAD and cutting history yet. Upload more CAD sheets to populate this.</div>';
+
+  // Master output
+  const mo = a.master_output, moEl = document.getElementById('masterOutput');
+  if(mo && mo.length){
+    moEl.innerHTML = `<table class="t"><thead><tr><th>Master</th><th>Lots (30d)</th><th>Pieces (30d)</th><th>Assigned</th><th>Cut</th></tr></thead><tbody>
+    ${mo.map(m=>`<tr><td>${esc(m.username||('#'+m.master_id))}</td><td>${m.lots}</td><td><strong>${cn(m.pieces)}</strong></td><td>${m.assigned}</td><td>${m.cut}</td></tr>`).join('')}
+    </tbody></table>`;
+  } else moEl.innerHTML = '<div class="empty">Unavailable.</div>';
+})();
+</script>
+
+<%- include('partials/footer') %>

--- a/views/productionManagerDashboard.ejs
+++ b/views/productionManagerDashboard.ejs
@@ -174,6 +174,7 @@
       <div class="who">Cutting recommendations • DRR • Open lots • Marketplace POs</div>
     </div>
     <div class="pm-actions">
+      <a class="pm-btn" href="/pm/analytics">📊 Analytics</a>
       <a class="pm-btn" href="/pm/api/recommendations.csv">Export CSV</a>
       <% if (userRole === 'admin') { %>
         <button class="pm-btn primary" id="pullNowBtn">Run Pull Now</button>

--- a/views/productionManagerDashboard.ejs
+++ b/views/productionManagerDashboard.ejs
@@ -86,6 +86,17 @@
   .pm-card-head h2 { font-size: 1rem; font-weight: 700; margin: 0; }
   .pm-card-body { padding: 1rem 1.125rem; }
 
+  .pm-summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 0.75rem; margin-bottom: 1rem; }
+  .sum-card { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 0.9rem 1rem; box-shadow: var(--shadow); }
+  .sum-card .label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-3); }
+  .sum-card .big { font-size: 1.7rem; font-weight: 800; letter-spacing: -0.02em; margin: 0.15rem 0 0.1rem; color: var(--text); }
+  .sum-card .sub { font-size: 0.78rem; color: var(--text-2); }
+  .sum-card.alert .big { color: var(--danger); }
+  .sum-card .chips { display: flex; gap: 0.3rem; flex-wrap: wrap; margin-top: 0.35rem; }
+  .sum-card .chip { font-size: 0.7rem; background: var(--bg); border-radius: 6px; padding: 0.15rem 0.4rem; color: var(--text-2); }
+  .spark { display: flex; align-items: flex-end; gap: 2px; height: 34px; margin-top: 0.35rem; }
+  .spark .bar { flex: 1; background: var(--primary); border-radius: 2px 2px 0 0; min-height: 2px; opacity: 0.85; }
+
   .pm-toolbar { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
   .pm-toolbar input[type="text"], .pm-toolbar select, .pm-toolbar input[type="number"], .pm-toolbar input[type="date"] {
     border: 1px solid var(--border); border-radius: 10px;
@@ -173,6 +184,8 @@
   <div class="pm-banner <%= warming ? 'show' : '' %>" id="warmingBanner">
     DRR warming up: inventory snapshot history &lt; 7 days. Calendar-day DRR is being used as fallback.
   </div>
+
+  <div class="pm-summary" id="pmSummary"></div>
 
   <nav class="pm-tabs" role="tablist">
     <button class="pm-tab active" data-tab="cutting">Cutting Today</button>
@@ -414,6 +427,80 @@ function escapeHtml(s) {
     .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
     .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
 }
+
+// Summary cards
+function compactNum(n) {
+  n = Number(n) || 0;
+  if (n >= 1e7) return (n / 1e7).toFixed(1) + ' Cr';
+  if (n >= 1e5) return (n / 1e5).toFixed(1) + ' L';
+  if (n >= 1e3) return (n / 1e3).toFixed(1) + 'k';
+  return String(Math.round(n));
+}
+function fmtDate(d) { return d ? new Date(d).toLocaleDateString('en-IN', { day: '2-digit', month: 'short' }) : ''; }
+
+async function loadSummary() {
+  const box = $('pmSummary');
+  try {
+    const s = await (await fetch('/pm/api/summary')).json();
+    if (!s.ok) { box.innerHTML = ''; return; }
+    const cards = [];
+
+    if (s.cut_priority) {
+      const cp = s.cut_priority;
+      cards.push(`<div class="sum-card ${cp.red ? 'alert' : ''}">
+        <div class="label">Cut priority</div>
+        <div class="big">${compactNum(cp.totalSuggested)}</div>
+        <div class="sub">pieces suggested across ${cp.stylesNeedingCut} styles</div>
+        <div class="chips"><span class="chip" style="color:var(--danger)">${cp.red} red</span><span class="chip" style="color:var(--warning)">${cp.amber} amber</span></div>
+      </div>`);
+    }
+    if (s.fabric_needed) {
+      const f = s.fabric_needed;
+      cards.push(`<div class="sum-card">
+        <div class="label">Fabric needed</div>
+        <div class="big">${compactNum(f.totalMeters)} m</div>
+        <div class="sub">for ${compactNum(f.coveredPieces)} pcs ${f.uncoveredPieces ? `· ${compactNum(f.uncoveredPieces)} pcs no CAD` : ''}</div>
+        <div class="chips">${f.byType.slice(0, 3).map(t => `<span class="chip">${escapeHtml(t.fabric_type)}: ${compactNum(t.meters)}m</span>`).join('')}</div>
+      </div>`);
+    }
+    if (s.wip) {
+      const w = s.wip; const order = ['stitching', 'jeans_assembly', 'washing', 'washing_in', 'finishing'];
+      const lbl = { stitching: 'Stitch', jeans_assembly: 'Assy', washing: 'Wash', washing_in: 'W-In', finishing: 'Finish' };
+      cards.push(`<div class="sum-card">
+        <div class="label">WIP in production</div>
+        <div class="big">${compactNum(w.totalInHand)}</div>
+        <div class="sub">pieces in hand across stages</div>
+        <div class="chips">${order.filter(k => w.byStage[k]).map(k => `<span class="chip">${lbl[k]}: ${compactNum(w.byStage[k])}</span>`).join('')}</div>
+      </div>`);
+    }
+    if (s.inventory) {
+      cards.push(`<div class="sum-card">
+        <div class="label">Inventory on hand</div>
+        <div class="big">${compactNum(s.inventory.units)}</div>
+        <div class="sub">units in stock · as of ${fmtDate(s.inventory.as_of)}</div>
+      </div>`);
+    }
+    if (s.dead_stock) {
+      cards.push(`<div class="sum-card">
+        <div class="label">Dead stock</div>
+        <div class="big">${compactNum(s.dead_stock.units)}</div>
+        <div class="sub">units in ${s.dead_stock.count} slow SKUs (45d no sale)</div>
+      </div>`);
+    }
+    if (s.sales_by_day && s.sales_by_day.length) {
+      const days = s.sales_by_day; const max = Math.max(...days.map(d => d.qty), 1);
+      const last = days[days.length - 1]; const avg = Math.round(days.reduce((a, d) => a + d.qty, 0) / days.length);
+      cards.push(`<div class="sum-card">
+        <div class="label">Sales / day (30d)</div>
+        <div class="big">${compactNum(avg)}</div>
+        <div class="sub">avg/day · last ${fmtDate(last.date)}: ${compactNum(last.qty)}</div>
+        <div class="spark">${days.map(d => `<div class="bar" style="height:${Math.max(2, Math.round(d.qty / max * 34))}px" title="${fmtDate(d.date)}: ${d.qty}"></div>`).join('')}</div>
+      </div>`);
+    }
+    box.innerHTML = cards.join('');
+  } catch (_) { box.innerHTML = ''; }
+}
+loadSummary();
 
 // Tabs
 $$('.pm-tab').forEach(btn => {

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -120,6 +120,16 @@
     </div>
   </div>
 
+  <div class="pm-card" style="margin-top: 1rem;">
+    <div class="pm-card-head">
+      <h2>Cut history &amp; lot status</h2>
+      <span style="font-size:0.78rem; color:var(--text-3);">where each lot cut for this style is now</span>
+    </div>
+    <div class="pm-card-body" id="lotHistoryBody">
+      <div class="pm-empty">Loading lot history…</div>
+    </div>
+  </div>
+
 </div>
 </div>
 
@@ -257,6 +267,45 @@ async function doAssign() {
 }
 
 loadAssignPanel();
+
+// ── Cut history & lot status ─────────────────────────────────────────
+const STATUS_COLOR = { done: 'var(--success)', in_progress: 'var(--warning)', not_started: '#cbd5e1' };
+
+async function loadLotHistory() {
+  const body = document.getElementById('lotHistoryBody');
+  try {
+    const r = await fetch('/pm/api/style-lots?style=' + encodeURIComponent(STYLE));
+    const j = await r.json();
+    if (!j.ok) { body.innerHTML = `<div class="pm-empty">${escapeHtml(j.error || 'failed')}</div>`; return; }
+    if (!j.lots.length) { body.innerHTML = `<div class="pm-empty">No lots cut for this style yet.</div>`; return; }
+    body.innerHTML = j.lots.map(lot => {
+      const steps = lot.timeline.map(t => `
+        <div style="display:flex; flex-direction:column; align-items:center; min-width:58px;">
+          <div title="${escapeHtml(t.status)}${t.master ? ' · ' + escapeHtml(t.master) : ''}"
+               style="width:14px;height:14px;border-radius:50%;background:${STATUS_COLOR[t.status] || '#cbd5e1'};"></div>
+          <div style="font-size:0.68rem; color:var(--text-2); margin-top:3px;">${escapeHtml(t.label)}</div>
+          <div style="font-size:0.66rem; color:var(--text-3);">${t.status === 'not_started' ? '—' : (t.completed || 0)}</div>
+        </div>`).join('<div style="flex:1;height:2px;background:var(--border-2);margin:7px 2px 0;min-width:10px;"></div>');
+      const disp = lot.dispatch;
+      const dispHtml = disp.finished > 0
+        ? `<span style="color:var(--text-2);">Dispatched <strong>${disp.dispatched}</strong>/${disp.finished}${disp.in_stock > 0 ? ` · ${disp.in_stock} in stock` : ''}</span>`
+        : '';
+      return `
+        <div style="padding:0.75rem 0; border-bottom:1px solid var(--border-2);">
+          <div style="display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap; gap:0.5rem;">
+            <div><strong>${escapeHtml(lot.lot_no)}</strong>${lot.manual_lot_number ? ` <span style="color:var(--text-3);">/ ${escapeHtml(lot.manual_lot_number)}</span>` : ''}
+              <span style="color:var(--text-3); font-size:0.82rem;">· ${lot.total_pieces} pcs · ${fmtDate(lot.created_at)}</span></div>
+            <span class="pm-pill ${lot.current_stage === 'Dispatched' ? 'green' : 'amber'}">${escapeHtml(lot.current_stage)}</span>
+          </div>
+          <div style="display:flex; align-items:flex-start; margin-top:0.6rem; overflow-x:auto;">${steps}</div>
+          ${dispHtml ? `<div style="font-size:0.8rem; margin-top:0.5rem;">${dispHtml}</div>` : ''}
+        </div>`;
+    }).join('');
+  } catch (err) {
+    body.innerHTML = `<div class="pm-empty">Error: ${escapeHtml(err.message)}</div>`;
+  }
+}
+loadLotHistory();
 </script>
 
 <%- include('partials/footer') %>

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -110,6 +110,16 @@
     </div>
   </div>
 
+  <div class="pm-card" style="margin-top: 1rem;">
+    <div class="pm-card-head">
+      <h2>Approve &amp; assign cut</h2>
+      <div id="planSummary"></div>
+    </div>
+    <div class="pm-card-body" id="assignBody">
+      <div class="pm-empty">Loading suggested cut…</div>
+    </div>
+  </div>
+
 </div>
 </div>
 
@@ -163,6 +173,90 @@ function escapeHtml(s) {
     tbody.innerHTML = `<tr><td colspan="11" class="pm-empty">Error: ${escapeHtml(err.message)}</td></tr>`;
   }
 })();
+
+// ── Approve & assign cut ─────────────────────────────────────────────
+let MASTERS = [];
+function fmtDate(d){ return d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short'}) : ''; }
+
+async function loadAssignPanel() {
+  const body = document.getElementById('assignBody');
+  const summary = document.getElementById('planSummary');
+  try {
+    const [planRes, mastersRes, asgRes] = await Promise.all([
+      fetch('/pm/api/cut-plan?style=' + encodeURIComponent(STYLE)).then(r => r.json()),
+      fetch('/pm/api/cut-masters').then(r => r.json()),
+      fetch('/pm/api/cut-assignments').then(r => r.json()),
+    ]);
+    MASTERS = (mastersRes.ok && mastersRes.masters) ? mastersRes.masters : [];
+    const styleAsg = (asgRes.ok ? asgRes.items : []).filter(a => a.style === STYLE);
+
+    if (!planRes.ok) { body.innerHTML = `<div class="pm-empty">${escapeHtml(planRes.warning || planRes.error || 'Could not load plan.')}</div>`; return; }
+    if (!planRes.totalPieces) {
+      summary.innerHTML = '';
+      body.innerHTML = `<div class="pm-empty">No suggested cut right now — stock is covered.</div>` + assignmentsHtml(styleAsg);
+      return;
+    }
+
+    summary.innerHTML = planRes.totalFabricMeters != null
+      ? `<span class="pm-pill green">${Number(planRes.totalFabricMeters).toFixed(1)} m ${escapeHtml(planRes.fabric_type || '')}</span>`
+      : `<span class="pm-pill warming">No CAD fabric</span>`;
+
+    const sizes = Object.entries(planRes.demand).sort((a,b)=>b[1]-a[1]);
+    const masterOpts = MASTERS.map(m => `<option value="${m.id}">${escapeHtml(m.username)}</option>`).join('');
+    body.innerHTML = `
+      <div style="display:flex; gap:1.5rem; flex-wrap:wrap; align-items:baseline; margin-bottom:0.75rem;">
+        <div><strong style="font-size:1.25rem;">${planRes.totalPieces}</strong> <span style="color:var(--text-3);">pieces</span></div>
+        <div><strong>${planRes.lotCount}</strong> <span style="color:var(--text-3);">lot(s) ≤1500</span></div>
+        <div style="color:var(--text-2);">${escapeHtml(planRes.fabric_type || 'fabric n/a')}</div>
+      </div>
+      <div style="display:flex; gap:0.5rem; flex-wrap:wrap; margin-bottom:0.5rem;">
+        ${sizes.map(([s,q]) => `<span style="background:#f1f5f9;border-radius:8px;padding:0.35rem 0.7rem;font-size:0.85rem;"><strong>${q}</strong> ${escapeHtml(s)}</span>`).join('')}
+      </div>
+      ${(planRes.missingSizes && planRes.missingSizes.length) ? `<div style="color:var(--warning);font-size:0.8rem;margin-bottom:0.5rem;">No CAD consumption yet for: ${planRes.missingSizes.map(escapeHtml).join(', ')}</div>` : ''}
+      <div style="display:flex; gap:0.5rem; flex-wrap:wrap; margin-bottom:0.75rem; font-size:0.8rem; color:var(--text-2);">
+        ${planRes.lots.map((l,i)=>`<span style="background:var(--primary-s);border-radius:8px;padding:0.3rem 0.6rem;">Lot ${i+1}: ${l.total} pcs${l.fabricMeters!=null?(' · '+Number(l.fabricMeters).toFixed(0)+'m'):''}</span>`).join('')}
+      </div>
+      <div style="display:flex; gap:0.6rem; align-items:center; flex-wrap:wrap; padding-top:0.5rem; border-top:1px solid var(--border-2);">
+        <label style="font-size:0.85rem; color:var(--text-2);">Assign to cutting master:</label>
+        <select id="masterSel" style="padding:0.4rem 0.6rem; border:1px solid var(--border); border-radius:10px; font-size:0.85rem;">${masterOpts || '<option value="">no masters</option>'}</select>
+        <button class="pm-btn" style="background:var(--primary); color:#fff; border-color:var(--primary);" onclick="doAssign()">Approve &amp; Assign</button>
+        <span id="assignMsg" style="font-size:0.85rem;"></span>
+      </div>
+      ${assignmentsHtml(styleAsg)}
+    `;
+  } catch (err) {
+    body.innerHTML = `<div class="pm-empty">Error: ${escapeHtml(err.message)}</div>`;
+  }
+}
+
+function assignmentsHtml(items) {
+  if (!items || !items.length) return '';
+  return `<div style="margin-top:1rem; padding-top:0.75rem; border-top:1px solid var(--border-2);">
+    <div style="font-size:0.75rem; text-transform:uppercase; letter-spacing:0.04em; color:var(--text-3); margin-bottom:0.4rem;">Already assigned for this style</div>
+    ${items.map(a => `<div style="font-size:0.85rem; color:var(--text-2); padding:0.2rem 0;">
+      <strong>${a.total_pieces}</strong> pcs → <strong>${escapeHtml(a.assigned_master_name||'')}</strong>
+      · ${a.status === 'cut' ? '<span style="color:var(--success);">cut</span>' : 'assigned'} · ${fmtDate(a.created_at)}</div>`).join('')}
+  </div>`;
+}
+
+async function doAssign() {
+  const sel = document.getElementById('masterSel');
+  const msg = document.getElementById('assignMsg');
+  const masterId = sel ? sel.value : '';
+  if (!masterId) { msg.innerHTML = '<span style="color:var(--danger);">pick a master</span>'; return; }
+  msg.textContent = 'Assigning…';
+  try {
+    const r = await fetch('/pm/api/cut-plan/assign', {
+      method: 'POST', headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ style: STYLE, master_id: masterId }),
+    });
+    const d = await r.json();
+    if (d.ok) { msg.innerHTML = `<span style="color:var(--success);">✓ Assigned to ${escapeHtml(d.assigned_to)}</span>`; loadAssignPanel(); }
+    else { msg.innerHTML = `<span style="color:var(--danger);">${escapeHtml(d.error || 'failed')}</span>`; }
+  } catch (err) { msg.innerHTML = `<span style="color:var(--danger);">${escapeHtml(err.message)}</span>`; }
+}
+
+loadAssignPanel();
 </script>
 
 <%- include('partials/footer') %>


### PR DESCRIPTION
## What

Adds analytics to the Production Manager area: a row of **summary cards** on `/pm`, and a dedicated **`/pm/analytics`** page.

> ⚠️ **Stacks on #451 and #453.** Merge order: **#451 → #453 → this.** Until they're in `main`, this PR's diff also shows their commits.

### Dashboard summary cards (top of /pm)
- **Cut priority** — styles red/amber + total pieces to cut
- **Fabric needed** — metres by fabric type (from CAD), with no-CAD pieces flagged
- **WIP in production** — pieces in hand per stage
- **Inventory on hand** — total units (latest snapshot)
- **Dead stock** — slow SKUs / units
- **Sales / day** — 30-day sparkline

### Analytics page (/pm/analytics)
- **Demand vs supply** — daily selling rate vs stock + on-order, days of cover, most under-supplied styles
- **Throughput & TAT** — lots cut vs dispatched per week + current bottleneck stage
- **Fabric usage & variance** — real consumption vs CAD standard per style (over = wasting fabric)
- **Master / cutter output** — pieces cut (30d) + assignment counts per master

## How
- **`utils/pmAnalytics.js`** (TDD, 7 tests): `cutPrioritySummary`, `fabricNeededByType`, `wipByStage`, `masterOutputSummary`, `fabricVarianceRows` (reuses `styleConsumption.varianceVsStandard`).
- **`GET /pm/api/summary`** and **`GET /pm/api/analytics`** — each card/section computed independently, degrades to null on error.
- Cards + sparkline in `productionManagerDashboard.ejs`; new `productionManagerAnalytics.ejs`.

## Validation (prod, read-only)
- WIP **278,893 pcs** in hand (stitching 149k, washing 68k…); **1,145,001 units** in stock; sales 13k–19k/day.
- Cut **106–154 lots/week**; **akshay 217,796 pcs / 215 lots**; fabric variance KTTWOMENSPANT261 **0.955 vs CAD 1.010 (−5.5% under)**.
- Full suite: **81 passing**. No schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)