### PR TITLE
fix(pm): set size on cutting recommendations

### DIFF
--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -596,6 +596,14 @@ function deriveStyle(sku) {
   return s.replace(/(?:_(?:3XL|4XL|5XL|6XL)|_\d{2,3}|XXL|XL|XS|S|M|L)$/, '') || s;
 }
 
+// The size label of a size-SKU = the suffix deriveStyle() strips (underscore dropped).
+// e.g. KTTWOMENSPANT677XL -> 'XL', KTTLADIESJEANS823_34 -> '34'. null if no size suffix.
+function deriveSize(sku) {
+  const s = String(sku || '').toUpperCase();
+  const m = s.match(/(?:_(3XL|4XL|5XL|6XL)|_(\d{2,3})|(XXL|XL|XS|S|M|L))$/);
+  return m ? (m[1] || m[2] || m[3] || null) : null;
+}
+
 // Clean-day demand metrics per size-SKU, company-wide. Gap/dup-safe.
 // A day counts as a clean in-stock day only if it was in stock the WHOLE day:
 // current snapshot qty>0 AND the most-recent-PRIOR present snapshot qty>0
@@ -848,6 +856,7 @@ async function getCuttingRecommendations(pool, { periodKey = '30d', shadow = fal
     results.push({
       sku,
       style: deriveStyle(sku),
+      size: deriveSize(sku),
       low_confidence: !!lowConfidence,
       soh,
       drr,


### PR DESCRIPTION
getCuttingRecommendations set `style` but never `size`, so the cut planner (keyed by `r.size`) returned 0 lots for every style — the style page showed 'CAD pending' even with real demand. Adds `deriveSize(sku)` and sets `size` on each record. Verified against prod: KTTWOMENSPANT677 now yields 5 sized rows (11,938 pcs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)