### PR TITLE
feat(pm): full PM UI redesign + per-lot cut assignment

### DIFF
--- a/public/css/pm-suite.css
+++ b/public/css/pm-suite.css
@@ -1,0 +1,466 @@
+/* ============================================================
+   Kotty PM — design system
+   Calm, refined production suite. Soft cool surfaces, light
+   shadows, restrained accents. Blue / green / red / black / white.
+   ============================================================ */
+
+:root{
+  /* surfaces — warm, faintly green-tinted neutrals (not cold gray) */
+  --bg:#f3f7f4;
+  --card:#ffffff;
+  --card-2:#f5f9f6;
+  --neutral:#ecf2ee;      /* warm neutral chip / fill */
+
+  /* ink */
+  --ink:#13201d;          /* deep, slightly warm */
+  --ink-2:#54625a;        /* secondary */
+  --ink-3:#90a097;        /* faint / muted */
+  --ink-4:#c4cfc8;
+
+  /* lines */
+  --line:#e1ebe4;
+  --line-2:#ecf2ee;
+
+  /* dual accent — blue = action, green = healthy; red = urgent only */
+  --blue:#2563eb;  --blue-ink:#1d4ed8;  --blue-bg:#e8f0ff;
+  --green:#0e9f6e; --green-ink:#0b8458; --green-bg:#d8f2e6;
+  --amber:#d98324; --amber-ink:#b06a16; --amber-bg:#fbecd4;
+  --red:#e5484d;   --red-ink:#c2363b;   --red-bg:#fdecec;
+  --charcoal:#1f2937;
+
+  /* shape + depth — light, single soft shadow */
+  --radius:14px;
+  --radius-sm:10px;
+  --radius-xs:8px;
+  --shadow:0 1px 2px rgba(19,27,46,.04);
+  --shadow-md:0 2px 8px -3px rgba(19,27,46,.10);
+  --shadow-hover:0 6px 18px -10px rgba(19,27,46,.16);
+
+  --sidebar-w:248px;
+  --font:'Hanken Grotesk',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+}
+
+*{box-sizing:border-box;margin:0;padding:0}
+html{-webkit-font-smoothing:antialiased;text-rendering:optimizeLegibility}
+body{
+  font-family:var(--font); color:var(--ink); background:var(--bg);
+  display:flex; min-height:100vh;
+}
+a{color:inherit;text-decoration:none}
+button{font-family:var(--font)}
+
+/* tabular numerals — same font, just aligned */
+.num{font-variant-numeric:tabular-nums;font-feature-settings:"tnum"}
+.eyebrow{font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--ink-3)}
+
+/* ───────────────── Sidebar ───────────────── */
+.sidebar{
+  width:var(--sidebar-w); flex-shrink:0; background:var(--card);
+  border-right:1px solid var(--line); display:flex; flex-direction:column;
+  position:sticky; top:0; height:100vh; z-index:10;
+}
+.brand{display:flex;align-items:center;gap:11px;padding:20px 20px 18px}
+.brand .logo{
+  width:38px; height:38px; border-radius:11px;
+  background:var(--ink); color:#fff;
+  display:grid; place-items:center; font-weight:800; font-size:19px;
+}
+.brand .name{font-weight:800;font-size:16px;color:var(--ink);line-height:1;letter-spacing:-.01em}
+.brand .sub{font-size:10px;letter-spacing:.1em;color:var(--ink-3);text-transform:uppercase;margin-top:5px;font-weight:600}
+
+.nav{padding:8px 12px;display:flex;flex-direction:column;gap:2px}
+.nav a{
+  display:flex; align-items:center; gap:12px; padding:9px 12px; border-radius:9px;
+  color:var(--ink-2); font-weight:500; font-size:14px; position:relative; transition:.15s;
+}
+.nav a svg{width:19px;height:19px;flex-shrink:0;stroke-width:1.9}
+.nav a:hover{background:#eef4f0;color:var(--ink)}
+.nav a.active{background:var(--blue-bg);color:var(--blue-ink);font-weight:600}
+.sidebar .spacer{flex:1}
+.user{display:flex;align-items:center;gap:11px;padding:14px 18px;border-top:1px solid var(--line-2)}
+.avatar{width:32px;height:32px;border-radius:50%;background:#e7efe9;color:var(--ink-2);display:grid;place-items:center;font-weight:700;font-size:13px;flex-shrink:0}
+.user .who b{font-size:13.5px;font-weight:700;display:block;line-height:1.2}
+.user .who span{font-size:11.5px;color:var(--ink-2)}
+
+/* ───────────────── Main shell ───────────────── */
+.main{flex:1;display:flex;flex-direction:column;min-width:0}
+.topbar{
+  height:64px; background:var(--card);
+  border-bottom:1px solid var(--line); display:flex; align-items:center; gap:16px;
+  padding:0 28px; position:sticky; top:0; z-index:8;
+}
+.search{position:relative;flex:1;max-width:540px}
+.search svg{position:absolute;left:13px;top:50%;transform:translateY(-50%);width:17px;height:17px;color:var(--ink-3)}
+.search input{
+  width:100%; height:40px; border:1px solid var(--line); background:#eef4f0; border-radius:10px;
+  padding:0 14px 0 38px; font-family:var(--font); font-size:14px; color:var(--ink); outline:none; transition:.15s;
+}
+.search input::placeholder{color:var(--ink-3)}
+.search input:focus{background:#fff;border-color:var(--blue);box-shadow:0 0 0 3px rgba(37,99,235,.1)}
+.topbar .right{margin-left:auto;display:flex;align-items:center;gap:14px}
+
+.btn{height:40px;padding:0 16px;border:none;border-radius:10px;font-weight:600;font-size:13.5px;cursor:pointer;display:inline-flex;align-items:center;gap:8px;transition:.15s}
+.btn svg{width:16px;height:16px;stroke-width:2}
+.btn.primary{background:var(--blue);color:#fff}
+.btn.primary:hover{background:var(--blue-ink)}
+.btn.ghost{background:#fff;color:var(--ink-2);border:1px solid var(--line)}
+.btn.ghost:hover{background:#eef4f0;color:var(--ink)}
+.btn:active{transform:translateY(.5px)}
+.btn-sm:active{transform:translateY(.5px)}
+
+.content{padding:28px 32px 56px;max-width:1200px;width:100%;margin:0 auto}
+
+/* page header / breadcrumb */
+.crumb{display:inline-flex;align-items:center;gap:7px;color:var(--blue);font-size:13px;font-weight:600;margin-bottom:14px}
+.crumb svg{width:16px;height:16px;stroke-width:2.2}
+.crumb:hover{text-decoration:underline}
+.page-head{display:flex;align-items:flex-end;justify-content:space-between;gap:20px;flex-wrap:wrap}
+.page-h{font-size:25px;font-weight:800;letter-spacing:-.025em}
+.page-sub{color:var(--ink-2);font-size:14px;margin-top:5px}
+.section-h{font-size:16px;font-weight:800;letter-spacing:-.01em;margin:30px 0 0;display:flex;align-items:center;justify-content:space-between}
+.section-h .link{font-size:13px;font-weight:600;color:var(--blue);display:inline-flex;align-items:center;gap:4px}
+.section-h .link svg{width:15px;height:15px;stroke-width:2.2}
+
+/* ───────────────── KPI cards ───────────────── */
+.kpis{display:grid;grid-template-columns:repeat(4,1fr);gap:18px;margin:22px 0 4px}
+.kpi{
+  background:var(--card); border:1px solid var(--line); border-radius:var(--radius);
+  padding:18px 20px 20px; box-shadow:var(--shadow); transition:.18s;
+}
+.kpi:hover{box-shadow:var(--shadow-hover)}
+.kpi .top{display:flex;align-items:flex-start;justify-content:space-between}
+.kpi .label{font-size:11.5px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-2)}
+/* neutral tile — a quiet glyph, not a colored badge competing with the number */
+.tile{width:34px;height:34px;border-radius:9px;display:grid;place-items:center;flex-shrink:0;background:#ecf2ee}
+.tile svg{width:18px;height:18px;stroke-width:2;color:var(--ink-2)}
+.kpi .val{font-size:32px;font-weight:800;letter-spacing:-.025em;margin-top:16px;line-height:1}
+/* thin rule under the number — the calm NOWI structure */
+.kpi .trend{font-size:12.5px;margin-top:14px;padding-top:13px;border-top:1px solid var(--line-2);display:flex;align-items:center;gap:5px}
+.kpi .trend svg{width:14px;height:14px;stroke-width:2.2}
+.trend.red{color:var(--red)} .trend.green{color:var(--green-ink)} .trend.blue{color:var(--ink-2)} .trend.muted{color:var(--ink-2)}
+/* subtle trend sparkline — one muted tone, never a third color on the card */
+.kpi .spark{display:block;width:100%;height:30px;margin-top:13px;overflow:visible}
+.kpi .spark polyline{fill:none;stroke:var(--ink-4);stroke-width:2;stroke-linecap:round;stroke-linejoin:round}
+.kpi .spark .dot{stroke:none;fill:var(--ink-3)}
+
+/* ───────────────── Table card ───────────────── */
+.card{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow)}
+.tcard{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);margin-top:14px;overflow:hidden}
+table{width:100%;border-collapse:collapse}
+thead th{text-align:right;font-size:11px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-2);padding:13px 18px;border-bottom:1px solid var(--line);background:var(--card-2)}
+thead th.l{text-align:left}
+tbody td{padding:15px 18px;border-bottom:1px solid var(--line-2);text-align:right;font-size:14px}
+tbody tr:last-child td{border-bottom:none}
+tbody tr{transition:.12s}
+tbody tr:hover{background:#f6faf7}
+td.l,td.style{text-align:left}
+td.style .row{display:flex;align-items:center;gap:12px}
+/* neutral thumbnail — no random per-row colour noise */
+.swatch{width:18px;height:18px;border-radius:5px;flex-shrink:0;background:#dfe9e3 !important;box-shadow:inset 0 0 0 1px rgba(0,0,0,.05)}
+.swatch.lg{width:32px;height:32px;border-radius:8px}
+td.style .code{font-weight:700;color:var(--ink);letter-spacing:-.01em}
+td.style .fab{font-size:12px;color:var(--ink-2);margin-top:1px}
+/* priority table — cluster the metrics so a row scans across cleanly */
+table.prio th:not(.l),table.prio td:not(.style):not(.status){width:118px}
+table.prio th.l:nth-child(5),table.prio td.status{width:150px}
+table.prio thead th:last-child,table.prio tbody td:last-child{width:118px}
+td .num{font-weight:500}
+td.cut .num{font-weight:700;color:var(--ink)}
+td.days.red .num{color:var(--red);font-weight:700}
+td.days.muted .num{color:var(--ink-2)}
+
+/* pills — soft tinted chip + dot; blue/green/red carry real meaning */
+.pill{display:inline-flex;align-items:center;gap:7px;font-size:12px;font-weight:600;padding:4px 11px;border-radius:999px;white-space:nowrap;background:var(--neutral);color:var(--ink-2)}
+.pill::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--ink-3)}
+.pill.red{background:var(--red-bg);color:var(--red-ink)} .pill.red::before{background:var(--red)}
+.pill.blue{background:var(--blue-bg);color:var(--blue-ink)} .pill.blue::before{background:var(--blue)}
+.pill.green{background:var(--green-bg);color:var(--green-ink)} .pill.green::before{background:var(--green)}
+.pill.flat::before{background:var(--ink-3)}
+td.status{text-align:left}
+
+.btn-sm{height:34px;padding:0 16px;border-radius:8px;font-weight:600;font-size:13px;cursor:pointer;border:1px solid transparent;transition:.15s;display:inline-flex;align-items:center;justify-content:center;text-decoration:none}
+.btn-sm.assign{background:var(--blue);color:#fff}
+.btn-sm.assign:hover{background:var(--blue-ink)}
+.btn-sm.review{background:#fff;color:var(--ink-2);border-color:var(--line)}
+.btn-sm.review:hover{background:#eef4f0;color:var(--ink)}
+
+/* ───────────────── Summary cards (style page) ───────────────── */
+.summary{display:grid;grid-template-columns:repeat(3,1fr);gap:18px;margin:22px 0 8px}
+.scard{display:flex;align-items:flex-start;gap:15px;background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:18px 20px;box-shadow:var(--shadow);transition:.18s}
+.scard:hover{box-shadow:var(--shadow-hover)}
+.scard .ico{width:40px;height:40px;border-radius:11px;display:grid;place-items:center;flex-shrink:0}
+.scard .ico svg{width:20px;height:20px;stroke-width:2}
+.scard .label{font-size:11px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-2)}
+.scard .big{font-size:26px;font-weight:800;letter-spacing:-.02em;margin-top:7px;line-height:1}
+.scard .big small{font-size:13px;font-weight:500;color:var(--ink-2);letter-spacing:0}
+
+/* status chip next to a title — soft tinted + dot */
+.title-chip{display:inline-flex;align-items:center;gap:7px;font-size:11px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;padding:5px 11px;border-radius:999px;vertical-align:middle;background:var(--neutral);color:var(--ink-2)}
+.title-chip::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--ink-3)}
+.title-chip.red{background:var(--red-bg);color:var(--red-ink)} .title-chip.red::before{background:var(--red)}
+.title-chip.blue{background:var(--blue-bg);color:var(--blue-ink)} .title-chip.blue::before{background:var(--blue)}
+.title-chip.green{background:var(--green-bg);color:var(--green-ink)} .title-chip.green::before{background:var(--green)}
+
+/* ───────────────── Size breakdown grid ───────────────── */
+.sizegrid{display:grid;grid-template-columns:repeat(5,1fr);gap:16px;margin-top:16px}
+.sizecard{display:flex;flex-direction:column;background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:16px 16px 14px;box-shadow:var(--shadow);transition:.18s}
+.sizecard:hover{box-shadow:var(--shadow-hover)}
+.sizecard.dim{background:var(--card-2);opacity:.9}
+.sizecard .sz{font-size:23px;font-weight:800;letter-spacing:-.02em;margin-bottom:16px}
+.sizecard .rows{margin-top:auto;display:flex;flex-direction:column;gap:8px}
+.sizecard .r{display:flex;align-items:center;justify-content:space-between;font-size:13px}
+.sizecard .r .k{color:var(--ink-2)}
+.sizecard .r .v{font-weight:600}
+.sizecard .r .v.red{color:var(--red)}
+.sizecard .sug{display:flex;align-items:center;justify-content:space-between;padding-top:10px;margin-top:2px;border-top:1px solid var(--line-2)}
+.sizecard .sug .k{font-size:12px;font-weight:700;color:var(--blue)}
+.sizecard .sug .v{font-weight:700;color:var(--blue)}
+.sizecard.dim .sug .k,.sizecard.dim .sug .v{color:var(--ink-3)}
+
+/* fabrication / BOM panel */
+.panel{margin-top:20px;border:1px solid var(--line);border-radius:var(--radius);overflow:hidden;box-shadow:var(--shadow);background:var(--card)}
+.panel-head{display:flex;align-items:center;justify-content:space-between;padding:15px 20px;border-bottom:1px solid var(--line);background:var(--card-2)}
+.panel-head h4{font-size:15px;font-weight:800}
+.panel-body{display:grid;grid-template-columns:1fr 1fr;gap:30px;padding:22px}
+.fabswatch{display:flex;align-items:center;gap:18px}
+.fabswatch .chip{width:104px;height:104px;border-radius:12px;flex-shrink:0;box-shadow:inset 0 0 0 1px rgba(0,0,0,.07)}
+.fabswatch h5{font-size:16px;font-weight:700;margin-bottom:8px}
+.tags{display:flex;gap:8px;flex-wrap:wrap}
+.tag{font-size:10.5px;font-weight:700;letter-spacing:.03em;text-transform:uppercase;padding:4px 9px;border-radius:6px;background:#e7efe9;color:var(--ink-2)}
+.specrows{display:flex;flex-direction:column}
+.specrow{display:flex;align-items:center;justify-content:space-between;padding:11px 0;border-bottom:1px solid var(--line-2);font-size:14px}
+.specrow:last-child{border-bottom:none}
+.specrow .k{color:var(--ink-2)}
+.specrow .v{font-weight:700}
+.specrow .v.blue{color:var(--blue)}
+
+/* ───────────────── Lot journey timeline ───────────────── */
+.lotmeta{display:flex;gap:26px;flex-wrap:wrap;margin-top:8px}
+.lotmeta .m .k{font-size:11px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-3)}
+.lotmeta .m .v{font-size:15px;font-weight:700;margin-top:3px}
+.timeline{position:relative;margin-top:8px;padding:6px 0}
+.tstep{position:relative;display:grid;grid-template-columns:42px 1fr;gap:16px;padding-bottom:4px}
+.tstep .rail{position:relative;display:flex;justify-content:center}
+.tstep .dot{width:32px;height:32px;border-radius:50%;display:grid;place-items:center;z-index:2;flex-shrink:0;background:#fff;border:2px solid var(--line);color:var(--ink-3)}
+.tstep .dot svg{width:15px;height:15px;stroke-width:2.4}
+.tstep.done .dot{background:var(--green);border-color:var(--green);color:#fff}
+.tstep.active .dot{background:var(--blue);border-color:var(--blue);color:#fff}
+.tstep .line{position:absolute;top:32px;bottom:-4px;width:2px;background:var(--line);z-index:1}
+.tstep.done .line{background:var(--green)}
+.tstep:last-child .line{display:none}
+.tstep .body{padding:4px 0 16px}
+.tstep .body .name{font-size:14px;font-weight:700}
+.tstep .body .when{font-size:12.5px;color:var(--ink-2);margin-top:2px}
+.tstep .body .when .num{font-weight:600}
+.tstep.pending .body .name{color:var(--ink-3)}
+
+/* dispatch card */
+.dispatch{display:grid;grid-template-columns:repeat(auto-fit,minmax(90px,1fr));gap:12px;margin-top:14px}
+.dcell{border:1px solid var(--line);border-radius:10px;padding:13px 14px;background:var(--card-2);text-align:center}
+.dcell .sz{font-size:12px;font-weight:700;color:var(--ink-2);letter-spacing:.03em}
+.dcell .qty{font-size:20px;font-weight:800;margin-top:5px}
+.dcell .st{font-size:10.5px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;margin-top:5px;color:var(--green)}
+
+/* ───────────────── Analytics ───────────────── */
+.statband{display:grid;grid-template-columns:repeat(4,1fr);gap:18px;margin:22px 0 4px}
+.stat{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:18px 20px;box-shadow:var(--shadow)}
+.stat .k{font-size:11.5px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-2)}
+.stat .v{font-size:27px;font-weight:800;letter-spacing:-.02em;margin-top:10px;line-height:1}
+.stat .d{font-size:12.5px;margin-top:8px;color:var(--ink-2)}
+.stat .d.red{color:var(--red)} .stat .d.green{color:var(--green-ink)}
+
+.grid-2{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:16px}
+.chartcard{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);padding:20px}
+.chartcard h4{font-size:15px;font-weight:800;margin-bottom:4px}
+.chartcard .cap{font-size:12.5px;color:var(--ink-2);margin-bottom:18px}
+.bars{display:flex;align-items:flex-end;gap:16px;height:170px;padding-top:8px}
+.barcol{flex:1;display:flex;flex-direction:column;align-items:center;gap:8px;height:100%;justify-content:flex-end}
+.barpair{display:flex;align-items:flex-end;gap:5px;height:100%;width:100%;justify-content:center}
+.bar{width:16px;border-radius:5px 5px 0 0}
+.bar.cut{background:var(--blue)}
+.bar.disp{background:var(--green)}
+.barcol .xl{font-size:11px;color:var(--ink-2);font-weight:600}
+.legend{display:flex;gap:18px;margin-top:14px}
+.legend .li{display:flex;align-items:center;gap:7px;font-size:12px;color:var(--ink-2)}
+.legend .sw{width:11px;height:11px;border-radius:3px}
+.callout{display:flex;align-items:center;gap:9px;margin-top:16px;padding:11px 14px;border-radius:10px;background:var(--red-bg);color:var(--red-ink);font-size:13px;font-weight:600}
+.callout svg{width:17px;height:17px;flex-shrink:0;stroke-width:2.2}
+
+.dsrow{padding:13px 0;border-bottom:1px solid var(--line-2)}
+.dsrow:last-child{border-bottom:none}
+.dsrow .top{display:flex;justify-content:space-between;align-items:baseline;margin-bottom:8px}
+.dsrow .nm{font-weight:700;font-size:14px}
+.dsrow .gap{font-size:12.5px;font-weight:700}
+.dsrow .gap.short{color:var(--red)} .dsrow .gap.ok{color:var(--green-ink)}
+.track{height:9px;border-radius:6px;background:#e7efe9;position:relative;overflow:hidden}
+.track .fill{position:absolute;left:0;top:0;bottom:0;border-radius:6px}
+.track .fill.demand{background:var(--charcoal);opacity:.14;width:100%}
+.track .fill.supply{background:var(--blue)}
+.track .fill.supply.short{background:var(--red)}
+
+.vpill{display:inline-flex;align-items:center;gap:7px;font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;background:var(--neutral);color:var(--ink-2)}
+.vpill::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--ink-3)}
+.vpill.over{background:var(--red-bg);color:var(--red-ink)} .vpill.over::before{background:var(--red)}
+.vpill.under{background:var(--green-bg);color:var(--green-ink)} .vpill.under::before{background:var(--green)}
+
+/* ───────────────── Cut planning ───────────────── */
+.plan{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);margin-top:16px;overflow:hidden}
+.plan-head{display:flex;align-items:center;gap:14px;padding:18px 20px;border-bottom:1px solid var(--line-2)}
+.plan-head .code{font-size:16px;font-weight:800;letter-spacing:-.01em}
+.plan-head .fab{font-size:12.5px;color:var(--ink-2);margin-top:2px}
+.plan-head .tot{margin-left:auto;text-align:right}
+.plan-head .tot .k{font-size:10.5px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:var(--ink-3)}
+.plan-head .tot .v{font-size:22px;font-weight:800;letter-spacing:-.02em;line-height:1.1}
+.plan-body{padding:18px 20px;display:grid;grid-template-columns:1.3fr 1fr;gap:26px}
+.chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}
+.chip-sz{display:inline-flex;align-items:baseline;gap:6px;padding:7px 12px;border-radius:9px;background:var(--card-2);border:1px solid var(--line)}
+.chip-sz .s{font-size:11px;font-weight:700;color:var(--ink-2);letter-spacing:.03em}
+.chip-sz .q{font-size:14px;font-weight:700}
+.lots{display:flex;flex-direction:column;gap:9px;margin-top:10px}
+.lotbar{display:flex;align-items:center;gap:12px}
+.lotbar .lab{font-size:12px;font-weight:700;color:var(--ink-2);width:54px;flex-shrink:0}
+.lotbar .meter{flex:1;height:26px;border-radius:7px;background:#e7efe9;position:relative;overflow:hidden}
+.lotbar .meter .f{position:absolute;left:0;top:0;bottom:0;background:var(--blue);border-radius:7px;display:flex;align-items:center;padding-left:10px;color:#fff;font-size:12px;font-weight:700}
+/* per-lot assignment rows — one master selectable per lot */
+.lotlist{display:flex;flex-direction:column;gap:10px;margin-top:12px}
+.lotrow{display:grid;grid-template-columns:72px 1fr 232px;gap:16px;align-items:center;padding:13px 15px;border:1px solid var(--line);border-radius:12px;background:var(--card-2)}
+.lotrow .lotid{font-size:14px;font-weight:800;letter-spacing:-.01em}
+.lotrow .lotid small{display:block;font-size:11px;font-weight:600;color:var(--ink-3);margin-top:2px}
+.lotrow .lotsizes{display:flex;gap:7px;flex-wrap:wrap}
+.lotrow .select{min-width:0;width:100%;height:38px}
+@media(max-width:820px){.lotrow{grid-template-columns:1fr}}
+.assignbar{display:flex;align-items:center;gap:12px;padding:16px 20px;border-top:1px solid var(--line-2);background:var(--card-2)}
+.fieldlab{font-size:11px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-3);margin-bottom:6px;display:block}
+.select{height:40px;min-width:220px;border:1px solid var(--line);border-radius:9px;background:#fff;padding:0 14px;font-family:var(--font);font-size:14px;color:var(--ink);outline:none;cursor:pointer}
+.select:focus{border-color:var(--blue);box-shadow:0 0 0 3px rgba(37,99,235,.1)}
+
+/* ───────────────── motion: gentle reveal ───────────────── */
+@keyframes fadeUp{from{opacity:0;transform:translateY(8px)}to{opacity:1;transform:translateY(0)}}
+.reveal{animation:fadeUp .45s cubic-bezier(.2,.7,.3,1) both}
+.reveal:nth-child(2){animation-delay:.05s}
+.reveal:nth-child(3){animation-delay:.1s}
+.reveal:nth-child(4){animation-delay:.15s}
+.reveal:nth-child(5){animation-delay:.2s}
+@media(prefers-reduced-motion:reduce){.reveal{animation:none}}
+
+/* ───────────────── responsive ───────────────── */
+@media(max-width:1080px){
+  .kpis,.statband{grid-template-columns:repeat(2,1fr)}
+  .sizegrid{grid-template-columns:repeat(3,1fr)}
+  .panel-body,.grid-2,.plan-body{grid-template-columns:1fr}
+}
+@media(max-width:720px){
+  .sidebar{display:none}
+  .kpis,.statband,.summary,.sizegrid{grid-template-columns:1fr}
+  .content{padding:20px}
+}
+
+/* ════════════════════════════════════════════════════════════
+   Live-app integration — sidebar user menu + legacy pm-* classes
+   (the dashboard JS emits pm-*, sum-card, pm-table, etc.; these
+   restyle that existing markup into the new design unchanged)
+   ════════════════════════════════════════════════════════════ */
+
+/* sidebar user dropdown (Profile / My Lots / Logout) */
+.usermenu{position:relative;border-top:1px solid var(--line-2)}
+.usermenu summary{list-style:none;display:flex;align-items:center;gap:11px;padding:14px 18px;cursor:pointer}
+.usermenu summary::-webkit-details-marker{display:none}
+.usermenu summary .who{flex:1;min-width:0}
+.usermenu summary .who b{font-size:13.5px;font-weight:700;display:block;line-height:1.2}
+.usermenu summary .who span{font-size:11.5px;color:var(--ink-2)}
+.usermenu summary .caret{width:16px;height:16px;color:var(--ink-3);transition:.15s}
+.usermenu[open] summary .caret{transform:rotate(180deg)}
+.usermenu .menu{position:absolute;left:14px;right:14px;bottom:62px;background:var(--card);border:1px solid var(--line);border-radius:12px;box-shadow:var(--shadow-hover);padding:6px;display:flex;flex-direction:column;gap:2px;z-index:30}
+.usermenu .menu a{display:flex;align-items:center;gap:10px;padding:9px 11px;border-radius:8px;font-size:13.5px;font-weight:500;color:var(--ink-2)}
+.usermenu .menu a:hover{background:var(--neutral);color:var(--ink)}
+.usermenu .menu a.danger{color:var(--red-ink)}
+.usermenu .menu a.danger:hover{background:var(--red-bg)}
+.usermenu .menu svg{width:16px;height:16px;stroke-width:2}
+.usermenu .menu hr{border:none;border-top:1px solid var(--line-2);margin:4px 2px}
+
+/* topbar actions row */
+.topbar .actions{margin-left:auto;display:flex;align-items:center;gap:10px}
+
+/* banner */
+.pm-banner{margin:0 0 18px;padding:11px 15px;border-radius:11px;border:1px solid var(--amber);background:var(--amber-bg);color:var(--amber-ink);font-size:13.5px;font-weight:500;display:none}
+.pm-banner.show{display:block}
+
+/* tabs */
+.pm-tabs{display:flex;gap:4px;flex-wrap:wrap;border-bottom:1px solid var(--line);margin:22px 0 18px}
+.pm-tab{border:none;background:transparent;padding:10px 15px;font-family:var(--font);font-weight:600;font-size:14px;color:var(--ink-2);cursor:pointer;border-bottom:2px solid transparent;margin-bottom:-1px;transition:.15s}
+.pm-tab:hover{color:var(--ink)}
+.pm-tab.active{color:var(--blue);border-bottom-color:var(--blue)}
+.pm-panel{display:none}
+.pm-panel.active{display:block;animation:fadeUp .35s cubic-bezier(.2,.7,.3,1) both}
+
+/* card */
+.pm-card{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow);overflow:hidden;margin-bottom:18px}
+.pm-card-head{padding:15px 20px;border-bottom:1px solid var(--line-2);display:flex;justify-content:space-between;align-items:center;gap:12px;flex-wrap:wrap}
+.pm-card-head h2{font-size:15px;font-weight:800;letter-spacing:-.01em;margin:0}
+.pm-card-body{padding:6px 0 0}
+
+/* summary cards (KPIs the JS builds) */
+.pm-summary{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:18px;margin:22px 0 4px}
+.sum-card{background:var(--card);border:1px solid var(--line);border-radius:var(--radius);padding:18px 20px 20px;box-shadow:var(--shadow);transition:.18s}
+.sum-card:hover{box-shadow:var(--shadow-hover)}
+.sum-card .label{font-size:11.5px;font-weight:600;letter-spacing:.04em;text-transform:uppercase;color:var(--ink-2)}
+.sum-card .big{font-size:30px;font-weight:800;letter-spacing:-.025em;margin:14px 0 0;line-height:1;color:var(--ink)}
+.sum-card.alert .big{color:var(--red)}
+.sum-card .sub{font-size:12.5px;color:var(--ink-2);margin-top:9px;padding-top:11px;border-top:1px solid var(--line-2)}
+.sum-card .chips{display:flex;gap:7px;flex-wrap:wrap;margin-top:10px}
+.sum-card .chip{font-size:11px;font-weight:600;background:var(--neutral);border-radius:7px;padding:3px 8px;color:var(--ink-2)}
+.sum-card .spark{display:flex;align-items:flex-end;gap:2px;height:32px;margin-top:12px}
+.sum-card .spark .bar{flex:1;background:var(--ink-4);border-radius:2px 2px 0 0;min-height:2px}
+
+/* toolbar inputs */
+.pm-toolbar{display:flex;gap:10px;flex-wrap:wrap;align-items:center}
+.pm-toolbar input[type=text],.pm-toolbar select,.pm-toolbar input[type=number],.pm-toolbar input[type=date]{border:1px solid var(--line);border-radius:9px;padding:8px 12px;font-family:var(--font);font-size:13.5px;color:var(--ink);background:#fff}
+.pm-toolbar input:focus,.pm-toolbar select:focus{outline:none;border-color:var(--blue);box-shadow:0 0 0 3px rgba(37,99,235,.1)}
+
+/* tables */
+.pm-table-wrap{overflow-x:auto}
+table.pm-table{width:100%;border-collapse:collapse;font-size:14px}
+table.pm-table thead th{background:var(--card-2);color:var(--ink-2);font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;padding:13px 18px;text-align:left;border-bottom:1px solid var(--line);white-space:nowrap}
+table.pm-table tbody td{padding:14px 18px;border-bottom:1px solid var(--line-2);vertical-align:middle}
+table.pm-table tbody tr:last-child td{border-bottom:none}
+table.pm-table tbody tr:hover{background:#fafbfc}
+table.pm-table tr.clickable{cursor:pointer}
+table.pm-table strong{font-weight:700}
+
+/* dots + pills (neutral chip, coloured dot) */
+.pm-dot{display:inline-block;width:8px;height:8px;border-radius:50%;vertical-align:middle}
+.pm-dot.red{background:var(--red)} .pm-dot.amber{background:var(--amber)} .pm-dot.green{background:var(--green)}
+.pm-pill{display:inline-flex;align-items:center;gap:7px;padding:4px 11px;border-radius:999px;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.03em;background:var(--neutral);color:var(--ink-2)}
+.pm-pill::before{content:"";width:6px;height:6px;border-radius:50%;background:var(--ink-3)}
+.pm-pill.red{background:var(--red-bg);color:var(--red-ink)} .pm-pill.red::before{background:var(--red)}
+.pm-pill.amber{background:var(--amber-bg);color:var(--amber-ink)} .pm-pill.amber::before{background:var(--amber)}
+.pm-pill.green{background:var(--green-bg);color:var(--green-ink)} .pm-pill.green::before{background:var(--green)}
+
+.pm-empty{padding:34px;text-align:center;color:var(--ink-3);font-size:14px}
+.tfoot{padding:13px 6px 2px;font-size:12.5px;color:var(--ink-3);font-weight:500}
+
+/* buttons (legacy pm-btn vocabulary) */
+.pm-btn{border:1px solid var(--line);background:#fff;color:var(--ink-2);padding:0 15px;height:38px;border-radius:9px;font-family:var(--font);font-weight:600;font-size:13.5px;cursor:pointer;transition:.15s;display:inline-flex;align-items:center;gap:7px;text-decoration:none}
+.pm-btn:hover{background:var(--neutral);color:var(--ink)}
+.pm-btn.primary{background:var(--blue);color:#fff;border-color:var(--blue)}
+.pm-btn.primary:hover{background:var(--blue-ink)}
+.pm-btn.danger{background:var(--red);color:#fff;border-color:var(--red)}
+.pm-btn.success{background:var(--green);color:#fff;border-color:var(--green)}
+.pm-btn:disabled{opacity:.55;cursor:not-allowed}
+.pm-btn:active{transform:translateY(.5px)}
+
+/* modal */
+.pm-modal-backdrop{position:fixed;inset:0;background:rgba(19,32,29,.42);display:none;align-items:center;justify-content:center;z-index:200}
+.pm-modal-backdrop.show{display:flex}
+.pm-modal{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow-hover);width:min(560px,96vw);padding:22px}
+.pm-modal h3{font-size:16px;font-weight:800;margin:0 0 14px}
+.pm-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:14px}
+.pm-field{display:flex;flex-direction:column;gap:5px}
+.pm-field label{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:var(--ink-3)}
+.pm-field input,.pm-field select{border:1px solid var(--line);border-radius:9px;padding:9px 12px;font-family:var(--font);font-size:14px;color:var(--ink)}
+.pm-field input:focus,.pm-field select:focus{outline:none;border-color:var(--blue);box-shadow:0 0 0 3px rgba(37,99,235,.1)}
+
+/* dropzone */
+.pm-drop{border:2px dashed var(--line);border-radius:12px;padding:26px;text-align:center;color:var(--ink-2);background:var(--card-2);cursor:pointer;transition:.15s;display:block}
+.pm-drop:hover,.pm-drop.dragging{border-color:var(--blue);background:var(--blue-bg);color:var(--blue-ink)}
+.pm-drop input{display:none}

--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -494,45 +494,96 @@ router.get('/api/cut-masters', async (req, res) => {
   }
 });
 
-// POST /pm/api/cut-plan/assign { style, master_id } — PM approves a style's suggested cut
-// and assigns it to a specific cutting master. Persists a pm_cut_assignment + size lines.
+// POST /pm/api/cut-plan/assign — PM approves a style's suggested cut and assigns it to
+// cutting master(s). Two shapes (both supported, back-compatible):
+//   { style, master_id }                  -> whole style to ONE master (single consolidated row)
+//   { style, lots: [{ master_id }, ...] }  -> one assignment PER LOT, each to its own master
+// Per-lot uses the lot's own size split (plan.lots[i].sizes) and tags note "Lot i/N".
 router.post('/api/cut-plan/assign', async (req, res) => {
   try {
     const style = String(req.body.style || '').trim();
-    const masterId = parseInt(req.body.master_id, 10);
     if (!style) return res.status(400).json({ ok: false, error: 'style is required' });
-    if (!masterId) return res.status(400).json({ ok: false, error: 'master_id is required' });
 
-    const [[master]] = await pool.query(
-      `SELECT u.id, u.username FROM users u JOIN roles r ON u.role_id = r.id
-        WHERE u.id = ? AND r.name = 'cutting_manager' AND u.is_active = TRUE`,
-      [masterId]
-    );
-    if (!master) return res.status(400).json({ ok: false, error: 'Not a valid cutting master.' });
+    const { plan, fabricType } = await computeStyleCutPlan(style);
+    const lots = (plan && plan.lots) || [];
+    if (!lots.length) return res.status(400).json({ ok: false, error: 'No cut plan to assign.' });
 
-    const { demand, plan, fabricType } = await computeStyleCutPlan(style);
-    const { header, sizes } = buildAssignmentPayload({
-      style, fabricType, masterId: master.id, masterName: master.username,
-      demand, plan, createdBy: req.session?.user?.id || null,
-    });
-
-    const [result] = await pool.query(
-      `INSERT INTO pm_cut_assignment
-         (style, fabric_type, total_pieces, lot_count, total_fabric_meters, fabric_complete,
-          assigned_master_id, assigned_master_name, status, created_by)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'assigned', ?)`,
-      [header.style, header.fabric_type, header.total_pieces, header.lot_count,
-       header.total_fabric_meters, header.fabric_complete ? 1 : 0,
-       header.assigned_master_id, header.assigned_master_name, header.created_by]
-    );
-    const assignmentId = result.insertId;
-    if (sizes.length) {
-      await pool.query(
-        `INSERT INTO pm_cut_assignment_sizes (assignment_id, size_label, qty) VALUES ?`,
-        [sizes.map((s) => [assignmentId, s.size_label, s.qty])]
-      );
+    // Resolve which master each lot goes to.
+    const perLot = Array.isArray(req.body.lots) && req.body.lots.length;
+    let lotMasterIds;
+    if (perLot) {
+      if (req.body.lots.length !== lots.length) {
+        return res.status(400).json({ ok: false, error: `Expected ${lots.length} lot assignment(s), got ${req.body.lots.length}.` });
+      }
+      lotMasterIds = req.body.lots.map((l) => parseInt(l.master_id, 10));
+    } else {
+      const m = parseInt(req.body.master_id, 10);
+      if (!m) return res.status(400).json({ ok: false, error: 'master_id (or per-lot lots[]) is required' });
+      lotMasterIds = lots.map(() => m);
     }
-    res.json({ ok: true, assignment_id: assignmentId, assigned_to: master.username, ...header });
+    if (lotMasterIds.some((m) => !m)) return res.status(400).json({ ok: false, error: 'Every lot needs a cutting master.' });
+
+    // Validate all chosen masters in one query.
+    const uniqueIds = [...new Set(lotMasterIds)];
+    const [mrows] = await pool.query(
+      `SELECT u.id, u.username FROM users u JOIN roles r ON u.role_id = r.id
+        WHERE u.id IN (?) AND r.name = 'cutting_manager' AND u.is_active = TRUE`,
+      [uniqueIds]
+    );
+    const nameById = new Map(mrows.map((m) => [m.id, m.username]));
+    if (uniqueIds.some((id) => !nameById.has(id))) {
+      return res.status(400).json({ ok: false, error: 'One or more selected masters are not valid cutting masters.' });
+    }
+    const createdBy = req.session?.user?.id || null;
+
+    async function insertAssignment(header, sizes, note) {
+      const [result] = await pool.query(
+        `INSERT INTO pm_cut_assignment
+           (style, fabric_type, total_pieces, lot_count, total_fabric_meters, fabric_complete,
+            assigned_master_id, assigned_master_name, status, created_by, note)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'assigned', ?, ?)`,
+        [header.style, header.fabric_type, header.total_pieces, header.lot_count,
+         header.total_fabric_meters, header.fabric_complete ? 1 : 0,
+         header.assigned_master_id, header.assigned_master_name, header.created_by, note]
+      );
+      const assignmentId = result.insertId;
+      if (sizes.length) {
+        await pool.query(
+          `INSERT INTO pm_cut_assignment_sizes (assignment_id, size_label, qty) VALUES ?`,
+          [sizes.map((s) => [assignmentId, s.size_label, s.qty])]
+        );
+      }
+      return assignmentId;
+    }
+
+    // Single-master (all lots same OR legacy master_id): one consolidated row — unchanged behaviour.
+    if (!perLot || uniqueIds.length === 1) {
+      const masterId = lotMasterIds[0];
+      const { demand, plan: fullPlan, fabricType: ft } = await computeStyleCutPlan(style);
+      const { header, sizes } = buildAssignmentPayload({
+        style, fabricType: ft, masterId, masterName: nameById.get(masterId),
+        demand, plan: fullPlan, createdBy,
+      });
+      const id = await insertAssignment(header, sizes, null);
+      return res.json({ ok: true, assignment_id: id, count: 1, assigned_to: nameById.get(masterId) });
+    }
+
+    // Per-lot: one row per lot, each to its own master, using the lot's own size split.
+    const n = lots.length;
+    const created = [];
+    for (let i = 0; i < n; i++) {
+      const lot = lots[i];
+      const masterId = lotMasterIds[i];
+      const { header, sizes } = buildAssignmentPayload({
+        style, fabricType, masterId, masterName: nameById.get(masterId),
+        demand: lot.sizes,
+        plan: { lotCount: 1, totalFabricMeters: lot.fabricMeters, fabricComplete: lot.fabricComplete },
+        createdBy,
+      });
+      const id = await insertAssignment(header, sizes, `Lot ${i + 1}/${n}`);
+      created.push({ assignment_id: id, lot: i + 1, pieces: header.total_pieces, master: nameById.get(masterId) });
+    }
+    res.json({ ok: true, count: created.length, assignments: created, assigned_to: [...new Set(created.map((c) => c.master))].join(', ') });
   } catch (err) {
     if (err.code === 'ER_NO_SUCH_TABLE') return res.status(400).json({ ok: false, error: 'Run the cut-assignment migration first.' });
     res.status(500).json({ ok: false, error: err.message });

--- a/views/cutPlanning.ejs
+++ b/views/cutPlanning.ejs
@@ -1,105 +1,102 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Cut Planning — Approve &amp; Assign</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
-  <style>
-    body { background:#f6f7fb; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }
-    .page-head { background:linear-gradient(135deg,#0f172a,#1e293b); color:#fff; padding:22px 24px; margin-bottom:18px; border-radius:0 0 14px 14px; }
-    .page-head h1 { font-size:1.35rem; font-weight:600; margin:0; }
-    .page-head .sub { color:#94a3b8; font-size:.9rem; margin-top:4px; }
-    .search-box { display:flex; gap:10px; margin-top:14px; max-width:560px; }
-    .search-box input { flex:1; border:0; padding:9px 12px; border-radius:8px; font-size:.95rem; }
-    .card-box { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:16px 18px; margin-bottom:14px; }
-    .sizes { display:flex; gap:10px; flex-wrap:wrap; margin-top:8px; }
-    .sizes .s { background:#f1f5f9; border-radius:8px; padding:6px 12px; text-align:center; min-width:62px; }
-    .sizes .s strong { display:block; font-size:1.05rem; color:#0f172a; }
-    .sizes .s span { font-size:.7rem; color:#64748b; text-transform:uppercase; }
-    .lot-row { display:flex; gap:8px; flex-wrap:wrap; font-size:.82rem; color:#334155; margin-top:6px; }
-    .lot-chip { background:#eef2ff; border-radius:8px; padding:4px 10px; }
-    .assign-bar { display:flex; gap:10px; align-items:center; margin-top:14px; flex-wrap:wrap; }
-    .muted { color:#94a3b8; }
-    table.asg td, table.asg th { font-size:.84rem; padding:6px 10px; }
-  </style>
-</head>
-<body>
-  <div class="page-head">
-    <h1><i class="bi bi-clipboard2-check"></i> Cut Planning — Approve &amp; Assign</h1>
-    <div class="sub">Review a style's suggested cut, then assign it to a cutting master. CAD makes the marker; the master cuts to these quantities.</div>
-    <div class="search-box">
-      <input id="style" type="text" placeholder="Style code, e.g. KTTWOMENSPANT261" value="<%= prefillStyle %>">
-      <button class="btn btn-light" onclick="loadPlan()"><i class="bi bi-search"></i> Load plan</button>
-    </div>
-  </div>
+<%- include('partials/pmHead', { pageTitle: 'PM · Cut Planning' }) %>
+<%- include('partials/pmSidebar', { active: 'cut-planning', user: user }) %>
 
-  <div class="container-fluid" style="max-width:820px;">
-    <div id="status" class="muted mb-2" style="display:none;"></div>
+<div class="main">
+  <header class="topbar">
+    <div class="search">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3-3"/></svg>
+      <input id="style" placeholder="Load a style — e.g. KTTWOMENSPANT261" value="<%= prefillStyle %>">
+    </div>
+    <div class="actions">
+      <button class="btn primary" onclick="loadPlan()">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="11" cy="11" r="7"/><path d="m20 20-3-3"/></svg>
+        Load plan
+      </button>
+    </div>
+  </header>
+
+  <main class="content">
+    <div class="page-head">
+      <div>
+        <h1 class="page-h">Cut Planning</h1>
+        <p class="page-sub">Review a style's suggested cut, then assign it to a cutting master. CAD makes the marker; the master cuts to these quantities.</p>
+      </div>
+    </div>
+
+    <div id="status" class="pm-banner" style="border-color:var(--blue);background:var(--blue-bg);color:var(--blue-ink);display:none"></div>
     <div id="plan"></div>
-    <h6 class="mt-4 mb-2 text-muted">Recently assigned</h6>
-    <div id="assignments" class="card-box"><div class="muted">Loading…</div></div>
-  </div>
+
+    <h2 class="section-h">Recently assigned</h2>
+    <div class="tcard" id="assignments"><div class="pm-empty">Loading…</div></div>
+  </main>
+</div>
 
 <script>
 let MASTERS = [];
-const esc = s => String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
-const fmtDate = d => d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short'}) : '';
+const esc = s => String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+const fmtDate = d => d ? new Date(d).toLocaleDateString('en-IN', { day: '2-digit', month: 'short' }) : '';
+const fmtNum = v => (v == null || Number.isNaN(Number(v))) ? '—' : Number(v).toLocaleString('en-IN');
 
-async function loadMasters(){
-  const r = await fetch('/pm/api/cut-masters'); const d = await r.json();
+async function loadMasters() {
+  const d = await (await fetch('/pm/api/cut-masters')).json();
   MASTERS = (d.ok && d.masters) ? d.masters : [];
 }
-async function loadAssignments(){
-  const r = await fetch('/pm/api/cut-assignments'); const d = await r.json();
+async function loadAssignments() {
+  const d = await (await fetch('/pm/api/cut-assignments')).json();
   const box = document.getElementById('assignments');
-  if(!d.ok || !d.items.length){ box.innerHTML = '<div class="muted">No assignments yet.</div>'; return; }
-  box.innerHTML = '<table class="table asg table-sm mb-0"><thead><tr><th>Style</th><th>Pcs</th><th>Master</th><th>Status</th><th>When</th></tr></thead><tbody>'+
-    d.items.map(a=>'<tr><td>'+esc(a.style)+'</td><td>'+a.total_pieces+'</td><td>'+esc(a.assigned_master_name||'')+'</td><td>'+
-      (a.status==='cut'?'<span class="text-success">cut</span>':'assigned')+'</td><td>'+fmtDate(a.created_at)+'</td></tr>').join('')+
+  if (!d.ok || !d.items.length) { box.innerHTML = '<div class="pm-empty">No assignments yet.</div>'; return; }
+  box.innerHTML = '<table class="pm-table"><thead><tr><th class="l">Style</th><th>Pieces</th><th class="l">Master</th><th class="l" style="padding-left:20px">Status</th><th>When</th></tr></thead><tbody>' +
+    d.items.map(a => '<tr><td class="l"><span class="code" style="font-weight:700">' + esc(a.style) + '</span></td><td style="text-align:right"><span class="num">' + fmtNum(a.total_pieces) + '</span></td><td class="l">' + esc(a.assigned_master_name || '') + '</td><td class="l" style="padding-left:20px"><span class="pill ' + (a.status === 'cut' ? 'green' : 'blue') + '">' + (a.status === 'cut' ? 'Cut' : 'Assigned') + '</span></td><td style="text-align:right"><span class="num">' + fmtDate(a.created_at) + '</span></td></tr>').join('') +
     '</tbody></table>';
 }
 
-async function loadPlan(){
+async function loadPlan() {
   const style = document.getElementById('style').value.trim();
   const status = document.getElementById('status'); const out = document.getElementById('plan');
-  out.innerHTML=''; if(!style) return;
-  status.style.display='block'; status.textContent='Loading…';
-  const r = await fetch('/pm/api/cut-plan?style='+encodeURIComponent(style));
-  const j = await r.json();
-  if(!j.ok){ status.textContent = j.warning || j.error || 'failed'; return; }
-  if(!j.totalPieces){ status.textContent = 'No suggested cut for "'+style+'" right now (stock is covered).'; return; }
-  status.style.display='none';
-  const sizes = Object.entries(j.demand).sort((a,b)=>b[1]-a[1]);
-  const opts = MASTERS.map(m=>'<option value="'+m.id+'">'+esc(m.username)+'</option>').join('');
-  out.innerHTML = '<div class="card-box">'+
-    '<div class="d-flex justify-content-between"><div><div style="font-size:1.15rem;font-weight:700">'+esc(j.style)+'</div>'+
-      '<div class="muted small">'+esc(j.fabric_type||'fabric n/a')+' · '+j.totalPieces+' pcs · '+j.lotCount+' lot(s)</div></div>'+
-      '<div class="text-end">'+(j.totalFabricMeters!=null?('<div style="font-size:1.2rem;font-weight:700">'+Number(j.totalFabricMeters).toFixed(1)+' m</div><div class="muted small">fabric to issue</div>'):'<div class="muted small">no CAD fabric</div>')+'</div></div>'+
-    '<div class="sizes">'+sizes.map(([s,q])=>'<div class="s"><strong>'+q+'</strong><span>'+esc(s)+'</span></div>').join('')+'</div>'+
-    (j.missingSizes&&j.missingSizes.length?('<div class="small text-warning mt-2">No CAD consumption yet for: '+j.missingSizes.map(esc).join(', ')+'</div>'):'')+
-    '<div class="lot-row">'+j.lots.map((l,i)=>'<span class="lot-chip">Lot '+(i+1)+': '+l.total+' pcs'+(l.fabricMeters!=null?(' · '+Number(l.fabricMeters).toFixed(0)+'m'):'')+'</span>').join('')+'</div>'+
-    '<div class="assign-bar"><label class="small text-muted">Assign to cutting master:</label>'+
-      '<select id="masterSel" class="form-select form-select-sm" style="max-width:220px">'+(opts||'<option>no masters</option>')+'</select>'+
-      '<button class="btn btn-primary btn-sm" onclick="assign(\''+esc(j.style)+'\')"><i class="bi bi-send"></i> Approve &amp; Assign</button>'+
-      '<span id="assignMsg" class="small"></span></div>'+
+  out.innerHTML = ''; if (!style) return;
+  status.style.display = 'block'; status.textContent = 'Loading…';
+  const j = await (await fetch('/pm/api/cut-plan?style=' + encodeURIComponent(style))).json();
+  if (!j.ok) { status.textContent = j.warning || j.error || 'failed'; return; }
+  if (!j.totalPieces) { status.textContent = 'No suggested cut for "' + style + '" right now (stock is covered).'; return; }
+  status.style.display = 'none';
+  const sizes = Object.entries(j.demand).sort((a, b) => b[1] - a[1]);
+  const opts = MASTERS.map(m => '<option value="' + m.id + '">' + esc(m.username) + '</option>').join('');
+  out.innerHTML =
+    '<div class="plan">' +
+      '<div class="plan-head"><span class="swatch lg"></span><div><div class="code">' + esc(j.style) + '</div><div class="fab">' + esc(j.fabric_type || 'fabric n/a') + ' · ' + j.lotCount + ' lot(s)</div></div>' +
+        '<div class="tot"><div class="k">Total to cut</div><div class="v num">' + fmtNum(j.totalPieces) + '</div></div></div>' +
+      '<div class="plan-body" style="display:block">' +
+        '<span class="fieldlab">Suggested size split · ' + fmtNum(j.totalPieces) + ' pcs total</span>' +
+        '<div class="chips">' + sizes.map(([s, q]) => '<div class="chip-sz"><span class="s">' + esc(s) + '</span><span class="q num">' + fmtNum(q) + '</span></div>').join('') + '</div>' +
+        (j.missingSizes && j.missingSizes.length ? '<div style="color:var(--amber-ink);font-size:12.5px;margin-top:10px">No CAD consumption yet for: ' + j.missingSizes.map(esc).join(', ') + '</div>' : '') +
+        '<span class="fieldlab" style="margin-top:16px">Lot split · 1,500 hard cap — assign each lot to a master</span>' +
+        '<div class="lotlist">' + j.lots.map(function (l, i) { var sz = Object.entries(l.sizes || {}).sort(function (a, b) { return b[1] - a[1]; }).map(function (e) { return '<div class="chip-sz"><span class="s">' + esc(e[0]) + '</span><span class="q num">' + fmtNum(e[1]) + '</span></div>'; }).join(''); return '<div class="lotrow"><div class="lotid">Lot ' + (i + 1) + ' <small><span class="num">' + fmtNum(l.total) + '</span> pcs' + (l.fabricMeters != null ? ' · ' + Number(l.fabricMeters).toFixed(0) + ' m' : '') + '</small></div><div class="lotsizes">' + sz + '</div><select class="select lotmaster">' + (opts || '<option value="">no masters</option>') + '</select></div>'; }).join('') + '</div>' +
+      '</div>' +
+      '<div class="assignbar">' +
+        '<span style="font-size:12.5px;color:var(--ink-2)">One master can take several lots — same master for all is fine.</span>' +
+        '<div style="flex:1"></div>' +
+        '<button class="btn primary" onclick="assign(\'' + esc(j.style) + '\')"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4 12 14.01l-3-3"/></svg> Approve &amp; assign</button>' +
+        '<span id="assignMsg" style="font-size:13px"></span>' +
+      '</div>' +
     '</div>';
 }
 
-async function assign(style){
-  const masterId = document.getElementById('masterSel').value;
+async function assign(style) {
+  const sels = Array.from(document.querySelectorAll('.lotmaster'));
   const msg = document.getElementById('assignMsg');
-  if(!masterId){ msg.textContent='pick a master'; return; }
-  msg.textContent='Assigning…';
-  const r = await fetch('/pm/api/cut-plan/assign',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({style,master_id:masterId})});
-  const d = await r.json();
-  if(d.ok){ msg.innerHTML='<span class="text-success">✓ Assigned to '+esc(d.assigned_to)+'</span>'; loadAssignments(); }
-  else { msg.innerHTML='<span class="text-danger">'+esc(d.error||'failed')+'</span>'; }
+  const ids = sels.map(s => s.value);
+  if (!ids.length || ids.some(v => !v)) { msg.innerHTML = '<span style="color:var(--red)">pick a master for every lot</span>'; return; }
+  msg.textContent = 'Assigning…';
+  const allSame = ids.every(v => v === ids[0]);
+  const body = allSame ? { style, master_id: ids[0] } : { style, lots: ids.map(v => ({ master_id: v })) };
+  const d = await (await fetch('/pm/api/cut-plan/assign', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })).json();
+  if (d.ok) { msg.innerHTML = '<span style="color:var(--green-ink)">✓ Assigned to ' + esc(d.assigned_to) + '</span>'; loadAssignments(); }
+  else { msg.innerHTML = '<span style="color:var(--red)">' + esc(d.error || 'failed') + '</span>'; }
 }
 
-(async()=>{ await loadMasters(); loadAssignments(); if(document.getElementById('style').value.trim()) loadPlan(); })();
-document.getElementById('style').addEventListener('keydown',e=>{ if(e.key==='Enter') loadPlan(); });
+(async () => { await loadMasters(); loadAssignments(); if (document.getElementById('style').value.trim()) loadPlan(); })();
+document.getElementById('style').addEventListener('keydown', e => { if (e.key === 'Enter') loadPlan(); });
 </script>
+
 </body>
 </html>

--- a/views/partials/pmHead.ejs
+++ b/views/partials/pmHead.ejs
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#2563eb" />
+  <title><%= typeof pageTitle !== 'undefined' ? pageTitle + ' · ' : '' %>Kotty PM</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Hanken+Grotesk:wght@400;500;600;700;800&family=IBM+Plex+Mono:wght@400;500;600&display=swap" rel="stylesheet">
+  <link href="/css/pm-suite.css" rel="stylesheet">
+</head>
+<body>

--- a/views/partials/pmSidebar.ejs
+++ b/views/partials/pmSidebar.ejs
@@ -1,0 +1,41 @@
+<%
+  // active: 'dashboard' | 'cut-planning' | 'analytics'
+  var _active = typeof active !== 'undefined' ? active : '';
+  var _name = (typeof user !== 'undefined' && user && user.username) ? user.username : 'User';
+  var _role = (typeof user !== 'undefined' && user && user.role) ? user.role : 'Production Manager';
+  var _initial = _name.charAt(0).toUpperCase();
+%>
+<aside class="sidebar">
+  <div class="brand">
+    <div class="logo">K</div>
+    <div><div class="name">Kotty PM</div><div class="sub">Manufacturing Suite</div></div>
+  </div>
+  <nav class="nav">
+    <a href="/pm" class="<%= _active === 'dashboard' ? 'active' : '' %>" <%= _active === 'dashboard' ? 'aria-current="page"' : '' %>>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="3" width="7" height="9" rx="1.5"/><rect x="14" y="3" width="7" height="5" rx="1.5"/><rect x="14" y="12" width="7" height="9" rx="1.5"/><rect x="3" y="16" width="7" height="5" rx="1.5"/></svg>
+      Dashboard
+    </a>
+    <a href="/pm/cut-planning" class="<%= _active === 'cut-planning' ? 'active' : '' %>" <%= _active === 'cut-planning' ? 'aria-current="page"' : '' %>>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="4" y="3" width="16" height="18" rx="2"/><path d="M9 3v3h6V3M8 11h8M8 15h5"/></svg>
+      Cut Planning
+    </a>
+    <a href="/pm/analytics" class="<%= _active === 'analytics' ? 'active' : '' %>" <%= _active === 'analytics' ? 'aria-current="page"' : '' %>>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 20V10M10 20V4M16 20v-7M22 20H2"/></svg>
+      Analytics
+    </a>
+  </nav>
+  <div class="spacer"></div>
+  <details class="usermenu">
+    <summary>
+      <div class="avatar"><%= _initial %></div>
+      <div class="who"><b><%= _name %></b><span><%= _role %></span></div>
+      <svg class="caret" viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="m6 9 6 6 6-6"/></svg>
+    </summary>
+    <div class="menu">
+      <a href="/my-lots"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z"/><path d="M3 6h18M16 10a4 4 0 0 1-8 0"/></svg> My Lots</a>
+      <a href="/profile"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="8" r="4"/><path d="M4 21a8 8 0 0 1 16 0"/></svg> Profile</a>
+      <hr>
+      <a href="/logout" class="danger"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4M16 17l5-5-5-5M21 12H9"/></svg> Logout</a>
+    </div>
+  </details>
+</aside>

--- a/views/productionManagerAnalytics.ejs
+++ b/views/productionManagerAnalytics.ejs
@@ -1,100 +1,106 @@
-<%- include('partials/header', { pageTitle: 'PM · Analytics' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/pm' }) %>
+<%- include('partials/pmHead', { pageTitle: 'PM · Analytics' }) %>
+<%- include('partials/pmSidebar', { active: 'analytics', user: user }) %>
 
-<style>
-  body { background: #f5f7fb; }
-  .pm { --bg:#f5f7fb; --card:#fff; --border:#e5e8ee; --border-2:#eef0f4; --text:#0f172a; --text-2:#475569; --text-3:#94a3b8;
-        --primary:#4f46e5; --success:#16a34a; --success-s:#dcfce7; --warning:#d97706; --warning-s:#fef3c7; --danger:#dc2626; --danger-s:#fee2e2;
-        --shadow:0 1px 3px rgba(15,23,42,0.05); font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif; color:var(--text); }
-  .pm-page { max-width:1300px; margin:0 auto; padding:calc(var(--navbar-height,60px) + 1.5rem) 1rem 4rem; }
-  .pm-head { display:flex; justify-content:space-between; align-items:center; flex-wrap:wrap; gap:.75rem; margin-bottom:1rem; }
-  .pm-head h1 { font-size:1.5rem; font-weight:700; margin:0; }
-  .pm-back { color:var(--primary); text-decoration:none; font-weight:600; font-size:.875rem; }
-  .pm-card { background:var(--card); border:1px solid var(--border); border-radius:16px; box-shadow:var(--shadow); margin-bottom:1rem; overflow:hidden; }
-  .pm-card-head { padding:.875rem 1.125rem; border-bottom:1px solid var(--border-2); background:linear-gradient(180deg,#fafbfd,#fff); }
-  .pm-card-head h2 { font-size:1rem; font-weight:700; margin:0; }
-  .pm-card-head .hint { font-size:.78rem; color:var(--text-3); margin-top:2px; }
-  .pm-card-body { padding:1rem 1.125rem; }
-  .metrics { display:flex; gap:2rem; flex-wrap:wrap; margin-bottom:1rem; }
-  .metric .v { font-size:1.6rem; font-weight:800; letter-spacing:-.02em; }
-  .metric .k { font-size:.75rem; text-transform:uppercase; letter-spacing:.04em; color:var(--text-3); }
-  table.t { width:100%; border-collapse:collapse; font-size:.85rem; }
-  table.t thead th { background:#f8fafc; color:var(--text-2); font-size:.7rem; font-weight:700; text-transform:uppercase; letter-spacing:.04em; padding:.5rem .7rem; text-align:left; border-bottom:1px solid var(--border-2); }
-  table.t tbody td { padding:.5rem .7rem; border-bottom:1px solid var(--border-2); }
-  .pill { font-size:.7rem; font-weight:700; padding:.15rem .5rem; border-radius:999px; }
-  .pill.red,.pill.over { background:var(--danger-s); color:var(--danger); }
-  .pill.amber { background:var(--warning-s); color:var(--warning); }
-  .pill.green,.pill.under,.pill.on_target { background:var(--success-s); color:var(--success); }
-  .bars { display:flex; align-items:flex-end; gap:4px; height:90px; }
-  .bars .col { flex:1; display:flex; flex-direction:column; align-items:center; gap:2px; }
-  .bars .bar { width:70%; background:var(--primary); border-radius:3px 3px 0 0; min-height:2px; }
-  .bars .bar.d { background:var(--success); }
-  .bars .lbl { font-size:.62rem; color:var(--text-3); }
-  .empty { padding:1.5rem; text-align:center; color:var(--text-3); }
-</style>
+<div class="main">
+  <header class="topbar">
+    <div class="search">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3-3"/></svg>
+      <input placeholder="Search style, lot, or order…">
+    </div>
+    <div class="actions">
+      <a class="pm-btn" href="/pm/api/recommendations.csv">Export CSV</a>
+    </div>
+  </header>
 
-<div class="pm"><div class="pm-page">
-  <div class="pm-head">
-    <div><a class="pm-back" href="/pm">← Dashboard</a><h1 style="margin-top:.4rem;">Production Analytics</h1></div>
-  </div>
+  <main class="content">
+    <div class="page-head">
+      <div>
+        <h1 class="page-h">Analytics</h1>
+        <p class="page-sub">Demand vs supply, throughput, and fabric accuracy</p>
+      </div>
+    </div>
 
-  <div class="pm-card"><div class="pm-card-head"><h2>Demand vs supply</h2><div class="hint">how fast we're selling vs what we hold + have on order</div></div><div class="pm-card-body" id="demandSupply"><div class="empty">Loading…</div></div></div>
-  <div class="pm-card"><div class="pm-card-head"><h2>Throughput &amp; TAT</h2><div class="hint">lots cut and dispatched per week · current bottleneck</div></div><div class="pm-card-body" id="throughput"><div class="empty">Loading…</div></div></div>
-  <div class="pm-card"><div class="pm-card-head"><h2>Fabric usage &amp; variance</h2><div class="hint">real consumption vs CAD standard (over = wasting fabric)</div></div><div class="pm-card-body" id="fabricVariance"><div class="empty">Loading…</div></div></div>
-  <div class="pm-card"><div class="pm-card-head"><h2>Master / cutter output</h2><div class="hint">pieces cut (30 days) and assignments per cutting master</div></div><div class="pm-card-body" id="masterOutput"><div class="empty">Loading…</div></div></div>
-</div></div>
+    <section class="statband" id="statBand">
+      <div class="stat"><div class="k">Demand / day</div><div class="v">—</div></div>
+      <div class="stat"><div class="k">In stock</div><div class="v">—</div></div>
+      <div class="stat"><div class="k">On order</div><div class="v">—</div></div>
+      <div class="stat"><div class="k">Suggested cut</div><div class="v">—</div></div>
+    </section>
+
+    <div class="grid-2" style="align-items:start">
+      <div class="chartcard" id="throughput"><h4>Throughput</h4><div class="cap">Cut vs dispatched, per week</div><div class="pm-empty">Loading…</div></div>
+      <div class="chartcard" id="masterOutput"><h4>Master output</h4><div class="cap">Pieces cut &amp; assignments · 30 days</div><div class="pm-empty">Loading…</div></div>
+    </div>
+
+    <h2 class="section-h">Most under-supplied styles</h2>
+    <div class="tcard" id="demandSupply"><div class="pm-empty">Loading…</div></div>
+
+    <h2 class="section-h">Fabric variance — actual vs CAD</h2>
+    <div class="tcard" id="fabricVariance"><div class="pm-empty">Loading…</div></div>
+  </main>
+</div>
 
 <script>
-const esc = s => String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
-const cn = n => { n=Number(n)||0; if(n>=1e7)return (n/1e7).toFixed(1)+' Cr'; if(n>=1e5)return (n/1e5).toFixed(1)+' L'; if(n>=1e3)return (n/1e3).toFixed(1)+'k'; return String(Math.round(n)); };
-const fd = d => d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short'}) : '';
+const esc = s => String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+const cn = n => { n = Number(n) || 0; if (n >= 1e7) return (n / 1e7).toFixed(1) + ' Cr'; if (n >= 1e5) return (n / 1e5).toFixed(1) + ' L'; if (n >= 1e3) return (n / 1e3).toFixed(1) + 'k'; return String(Math.round(n)); };
+const fd = d => d ? new Date(d).toLocaleDateString('en-IN', { day: '2-digit', month: 'short' }) : '';
+const STATUS = { red: 'red', amber: 'amber', green: 'green' };
 
-(async function(){
+(async function () {
   let a;
-  try { a = await (await fetch('/pm/api/analytics')).json(); } catch(e){ return; }
-  if(!a.ok) return;
+  try { a = await (await fetch('/pm/api/analytics')).json(); } catch (e) { return; }
+  if (!a.ok) return;
 
-  // Demand vs supply
-  const ds = a.demand_supply, dsEl = document.getElementById('demandSupply');
-  if(ds){
-    dsEl.innerHTML = `<div class="metrics">
-      <div class="metric"><div class="v">${cn(ds.dailyDemand)}</div><div class="k">selling / day</div></div>
-      <div class="metric"><div class="v">${cn(ds.soh)}</div><div class="k">in stock</div></div>
-      <div class="metric"><div class="v">${cn(ds.onOrder)}</div><div class="k">on order</div></div>
-      <div class="metric"><div class="v">${ds.daysCover!=null?Math.round(ds.daysCover):'—'}</div><div class="k">days of cover</div></div>
-      <div class="metric"><div class="v">${cn(ds.suggested)}</div><div class="k">suggested cut</div></div>
-    </div>
-    <table class="t"><thead><tr><th>Style (most under-supplied)</th><th>Suggested</th><th>SOH</th><th>DRR</th><th>DOH</th><th>On order</th><th></th></tr></thead><tbody>
-    ${ds.top.map(s=>`<tr><td>${esc(s.style)}</td><td><strong>${cn(s.suggested)}</strong></td><td>${cn(s.soh)}</td><td>${(s.drr||0).toFixed(1)}</td><td>${s.doh==null?'—':Math.round(s.doh)}</td><td>${cn(s.on_order)}</td><td><span class="pill ${esc(s.trigger)}">${esc(s.trigger)}</span></td></tr>`).join('')}
+  // Stat band
+  const ds = a.demand_supply;
+  if (ds) {
+    document.getElementById('statBand').innerHTML = [
+      ['Demand / day', cn(ds.dailyDemand), ''],
+      ['In stock', cn(ds.soh), ds.daysCover != null ? Math.round(ds.daysCover) + ' days of cover' : ''],
+      ['On order', cn(ds.onOrder), 'cut, not yet dispatched'],
+      ['Suggested cut', cn(ds.suggested), 'across all styles'],
+    ].map(s => `<div class="stat"><div class="k">${s[0]}</div><div class="v num">${s[1]}</div>${s[2] ? `<div class="d">${s[2]}</div>` : ''}</div>`).join('');
+  }
+
+  // Demand vs supply — under-supplied styles table
+  const dsEl = document.getElementById('demandSupply');
+  if (ds && ds.top && ds.top.length) {
+    dsEl.innerHTML = `<table class="pm-table"><thead><tr><th class="l">Style</th><th>Suggested</th><th>SOH</th><th>DRR</th><th>DOH</th><th>On order</th><th class="l" style="padding-left:20px">Status</th></tr></thead><tbody>
+      ${ds.top.map(s => `<tr><td class="l"><span class="code" style="font-weight:700">${esc(s.style)}</span></td><td style="text-align:right"><span class="num" style="font-weight:700">${cn(s.suggested)}</span></td><td style="text-align:right"><span class="num">${cn(s.soh)}</span></td><td style="text-align:right"><span class="num">${(s.drr || 0).toFixed(1)}</span></td><td style="text-align:right"><span class="num">${s.doh == null ? '—' : Math.round(s.doh)}</span></td><td style="text-align:right"><span class="num">${cn(s.on_order)}</span></td><td class="l" style="padding-left:20px"><span class="pill ${STATUS[s.trigger] || 'green'}">${esc(s.trigger)}</span></td></tr>`).join('')}
     </tbody></table>`;
-  } else dsEl.innerHTML = '<div class="empty">Unavailable.</div>';
+  } else dsEl.innerHTML = '<div class="pm-empty">Unavailable.</div>';
 
   // Throughput
   const tp = a.throughput, tpEl = document.getElementById('throughput');
-  if(tp){
-    const weeks = tp.cut_per_week; const dmap = Object.fromEntries(tp.dispatch_per_week.map(d=>[fd(d.week_start),d.pieces]));
-    const max = Math.max(1, ...weeks.map(w=>w.pieces), ...tp.dispatch_per_week.map(d=>d.pieces));
-    tpEl.innerHTML = `${tp.bottleneck?`<div class="metrics"><div class="metric"><div class="v" style="color:var(--warning)">${esc(tp.bottleneck.stage.replace('_',' '))}</div><div class="k">bottleneck · ${cn(tp.bottleneck.wip)} pcs WIP</div></div></div>`:''}
-      <div class="bars">${weeks.map(w=>{const dp=dmap[fd(w.week_start)]||0;return `<div class="col"><div style="display:flex;gap:2px;align-items:flex-end;height:70px;"><div class="bar" style="height:${Math.round(w.pieces/max*70)}px" title="cut ${w.pieces}"></div><div class="bar d" style="height:${Math.round(dp/max*70)}px" title="dispatched ${dp}"></div></div><div class="lbl">${fd(w.week_start)}</div></div>`;}).join('')}</div>
-      <div style="font-size:.75rem;color:var(--text-3);margin-top:.5rem;"><span style="color:var(--primary)">■</span> cut &nbsp; <span style="color:var(--success)">■</span> dispatched · per week</div>`;
-  } else tpEl.innerHTML = '<div class="empty">Unavailable.</div>';
-
-  // Fabric variance
-  const fv = a.fabric_variance, fvEl = document.getElementById('fabricVariance');
-  if(fv && fv.length){
-    fvEl.innerHTML = `<table class="t"><thead><tr><th>Style</th><th>Actual m/pc</th><th>CAD standard</th><th>Variance</th><th></th></tr></thead><tbody>
-    ${fv.map(r=>`<tr><td>${esc(r.style)}</td><td>${r.real.toFixed(3)}</td><td>${r.standard.toFixed(3)}</td><td>${r.variancePct>0?'+':''}${r.variancePct.toFixed(1)}%</td><td><span class="pill ${esc(r.status)}">${esc(r.status)}</span></td></tr>`).join('')}
-    </tbody></table>`;
-  } else fvEl.innerHTML = '<div class="empty">No styles with both CAD and cutting history yet. Upload more CAD sheets to populate this.</div>';
+  if (tp && tp.cut_per_week && tp.cut_per_week.length) {
+    const weeks = tp.cut_per_week.slice(-8);
+    const dmap = Object.fromEntries(tp.dispatch_per_week.map(d => [fd(d.week_start), d.pieces]));
+    const max = Math.max(1, ...weeks.map(w => w.pieces), ...tp.dispatch_per_week.map(d => d.pieces));
+    tpEl.innerHTML = `<h4>Throughput</h4><div class="cap">Cut vs dispatched, per week</div>
+      <div class="bars">${weeks.map(w => { const dp = dmap[fd(w.week_start)] || 0; return `<div class="barcol"><div class="barpair"><div class="bar cut" style="height:${Math.max(2, Math.round(w.pieces / max * 100))}%" title="cut ${w.pieces}"></div><div class="bar disp" style="height:${Math.max(2, Math.round(dp / max * 100))}%" title="dispatched ${dp}"></div></div><span class="xl">${fd(w.week_start)}</span></div>`; }).join('')}</div>
+      <div class="legend"><div class="li"><span class="sw" style="background:var(--blue)"></span>Cut</div><div class="li"><span class="sw" style="background:var(--green)"></span>Dispatched</div></div>
+      ${tp.bottleneck ? `<div class="callout"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 9v4M12 17h.01M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/></svg>Bottleneck: ${esc(tp.bottleneck.stage.replace(/_/g, ' '))} — ${cn(tp.bottleneck.wip)} pcs WIP</div>` : ''}`;
+  } else tpEl.innerHTML = '<h4>Throughput</h4><div class="cap">Cut vs dispatched, per week</div><div class="pm-empty">Unavailable.</div>';
 
   // Master output
   const mo = a.master_output, moEl = document.getElementById('masterOutput');
-  if(mo && mo.length){
-    moEl.innerHTML = `<table class="t"><thead><tr><th>Master</th><th>Lots (30d)</th><th>Pieces (30d)</th><th>Assigned</th><th>Cut</th></tr></thead><tbody>
-    ${mo.map(m=>`<tr><td>${esc(m.username||('#'+m.master_id))}</td><td>${m.lots}</td><td><strong>${cn(m.pieces)}</strong></td><td>${m.assigned}</td><td>${m.cut}</td></tr>`).join('')}
+  if (mo && mo.length) {
+    moEl.innerHTML = `<h4>Master output</h4><div class="cap">Pieces cut &amp; assignments · 30 days</div>
+      <table class="pm-table"><thead><tr><th class="l">Master</th><th>Lots</th><th>Pieces</th><th>Assigned</th><th>Cut</th></tr></thead><tbody>
+      ${mo.map(m => `<tr><td class="l" style="font-weight:700">${esc(m.username || ('#' + m.master_id))}</td><td style="text-align:right"><span class="num">${m.lots}</span></td><td style="text-align:right"><span class="num" style="font-weight:700">${cn(m.pieces)}</span></td><td style="text-align:right"><span class="num">${m.assigned}</span></td><td style="text-align:right"><span class="num">${m.cut}</span></td></tr>`).join('')}
     </tbody></table>`;
-  } else moEl.innerHTML = '<div class="empty">Unavailable.</div>';
+  } else moEl.innerHTML = '<h4>Master output</h4><div class="cap">Pieces cut &amp; assignments · 30 days</div><div class="pm-empty">Unavailable.</div>';
+
+  // Fabric variance
+  const fv = a.fabric_variance, fvEl = document.getElementById('fabricVariance');
+  if (fv && fv.length) {
+    const vcls = { over: 'over', under: 'under', on_target: '' };
+    fvEl.innerHTML = `<table class="pm-table"><thead><tr><th class="l">Style</th><th>Actual m/pc</th><th>CAD standard</th><th>Variance</th><th class="l" style="padding-left:20px">Status</th></tr></thead><tbody>
+      ${fv.map(r => `<tr><td class="l"><span class="code" style="font-weight:700">${esc(r.style)}</span></td><td style="text-align:right"><span class="num">${r.real.toFixed(3)}</span></td><td style="text-align:right"><span class="num">${r.standard.toFixed(3)}</span></td><td style="text-align:right"><span class="num">${r.variancePct > 0 ? '+' : ''}${r.variancePct.toFixed(1)}%</span></td><td class="l" style="padding-left:20px"><span class="vpill ${vcls[r.status] || ''}">${esc((r.status || '').replace(/_/g, ' '))}</span></td></tr>`).join('')}
+    </tbody></table>`;
+  } else fvEl.innerHTML = '<div class="pm-empty">No styles with both CAD and cutting history yet. Upload more CAD sheets to populate this.</div>';
 })();
 </script>
 
-<%- include('partials/footer') %>
+</body>
+</html>

--- a/views/productionManagerDashboard.ejs
+++ b/views/productionManagerDashboard.ejs
@@ -1,184 +1,24 @@
-<%- include('partials/header', { pageTitle: 'Production Manager' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/pm' }) %>
+<%- include('partials/pmHead', { pageTitle: 'Production Manager' }) %>
+<%- include('partials/pmSidebar', { active: 'dashboard', user: user }) %>
 
-<style>
-  body { background: #f5f7fb; }
-  .pm {
-    --bg: #f5f7fb;
-    --card: #ffffff;
-    --border: #e5e8ee;
-    --border-2: #eef0f4;
-    --text: #0f172a;
-    --text-2: #475569;
-    --text-3: #94a3b8;
-    --primary: #4f46e5;
-    --primary-h: #4338ca;
-    --primary-s: #eef2ff;
-    --success: #16a34a;
-    --success-s: #dcfce7;
-    --warning: #d97706;
-    --warning-s: #fef3c7;
-    --danger: #dc2626;
-    --danger-s: #fee2e2;
-    --shadow: 0 1px 3px rgba(15,23,42,0.05);
-    --shadow-l: 0 10px 24px rgba(15,23,42,0.08);
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    color: var(--text);
-    -webkit-font-smoothing: antialiased;
-  }
-  .pm-page {
-    max-width: 1500px;
-    margin: 0 auto;
-    padding: calc(var(--navbar-height, 60px) + 1.5rem) 1rem 4rem;
-  }
-  .pm-head { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 1rem; }
-  .pm-head h1 { font-size: 1.6rem; font-weight: 700; letter-spacing: -0.02em; margin: 0; }
-  .pm-head .who { color: var(--text-2); font-size: 0.85rem; }
-  .pm-actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
 
-  .pm-btn {
-    border: 1px solid var(--border); background: var(--card); color: var(--text);
-    padding: 0.45rem 0.85rem; border-radius: 10px;
-    font-weight: 600; font-size: 0.85rem; cursor: pointer;
-    transition: all .12s; display: inline-flex; align-items: center; gap: 0.35rem;
-  }
-  .pm-btn:hover { background: var(--bg); border-color: #cbd5e1; }
-  .pm-btn.primary { background: var(--primary); color: #fff; border-color: var(--primary); }
-  .pm-btn.primary:hover { background: var(--primary-h); }
-  .pm-btn.danger { background: var(--danger); color: #fff; border-color: var(--danger); }
-  .pm-btn.success { background: var(--success); color: #fff; border-color: var(--success); }
-  .pm-btn:disabled { opacity: .55; cursor: not-allowed; }
-
-  .pm-banner {
-    margin-bottom: 1rem; padding: 0.75rem 1rem;
-    border-radius: 12px; border: 1px solid var(--warning);
-    background: var(--warning-s); color: #7c4a03;
-    font-size: 0.875rem; display: none;
-  }
-  .pm-banner.show { display: block; }
-
-  .pm-tabs {
-    display: flex; gap: 0.4rem; flex-wrap: wrap;
-    border-bottom: 1px solid var(--border); margin-bottom: 1rem;
-  }
-  .pm-tab {
-    border: none; background: transparent; padding: 0.6rem 1rem;
-    font-weight: 600; font-size: 0.9rem; color: var(--text-2);
-    cursor: pointer; border-radius: 10px 10px 0 0;
-    border-bottom: 3px solid transparent; margin-bottom: -1px;
-  }
-  .pm-tab:hover { color: var(--text); }
-  .pm-tab.active { color: var(--primary); border-bottom-color: var(--primary); background: var(--primary-s); }
-
-  .pm-panel { display: none; }
-  .pm-panel.active { display: block; }
-
-  .pm-card {
-    background: var(--card); border: 1px solid var(--border);
-    border-radius: 16px; box-shadow: var(--shadow);
-    overflow: hidden; margin-bottom: 1rem;
-  }
-  .pm-card-head {
-    padding: 0.875rem 1.125rem; border-bottom: 1px solid var(--border-2);
-    display: flex; justify-content: space-between; align-items: center; gap: 0.5rem; flex-wrap: wrap;
-    background: linear-gradient(180deg, #fafbfd 0%, #ffffff 100%);
-  }
-  .pm-card-head h2 { font-size: 1rem; font-weight: 700; margin: 0; }
-  .pm-card-body { padding: 1rem 1.125rem; }
-
-  .pm-summary { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 0.75rem; margin-bottom: 1rem; }
-  .sum-card { background: var(--card); border: 1px solid var(--border); border-radius: 14px; padding: 0.9rem 1rem; box-shadow: var(--shadow); }
-  .sum-card .label { font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; color: var(--text-3); }
-  .sum-card .big { font-size: 1.7rem; font-weight: 800; letter-spacing: -0.02em; margin: 0.15rem 0 0.1rem; color: var(--text); }
-  .sum-card .sub { font-size: 0.78rem; color: var(--text-2); }
-  .sum-card.alert .big { color: var(--danger); }
-  .sum-card .chips { display: flex; gap: 0.3rem; flex-wrap: wrap; margin-top: 0.35rem; }
-  .sum-card .chip { font-size: 0.7rem; background: var(--bg); border-radius: 6px; padding: 0.15rem 0.4rem; color: var(--text-2); }
-  .spark { display: flex; align-items: flex-end; gap: 2px; height: 34px; margin-top: 0.35rem; }
-  .spark .bar { flex: 1; background: var(--primary); border-radius: 2px 2px 0 0; min-height: 2px; opacity: 0.85; }
-
-  .pm-toolbar { display: flex; gap: 0.5rem; flex-wrap: wrap; align-items: center; }
-  .pm-toolbar input[type="text"], .pm-toolbar select, .pm-toolbar input[type="number"], .pm-toolbar input[type="date"] {
-    border: 1px solid var(--border); border-radius: 10px;
-    padding: 0.4rem 0.7rem; font-family: inherit; font-size: 0.875rem;
-  }
-  .pm-toolbar input:focus, .pm-toolbar select:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-s); }
-
-  .pm-table-wrap { overflow-x: auto; }
-  table.pm-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
-  table.pm-table thead th {
-    background: #f8fafc; color: var(--text-2);
-    font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
-    padding: 0.55rem 0.75rem; text-align: left;
-    border-bottom: 1px solid var(--border-2); white-space: nowrap;
-  }
-  table.pm-table tbody td {
-    padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border-2);
-    vertical-align: middle;
-  }
-  table.pm-table tbody tr:hover { background: #fafbfd; }
-  table.pm-table tr.clickable { cursor: pointer; }
-
-  .pm-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; vertical-align: middle; }
-  .pm-dot.red    { background: var(--danger); }
-  .pm-dot.amber  { background: var(--warning); }
-  .pm-dot.green  { background: var(--success); }
-  .pm-pill {
-    display: inline-block; padding: 0.15rem 0.55rem; border-radius: 9999px;
-    font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
-  }
-  .pm-pill.red   { background: var(--danger-s);  color: var(--danger); }
-  .pm-pill.amber { background: var(--warning-s); color: var(--warning); }
-  .pm-pill.green { background: var(--success-s); color: var(--success); }
-
-  .pm-empty { padding: 2rem; text-align: center; color: var(--text-3); font-size: 0.9rem; }
-
-  .pm-modal-backdrop {
-    position: fixed; inset: 0; background: rgba(15,23,42,0.4);
-    display: none; align-items: center; justify-content: center;
-    z-index: 200;
-  }
-  .pm-modal-backdrop.show { display: flex; }
-  .pm-modal {
-    background: var(--card); border-radius: 16px; box-shadow: var(--shadow-l);
-    width: min(560px, 96vw); padding: 1.25rem;
-  }
-  .pm-modal h3 { font-size: 1.05rem; font-weight: 700; margin: 0 0 0.75rem; }
-  .pm-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 0.75rem; }
-  .pm-field { display: flex; flex-direction: column; gap: 0.25rem; }
-  .pm-field label {
-    font-size: 0.7rem; font-weight: 700; text-transform: uppercase;
-    letter-spacing: 0.04em; color: var(--text-2);
-  }
-  .pm-field input, .pm-field select {
-    border: 1px solid var(--border); border-radius: 10px;
-    padding: 0.45rem 0.7rem; font-family: inherit; font-size: 0.9rem;
-  }
-  .pm-field input:focus, .pm-field select:focus { outline: none; border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-s); }
-
-  .pm-drop {
-    border: 2px dashed var(--border); border-radius: 12px;
-    padding: 1.5rem; text-align: center; color: var(--text-2);
-    background: #fafbfd; cursor: pointer; transition: all .12s;
-  }
-  .pm-drop:hover, .pm-drop.dragging { border-color: var(--primary); background: var(--primary-s); color: var(--primary); }
-  .pm-drop input { display: none; }
-</style>
-
-<div class="pm">
-<div class="pm-page">
-
-  <div class="pm-head">
-    <div>
-      <h1>Production Manager</h1>
-      <div class="who">Cutting recommendations • DRR • Open lots • Marketplace POs</div>
+<div class="main">
+  <header class="topbar">
+    <div class="search">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3-3"/></svg>
+      <input placeholder="Search style, lot, or order…" id="topSearch">
     </div>
-    <div class="pm-actions">
-      <a class="pm-btn" href="/pm/analytics">📊 Analytics</a>
+    <div class="actions">
       <a class="pm-btn" href="/pm/api/recommendations.csv">Export CSV</a>
-      <% if (userRole === 'admin') { %>
-        <button class="pm-btn primary" id="pullNowBtn">Run Pull Now</button>
-      <% } %>
+      <% if (userRole === 'admin') { %><button class="pm-btn primary" id="pullNowBtn">Run pull</button><% } %>
+    </div>
+  </header>
+  <main class="content">
+
+  <div class="page-head">
+    <div>
+      <h1 class="page-h">Overview</h1>
+      <p class="page-sub">Cutting recommendations · DRR · open lots · marketplace POs</p>
     </div>
   </div>
 
@@ -189,50 +29,43 @@
   <div class="pm-summary" id="pmSummary"></div>
 
   <nav class="pm-tabs" role="tablist">
-    <button class="pm-tab active" data-tab="cutting">Cutting Today</button>
+    <button class="pm-tab active" data-tab="cutting">Priority to cut</button>
     <button class="pm-tab" data-tab="dead">Dead Stock</button>
     <button class="pm-tab" data-tab="lots">Open Lots</button>
     <button class="pm-tab" data-tab="pos">Marketplace POs</button>
     <button class="pm-tab" data-tab="config">Config</button>
   </nav>
 
-  <!-- CUTTING TODAY -->
+  <!-- PRIORITY TO CUT -->
   <section class="pm-panel active" data-panel="cutting">
-    <div class="pm-card">
-      <div class="pm-card-head">
-        <h2>Cutting Today</h2>
-        <div class="pm-toolbar">
-          <input type="text" id="cuttingSearch" placeholder="Search style…">
-          <select id="cuttingTrigger">
-            <option value="all">All triggers</option>
-            <option value="red">Red (≤ LT)</option>
-            <option value="amber">Amber (≤ LT+safety)</option>
-            <option value="green">Green</option>
-          </select>
-          <button class="pm-btn" id="cuttingRefresh">Refresh</button>
-        </div>
+    <h2 class="section-h" style="margin-top:6px">Priority to cut
+      <div class="pm-toolbar">
+        <input type="text" id="cuttingSearch" placeholder="Search style…">
+        <select id="cuttingTrigger">
+          <option value="all">All</option>
+          <option value="red">Cut now</option>
+          <option value="amber">Cut soon</option>
+          <option value="green">Covered</option>
+        </select>
+        <button class="pm-btn" id="cuttingRefresh">Refresh</button>
       </div>
-      <div class="pm-card-body">
-        <div class="pm-table-wrap">
-          <table class="pm-table" id="cuttingTable">
-            <thead>
-              <tr>
-                <th>Style</th>
-                <th>Total SOH</th>
-                <th>Avg DRR</th>
-                <th>Worst-size DOH</th>
-                <th>Sizes below LT</th>
-                <th>Open-lot qty</th>
-                <th>Upcoming MP-PO</th>
-                <th>Suggested action</th>
-                <th>Trigger</th>
-              </tr>
-            </thead>
-            <tbody></tbody>
-          </table>
-        </div>
-      </div>
+    </h2>
+    <div class="tcard">
+      <table class="prio" id="cuttingTable">
+        <thead>
+          <tr>
+            <th class="l">Style</th>
+            <th>Stock</th>
+            <th>Days left</th>
+            <th>Suggested cut</th>
+            <th class="l" style="padding-left:32px">Status</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
     </div>
+    <div class="tfoot" id="cuttingFoot"></div>
   </section>
 
   <!-- DEAD STOCK -->
@@ -391,7 +224,7 @@
     </div>
   </section>
 
-</div>
+  </main>
 </div>
 
 <!-- Add-lot modal -->
@@ -439,6 +272,31 @@ function compactNum(n) {
 }
 function fmtDate(d) { return d ? new Date(d).toLocaleDateString('en-IN', { day: '2-digit', month: 'short' }) : ''; }
 
+const KPI_ICON = {
+  cut:  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M20 4 8.12 15.88M14.47 14.48 20 20M8.12 8.12 12 12"/></svg>',
+  prod: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 21V8l6 4V8l6 4V5l6 3v13H3z"/></svg>',
+  inv:  '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M21 8 12 3 3 8l9 5 9-5z"/><path d="M3 8v8l9 5 9-5V8"/></svg>',
+  sales:'<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 17l6-6 4 4 8-8"/><path d="M21 7v5h-5"/></svg>',
+};
+function kpiSpark(series) {
+  if (!series || series.length < 2) return '';
+  const max = Math.max(...series), min = Math.min(...series, 0), span = (max - min) || 1;
+  const pts = series.map((v, i) => {
+    const x = (i / (series.length - 1)) * 100;
+    const y = 26 - ((v - min) / span) * 22;
+    return x.toFixed(1) + ',' + y.toFixed(1);
+  });
+  const last = pts[pts.length - 1].split(',');
+  return `<svg class="spark" viewBox="0 0 100 30" preserveAspectRatio="none"><polyline points="${pts.join(' ')}"/><circle class="dot" cx="${last[0]}" cy="${last[1]}" r="2.4"/></svg>`;
+}
+function kpiCard(label, tile, icon, val, trendCls, trendIcon, trendText, sparkHtml) {
+  return `<div class="kpi">
+    <div class="top"><span class="label">${label}</span><span class="tile ${tile}">${icon}</span></div>
+    <div class="val num">${val}</div>
+    ${sparkHtml || ''}
+    <div class="trend ${trendCls}">${trendIcon}${trendText}</div>
+  </div>`;
+}
 async function loadSummary() {
   const box = $('pmSummary');
   try {
@@ -448,55 +306,28 @@ async function loadSummary() {
 
     if (s.cut_priority) {
       const cp = s.cut_priority;
-      cards.push(`<div class="sum-card ${cp.red ? 'alert' : ''}">
-        <div class="label">Cut priority</div>
-        <div class="big">${compactNum(cp.totalSuggested)}</div>
-        <div class="sub">pieces suggested across ${cp.stylesNeedingCut} styles</div>
-        <div class="chips"><span class="chip" style="color:var(--danger)">${cp.red} red</span><span class="chip" style="color:var(--warning)">${cp.amber} amber</span></div>
-      </div>`);
-    }
-    if (s.fabric_needed) {
-      const f = s.fabric_needed;
-      cards.push(`<div class="sum-card">
-        <div class="label">Fabric needed</div>
-        <div class="big">${compactNum(f.totalMeters)} m</div>
-        <div class="sub">for ${compactNum(f.coveredPieces)} pcs ${f.uncoveredPieces ? `· ${compactNum(f.uncoveredPieces)} pcs no CAD` : ''}</div>
-        <div class="chips">${f.byType.slice(0, 3).map(t => `<span class="chip">${escapeHtml(t.fabric_type)}: ${compactNum(t.meters)}m</span>`).join('')}</div>
-      </div>`);
+      cards.push(kpiCard('To cut today', 'red', KPI_ICON.cut, compactNum(cp.totalSuggested), 'red',
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M10.29 3.86 1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/><line x1="12" y1="9" x2="12" y2="13"/><line x1="12" y1="17" x2="12" y2="17"/></svg>',
+        `${cp.red || 0} styles urgent`));
     }
     if (s.wip) {
-      const w = s.wip; const order = ['stitching', 'jeans_assembly', 'washing', 'washing_in', 'finishing'];
-      const lbl = { stitching: 'Stitch', jeans_assembly: 'Assy', washing: 'Wash', washing_in: 'W-In', finishing: 'Finish' };
-      cards.push(`<div class="sum-card">
-        <div class="label">WIP in production</div>
-        <div class="big">${compactNum(w.totalInHand)}</div>
-        <div class="sub">pieces in hand across stages</div>
-        <div class="chips">${order.filter(k => w.byStage[k]).map(k => `<span class="chip">${lbl[k]}: ${compactNum(w.byStage[k])}</span>`).join('')}</div>
-      </div>`);
+      cards.push(kpiCard('In production', 'blue', KPI_ICON.prod, compactNum(s.wip.totalInHand), 'muted',
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9"/><path d="m8 12 3 3 5-6"/></svg>',
+        'pieces across all stages'));
     }
     if (s.inventory) {
-      cards.push(`<div class="sum-card">
-        <div class="label">Inventory on hand</div>
-        <div class="big">${compactNum(s.inventory.units)}</div>
-        <div class="sub">units in stock · as of ${fmtDate(s.inventory.as_of)}</div>
-      </div>`);
-    }
-    if (s.dead_stock) {
-      cards.push(`<div class="sum-card">
-        <div class="label">Dead stock</div>
-        <div class="big">${compactNum(s.dead_stock.units)}</div>
-        <div class="sub">units in ${s.dead_stock.count} slow SKUs (45d no sale)</div>
-      </div>`);
+      cards.push(kpiCard('Inventory', 'green', KPI_ICON.inv, compactNum(s.inventory.units), 'green',
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg>',
+        `units · as of ${fmtDate(s.inventory.as_of)}`));
     }
     if (s.sales_by_day && s.sales_by_day.length) {
-      const days = s.sales_by_day; const max = Math.max(...days.map(d => d.qty), 1);
-      const last = days[days.length - 1]; const avg = Math.round(days.reduce((a, d) => a + d.qty, 0) / days.length);
-      cards.push(`<div class="sum-card">
-        <div class="label">Sales / day (30d)</div>
-        <div class="big">${compactNum(avg)}</div>
-        <div class="sub">avg/day · last ${fmtDate(last.date)}: ${compactNum(last.qty)}</div>
-        <div class="spark">${days.map(d => `<div class="bar" style="height:${Math.max(2, Math.round(d.qty / max * 34))}px" title="${fmtDate(d.date)}: ${d.qty}"></div>`).join('')}</div>
-      </div>`);
+      const days = s.sales_by_day;
+      const avg = Math.round(days.reduce((a, d) => a + d.qty, 0) / days.length);
+      const last = days[days.length - 1];
+      cards.push(kpiCard('Sales / day', 'blue', KPI_ICON.sales, compactNum(avg), 'muted',
+        '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M7 17 17 7M8 7h9v9"/></svg>',
+        `last ${fmtDate(last.date)}: ${compactNum(last.qty)}`,
+        kpiSpark(days.slice(-14).map(d => Number(d.qty) || 0))));
     }
     box.innerHTML = cards.join('');
   } catch (_) { box.innerHTML = ''; }
@@ -525,40 +356,49 @@ async function loadCutting() {
   if (search) params.set('search', search);
   if (trigger && trigger !== 'all') params.set('trigger', trigger);
   const tbody = $('cuttingTable').querySelector('tbody');
-  tbody.innerHTML = `<tr><td colspan="9" class="pm-empty">Loading…</td></tr>`;
+  tbody.innerHTML = `<tr><td colspan="6" class="pm-empty">Loading…</td></tr>`;
+  { const _f = $('cuttingFoot'); if (_f) _f.textContent = ''; }
   try {
     const r = await fetch('/pm/api/styles?' + params.toString(), { headers: { Accept: 'application/json' } });
     const json = await r.json();
     if (!json.ok && json.warning) {
-      tbody.innerHTML = `<tr><td colspan="9" class="pm-empty">${escapeHtml(json.warning)}</td></tr>`;
+      tbody.innerHTML = `<tr><td colspan="6" class="pm-empty">${escapeHtml(json.warning)}</td></tr>`;
       return;
     }
     if (json.dataQuality === 'warming_up') $('warmingBanner').classList.add('show');
     const items = json.items || [];
     if (!items.length) {
-      tbody.innerHTML = `<tr><td colspan="9" class="pm-empty">No styles.</td></tr>`;
+      tbody.innerHTML = `<tr><td colspan="6" class="pm-empty">No styles.</td></tr>`;
       return;
     }
-    tbody.innerHTML = items.map(s => `
-      <tr class="clickable" data-style="${escapeHtml(s.style)}">
-        <td><strong>${escapeHtml(s.style)}</strong></td>
-        <td>${fmtNum(s.total_soh)}</td>
-        <td>${fmtNum(s.avg_drr, 2)}</td>
-        <td>${s.worst_size_doh == null ? '—' : fmtNum(s.worst_size_doh, 1)}</td>
-        <td>${fmtNum(s.sizes_below_lt)}</td>
-        <td>${fmtNum(s.open_lot_qty)}</td>
-        <td>${fmtNum(s.upcoming_po_qty)}</td>
-        <td>${escapeHtml(s.suggested_action || '')} ${s.suggested_cut_qty ? `· <strong>${fmtNum(s.suggested_cut_qty)}</strong>` : ''}</td>
-        <td><span class="pm-pill ${escapeHtml(s.trigger || 'green')}">${escapeHtml(s.trigger || 'green')}</span></td>
-      </tr>
-    `).join('');
+    const STATUS = { red: ['red', 'Cut now'], amber: ['amber', 'Cut soon'], green: ['green', 'Covered'] };
+    tbody.innerHTML = items.map(s => {
+      const tg = s.trigger || 'green';
+      const st = STATUS[tg] || STATUS.green;
+      const doh = s.worst_size_doh == null ? null : Math.round(s.worst_size_doh);
+      const daysCls = tg === 'red' ? 'red' : 'muted';
+      const sug = Number(s.suggested_cut_qty) || 0;
+      const action = sug > 0
+        ? `<a class="btn-sm assign" href="/pm/cut-planning?style=${encodeURIComponent(s.style)}">Assign</a>`
+        : `<a class="btn-sm review" href="/pm/style/${encodeURIComponent(s.style)}">Review</a>`;
+      return `<tr class="clickable" data-style="${escapeHtml(s.style)}">
+        <td class="style"><div class="row"><span class="swatch"></span><div><div class="code">${escapeHtml(s.style)}</div><div class="fab">DRR ${fmtNum(s.avg_drr, 2)}/day</div></div></div></td>
+        <td><span class="num">${fmtNum(s.total_soh)}</span></td>
+        <td class="days ${daysCls}"><span class="num">${doh == null ? '—' : doh + 'd'}</span></td>
+        <td class="cut"><span class="num">${sug ? fmtNum(sug) : '0'}</span></td>
+        <td class="status" style="padding-left:32px"><span class="pill ${st[0]}">${st[1]}</span></td>
+        <td><span class="actwrap" onclick="event.stopPropagation()">${action}</span></td>
+      </tr>`;
+    }).join('');
+    const foot = $('cuttingFoot');
+    if (foot) foot.textContent = 'Showing ' + items.length + ' style' + (items.length === 1 ? '' : 's') + ' requiring attention';
     tbody.querySelectorAll('tr.clickable').forEach(tr => {
       tr.addEventListener('click', () => {
         window.location.href = '/pm/style/' + encodeURIComponent(tr.dataset.style);
       });
     });
   } catch (err) {
-    tbody.innerHTML = `<tr><td colspan="9" class="pm-empty">Error: ${escapeHtml(err.message)}</td></tr>`;
+    tbody.innerHTML = `<tr><td colspan="6" class="pm-empty">Error: ${escapeHtml(err.message)}</td></tr>`;
   }
 }
 $('cuttingSearch').addEventListener('input', debounce(loadCutting, 250));
@@ -800,4 +640,5 @@ if (pullBtn) {
 loadCutting();
 </script>
 
-<%- include('partials/footer') %>
+</body>
+</html>

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -1,196 +1,118 @@
-<%- include('partials/header', { pageTitle: 'PM · ' + style }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/pm' }) %>
+<%- include('partials/pmHead', { pageTitle: 'PM · ' + style }) %>
+<%- include('partials/pmSidebar', { active: 'styles', user: user }) %>
 
-<style>
-  body { background: #f5f7fb; }
-  .pm {
-    --bg: #f5f7fb;
-    --card: #ffffff;
-    --border: #e5e8ee;
-    --border-2: #eef0f4;
-    --text: #0f172a;
-    --text-2: #475569;
-    --text-3: #94a3b8;
-    --primary: #4f46e5;
-    --primary-h: #4338ca;
-    --primary-s: #eef2ff;
-    --success: #16a34a;
-    --success-s: #dcfce7;
-    --warning: #d97706;
-    --warning-s: #fef3c7;
-    --danger: #dc2626;
-    --danger-s: #fee2e2;
-    --shadow: 0 1px 3px rgba(15,23,42,0.05);
-    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    color: var(--text);
-  }
-  .pm-page { max-width: 1500px; margin: 0 auto; padding: calc(var(--navbar-height, 60px) + 1.5rem) 1rem 4rem; }
-  .pm-head { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 0.75rem; margin-bottom: 1rem; }
-  .pm-head h1 { font-size: 1.5rem; font-weight: 700; letter-spacing: -0.02em; margin: 0; }
-  .pm-back { color: var(--primary); text-decoration: none; font-weight: 600; font-size: 0.875rem; }
-  .pm-back:hover { text-decoration: underline; }
-
-  .pm-card { background: var(--card); border: 1px solid var(--border); border-radius: 16px; box-shadow: var(--shadow); overflow: hidden; }
-  .pm-card-head { padding: 0.875rem 1.125rem; border-bottom: 1px solid var(--border-2); background: linear-gradient(180deg, #fafbfd 0%, #ffffff 100%); display:flex; justify-content: space-between; align-items: center; gap: 0.5rem; flex-wrap: wrap; }
-  .pm-card-head h2 { font-size: 1rem; font-weight: 700; margin: 0; }
-  .pm-card-body { padding: 1rem 1.125rem; }
-
-  .pm-pill {
-    display: inline-block; padding: 0.2rem 0.65rem; border-radius: 9999px;
-    font-size: 0.75rem; font-weight: 700;
-  }
-  .pm-pill.real { background: var(--success-s); color: var(--success); }
-  .pm-pill.warming { background: var(--warning-s); color: var(--warning); }
-  .pm-pill.red   { background: var(--danger-s);  color: var(--danger); }
-  .pm-pill.amber { background: var(--warning-s); color: var(--warning); }
-  .pm-pill.green { background: var(--success-s); color: var(--success); }
-  .pm-dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; vertical-align: middle; margin-right: 0.35rem; }
-  .pm-dot.red { background: var(--danger); }
-  .pm-dot.amber { background: var(--warning); }
-  .pm-dot.green { background: var(--success); }
-
-  .pm-table-wrap { overflow-x: auto; }
-  table.pm-table { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
-  table.pm-table thead th {
-    background: #f8fafc; color: var(--text-2);
-    font-size: 0.7rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em;
-    padding: 0.55rem 0.75rem; text-align: left;
-    border-bottom: 1px solid var(--border-2); white-space: nowrap;
-  }
-  table.pm-table tbody td { padding: 0.55rem 0.75rem; border-bottom: 1px solid var(--border-2); }
-  table.pm-table tbody tr:hover { background: #fafbfd; }
-  .pm-empty { padding: 2rem; text-align: center; color: var(--text-3); font-size: 0.9rem; }
-  .pm-btn {
-    border: 1px solid var(--border); background: var(--card); color: var(--text);
-    padding: 0.4rem 0.8rem; border-radius: 10px; font-weight: 600; font-size: 0.85rem;
-    cursor: pointer; text-decoration: none; display: inline-flex; align-items: center; gap: 0.25rem;
-  }
-  .pm-btn:hover { background: var(--bg); }
-</style>
-
-<div class="pm">
-<div class="pm-page">
-
-  <div class="pm-head">
-    <div>
-      <a class="pm-back" href="/pm">← All styles</a>
-      <h1 style="margin-top: 0.5rem;">Style: <%= style %></h1>
+<div class="main">
+  <header class="topbar">
+    <div class="search">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="m20 20-3-3"/></svg>
+      <input placeholder="Search style, lot, or order…">
     </div>
-    <div>
+    <div class="actions">
       <a class="pm-btn" href="/pm/api/recommendations.csv?style=<%= encodeURIComponent(style) %>">Export CSV</a>
+      <% if (typeof userRole !== 'undefined' && userRole === 'admin') { %><a class="pm-btn primary" href="/pm">Run pull</a><% } %>
     </div>
-  </div>
+  </header>
 
-  <div class="pm-card">
-    <div class="pm-card-head">
-      <h2>Size-level recommendation</h2>
-      <div id="qualityPill"></div>
+  <main class="content">
+    <a href="/pm" class="crumb">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+      All styles
+    </a>
+
+    <div class="page-head">
+      <div>
+        <h1 class="page-h"><%= style %> <span class="title-chip" id="styleTrigger"></span></h1>
+        <p class="page-sub" id="styleSub">Loading…</p>
+      </div>
+      <button class="btn primary" id="approveTop" onclick="document.getElementById('assignSection').scrollIntoView({behavior:'smooth'})">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4 12 14.01l-3-3"/></svg>
+        Approve &amp; assign
+      </button>
     </div>
-    <div class="pm-card-body">
-      <div class="pm-table-wrap">
-        <table class="pm-table" id="sizesTable">
-          <thead>
-            <tr>
-              <th>SKU</th>
-              <th>Size</th>
-              <th>SOH</th>
-              <th>DRR</th>
-              <th>Selling-days / window</th>
-              <th>DOH</th>
-              <th>Lead time</th>
-              <th>Open-lot qty</th>
-              <th>MP-PO due in LT</th>
-              <th>Suggested cut qty</th>
-              <th>Trigger</th>
-            </tr>
-          </thead>
-          <tbody></tbody>
-        </table>
+
+    <!-- Summary cards -->
+    <section class="summary" id="summaryCards">
+      <div class="scard"><div class="ico" style="background:var(--neutral);color:var(--blue)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M20 4 8.12 15.88M14.47 14.48 20 20M8.12 8.12 12 12"/></svg></div><div><div class="label">Suggested cut</div><div class="big" id="kSuggested">—</div></div></div>
+      <div class="scard"><div class="ico" style="background:var(--neutral);color:var(--green)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 7v10l9 4 9-4V7"/><path d="M12 11v10"/></svg></div><div><div class="label">Fabric to issue</div><div class="big" id="kFabric">—</div></div></div>
+      <div class="scard"><div class="ico" style="background:var(--neutral);color:var(--ink-2)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5M2 12l10 5 10-5"/></svg></div><div><div class="label">Lots (≤1,500 each)</div><div class="big" id="kLots">—</div></div></div>
+    </section>
+
+    <!-- Size breakdown -->
+    <h2 class="section-h">Size breakdown <span class="link" id="sizeQuality"></span></h2>
+    <div class="sizegrid" id="sizeGrid"><div class="pm-empty">Loading sizes…</div></div>
+
+    <!-- Fabrication & BOM -->
+    <div class="panel" id="fabPanel" style="display:none">
+      <div class="panel-head"><h4>Fabrication &amp; BOM</h4><span class="pill flat">Standard spec</span></div>
+      <div class="panel-body">
+        <div class="fabswatch">
+          <div class="chip" style="background:linear-gradient(135deg,#1f2937,#374151)"></div>
+          <div>
+            <h5 id="fabName">Primary</h5>
+            <div class="tags" id="fabTags"></div>
+          </div>
+        </div>
+        <div class="specrows" id="fabSpecs"></div>
       </div>
     </div>
-  </div>
 
-  <div class="pm-card" style="margin-top: 1rem;">
-    <div class="pm-card-head">
-      <h2>Approve &amp; assign cut</h2>
-      <div id="planSummary"></div>
+    <!-- Approve & assign -->
+    <h2 class="section-h" id="assignSection">Approve &amp; assign cut <span class="link" id="planSummary"></span></h2>
+    <div class="tcard" style="padding:0">
+      <div id="assignBody" style="padding:20px"><div class="pm-empty">Loading suggested cut…</div></div>
     </div>
-    <div class="pm-card-body" id="assignBody">
-      <div class="pm-empty">Loading suggested cut…</div>
-    </div>
-  </div>
 
-  <div class="pm-card" style="margin-top: 1rem;">
-    <div class="pm-card-head">
-      <h2>Cut history &amp; lot status</h2>
-      <span style="font-size:0.78rem; color:var(--text-3);">where each lot cut for this style is now</span>
-    </div>
-    <div class="pm-card-body" id="lotHistoryBody">
-      <div class="pm-empty">Loading lot history…</div>
-    </div>
-  </div>
-
-</div>
+    <!-- Lot journey -->
+    <h2 class="section-h">Lot journey <select class="select" id="lotPicker" style="height:36px;min-width:220px;font-size:13px"></select></h2>
+    <div id="lotJourney"><div class="tcard" style="padding:0"><div class="pm-empty" id="lotEmpty">Loading lot history…</div></div></div>
+  </main>
 </div>
 
 <script>
 const STYLE = <%- JSON.stringify(style) %>;
-function fmtNum(v, digits = 0) {
-  if (v === null || v === undefined || Number.isNaN(Number(v))) return '—';
-  return Number(v).toFixed(digits);
-}
-function escapeHtml(s) {
-  return String(s == null ? '' : s)
-    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
-}
+const $ = (id) => document.getElementById(id);
+function fmtNum(v, d = 0) { if (v == null || Number.isNaN(Number(v))) return '—'; return Number(v).toLocaleString('en-IN', { minimumFractionDigits: d, maximumFractionDigits: d }); }
+function compactNum(n) { n = Number(n) || 0; if (n >= 1e7) return (n/1e7).toFixed(1)+' Cr'; if (n >= 1e5) return (n/1e5).toFixed(1)+' L'; if (n >= 1e3) return (n/1e3).toFixed(1)+'k'; return String(Math.round(n)); }
+function escapeHtml(s){ return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
+function fmtDate(d){ return d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short'}) : ''; }
+const STATUS = { red:['red','Cut now'], amber:['amber','Cut soon'], green:['green','Covered'] };
 
-(async function load() {
-  const tbody = document.querySelector('#sizesTable tbody');
-  tbody.innerHTML = `<tr><td colspan="11" class="pm-empty">Loading…</td></tr>`;
+// ── Sizes → header chip, subtitle, size grid ──────────────────────────
+let SIZES = [];
+(async function loadSizes() {
+  const grid = $('sizeGrid');
   try {
-    const r = await fetch('/pm/api/sizes?style=' + encodeURIComponent(STYLE), { headers: { Accept: 'application/json' } });
-    const json = await r.json();
-    if (!json.ok && json.warning) {
-      tbody.innerHTML = `<tr><td colspan="11" class="pm-empty">${escapeHtml(json.warning)}</td></tr>`;
-      return;
-    }
-    const items = json.items || [];
-    const warming = items.some(r => r.dataQuality === 'warming_up');
-    document.getElementById('qualityPill').innerHTML = warming
-      ? `<span class="pm-pill warming">Warming up — using calendar days</span>`
-      : `<span class="pm-pill real">Real (≥7 selling days)</span>`;
-    if (!items.length) {
-      tbody.innerHTML = `<tr><td colspan="11" class="pm-empty">No sizes for this style.</td></tr>`;
-      return;
-    }
-    tbody.innerHTML = items.map(r => `
-      <tr>
-        <td>${escapeHtml(r.sku)}</td>
-        <td>${escapeHtml(r.size)}</td>
-        <td>${fmtNum(r.soh)}</td>
-        <td>${fmtNum(r.drr, 3)}</td>
-        <td>${fmtNum(r.selling_days)} / ${fmtNum(r.calendar_days)}</td>
-        <td>${r.doh == null ? '—' : fmtNum(r.doh, 1)}</td>
-        <td>${fmtNum(r.lead_time)}${r.safety_days ? ' + ' + fmtNum(r.safety_days) : ''}</td>
-        <td>${fmtNum(r.open_lot_qty)}</td>
-        <td>${fmtNum(r.upcoming_po_qty)}</td>
-        <td><strong>${fmtNum(r.suggested_cut_qty)}</strong></td>
-        <td><span class="pm-dot ${escapeHtml(r.trigger || 'green')}"></span>${escapeHtml(r.trigger || 'green')}</td>
-      </tr>
-    `).join('');
-  } catch (err) {
-    tbody.innerHTML = `<tr><td colspan="11" class="pm-empty">Error: ${escapeHtml(err.message)}</td></tr>`;
-  }
+    const json = await (await fetch('/pm/api/sizes?style=' + encodeURIComponent(STYLE), { headers: { Accept: 'application/json' } })).json();
+    if (!json.ok && json.warning) { grid.innerHTML = `<div class="pm-empty">${escapeHtml(json.warning)}</div>`; return; }
+    SIZES = json.items || [];
+    const warming = SIZES.some(r => r.dataQuality === 'warming_up');
+    $('sizeQuality').textContent = warming ? 'Warming up — calendar days' : 'Real · ≥7 selling days';
+    // worst trigger drives the header chip
+    const order = { red:0, amber:1, green:2 };
+    let worst = 'green';
+    SIZES.forEach(r => { const t = r.trigger || 'green'; if (order[t] < order[worst]) worst = t; });
+    const st = STATUS[worst];
+    const chip = $('styleTrigger'); chip.className = 'title-chip ' + st[0]; chip.textContent = st[1];
+    if (!SIZES.length) { grid.innerHTML = `<div class="pm-empty">No sizes for this style.</div>`; return; }
+    grid.innerHTML = SIZES.map(r => {
+      const sug = Number(r.suggested_cut_qty) || 0;
+      const dohRed = (r.trigger || 'green') === 'red';
+      return `<div class="sizecard ${sug > 0 ? '' : 'dim'}">
+        <div class="sz">${escapeHtml(r.size)}</div>
+        <div class="rows">
+          <div class="r"><span class="k">Stock</span><span class="v num">${fmtNum(r.soh)}</span></div>
+          <div class="r"><span class="k">Days left</span><span class="v num ${dohRed ? 'red' : ''}">${r.doh == null ? '—' : Math.round(r.doh) + 'd'}</span></div>
+        </div>
+        <div class="sug"><span class="k">Suggested</span><span class="v num">${sug ? fmtNum(sug) : '0'}</span></div>
+      </div>`;
+    }).join('');
+  } catch (err) { grid.innerHTML = `<div class="pm-empty">Error: ${escapeHtml(err.message)}</div>`; }
 })();
 
-// ── Approve & assign cut ─────────────────────────────────────────────
+// ── Cut plan → summary cards, fabrication, assign panel ───────────────
 let MASTERS = [];
-function fmtDate(d){ return d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short'}) : ''; }
-
 async function loadAssignPanel() {
-  const body = document.getElementById('assignBody');
-  const summary = document.getElementById('planSummary');
+  const body = $('assignBody');
   try {
     const [planRes, mastersRes, asgRes] = await Promise.all([
       fetch('/pm/api/cut-plan?style=' + encodeURIComponent(STYLE)).then(r => r.json()),
@@ -200,112 +122,136 @@ async function loadAssignPanel() {
     MASTERS = (mastersRes.ok && mastersRes.masters) ? mastersRes.masters : [];
     const styleAsg = (asgRes.ok ? asgRes.items : []).filter(a => a.style === STYLE);
 
+    // summary cards
+    if (planRes.ok && planRes.totalPieces) {
+      $('kSuggested').innerHTML = `<span class="num">${fmtNum(planRes.totalPieces)}</span> <small>pcs</small>`;
+      $('kFabric').innerHTML = planRes.totalFabricMeters != null ? `<span class="num">${fmtNum(planRes.totalFabricMeters)}</span> <small>m</small>` : '<small>no CAD</small>';
+      $('kLots').innerHTML = `<span class="num">${planRes.lotCount || 0}</span>`;
+      $('styleSub').textContent = (planRes.fabric_type ? planRes.fabric_type : 'Fabric n/a') + (planRes.totalFabricMeters != null && planRes.totalPieces ? ` · ${(planRes.totalFabricMeters / planRes.totalPieces).toFixed(3)} m per piece` : '');
+      renderFabrication(planRes);
+    } else {
+      $('kSuggested').innerHTML = '<span class="num">0</span> <small>pcs</small>';
+      $('kFabric').innerHTML = '<span class="num">0</span> <small>m</small>';
+      $('kLots').innerHTML = '<span class="num">0</span>';
+      $('styleSub').textContent = 'Stock is covered — no cut suggested right now';
+    }
+
     if (!planRes.ok) { body.innerHTML = `<div class="pm-empty">${escapeHtml(planRes.warning || planRes.error || 'Could not load plan.')}</div>`; return; }
     if (!planRes.totalPieces) {
-      summary.innerHTML = '';
+      $('planSummary').textContent = '';
       body.innerHTML = `<div class="pm-empty">No suggested cut right now — stock is covered.</div>` + assignmentsHtml(styleAsg);
       return;
     }
 
-    summary.innerHTML = planRes.totalFabricMeters != null
-      ? `<span class="pm-pill green">${Number(planRes.totalFabricMeters).toFixed(1)} m ${escapeHtml(planRes.fabric_type || '')}</span>`
-      : `<span class="pm-pill warming">No CAD fabric</span>`;
-
-    const sizes = Object.entries(planRes.demand).sort((a,b)=>b[1]-a[1]);
+    $('planSummary').textContent = planRes.totalFabricMeters != null ? `${Number(planRes.totalFabricMeters).toFixed(0)} m ${planRes.fabric_type || ''}` : 'No CAD fabric';
+    const sizes = Object.entries(planRes.demand).sort((a, b) => b[1] - a[1]);
     const masterOpts = MASTERS.map(m => `<option value="${m.id}">${escapeHtml(m.username)}</option>`).join('');
     body.innerHTML = `
-      <div style="display:flex; gap:1.5rem; flex-wrap:wrap; align-items:baseline; margin-bottom:0.75rem;">
-        <div><strong style="font-size:1.25rem;">${planRes.totalPieces}</strong> <span style="color:var(--text-3);">pieces</span></div>
-        <div><strong>${planRes.lotCount}</strong> <span style="color:var(--text-3);">lot(s) ≤1500</span></div>
-        <div style="color:var(--text-2);">${escapeHtml(planRes.fabric_type || 'fabric n/a')}</div>
+      <span class="fieldlab">Suggested size split · ${fmtNum(planRes.totalPieces)} pcs total</span>
+      <div class="chips">${sizes.map(([s, q]) => `<div class="chip-sz"><span class="s">${escapeHtml(s)}</span><span class="q num">${fmtNum(q)}</span></div>`).join('')}</div>
+      ${(planRes.missingSizes && planRes.missingSizes.length) ? `<div style="color:var(--amber-ink);font-size:12.5px;margin-top:10px">No CAD consumption yet for: ${planRes.missingSizes.map(escapeHtml).join(', ')}</div>` : ''}
+      <span class="fieldlab" style="margin-top:16px">Lot split · 1,500 hard cap — assign each lot to a master</span>
+      <div class="lotlist">
+        ${planRes.lots.map((l, i) => { const sz = Object.entries(l.sizes || {}).sort((a, b) => b[1] - a[1]).map(([s, q]) => `<div class="chip-sz"><span class="s">${escapeHtml(s)}</span><span class="q num">${fmtNum(q)}</span></div>`).join(''); return `<div class="lotrow"><div class="lotid">Lot ${i + 1} <small><span class="num">${fmtNum(l.total)}</span> pcs${l.fabricMeters != null ? ' · ' + Number(l.fabricMeters).toFixed(0) + ' m' : ''}</small></div><div class="lotsizes">${sz}</div><select class="select lotmaster">${masterOpts || '<option value="">no masters</option>'}</select></div>`; }).join('')}
       </div>
-      <div style="display:flex; gap:0.5rem; flex-wrap:wrap; margin-bottom:0.5rem;">
-        ${sizes.map(([s,q]) => `<span style="background:#f1f5f9;border-radius:8px;padding:0.35rem 0.7rem;font-size:0.85rem;"><strong>${q}</strong> ${escapeHtml(s)}</span>`).join('')}
-      </div>
-      ${(planRes.missingSizes && planRes.missingSizes.length) ? `<div style="color:var(--warning);font-size:0.8rem;margin-bottom:0.5rem;">No CAD consumption yet for: ${planRes.missingSizes.map(escapeHtml).join(', ')}</div>` : ''}
-      <div style="display:flex; gap:0.5rem; flex-wrap:wrap; margin-bottom:0.75rem; font-size:0.8rem; color:var(--text-2);">
-        ${planRes.lots.map((l,i)=>`<span style="background:var(--primary-s);border-radius:8px;padding:0.3rem 0.6rem;">Lot ${i+1}: ${l.total} pcs${l.fabricMeters!=null?(' · '+Number(l.fabricMeters).toFixed(0)+'m'):''}</span>`).join('')}
-      </div>
-      <div style="display:flex; gap:0.6rem; align-items:center; flex-wrap:wrap; padding-top:0.5rem; border-top:1px solid var(--border-2);">
-        <label style="font-size:0.85rem; color:var(--text-2);">Assign to cutting master:</label>
-        <select id="masterSel" style="padding:0.4rem 0.6rem; border:1px solid var(--border); border-radius:10px; font-size:0.85rem;">${masterOpts || '<option value="">no masters</option>'}</select>
-        <button class="pm-btn" style="background:var(--primary); color:#fff; border-color:var(--primary);" onclick="doAssign()">Approve &amp; Assign</button>
-        <span id="assignMsg" style="font-size:0.85rem;"></span>
+      <div class="assignbar" style="margin-top:18px;border-radius:11px;border:1px solid var(--line)">
+        <span style="font-size:12.5px;color:var(--ink-2)">One master can take several lots — same master for all is fine.</span>
+        <div style="flex:1"></div>
+        <button class="btn primary" onclick="doAssign()">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4 12 14.01l-3-3"/></svg>
+          Approve &amp; assign
+        </button>
+        <span id="assignMsg" style="font-size:13px"></span>
       </div>
       ${assignmentsHtml(styleAsg)}
     `;
-  } catch (err) {
-    body.innerHTML = `<div class="pm-empty">Error: ${escapeHtml(err.message)}</div>`;
-  }
+  } catch (err) { body.innerHTML = `<div class="pm-empty">Error: ${escapeHtml(err.message)}</div>`; }
+}
+
+function renderFabrication(plan) {
+  const panel = $('fabPanel'); panel.style.display = '';
+  $('fabName').textContent = 'Primary — ' + (plan.fabric_type || 'fabric');
+  $('fabTags').innerHTML = ['Washable', 'Shrink tested'].map(t => `<span class="tag">${t}</span>`).join('');
+  const cons = (plan.totalFabricMeters != null && plan.totalPieces) ? (plan.totalFabricMeters / plan.totalPieces).toFixed(3) : null;
+  const rows = [
+    ['Consumption per unit', cons != null ? `<span class="num">${cons}</span> m` : '—'],
+    ['Fabric type', escapeHtml(plan.fabric_type || '—')],
+    ['Total fabric to issue', plan.totalFabricMeters != null ? `<span class="num">${fmtNum(plan.totalFabricMeters)}</span> m` : '—'],
+    ['Source', cons != null ? 'CAD cut plan' : 'No CAD data'],
+  ];
+  $('fabSpecs').innerHTML = rows.map(r => `<div class="specrow"><span class="k">${r[0]}</span><span class="v">${r[1]}</span></div>`).join('');
 }
 
 function assignmentsHtml(items) {
   if (!items || !items.length) return '';
-  return `<div style="margin-top:1rem; padding-top:0.75rem; border-top:1px solid var(--border-2);">
-    <div style="font-size:0.75rem; text-transform:uppercase; letter-spacing:0.04em; color:var(--text-3); margin-bottom:0.4rem;">Already assigned for this style</div>
-    ${items.map(a => `<div style="font-size:0.85rem; color:var(--text-2); padding:0.2rem 0;">
-      <strong>${a.total_pieces}</strong> pcs → <strong>${escapeHtml(a.assigned_master_name||'')}</strong>
-      · ${a.status === 'cut' ? '<span style="color:var(--success);">cut</span>' : 'assigned'} · ${fmtDate(a.created_at)}</div>`).join('')}
+  return `<div style="margin-top:18px;padding-top:14px;border-top:1px solid var(--line-2)">
+    <span class="fieldlab">Already assigned for this style</span>
+    ${items.map(a => `<div style="font-size:13.5px;color:var(--ink-2);padding:4px 0"><b>${fmtNum(a.total_pieces)}</b> pcs → <b>${escapeHtml(a.assigned_master_name || '')}</b> · ${a.status === 'cut' ? '<span style="color:var(--green-ink)">cut</span>' : 'assigned'} · ${fmtDate(a.created_at)}</div>`).join('')}
   </div>`;
 }
 
 async function doAssign() {
-  const sel = document.getElementById('masterSel');
-  const msg = document.getElementById('assignMsg');
-  const masterId = sel ? sel.value : '';
-  if (!masterId) { msg.innerHTML = '<span style="color:var(--danger);">pick a master</span>'; return; }
+  const sels = Array.from(document.querySelectorAll('.lotmaster'));
+  const msg = $('assignMsg');
+  const ids = sels.map(s => s.value);
+  if (!ids.length || ids.some(v => !v)) { msg.innerHTML = '<span style="color:var(--red)">pick a master for every lot</span>'; return; }
   msg.textContent = 'Assigning…';
+  const allSame = ids.every(v => v === ids[0]);
+  const body = allSame ? { style: STYLE, master_id: ids[0] } : { style: STYLE, lots: ids.map(v => ({ master_id: v })) };
   try {
-    const r = await fetch('/pm/api/cut-plan/assign', {
-      method: 'POST', headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ style: STYLE, master_id: masterId }),
-    });
-    const d = await r.json();
-    if (d.ok) { msg.innerHTML = `<span style="color:var(--success);">✓ Assigned to ${escapeHtml(d.assigned_to)}</span>`; loadAssignPanel(); }
-    else { msg.innerHTML = `<span style="color:var(--danger);">${escapeHtml(d.error || 'failed')}</span>`; }
-  } catch (err) { msg.innerHTML = `<span style="color:var(--danger);">${escapeHtml(err.message)}</span>`; }
+    const d = await (await fetch('/pm/api/cut-plan/assign', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })).json();
+    if (d.ok) { msg.innerHTML = `<span style="color:var(--green-ink)">✓ Assigned to ${escapeHtml(d.assigned_to)}</span>`; loadAssignPanel(); }
+    else { msg.innerHTML = `<span style="color:var(--red)">${escapeHtml(d.error || 'failed')}</span>`; }
+  } catch (err) { msg.innerHTML = `<span style="color:var(--red)">${escapeHtml(err.message)}</span>`; }
 }
-
 loadAssignPanel();
 
-// ── Cut history & lot status ─────────────────────────────────────────
-const STATUS_COLOR = { done: 'var(--success)', in_progress: 'var(--warning)', not_started: '#cbd5e1' };
-
+// ── Lot journey: picker + vertical timeline + dispatch ────────────────
+let LOTS = [];
+const STAGE_STATE = { done: 'done', in_progress: 'active', not_started: 'pending' };
 async function loadLotHistory() {
-  const body = document.getElementById('lotHistoryBody');
   try {
-    const r = await fetch('/pm/api/style-lots?style=' + encodeURIComponent(STYLE));
-    const j = await r.json();
-    if (!j.ok) { body.innerHTML = `<div class="pm-empty">${escapeHtml(j.error || 'failed')}</div>`; return; }
-    if (!j.lots.length) { body.innerHTML = `<div class="pm-empty">No lots cut for this style yet.</div>`; return; }
-    body.innerHTML = j.lots.map(lot => {
-      const steps = lot.timeline.map(t => `
-        <div style="display:flex; flex-direction:column; align-items:center; min-width:58px;">
-          <div title="${escapeHtml(t.status)}${t.master ? ' · ' + escapeHtml(t.master) : ''}"
-               style="width:14px;height:14px;border-radius:50%;background:${STATUS_COLOR[t.status] || '#cbd5e1'};"></div>
-          <div style="font-size:0.68rem; color:var(--text-2); margin-top:3px;">${escapeHtml(t.label)}</div>
-          <div style="font-size:0.66rem; color:var(--text-3);">${t.status === 'not_started' ? '—' : (t.completed || 0)}</div>
-        </div>`).join('<div style="flex:1;height:2px;background:var(--border-2);margin:7px 2px 0;min-width:10px;"></div>');
-      const disp = lot.dispatch;
-      const dispHtml = disp.finished > 0
-        ? `<span style="color:var(--text-2);">Dispatched <strong>${disp.dispatched}</strong>/${disp.finished}${disp.in_stock > 0 ? ` · ${disp.in_stock} in stock` : ''}</span>`
-        : '';
-      return `
-        <div style="padding:0.75rem 0; border-bottom:1px solid var(--border-2);">
-          <div style="display:flex; justify-content:space-between; align-items:baseline; flex-wrap:wrap; gap:0.5rem;">
-            <div><strong>${escapeHtml(lot.lot_no)}</strong>${lot.manual_lot_number ? ` <span style="color:var(--text-3);">/ ${escapeHtml(lot.manual_lot_number)}</span>` : ''}
-              <span style="color:var(--text-3); font-size:0.82rem;">· ${lot.total_pieces} pcs · ${fmtDate(lot.created_at)}</span></div>
-            <span class="pm-pill ${lot.current_stage === 'Dispatched' ? 'green' : 'amber'}">${escapeHtml(lot.current_stage)}</span>
-          </div>
-          <div style="display:flex; align-items:flex-start; margin-top:0.6rem; overflow-x:auto;">${steps}</div>
-          ${dispHtml ? `<div style="font-size:0.8rem; margin-top:0.5rem;">${dispHtml}</div>` : ''}
-        </div>`;
-    }).join('');
-  } catch (err) {
-    body.innerHTML = `<div class="pm-empty">Error: ${escapeHtml(err.message)}</div>`;
-  }
+    const j = await (await fetch('/pm/api/style-lots?style=' + encodeURIComponent(STYLE))).json();
+    if (!j.ok || !j.lots || !j.lots.length) { $('lotEmpty').textContent = 'No lots cut for this style yet.'; return; }
+    LOTS = j.lots;
+    $('lotPicker').innerHTML = LOTS.map((l, i) => `<option value="${i}">${escapeHtml(l.lot_no)} · ${fmtNum(l.total_pieces)} pcs · ${escapeHtml(l.current_stage)}</option>`).join('');
+    $('lotPicker').addEventListener('change', () => renderLot(Number($('lotPicker').value)));
+    renderLot(0);
+  } catch (err) { $('lotEmpty').textContent = 'Error: ' + err.message; }
+}
+function renderLot(idx) {
+  const lot = LOTS[idx]; if (!lot) return;
+  const steps = lot.timeline.map((t, i) => {
+    const state = STAGE_STATE[t.status] || 'pending';
+    const icon = state === 'done' ? '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M20 6 9 17l-5-5"/></svg>' : (state === 'active' ? '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3"/></svg>' : '');
+    const when = t.status === 'not_started' ? 'Pending' : `${escapeHtml(t.label)}${t.completed != null ? ' · ' + fmtNum(t.completed) + ' pcs' : ''}${t.master ? ' · ' + escapeHtml(t.master) : ''}`;
+    return `<div class="tstep ${state}">
+      <div class="rail"><div class="dot">${icon}</div>${i < lot.timeline.length - 1 ? '<div class="line"></div>' : ''}</div>
+      <div class="body"><div class="name">${escapeHtml(t.label)}</div><div class="when">${when}</div></div>
+    </div>`;
+  }).join('');
+  const d = lot.dispatch || {};
+  const dcells = [
+    ['Finished', d.finished || 0, ''],
+    ['Dispatched', d.dispatched || 0, 'green'],
+    ['In stock', d.in_stock || 0, ''],
+  ].map(c => `<div class="dcell"><div class="sz">${c[0]}</div><div class="qty num">${fmtNum(c[1])}</div>${c[2] ? `<div class="st">back in stock</div>` : ''}</div>`).join('');
+  $('lotJourney').innerHTML = `
+    <div class="grid-2" style="grid-template-columns:1.1fr .9fr;align-items:start;margin-top:14px">
+      <div class="chartcard">
+        <div class="lotmeta" style="margin-top:0;margin-bottom:18px">
+          <div class="m"><div class="k">Lot</div><div class="v">${escapeHtml(lot.lot_no)}${lot.manual_lot_number ? ' / ' + escapeHtml(lot.manual_lot_number) : ''}</div></div>
+          <div class="m"><div class="k">Pieces</div><div class="v"><span class="num">${fmtNum(lot.total_pieces)}</span></div></div>
+          <div class="m"><div class="k">Stage</div><div class="v">${escapeHtml(lot.current_stage)}</div></div>
+          <div class="m"><div class="k">Cut on</div><div class="v"><span class="num">${fmtDate(lot.created_at)}</span></div></div>
+        </div>
+        <div class="timeline">${steps}</div>
+      </div>
+      <div><div class="chartcard"><h4 style="margin-bottom:4px">Dispatch breakdown</h4><div class="cap" style="margin-bottom:4px">Back as sellable stock</div><div class="dispatch">${dcells}</div></div></div>
+    </div>`;
 }
 loadLotHistory();
 </script>
 
-<%- include('partials/footer') %>
+</body>
+</html>


### PR DESCRIPTION
Rebuilds the Production Manager suite on one shared design system and adds per-lot cut assignment.

## UI redesign
- New `public/css/pm-suite.css` + `views/partials/pmHead.ejs` + `views/partials/pmSidebar.ejs` — a self-contained sidebar + topbar shell (drops the global navbar for PM pages; Logout/Profile/My Lots live in the sidebar user menu). Warm green-tinted neutrals, single blue action accent, green=healthy, amber/red=status, soft pill+dot chips. No Bootstrap (no conflicts).
- **Dashboard** (`/pm`): 4 KPI cards + Priority-to-cut table (correct labels: Stock / Days left / Suggested cut) + count footer. Secondary tools (Dead Stock, Open Lots + modal, Marketplace POs + upload, Config) preserved & restyled. All ids / JS / data wiring unchanged.
- **Style detail** (`/pm/style/:style`): summary cards, size-breakdown grid, Fabrication & BOM, embedded Lot journey (vertical timeline + dispatch), Approve-&-assign. Same endpoints.
- **Cut Planning** + **Analytics**: ported to the shell + design-system components.

## Per-lot cut assignment
`POST /api/cut-plan/assign` now also accepts `{ style, lots: [{ master_id }] }` — one assignment row per lot, each to its own master (using the lot's own size split, tagged `Lot i/N`). Back-compatible: `{ style, master_id }` still creates one consolidated row. **No schema migration** (uses the existing multi-row-per-style table + `note` column). UI sends per-lot only when masters differ; identical selections collapse to the legacy single row.

## Verification
- All four views render; inline browser JS syntax-checked; route compiles.
- Deploy is safe: Cloud Build uses `--update-env-vars` + `--set-secrets` (sensitive env vars preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)