### PR TITLE
feat(pm): Myntra links + size-split ratio

### DIFF
--- a/public/css/pm-suite.css
+++ b/public/css/pm-suite.css
@@ -161,6 +161,12 @@ td.style .row{display:flex;align-items:center;gap:12px}
 .swatch.lg{width:32px;height:32px;border-radius:8px}
 td.style .code{font-weight:700;color:var(--ink);letter-spacing:-.01em}
 td.style .fab{font-size:12px;color:var(--ink-2);margin-top:1px}
+/* marketplace (Myntra) link — small external icon, pink on hover */
+.mlink{display:inline-flex;vertical-align:middle;margin-left:7px;color:var(--ink-3);transition:.15s}
+.mlink svg{width:14px;height:14px;stroke-width:2}
+.mlink:hover{color:#ff3f6c}
+.ratioline{font-size:12.5px;color:var(--ink-2);margin-top:9px}
+.ratioline b{color:var(--ink);font-variant-numeric:tabular-nums;font-weight:700}
 /* priority table — cluster the metrics so a row scans across cleanly */
 table.prio th:not(.l),table.prio td:not(.style):not(.status){width:118px}
 table.prio th.l:nth-child(5),table.prio td.status{width:150px}

--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -300,6 +300,29 @@ router.get('/api/summary', async (req, res) => {
   res.json({ ok: true, ...out });
 });
 
+// Marketplace links per style, from the existing product_links table. A product_links
+// sku may be the style code itself or a full size-SKU, so match either; degrade quietly
+// (returns {} if the table is absent or the query fails).
+function escapeRegExp(s) { return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+async function myntraByStyles(styleList) {
+  const map = {};
+  const styles = [...new Set((styleList || []).filter(Boolean))];
+  if (!styles.length) return map;
+  try {
+    const re = '^(' + styles.map(escapeRegExp).join('|') + ')';
+    const [links] = await pool.query(
+      `SELECT sku, myntra_link FROM product_links
+        WHERE myntra_link IS NOT NULL AND myntra_link <> '' AND sku REGEXP ?`,
+      [re]
+    );
+    for (const row of links) {
+      const st = styles.find((s) => row.sku === s || String(row.sku).startsWith(s));
+      if (st && !map[st]) map[st] = row.myntra_link;
+    }
+  } catch (_) { /* table missing or query failed — no links */ }
+  return map;
+}
+
 router.get('/api/styles', async (req, res) => {
   try {
     const rows = await safeCall('getCuttingRecommendations', pool, { periodKey: '30d' });
@@ -309,6 +332,8 @@ router.get('/api/styles', async (req, res) => {
     if (search) styles = styles.filter(s => (s.style || '').toLowerCase().includes(search));
     if (trigger && trigger !== 'all') styles = styles.filter(s => s.trigger === trigger);
     const dataQuality = (rows || []).some(r => r.dataQuality === 'warming_up') ? 'warming_up' : 'real';
+    const links = await myntraByStyles(styles.map((s) => s.style));
+    styles.forEach((s) => { s.myntra_link = links[s.style] || null; });
     res.json({ ok: true, items: styles, dataQuality });
   } catch (err) {
     if (err.code === 'ANALYTICS_MISSING') {
@@ -323,7 +348,8 @@ router.get('/api/sizes', async (req, res) => {
     const style = String(req.query.style || '').trim();
     const rows = await safeCall('getCuttingRecommendations', pool, { periodKey: '30d' });
     const filtered = style ? (rows || []).filter(r => r.style === style) : (rows || []);
-    res.json({ ok: true, items: filtered });
+    const links = style ? await myntraByStyles([style]) : {};
+    res.json({ ok: true, items: filtered, myntra_link: links[style] || null });
   } catch (err) {
     if (err.code === 'ANALYTICS_MISSING') {
       return res.json({ ok: false, items: [], warning: err.message });

--- a/views/cutPlanning.ejs
+++ b/views/cutPlanning.ejs
@@ -36,6 +36,8 @@ let MASTERS = [];
 const esc = s => String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
 const fmtDate = d => d ? new Date(d).toLocaleDateString('en-IN', { day: '2-digit', month: 'short' }) : '';
 const fmtNum = v => (v == null || Number.isNaN(Number(v))) ? '—' : Number(v).toLocaleString('en-IN');
+function gcd(a, b) { a = Math.abs(a); b = Math.abs(b); while (b) { const t = b; b = a % b; a = t; } return a || 1; }
+function sizeRatio(obj) { const e = Object.entries(obj || {}).map(([s, q]) => [s, Number(q) || 0]).filter(([, q]) => q > 0); if (!e.length) return ''; const g = e.reduce((a, [, q]) => gcd(a, q), 0) || 1; return e.map(([s, q]) => s + ':' + Math.round(q / g)).join('  '); }
 
 async function loadMasters() {
   const d = await (await fetch('/pm/api/cut-masters')).json();
@@ -68,6 +70,7 @@ async function loadPlan() {
       '<div class="plan-body" style="display:block">' +
         '<span class="fieldlab">Suggested size split · ' + fmtNum(j.totalPieces) + ' pcs total</span>' +
         '<div class="chips">' + sizes.map(([s, q]) => '<div class="chip-sz"><span class="s">' + esc(s) + '</span><span class="q num">' + fmtNum(q) + '</span></div>').join('') + '</div>' +
+        '<div class="ratioline">Ratio · <b>' + sizeRatio(j.demand) + '</b></div>' +
         (j.missingSizes && j.missingSizes.length ? '<div style="color:var(--amber-ink);font-size:12.5px;margin-top:10px">No CAD consumption yet for: ' + j.missingSizes.map(esc).join(', ') + '</div>' : '') +
         '<span class="fieldlab" style="margin-top:16px">Lot split · 1,500 hard cap — assign each lot to a master</span>' +
         '<div class="lotlist">' + j.lots.map(function (l, i) { var sz = Object.entries(l.sizes || {}).sort(function (a, b) { return b[1] - a[1]; }).map(function (e) { return '<div class="chip-sz"><span class="s">' + esc(e[0]) + '</span><span class="q num">' + fmtNum(e[1]) + '</span></div>'; }).join(''); return '<div class="lotrow"><div class="lotid">Lot ' + (i + 1) + ' <small><span class="num">' + fmtNum(l.total) + '</span> pcs' + (l.fabricMeters != null ? ' · ' + Number(l.fabricMeters).toFixed(0) + ' m' : '') + '</small></div><div class="lotsizes">' + sz + '</div><select class="select lotmaster">' + (opts || '<option value="">no masters</option>') + '</select></div>'; }).join('') + '</div>' +

--- a/views/productionManagerDashboard.ejs
+++ b/views/productionManagerDashboard.ejs
@@ -377,7 +377,7 @@ async function loadCutting() {
         ? `<a class="btn-sm assign" href="/pm/cut-planning?style=${encodeURIComponent(s.style)}">Assign</a>`
         : `<a class="btn-sm review" href="/pm/style/${encodeURIComponent(s.style)}">Review</a>`;
       return `<tr class="clickable" data-style="${escapeHtml(s.style)}">
-        <td class="style"><div class="row"><span class="swatch"></span><div><div class="code">${escapeHtml(s.style)}</div><div class="fab">DRR ${fmtNum(s.avg_drr, 2)}/day</div></div></div></td>
+        <td class="style"><div class="row"><span class="swatch"></span><div><div class="code">${escapeHtml(s.style)}${s.myntra_link ? `<a class="mlink" href="${escapeHtml(s.myntra_link)}" target="_blank" rel="noopener" title="View on Myntra" onclick="event.stopPropagation()"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6M10 14 21 3"/></svg></a>` : ''}</div><div class="fab">DRR ${fmtNum(s.avg_drr, 2)}/day</div></div></div></td>
         <td><span class="num">${fmtNum(s.total_soh)}</span></td>
         <td class="days ${daysCls}"><span class="num">${doh == null ? '—' : doh + 'd'}</span></td>
         <td class="cut"><span class="num">${sug ? fmtNum(sug) : '0'}</span></td>

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -24,10 +24,16 @@
         <h1 class="page-h"><%= style %> <span class="title-chip" id="styleTrigger"></span></h1>
         <p class="page-sub" id="styleSub">Loading…</p>
       </div>
-      <button class="btn primary" id="approveTop" onclick="document.getElementById('assignSection').scrollIntoView({behavior:'smooth'})">
-        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4 12 14.01l-3-3"/></svg>
-        Approve &amp; assign
-      </button>
+      <div style="display:flex;gap:10px;align-items:center">
+        <a class="btn ghost" id="myntraBtn" target="_blank" rel="noopener" style="display:none">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><path d="M15 3h6v6M10 14 21 3"/></svg>
+          View on Myntra
+        </a>
+        <button class="btn primary" id="approveTop" onclick="document.getElementById('assignSection').scrollIntoView({behavior:'smooth'})">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><path d="M22 4 12 14.01l-3-3"/></svg>
+          Approve &amp; assign
+        </button>
+      </div>
     </div>
 
     <!-- Summary cards -->
@@ -76,6 +82,13 @@ function compactNum(n) { n = Number(n) || 0; if (n >= 1e7) return (n/1e7).toFixe
 function escapeHtml(s){ return String(s==null?'':s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;'); }
 function fmtDate(d){ return d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short'}) : ''; }
 const STATUS = { red:['red','Cut now'], amber:['amber','Cut soon'], green:['green','Covered'] };
+function gcd(a, b) { a = Math.abs(a); b = Math.abs(b); while (b) { const t = b; b = a % b; a = t; } return a || 1; }
+function sizeRatio(obj) {
+  const ents = Object.entries(obj || {}).map(([s, q]) => [s, Number(q) || 0]).filter(([, q]) => q > 0);
+  if (!ents.length) return '';
+  const g = ents.reduce((acc, [, q]) => gcd(acc, q), 0) || 1;
+  return ents.map(([s, q]) => `${s}:${Math.round(q / g)}`).join('  ');
+}
 
 // ── Sizes → header chip, subtitle, size grid ──────────────────────────
 let SIZES = [];
@@ -86,6 +99,7 @@ async function loadSizes() {
     const json = await (await fetch('/pm/api/sizes?style=' + encodeURIComponent(STYLE), { headers: { Accept: 'application/json' } })).json();
     if (!json.ok && json.warning) { grid.innerHTML = `<div class="pm-empty">${escapeHtml(json.warning)}</div>`; return; }
     SIZES = json.items || [];
+    if (json.myntra_link) { const b = $('myntraBtn'); b.href = json.myntra_link; b.style.display = ''; }
     const warming = SIZES.some(r => r.dataQuality === 'warming_up');
     $('sizeQuality').textContent = warming ? 'Warming up — calendar days' : 'Real · ≥7 selling days';
     // worst trigger drives the header chip
@@ -154,6 +168,7 @@ async function loadAssignPanel() {
     body.innerHTML = `
       <span class="fieldlab">Suggested size split · ${fmtNum(planRes.totalPieces)} pcs total</span>
       <div class="chips">${sizes.map(([s, q]) => `<div class="chip-sz"><span class="s">${escapeHtml(s)}</span><span class="q num">${fmtNum(q)}</span></div>`).join('')}</div>
+      <div class="ratioline">Ratio · <b>${sizeRatio(planRes.demand)}</b></div>
       ${(planRes.missingSizes && planRes.missingSizes.length) ? `<div style="color:var(--amber-ink);font-size:12.5px;margin-top:10px">No CAD consumption yet for: ${planRes.missingSizes.map(escapeHtml).join(', ')}</div>` : ''}
       <span class="fieldlab" style="margin-top:16px">Lot split · 1,500 hard cap — assign each lot to a master</span>
       <div class="lotlist">


### PR DESCRIPTION
Myntra 'View on Myntra' links on the style page + dashboard rows (from existing product_links), and the suggested size split shown as a reduced ratio (S:1 M:2 L:2 XL:1). Verified: route compiles, all views render + JS syntax-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)