### PR TITLE
fix(pm): tools to sidebar + style suggested-cut coherence + manual lot #

### DIFF
--- a/public/css/pm-suite.css
+++ b/public/css/pm-suite.css
@@ -76,6 +76,7 @@ button{font-family:var(--font)}
 .nav a svg{width:19px;height:19px;flex-shrink:0;stroke-width:1.9}
 .nav a:hover{background:#eef4f0;color:var(--ink)}
 .nav a.active{background:var(--blue-bg);color:var(--blue-ink);font-weight:600}
+.nav-group{font-size:10px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-4);padding:16px 12px 6px;margin-top:4px;border-top:1px solid var(--line-2)}
 .sidebar .spacer{flex:1}
 .user{display:flex;align-items:center;gap:11px;padding:14px 18px;border-top:1px solid var(--line-2)}
 .avatar{width:32px;height:32px;border-radius:50%;background:#e7efe9;color:var(--ink-2);display:grid;place-items:center;font-weight:700;font-size:13px;flex-shrink:0}

--- a/views/partials/pmSidebar.ejs
+++ b/views/partials/pmSidebar.ejs
@@ -23,6 +23,23 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M4 20V10M10 20V4M16 20v-7M22 20H2"/></svg>
       Analytics
     </a>
+    <div class="nav-group">Tools</div>
+    <a href="/pm#dead" data-view="dead">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><rect x="3" y="4" width="18" height="4" rx="1"/><path d="M5 8v11a1 1 0 0 0 1 1h12a1 1 0 0 0 1-1V8M10 12h4"/></svg>
+      Dead Stock
+    </a>
+    <a href="/pm#lots" data-view="lots">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 2 2 7l10 5 10-5-10-5zM2 17l10 5 10-5M2 12l10 5 10-5"/></svg>
+      Open Lots
+    </a>
+    <a href="/pm#pos" data-view="pos">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/></svg>
+      Marketplace POs
+    </a>
+    <a href="/pm#config" data-view="config">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+      Config
+    </a>
   </nav>
   <div class="spacer"></div>
   <details class="usermenu">

--- a/views/productionManagerDashboard.ejs
+++ b/views/productionManagerDashboard.ejs
@@ -28,14 +28,6 @@
 
   <div class="pm-summary" id="pmSummary"></div>
 
-  <nav class="pm-tabs" role="tablist">
-    <button class="pm-tab active" data-tab="cutting">Priority to cut</button>
-    <button class="pm-tab" data-tab="dead">Dead Stock</button>
-    <button class="pm-tab" data-tab="lots">Open Lots</button>
-    <button class="pm-tab" data-tab="pos">Marketplace POs</button>
-    <button class="pm-tab" data-tab="config">Config</button>
-  </nav>
-
   <!-- PRIORITY TO CUT -->
   <section class="pm-panel active" data-panel="cutting">
     <h2 class="section-h" style="margin-top:6px">Priority to cut
@@ -334,19 +326,22 @@ async function loadSummary() {
 }
 loadSummary();
 
-// Tabs
-$$('.pm-tab').forEach(btn => {
-  btn.addEventListener('click', () => {
-    const tab = btn.dataset.tab;
-    $$('.pm-tab').forEach(b => b.classList.toggle('active', b === btn));
-    $$('.pm-panel').forEach(p => p.classList.toggle('active', p.dataset.panel === tab));
-    if (tab === 'cutting') loadCutting();
-    else if (tab === 'dead') loadDead();
-    else if (tab === 'lots') loadLots();
-    else if (tab === 'pos')  loadPos();
-    else if (tab === 'config') loadConfig();
-  });
-});
+// Panels are now driven from the sidebar Tools group via the URL hash (#dead, #lots, …).
+const TOOL_VIEWS = ['dead', 'lots', 'pos', 'config'];
+function viewFromHash() { const h = (location.hash || '').replace('#', '').toLowerCase(); return TOOL_VIEWS.includes(h) ? h : 'cutting'; }
+function showPanel(key) {
+  $$('.pm-panel').forEach(p => p.classList.toggle('active', p.dataset.panel === key));
+  // sync sidebar highlight: Dashboard for the default view, the matching tool otherwise
+  $$('.sidebar [data-view]').forEach(a => a.classList.toggle('active', a.dataset.view === key));
+  const dash = document.querySelector('.sidebar a[href="/pm"]');
+  if (dash) dash.classList.toggle('active', key === 'cutting');
+  if (key === 'cutting') loadCutting();
+  else if (key === 'dead') loadDead();
+  else if (key === 'lots') loadLots();
+  else if (key === 'pos') loadPos();
+  else if (key === 'config') loadConfig();
+}
+window.addEventListener('hashchange', () => showPanel(viewFromHash()));
 
 // ── CUTTING TODAY ───────────────────────────────────────────────
 async function loadCutting() {
@@ -636,8 +631,8 @@ if (pullBtn) {
   });
 }
 
-// Initial load
-loadCutting();
+// Initial load — honour the URL hash so deep links (/pm#lots) open the right panel
+showPanel(viewFromHash());
 </script>
 
 </body>

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -79,7 +79,8 @@ const STATUS = { red:['red','Cut now'], amber:['amber','Cut soon'], green:['gree
 
 // ── Sizes → header chip, subtitle, size grid ──────────────────────────
 let SIZES = [];
-(async function loadSizes() {
+let SUGGESTED_TOTAL = 0;
+async function loadSizes() {
   const grid = $('sizeGrid');
   try {
     const json = await (await fetch('/pm/api/sizes?style=' + encodeURIComponent(STYLE), { headers: { Accept: 'application/json' } })).json();
@@ -93,6 +94,10 @@ let SIZES = [];
     SIZES.forEach(r => { const t = r.trigger || 'green'; if (order[t] < order[worst]) worst = t; });
     const st = STATUS[worst];
     const chip = $('styleTrigger'); chip.className = 'title-chip ' + st[0]; chip.textContent = st[1];
+    // Suggested cut is the sum of per-size recommendations — the authoritative number
+    // (matches the dashboard). Fabric/lots come from the CAD planner separately.
+    SUGGESTED_TOTAL = SIZES.reduce((s, r) => s + (Number(r.suggested_cut_qty) || 0), 0);
+    $('kSuggested').innerHTML = `<span class="num">${fmtNum(SUGGESTED_TOTAL)}</span> <small>pcs</small>`;
     if (!SIZES.length) { grid.innerHTML = `<div class="pm-empty">No sizes for this style.</div>`; return; }
     grid.innerHTML = SIZES.map(r => {
       const sug = Number(r.suggested_cut_qty) || 0;
@@ -107,7 +112,7 @@ let SIZES = [];
       </div>`;
     }).join('');
   } catch (err) { grid.innerHTML = `<div class="pm-empty">Error: ${escapeHtml(err.message)}</div>`; }
-})();
+}
 
 // ── Cut plan → summary cards, fabrication, assign panel ───────────────
 let MASTERS = [];
@@ -122,24 +127,24 @@ async function loadAssignPanel() {
     MASTERS = (mastersRes.ok && mastersRes.masters) ? mastersRes.masters : [];
     const styleAsg = (asgRes.ok ? asgRes.items : []).filter(a => a.style === STYLE);
 
-    // summary cards
+    // Fabric & lots come from the CAD planner; Suggested cut already set from sizes.
     if (planRes.ok && planRes.totalPieces) {
-      $('kSuggested').innerHTML = `<span class="num">${fmtNum(planRes.totalPieces)}</span> <small>pcs</small>`;
       $('kFabric').innerHTML = planRes.totalFabricMeters != null ? `<span class="num">${fmtNum(planRes.totalFabricMeters)}</span> <small>m</small>` : '<small>no CAD</small>';
       $('kLots').innerHTML = `<span class="num">${planRes.lotCount || 0}</span>`;
       $('styleSub').textContent = (planRes.fabric_type ? planRes.fabric_type : 'Fabric n/a') + (planRes.totalFabricMeters != null && planRes.totalPieces ? ` · ${(planRes.totalFabricMeters / planRes.totalPieces).toFixed(3)} m per piece` : '');
       renderFabrication(planRes);
     } else {
-      $('kSuggested').innerHTML = '<span class="num">0</span> <small>pcs</small>';
-      $('kFabric').innerHTML = '<span class="num">0</span> <small>m</small>';
+      $('kFabric').innerHTML = '<small>no CAD</small>';
       $('kLots').innerHTML = '<span class="num">0</span>';
-      $('styleSub').textContent = 'Stock is covered — no cut suggested right now';
+      $('styleSub').textContent = SUGGESTED_TOTAL > 0
+        ? 'Needs cutting — CAD consumption pending, so lots & fabric can’t be planned yet'
+        : 'Stock is covered — no cut suggested right now';
     }
 
     if (!planRes.ok) { body.innerHTML = `<div class="pm-empty">${escapeHtml(planRes.warning || planRes.error || 'Could not load plan.')}</div>`; return; }
     if (!planRes.totalPieces) {
       $('planSummary').textContent = '';
-      body.innerHTML = `<div class="pm-empty">No suggested cut right now — stock is covered.</div>` + assignmentsHtml(styleAsg);
+      body.innerHTML = `<div class="pm-empty">${SUGGESTED_TOTAL > 0 ? 'Needs ' + fmtNum(SUGGESTED_TOTAL) + ' pcs across sizes, but there’s no CAD consumption for this style yet — upload CAD to plan lots &amp; fabric.' : 'No suggested cut right now — stock is covered.'}</div>` + assignmentsHtml(styleAsg);
       return;
     }
 
@@ -204,7 +209,8 @@ async function doAssign() {
     else { msg.innerHTML = `<span style="color:var(--red)">${escapeHtml(d.error || 'failed')}</span>`; }
   } catch (err) { msg.innerHTML = `<span style="color:var(--red)">${escapeHtml(err.message)}</span>`; }
 }
-loadAssignPanel();
+// Init: sizes first (sets Suggested cut), then the CAD plan / assign panel.
+(async () => { await loadSizes(); loadAssignPanel(); })();
 
 // ── Lot journey: picker + vertical timeline + dispatch ────────────────
 let LOTS = [];
@@ -214,7 +220,7 @@ async function loadLotHistory() {
     const j = await (await fetch('/pm/api/style-lots?style=' + encodeURIComponent(STYLE))).json();
     if (!j.ok || !j.lots || !j.lots.length) { $('lotEmpty').textContent = 'No lots cut for this style yet.'; return; }
     LOTS = j.lots;
-    $('lotPicker').innerHTML = LOTS.map((l, i) => `<option value="${i}">${escapeHtml(l.lot_no)} · ${fmtNum(l.total_pieces)} pcs · ${escapeHtml(l.current_stage)}</option>`).join('');
+    $('lotPicker').innerHTML = LOTS.map((l, i) => `<option value="${i}">${escapeHtml(l.lot_no)}${l.manual_lot_number ? ' (' + escapeHtml(l.manual_lot_number) + ')' : ''} · ${fmtNum(l.total_pieces)} pcs · ${escapeHtml(l.current_stage)}</option>`).join('');
     $('lotPicker').addEventListener('change', () => renderLot(Number($('lotPicker').value)));
     renderLot(0);
   } catch (err) { $('lotEmpty').textContent = 'Error: ' + err.message; }
@@ -240,7 +246,8 @@ function renderLot(idx) {
     <div class="grid-2" style="grid-template-columns:1.1fr .9fr;align-items:start;margin-top:14px">
       <div class="chartcard">
         <div class="lotmeta" style="margin-top:0;margin-bottom:18px">
-          <div class="m"><div class="k">Lot</div><div class="v">${escapeHtml(lot.lot_no)}${lot.manual_lot_number ? ' / ' + escapeHtml(lot.manual_lot_number) : ''}</div></div>
+          <div class="m"><div class="k">Lot</div><div class="v">${escapeHtml(lot.lot_no)}</div></div>
+          ${lot.manual_lot_number ? `<div class="m"><div class="k">Manual lot #</div><div class="v">${escapeHtml(lot.manual_lot_number)}</div></div>` : ''}
           <div class="m"><div class="k">Pieces</div><div class="v"><span class="num">${fmtNum(lot.total_pieces)}</span></div></div>
           <div class="m"><div class="k">Stage</div><div class="v">${escapeHtml(lot.current_stage)}</div></div>
           <div class="m"><div class="k">Cut on</div><div class="v"><span class="num">${fmtDate(lot.created_at)}</span></div></div>


### PR DESCRIPTION
Follow-up fixes on the live PM redesign, from review of the deployed pages.

- **Dashboard tabs → sidebar.** Removed the inline tab strip (misplaced between KPIs and the table; duplicated the "Priority to cut" heading). Dead Stock / Open Lots / Marketplace POs / Config now live in a sidebar **Tools** group and switch the dashboard panel via the URL hash (`/pm#lots`), with sidebar highlight synced and deep-linking.
- **Style detail data coherence.** "Suggested cut" now reflects the real per-size recommendation (sum from `/api/sizes`) instead of the CAD planner's gated number — so it no longer contradicts the size grid and the "Cut now" chip. When there's no CAD consumption, the subtitle + assign panel now say *needs cutting, CAD pending* rather than the misleading *stock is covered*.
- **Manual lot number** visible everywhere in the lot journey: the lot picker and a dedicated "Manual lot #" field.

Verified: all four views render, dashboard + style inline JS syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)