### PR TITLE
feat(return-challan): standard departments + 7-day edit window

### DIFF
--- a/docs/superpowers/plans/2026-06-20-pm-overcut-fix.md
+++ b/docs/superpowers/plans/2026-06-20-pm-overcut-fix.md
@@ -1,0 +1,636 @@
+# PM Overcut Fix (Feature B) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Net real in-flight cut lots out of `/pm`'s suggested-cut number so it stops re-suggesting what's already in production.
+
+**Architecture:** A new focused module `utils/onOrder.js` exposes two pure functions (`resolveSizeSku`, `buildOnOrderMap`) and one DB wrapper (`computeOnOrderBySku`). `getCuttingRecommendations` replaces its manual-table-only `openLotMap` with a call to `computeOnOrderBySku`, which (behind the `PM_CLOSED_LOOP` flag) unions the manual table with real in-flight lots netted against finishing dispatches. Because every downstream surface already reads `suggested_cut_qty`, the fix propagates with no other logic changes.
+
+**Tech Stack:** Node.js, Express, EJS, mysql2; tests via Node's built-in runner (`node --test`), no mocking library — fake pools are hand-written stubs dispatching by SQL shape (house pattern, see `test/approvalCorrection.test.js`).
+
+## Global Constraints
+
+- New real-lot behavior is gated behind env flag **`PM_CLOSED_LOOP`** — truthy (`'1'` or `'true'`) enables it; default OFF reproduces today's exact numbers (manual `pm_open_cutting_lots` only).
+- Staleness window env **`PM_INFLIGHT_WINDOW_DAYS`** (default `120`) bounds which cut lots count as in-flight.
+- `computeOnOrderBySku` must use a small fixed number of set-based queries (not per-SKU) and build its map once per `getCuttingRecommendations` call.
+- Tests run with `node --test`. Test files live in `test/*.test.js`.
+- Deploy ONLY from `main` (merge a PR to ship). Never wipe Cloud Run env vars — `--update-env-vars`/`--update-secrets` only.
+- Every commit ends with: `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>`
+- Branch: `feat/pm-overcut-fix` (already created; the design spec is committed there).
+
+---
+
+## File Structure
+
+- **Create** `utils/onOrder.js` — on-order computation: `resolveSizeSku` (size-label→ecom-SKU binding), `buildOnOrderMap` (net + union + unresolved tally), `computeOnOrderBySku` (DB wrapper, flag-aware).
+- **Create** `test/onOrder.test.js` — unit tests for all three.
+- **Modify** `utils/easyecomAnalytics.js` — require `computeOnOrderBySku`; replace the `openLotMap` block ([:756-761](../../../utils/easyecomAnalytics.js#L756)); attach `results.onOrderUnresolved`.
+- **Modify** `routes/productionManagerRoutes.js` — `/api/styles` ([:326-344](../../../routes/productionManagerRoutes.js#L326)) returns `in_flight_unresolved`.
+- **Modify** `views/productionManagerDashboard.ejs` — show an "unresolved in-flight" data-quality line when present.
+- **Modify** `views/productionManagerStyle.ejs` — show "X pcs already in production across Y lots" near the suggested cut.
+
+---
+
+### Task 1: `resolveSizeSku` — bind a lot's (style, size_label) to an EasyEcom size-SKU
+
+**Files:**
+- Create: `utils/onOrder.js`
+- Test: `test/onOrder.test.js`
+
+**Interfaces:**
+- Produces: `resolveSizeSku(style, sizeLabel, resolutionMap, canonSet) -> string | null`
+  - `resolutionMap`: `Map<string, string>` keyed `UPPER(style)+'||'+UPPER(sizeLabel)` → size_sku (from `pm_sku_resolution`).
+  - `canonSet`: `Set<string>` of UPPERCASE canonical ecom SKUs (from `ee_suborders`).
+  - Returns the resolved size-SKU (as stored — uppercase) or `null`.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// test/onOrder.test.js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { resolveSizeSku } = require('../utils/onOrder.js');
+
+test('resolveSizeSku: prefers pm_sku_resolution map', () => {
+  const rmap = new Map([['KTTTOP374||L', 'KTTTOP374L']]);
+  assert.strictEqual(resolveSizeSku('KTTTOP374', 'L', rmap, new Set()), 'KTTTOP374L');
+});
+
+test('resolveSizeSku: falls back to STYLE+LABEL against canon set', () => {
+  const canon = new Set(['KTTTOP374L']);
+  assert.strictEqual(resolveSizeSku('KTTTOP374', 'L', new Map(), canon), 'KTTTOP374L');
+});
+
+test('resolveSizeSku: falls back to STYLE+_+LABEL for numeric sizes', () => {
+  const canon = new Set(['KTTMENSJEANS381_28']);
+  assert.strictEqual(resolveSizeSku('KTTMENSJEANS381', '28', new Map(), canon), 'KTTMENSJEANS381_28');
+});
+
+test('resolveSizeSku: case-insensitive on inputs', () => {
+  const rmap = new Map([['KTTTOP374||L', 'KTTTOP374L']]);
+  assert.strictEqual(resolveSizeSku('ktttop374', 'l', rmap, new Set()), 'KTTTOP374L');
+});
+
+test('resolveSizeSku: returns null when nothing matches', () => {
+  assert.strictEqual(resolveSizeSku('NOPE', 'XL', new Map(), new Set()), null);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/onOrder.test.js`
+Expected: FAIL — `Cannot find module '../utils/onOrder.js'`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```javascript
+// utils/onOrder.js
+'use strict';
+
+const U = (s) => String(s == null ? '' : s).toUpperCase().trim();
+
+// Bind a cut lot's (style, size_label) to an EasyEcom size-SKU.
+// Primary: the human-authored pm_sku_resolution map. Fallback: concatenation
+// (letter sizes attach directly, numeric/long sizes via underscore) validated
+// against the canonical ecom SKU set. Returns the size-SKU or null.
+function resolveSizeSku(style, sizeLabel, resolutionMap, canonSet) {
+  const st = U(style);
+  const lbl = U(sizeLabel);
+  if (!st || !lbl) return null;
+  const fromMap = resolutionMap.get(st + '||' + lbl);
+  if (fromMap) return fromMap;
+  const direct = st + lbl;
+  if (canonSet.has(direct)) return direct;
+  const underscored = st + '_' + lbl;
+  if (canonSet.has(underscored)) return underscored;
+  return null;
+}
+
+module.exports = { resolveSizeSku, U };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/onOrder.test.js`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/onOrder.js test/onOrder.test.js
+git commit -m "feat(pm): resolveSizeSku — bind cut-lot size to ecom size-SKU
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `buildOnOrderMap` — net dispatched, union manual, tally unresolved
+
+**Files:**
+- Modify: `utils/onOrder.js`
+- Test: `test/onOrder.test.js`
+
+**Interfaces:**
+- Consumes: `resolveSizeSku` (Task 1).
+- Produces: `buildOnOrderMap({ inFlightRows, dispatchedMap, manualRows, resolutionMap, canonSet }) -> { map, unresolvedLots, unresolvedPieces }`
+  - `inFlightRows`: `Array<{ lot_no, style, size_label, cut_pieces }>` (one per cut lot-size).
+  - `dispatchedMap`: `Map<string, number>` keyed `UPPER(lot_no)+'||'+UPPER(size_label)` → dispatched qty.
+  - `manualRows`: `Array<{ sku, qty }>` from `pm_open_cutting_lots`.
+  - `map`: `Map<string, number>` size_sku → on-order qty.
+  - `unresolvedLots`: count of DISTINCT `lot_no` with at least one unresolved size.
+  - `unresolvedPieces`: total net pieces that could not be bound to a size-SKU.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// append to test/onOrder.test.js
+const { buildOnOrderMap } = require('../utils/onOrder.js');
+
+const RMAP = new Map([
+  ['KTTTOP374||M', 'KTTTOP374M'],
+  ['KTTTOP374||L', 'KTTTOP374L'],
+]);
+const CANON = new Set(['KTTTOP374M', 'KTTTOP374L']);
+
+test('buildOnOrderMap: nets dispatched pieces off the cut qty', () => {
+  const res = buildOnOrderMap({
+    inFlightRows: [{ lot_no: 'A1', style: 'KTTTOP374', size_label: 'M', cut_pieces: 80 }],
+    dispatchedMap: new Map([['A1||M', 20]]),
+    manualRows: [],
+    resolutionMap: RMAP, canonSet: CANON,
+  });
+  assert.strictEqual(res.map.get('KTTTOP374M'), 60);
+  assert.strictEqual(res.unresolvedLots, 0);
+});
+
+test('buildOnOrderMap: fully dispatched lot-size contributes 0 and is omitted', () => {
+  const res = buildOnOrderMap({
+    inFlightRows: [{ lot_no: 'A1', style: 'KTTTOP374', size_label: 'M', cut_pieces: 50 }],
+    dispatchedMap: new Map([['A1||M', 50]]),
+    manualRows: [], resolutionMap: RMAP, canonSet: CANON,
+  });
+  assert.strictEqual(res.map.has('KTTTOP374M'), false);
+});
+
+test('buildOnOrderMap: sums multiple lots into the same size-SKU', () => {
+  const res = buildOnOrderMap({
+    inFlightRows: [
+      { lot_no: 'A1', style: 'KTTTOP374', size_label: 'M', cut_pieces: 30 },
+      { lot_no: 'A2', style: 'KTTTOP374', size_label: 'M', cut_pieces: 40 },
+    ],
+    dispatchedMap: new Map(), manualRows: [], resolutionMap: RMAP, canonSet: CANON,
+  });
+  assert.strictEqual(res.map.get('KTTTOP374M'), 70);
+});
+
+test('buildOnOrderMap: unresolved size tallied by distinct lot, not dropped silently', () => {
+  const res = buildOnOrderMap({
+    inFlightRows: [
+      { lot_no: 'A1', style: 'WEIRDSTYLE', size_label: 'M', cut_pieces: 25 },
+      { lot_no: 'A1', style: 'WEIRDSTYLE', size_label: 'L', cut_pieces: 15 },
+    ],
+    dispatchedMap: new Map(), manualRows: [], resolutionMap: RMAP, canonSet: CANON,
+  });
+  assert.strictEqual(res.map.size, 0);
+  assert.strictEqual(res.unresolvedLots, 1);   // one distinct lot_no
+  assert.strictEqual(res.unresolvedPieces, 40);
+});
+
+test('buildOnOrderMap: unions manual rows on top of real lots', () => {
+  const res = buildOnOrderMap({
+    inFlightRows: [{ lot_no: 'A1', style: 'KTTTOP374', size_label: 'L', cut_pieces: 10 }],
+    dispatchedMap: new Map(),
+    manualRows: [{ sku: 'KTTTOP374L', qty: 5 }, { sku: 'KTTTOP374M', qty: 7 }],
+    resolutionMap: RMAP, canonSet: CANON,
+  });
+  assert.strictEqual(res.map.get('KTTTOP374L'), 15); // 10 real + 5 manual
+  assert.strictEqual(res.map.get('KTTTOP374M'), 7);
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/onOrder.test.js`
+Expected: FAIL — `buildOnOrderMap is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```javascript
+// utils/onOrder.js — add above module.exports
+// Build the size_sku -> on-order qty map. In-flight = cut pieces net of pieces
+// already dispatched (finishing); unresolved sizes are tallied, never dropped
+// silently. The manual pm_open_cutting_lots rows are summed on top (transition).
+function buildOnOrderMap({ inFlightRows, dispatchedMap, manualRows, resolutionMap, canonSet }) {
+  const map = new Map();
+  const unresolvedLotSet = new Set();
+  let unresolvedPieces = 0;
+
+  for (const r of (inFlightRows || [])) {
+    const dispatched = dispatchedMap.get(U(r.lot_no) + '||' + U(r.size_label)) || 0;
+    const net = (Number(r.cut_pieces) || 0) - dispatched;
+    if (net <= 0) continue;
+    const sku = resolveSizeSku(r.style, r.size_label, resolutionMap, canonSet);
+    if (!sku) {
+      unresolvedLotSet.add(U(r.lot_no));
+      unresolvedPieces += net;
+      continue;
+    }
+    map.set(sku, (map.get(sku) || 0) + net);
+  }
+
+  for (const r of (manualRows || [])) {
+    const sku = U(r.sku);
+    if (!sku) continue;
+    map.set(sku, (map.get(sku) || 0) + (Number(r.qty) || 0));
+  }
+
+  return { map, unresolvedLots: unresolvedLotSet.size, unresolvedPieces };
+}
+```
+
+Update `module.exports`:
+
+```javascript
+module.exports = { resolveSizeSku, buildOnOrderMap, U };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/onOrder.test.js`
+Expected: PASS (10 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/onOrder.js test/onOrder.test.js
+git commit -m "feat(pm): buildOnOrderMap — net dispatched, union manual, tally unresolved
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `computeOnOrderBySku(pool)` — flag-aware DB wrapper
+
+**Files:**
+- Modify: `utils/onOrder.js`
+- Test: `test/onOrder.test.js`
+
+**Interfaces:**
+- Consumes: `buildOnOrderMap` (Task 2).
+- Produces: `async computeOnOrderBySku(pool, { windowDays } = {}) -> { onOrder: Map<string,number>, unresolved: { lots: number, pieces: number } }`
+  - When `PM_CLOSED_LOOP` is NOT truthy: runs ONLY the manual `pm_open_cutting_lots` query and returns `{ onOrder, unresolved: { lots: 0, pieces: 0 } }` (today's behavior).
+  - When truthy: also loads in-flight lots (cut within `windowDays`, default `PM_INFLIGHT_WINDOW_DAYS` or 120), dispatches, resolution map, and canon set; returns the netted+unioned map + unresolved tally.
+
+- [ ] **Step 1: Write the failing test**
+
+```javascript
+// append to test/onOrder.test.js
+const { computeOnOrderBySku } = require('../utils/onOrder.js');
+
+// Fake pool dispatching by SQL shape (house pattern, cf. test/approvalCorrection.test.js).
+function fakePool(data) {
+  return {
+    queries: [],
+    async query(sql) {
+      this.queries.push(sql.replace(/\s+/g, ' ').trim());
+      if (/FROM pm_open_cutting_lots/.test(sql)) return [data.manual || []];
+      if (/FROM cutting_lots/.test(sql)) return [data.inflight || []];
+      if (/FROM finishing_dispatches/.test(sql)) return [data.dispatched || []];
+      if (/FROM pm_sku_resolution/.test(sql)) return [data.resolution || []];
+      if (/FROM ee_suborders/.test(sql)) return [data.canon || []];
+      throw new Error('unexpected query: ' + sql);
+    },
+  };
+}
+
+test('computeOnOrderBySku: flag OFF uses ONLY the manual table', async () => {
+  delete process.env.PM_CLOSED_LOOP;
+  const pool = fakePool({ manual: [{ sku: 'KTTTOP374L', qty: 12 }] });
+  const res = await computeOnOrderBySku(pool);
+  assert.strictEqual(res.onOrder.get('KTTTOP374L'), 12);
+  assert.deepStrictEqual(res.unresolved, { lots: 0, pieces: 0 });
+  // Only the manual query should have run.
+  assert.strictEqual(pool.queries.some((q) => /FROM cutting_lots/.test(q)), false);
+});
+
+test('computeOnOrderBySku: flag ON nets real lots + unions manual + tallies unresolved', async () => {
+  process.env.PM_CLOSED_LOOP = '1';
+  const pool = fakePool({
+    manual: [{ sku: 'KTTTOP374M', qty: 5 }],
+    inflight: [
+      { lot_no: 'A1', style: 'KTTTOP374', size_label: 'L', cut_pieces: 80 },
+      { lot_no: 'B2', style: 'WEIRDSTYLE', size_label: 'XL', cut_pieces: 30 },
+    ],
+    dispatched: [{ lot_no: 'A1', size_label: 'L', qty: 20 }],
+    resolution: [{ cl_sku: 'KTTTOP374', size_label: 'L', size_sku: 'KTTTOP374L' }],
+    canon: [{ sku: 'KTTTOP374L' }],
+  });
+  const res = await computeOnOrderBySku(pool);
+  assert.strictEqual(res.onOrder.get('KTTTOP374L'), 60); // 80 - 20 dispatched
+  assert.strictEqual(res.onOrder.get('KTTTOP374M'), 5);  // manual
+  assert.deepStrictEqual(res.unresolved, { lots: 1, pieces: 30 }); // WEIRDSTYLE/B2
+  delete process.env.PM_CLOSED_LOOP;
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `node --test test/onOrder.test.js`
+Expected: FAIL — `computeOnOrderBySku is not a function`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+```javascript
+// utils/onOrder.js — add above module.exports
+function flagOn() {
+  const v = String(process.env.PM_CLOSED_LOOP || '').toLowerCase();
+  return v === '1' || v === 'true';
+}
+
+async function loadManualRows(pool) {
+  const [rows] = await pool.query(
+    `SELECT sku, COALESCE(SUM(qty), 0) AS qty FROM pm_open_cutting_lots
+     WHERE closed_at IS NULL GROUP BY sku`
+  );
+  return rows.map((r) => ({ sku: r.sku, qty: Number(r.qty) || 0 }));
+}
+
+// Returns { onOrder: Map<size_sku, qty>, unresolved: { lots, pieces } }.
+// Flag OFF -> manual table only (today's behavior). Flag ON -> union real
+// in-flight lots (cut within windowDays, net of dispatches) with the manual table.
+async function computeOnOrderBySku(pool, { windowDays } = {}) {
+  const manualRows = await loadManualRows(pool);
+
+  if (!flagOn()) {
+    const map = new Map();
+    for (const r of manualRows) map.set(U(r.sku), (map.get(U(r.sku)) || 0) + r.qty);
+    return { onOrder: map, unresolved: { lots: 0, pieces: 0 } };
+  }
+
+  const days = Number(windowDays || process.env.PM_INFLIGHT_WINDOW_DAYS || 120);
+
+  const [inflight] = await pool.query(
+    `SELECT cl.lot_no, cl.sku AS style, cls.size_label,
+            COALESCE(cls.total_pieces, 0) AS cut_pieces
+     FROM cutting_lots cl
+     JOIN cutting_lot_sizes cls ON cls.cutting_lot_id = cl.id
+     WHERE cl.created_at >= DATE_SUB(CURDATE(), INTERVAL ? DAY)`,
+    [days]
+  );
+
+  const [dispatched] = await pool.query(
+    `SELECT lot_no, size_label, COALESCE(SUM(quantity), 0) AS qty
+     FROM finishing_dispatches GROUP BY lot_no, size_label`
+  );
+  const dispatchedMap = new Map(
+    dispatched.map((r) => [U(r.lot_no) + '||' + U(r.size_label), Number(r.qty) || 0])
+  );
+
+  const [resolution] = await pool.query(
+    `SELECT cl_sku, size_label, size_sku FROM pm_sku_resolution
+     WHERE state = 'resolved' AND size_sku IS NOT NULL`
+  );
+  const resolutionMap = new Map(
+    resolution.map((r) => [U(r.cl_sku) + '||' + U(r.size_label), U(r.size_sku)])
+  );
+
+  const [canonRows] = await pool.query(
+    `SELECT DISTINCT UPPER(sku) AS sku FROM ee_suborders WHERE sku IS NOT NULL AND sku <> ''`
+  );
+  const canonSet = new Set(canonRows.map((r) => r.sku));
+
+  const built = buildOnOrderMap({
+    inFlightRows: inflight, dispatchedMap, manualRows, resolutionMap, canonSet,
+  });
+  return {
+    onOrder: built.map,
+    unresolved: { lots: built.unresolvedLots, pieces: built.unresolvedPieces },
+  };
+}
+```
+
+Update `module.exports`:
+
+```javascript
+module.exports = { resolveSizeSku, buildOnOrderMap, computeOnOrderBySku, U };
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `node --test test/onOrder.test.js`
+Expected: PASS (12 tests total).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add utils/onOrder.js test/onOrder.test.js
+git commit -m "feat(pm): computeOnOrderBySku — flag-aware on-order from real lots + manual
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: Wire `computeOnOrderBySku` into `getCuttingRecommendations`
+
+**Files:**
+- Modify: `utils/easyecomAnalytics.js` (require at top; replace `openLotMap` block at [:756-761](../../../utils/easyecomAnalytics.js#L756); attach `results.onOrderUnresolved` before `return results`).
+
+**Interfaces:**
+- Consumes: `computeOnOrderBySku` (Task 3).
+- Produces: `getCuttingRecommendations` returns its existing array, now carrying a non-enumerable-safe property `results.onOrderUnresolved = { lots, pieces }`. `openLotQty` per result now reflects the unioned on-order map.
+
+This is an integration wiring task (no new pure logic). It is verified by: (a) the full suite still passing, and (b) the manual DB check in the Verification section.
+
+- [ ] **Step 1: Add the require near the other requires at the top of `utils/easyecomAnalytics.js`**
+
+```javascript
+const { computeOnOrderBySku } = require('./onOrder');
+```
+
+- [ ] **Step 2: Replace the manual-only open-lot block**
+
+Find (around [utils/easyecomAnalytics.js:756-761](../../../utils/easyecomAnalytics.js#L756)):
+
+```javascript
+  const [openLotRows] = await pool.query(
+    `SELECT sku, COALESCE(SUM(qty), 0) AS qty FROM pm_open_cutting_lots
+     WHERE closed_at IS NULL GROUP BY sku`
+  );
+  const openLotMap = new Map(openLotRows.map((r) => [r.sku, Number(r.qty) || 0]));
+```
+
+Replace with:
+
+```javascript
+  const { onOrder: openLotMap, unresolved: onOrderUnresolved } =
+    await computeOnOrderBySku(pool);
+```
+
+- [ ] **Step 3: Make `openLotQty` lookup case-insensitive**
+
+The map is now keyed by UPPERCASE size-SKU (canonical). Find (around [:835](../../../utils/easyecomAnalytics.js#L835)):
+
+```javascript
+    const openLotQty = openLotMap.get(sku) || 0;
+```
+
+Replace with:
+
+```javascript
+    const openLotQty = openLotMap.get(String(sku).toUpperCase()) || 0;
+```
+
+- [ ] **Step 4: Attach the unresolved tally to the result**
+
+Find the end of `getCuttingRecommendations` (around [:887-889](../../../utils/easyecomAnalytics.js#L887)):
+
+```javascript
+  results.sort((a, b) => b.suggested_cut_qty - a.suggested_cut_qty);
+  return results;
+}
+```
+
+Replace with:
+
+```javascript
+  results.sort((a, b) => b.suggested_cut_qty - a.suggested_cut_qty);
+  results.onOrderUnresolved = onOrderUnresolved || { lots: 0, pieces: 0 };
+  return results;
+}
+```
+
+- [ ] **Step 5: Run the full suite to verify no regressions**
+
+Run: `node --test`
+Expected: PASS — all existing suites green (the new `test/onOrder.test.js` included). No test references the removed inline query.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add utils/easyecomAnalytics.js
+git commit -m "feat(pm): wire computeOnOrderBySku into getCuttingRecommendations (PM_CLOSED_LOOP)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: Surface the unresolved-in-flight signal on the dashboard
+
+**Files:**
+- Modify: `routes/productionManagerRoutes.js` (`/api/styles`, [:326-344](../../../routes/productionManagerRoutes.js#L326)).
+- Modify: `views/productionManagerDashboard.ejs` (render the line in `loadCutting`/summary area).
+
+**Interfaces:**
+- Consumes: `recs.onOrderUnresolved` from Task 4.
+- Produces: `/api/styles` response gains `in_flight_unresolved: { lots, pieces }`.
+
+- [ ] **Step 1: Confirm the handler shape**
+
+The `/api/styles` handler ([routes/productionManagerRoutes.js:326-344](../../../routes/productionManagerRoutes.js#L326)) holds the `getCuttingRecommendations` result in `rows`, aggregates to `styles`, and returns `{ ok: true, items: styles, dataQuality }`. The `onOrderUnresolved` property rides on `rows` (the array) from Task 4.
+
+- [ ] **Step 2: Add `in_flight_unresolved` to the response**
+
+Change the success response line at [:337](../../../routes/productionManagerRoutes.js#L337):
+
+```javascript
+    res.json({ ok: true, items: styles, dataQuality });
+```
+
+to:
+
+```javascript
+    res.json({ ok: true, items: styles, dataQuality, in_flight_unresolved: rows.onOrderUnresolved || { lots: 0, pieces: 0 } });
+```
+
+- [ ] **Step 3: Render the line on the dashboard**
+
+In `views/productionManagerDashboard.ejs`, in the `loadCutting` / summary JS where the `/pm/api/styles` JSON is consumed, after the table renders add (near the `cuttingFoot` line):
+
+```javascript
+      const unres = json.in_flight_unresolved;
+      if (unres && unres.lots > 0) {
+        const foot = $('cuttingFoot');
+        if (foot) foot.innerHTML += ` · <span style="color:var(--amber-ink)">${fmtNum(unres.pieces)} pcs in ${unres.lots} in-flight lot${unres.lots === 1 ? '' : 's'} not matched to a SKU — resolve to avoid overcut</span>`;
+      }
+```
+
+- [ ] **Step 4: Manually verify the render**
+
+Regenerate the faithful preview if available, or load `/pm` against a dev DB with `PM_CLOSED_LOOP=1`. Confirm the amber line appears only when `lots > 0` and is absent otherwise.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add routes/productionManagerRoutes.js views/productionManagerDashboard.ejs
+git commit -m "feat(pm): surface unresolved in-flight lots on dashboard
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: Style-page "already in production" line
+
+**Files:**
+- Modify: `views/productionManagerStyle.ejs` (near the per-size suggested cut / assign section).
+
+**Interfaces:**
+- Consumes: per-size `open_lot_qty` from `/pm/api/sizes` (already returned) and `LOTS` from `/pm/api/style-lots` (already loaded in `loadLotHistory`).
+
+- [ ] **Step 1: Locate where `SIZES` is set (suggested cut) and where `LOTS` is populated**
+
+Run: `grep -n "SIZES =\|LOTS =\|open_lot_qty\|SUGGESTED_TOTAL" views/productionManagerStyle.ejs`
+Expected: `SIZES` assigned from `/pm/api/sizes`; `LOTS` from `/pm/api/style-lots`; `SUGGESTED_TOTAL` computed from `suggested_cut_qty`.
+
+- [ ] **Step 2: Add the in-production summary line**
+
+Where `SUGGESTED_TOTAL` is computed (around [:113](../../../views/productionManagerStyle.ejs#L113)), compute the in-production total from the same `SIZES` data and render it under the suggested-cut header. Add:
+
+```javascript
+  const IN_PROD = SIZES.reduce((s, r) => s + (Number(r.open_lot_qty) || 0), 0);
+  const planSummary = document.getElementById('planSummary');
+  if (planSummary && IN_PROD > 0) {
+    planSummary.textContent = fmtNum(IN_PROD) + ' pcs already in production';
+  }
+```
+
+(`#planSummary` already exists in the "Approve & assign cut" header at [:66](../../../views/productionManagerStyle.ejs#L66).)
+
+- [ ] **Step 3: Manually verify**
+
+Load `/pm/style/<a style with a recent undispatched lot>` with `PM_CLOSED_LOOP=1`. Confirm the header shows "N pcs already in production" and that the suggested cut is correspondingly lower than `horizon×DRR − SOH`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add views/productionManagerStyle.ejs
+git commit -m "feat(pm): style page shows pieces already in production
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Verification (end-to-end, against a dev DB)
+
+Run with `PM_CLOSED_LOOP=1` set in the app environment.
+
+1. **Suppression:** pick a recent **undispatched** `cutting_lots` row for style X, size M (say 80 pcs). `/pm/api/sizes?style=X` shows `open_lot_qty` for M ≥ 80 and `suggested_cut_qty` for M dropped by ~80 vs the flag-off value. The dashboard priority row and the CAD cut-plan `demand` shrink to match.
+2. **Partial dispatch:** insert a partial `finishing_dispatches` (20 of the 80) → in-flight for X-M becomes 60; suggested rises by 20.
+3. **Full dispatch:** dispatch the remaining 60 → the lot drops out of on-order; suggested returns to its pre-lot value (modulo the dispatch→SOH transit gap, which Feature C will close).
+4. **Toggle parity:** unset `PM_CLOSED_LOOP` → numbers exactly match production today (manual table only). `node --test` passes in both states (tests set/unset the flag themselves).
+5. **Double-count check:** for a size-SKU present in BOTH `pm_open_cutting_lots` and a real lot, confirm `open_lot_qty` equals the intended union (manual qty + netted real qty), not an accidental separate path.
+6. **Unresolved flag:** with a cut lot whose size can't bind to a size-SKU, the dashboard shows the amber "N pcs in M in-flight lots not matched" line and `/api/styles` returns a non-zero `in_flight_unresolved`.
+7. **Staleness:** a lot older than `PM_INFLIGHT_WINDOW_DAYS` with no dispatch does NOT suppress (excluded by the cut-date window).
+
+---
+
+## Self-Review
+
+- **Spec coverage:** computeOnOrderBySku union (Tasks 2–3); net cut−dispatched (Task 2); staleness window (Task 3); pm_sku_resolution primary + concat fallback (Task 1); unresolved flagged not dropped (Tasks 2,5); single wiring point + PM_CLOSED_LOOP gate (Task 4); style-page surfacing (Task 6). All spec sections map to tasks.
+- **Placeholder scan:** every code step shows full code; no TBD/TODO.
+- **Type consistency:** `resolveSizeSku(style, sizeLabel, resolutionMap, canonSet)`, `buildOnOrderMap({inFlightRows, dispatchedMap, manualRows, resolutionMap, canonSet}) -> {map, unresolvedLots, unresolvedPieces}`, `computeOnOrderBySku(pool, {windowDays}) -> {onOrder, unresolved:{lots,pieces}}` — names/shapes used consistently across Tasks 1–6. Dispatch/inflight map key is `UPPER(lot_no)+'||'+UPPER(size_label)` everywhere; resolution key `UPPER(style)+'||'+UPPER(label)` everywhere.

--- a/docs/superpowers/specs/2026-06-20-pm-overcut-fix-design.md
+++ b/docs/superpowers/specs/2026-06-20-pm-overcut-fix-design.md
@@ -1,0 +1,128 @@
+# PM Overcut Fix — In-flight-aware suggested cut (Feature B)
+
+*Date: 2026-06-20. Status: design approved, ready for implementation plan.*
+
+## Context / Problem
+
+`/pm` recommends how much to cut per size-SKU with:
+
+```
+suggested = max(0, horizon×DRR − SOH − openLotQty + upcomingPO)
+```
+([utils/easyecomAnalytics.js:842-845](../../../utils/easyecomAnalytics.js#L842))
+
+The formula already subtracts an "on-order" quantity (`openLotQty`), **but that number is
+built only from the manual `pm_open_cutting_lots` table**
+([easyecomAnalytics.js:757-761](../../../utils/easyecomAnalytics.js#L757)). It does **not**
+look at the real lots currently in production — the same lots the style page's lot-journey
+panel displays. So when a lot for a size is sitting in stitching / washing / finishing, the
+system is blind to it and re-suggests cutting it again → **overcut**.
+
+The owner's intent: the in-flight ("inline") pipeline must be netted out of the suggested
+cut, so that only the *remaining* gap is presented for assignment. This is the "close the
+awareness loop / PE1" item from the cutting-planning roadmap.
+
+## Goal
+
+Make `suggested_cut_qty` (and therefore everything derived from it) account for real
+in-flight cut lots, not just the manual table — with no overcut and no double-counting
+against incoming stock.
+
+## Why this is a small, well-bounded change
+
+The assign flow's per-size `demand` is built **directly** from `getCuttingRecommendations`'
+`suggested_cut_qty` ([routes/productionManagerRoutes.js:470-490](../../../routes/productionManagerRoutes.js#L470)
+— `computeStyleCutPlan`). The dashboard priority table, the style page's per-size suggested,
+the CAD cut-plan, the lot split, and the assign panel **all** read `suggested_cut_qty`
+downstream. Therefore fixing the single on-order input fixes every surface automatically:
+"after the inline data, whatever is left is assignable" falls out for free.
+
+## Design
+
+### 1. New function: `computeOnOrderBySku(pool)` (in `utils/easyecomAnalytics.js`)
+
+Returns `Map<size_sku, qty>` = the union of two sources:
+
+- **(a) Real in-flight lots.** Join `cutting_lots` → `cutting_lot_sizes`, net against shipped:
+  per lot-size, **in-flight qty = cut pieces − pieces already dispatched**, where dispatched
+  is `SUM(finishing_dispatches.quantity)` aggregated by `lot_no` + `size_label`. A fully
+  dispatched lot-size contributes 0. Negative/zero results are clamped to 0.
+  - Rationale for netting the dispatched portion (rather than treating a lot as all-or-nothing
+    until fully dispatched): the already-shipped pieces are about to appear in EasyEcom SOH;
+    counting them as both on-order **and** soon-to-be-SOH would double-count and over-suppress.
+    Netting is the precise form of the approved "stop at dispatch" rule.
+- **(b) Manual `pm_open_cutting_lots`** (existing query, `WHERE closed_at IS NULL`), kept
+  during the transition while the real-lot path proves out. The manual table winds down over
+  time; where a style has real in-flight lots, those are the source of truth.
+
+Union semantics: sum (a)+(b) per `size_sku`. (Double-count risk only arises if an operator
+both manually logged a lot **and** it exists as a real `cutting_lots` row for the same
+size-SKU — surfaced by the verification step below; the manual table is being deprecated.)
+
+### 2. Binding a lot's size → EasyEcom size-SKU
+
+Suggested cut is keyed by ecom size-SKU, so each in-flight lot-size must resolve to one:
+
+- **Primary — `pm_sku_resolution`:** look up `(cl_sku = lot.sku/style, size_label) → size_sku`
+  where `state = 'resolved'`. This table exists for exactly this forward-binding purpose
+  ([sql/2026_06_pm_sku_resolution.sql](../../../sql/2026_06_pm_sku_resolution.sql)).
+- **Fallback (row not in the resolver):** build candidates `UPPER(style)+UPPER(label)` and
+  `UPPER(style)+'_'+UPPER(label)`; accept whichever exists in the canonical EasyEcom SKU set
+  (`ee_suborders`). Reuses the existing letter-matching approach in
+  [utils/skuResolver.js](../../../utils/skuResolver.js).
+- **Unresolved (neither resolves):** **not** silently dropped. Aggregate into a data-quality
+  signal returned alongside the recommendations (count of lots + pieces that could not be
+  netted) and surface it on the dashboard ("N in-flight lots, M pcs not netted — resolve
+  these"). This keeps unresolved in-flight visible instead of letting it cause silent overcut.
+
+### 3. Wiring point
+
+Replace the `openLotMap` construction at
+[easyecomAnalytics.js:757-761](../../../utils/easyecomAnalytics.js#L757) with a call to
+`computeOnOrderBySku(pool)`. No change to the formula itself. Gate the new real-lot source
+behind an env flag **`PM_CLOSED_LOOP`** (default off until validated on prod), so the
+behavior can be toggled without a redeploy of logic.
+
+### 4. Style-page surfacing (small, optional but recommended)
+
+Near the per-size suggested cut on the style page
+([views/productionManagerStyle.ejs](../../../views/productionManagerStyle.ejs)), add one line:
+*"X pcs already in production across Y lots"*, driven by the same on-order data (the API
+already returns `open_lot_qty` per size). This explains **why** the suggested number shrank;
+the lot-journey panel directly below already enumerates those lots.
+
+## Out of scope (separate specs)
+
+- **C — Audit ledger:** persist DRR/suggested at decision time and reconcile finishing
+  dispatches against EasyEcom snapshot deltas (the "did dispatched goods reflect in stock?"
+  audit). When C lands, it upgrades the in-flight end-boundary from "stop at dispatch" to
+  "stop when SOH actually reflects it," closing the 1–3 day transit gap.
+- **A — Style-page UX:** sales/inventory period picker, collapse Approve & Assign into a
+  dropdown, move lot journey above it.
+
+## Risks / assumptions
+
+- **Resolver coverage.** Netting at size-SKU grain is only as good as `pm_sku_resolution` +
+  the fallback heuristic. Sparse coverage → more "unresolved" lots (flagged, not silently
+  dropped). The data-quality signal makes the coverage gap visible and drives resolver fills.
+- **Manual/real double-count.** Summing (a)+(b) can double-count if the same lot is in both.
+  Mitigated by deprecating the manual table; the verification step checks for it explicitly.
+- **Performance.** `computeOnOrderBySku` must be a small number of set-based queries (one for
+  in-flight lots + dispatched aggregation, one for resolution, one for the manual table),
+  building the map once per `getCuttingRecommendations` call — not per-SKU.
+
+## Verification (end-to-end)
+
+1. Pick a recent **undispatched** `cutting_lots` row for style X, size M (e.g. 80 pcs).
+   With `PM_CLOSED_LOOP` on: `open_lot_qty` for X-M rises by 80, `suggested_cut_qty` for X-M
+   drops by 80, the CAD cut-plan `demand` and lot split shrink accordingly; if the size is
+   fully covered, the assign panel shows "covered."
+2. Record a **partial** `finishing_dispatches` (e.g. 20 of the 80) → in-flight for X-M becomes
+   60; suggested rises by 20.
+3. Dispatch the remainder → the lot drops out of on-order entirely; suggested returns to the
+   pre-lot value (modulo the 1–3 day SOH transit gap, which C will close).
+4. **Double-count check:** a size-SKU present in both `pm_open_cutting_lots` and a real lot —
+   confirm the reported on-order matches the intended union, not an accidental 2× subtraction.
+5. **Toggle:** `PM_CLOSED_LOOP` off reproduces today's exact numbers (manual table only).
+6. Dashboard shows the "unresolved in-flight" data-quality line when a lot's size can't be
+   bound to a size-SKU.

--- a/docs/superpowers/specs/2026-06-20-pm-overcut-fix-design.md
+++ b/docs/superpowers/specs/2026-06-20-pm-overcut-fix-design.md
@@ -47,6 +47,9 @@ Returns `Map<size_sku, qty>` = the union of two sources:
   per lot-size, **in-flight qty = cut pieces − pieces already dispatched**, where dispatched
   is `SUM(finishing_dispatches.quantity)` aggregated by `lot_no` + `size_label`. A fully
   dispatched lot-size contributes 0. Negative/zero results are clamped to 0.
+  - **Staleness guard:** only consider lots cut within the last `PM_INFLIGHT_WINDOW_DAYS`
+    (default 120). A lot cut long ago that was never recorded as dispatched would otherwise
+    suppress new cuts forever; bounding by cut date assumes such lots are settled/abandoned.
   - Rationale for netting the dispatched portion (rather than treating a lot as all-or-nothing
     until fully dispatched): the already-shipped pieces are about to appear in EasyEcom SOH;
     counting them as both on-order **and** soon-to-be-SOH would double-count and over-suppress.

--- a/routes/returnChallanRoutes.js
+++ b/routes/returnChallanRoutes.js
@@ -23,7 +23,7 @@ const {
 router.use(isAuthenticated, isReturnChallan);
 
 const PAGE_SIZE = 100;
-const EDIT_WINDOW_HOURS = 24;
+const EDIT_WINDOW_HOURS = 7 * 24; // 7 days
 const MAX_IMAGES_PER_CHALLAN = 15;
 
 // ─── Helpers ──────────────────────────────────────────────────────────
@@ -287,6 +287,19 @@ router.patch('/api/fields/:id', async (req, res) => {
   }
 });
 
+// ─── Departments ─────────────────────────────────────────────────────
+
+// GET /return-challan/api/departments — names from the master departments table
+// so the dashboard's Department field offers the standard, admin-managed list.
+router.get('/api/departments', async (req, res) => {
+  try {
+    const [rows] = await pool.query('SELECT name FROM departments ORDER BY name');
+    res.json({ ok: true, departments: rows.map(r => r.name) });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
 // ─── Image presigned upload ──────────────────────────────────────────
 
 router.post('/api/image/sign', async (req, res) => {
@@ -545,7 +558,7 @@ router.patch('/api/entries/:id', async (req, res) => {
     conn = await pool.getConnection();
     await conn.beginTransaction();
 
-    // Edit-window guard: lock the row and verify created_at < 24h ago.
+    // Edit-window guard: lock the row and verify created_at is within the window.
     const [[entry]] = await conn.query(
       `SELECT id, created_at FROM return_challans
         WHERE id = ?
@@ -557,7 +570,7 @@ router.patch('/api/entries/:id', async (req, res) => {
       await conn.rollback();
       return res.status(403).json({
         ok: false,
-        error: `Edit window passed (entries can only be edited within ${EDIT_WINDOW_HOURS} hours).`,
+        error: `Edit window passed (entries can only be edited within ${EDIT_WINDOW_HOURS / 24} days).`,
       });
     }
 

--- a/sql/seed_return_challan_departments.sql
+++ b/sql/seed_return_challan_departments.sql
@@ -1,0 +1,14 @@
+-- Seed standard departments used by the return-challan dashboard.
+-- Idempotent: inserts only names that don't already exist (the `departments`
+-- table has no guaranteed UNIQUE constraint on name, so guard with NOT EXISTS).
+-- Run against prod DB.
+INSERT INTO departments (name)
+SELECT v.name FROM (
+  SELECT 'EROS' AS name UNION ALL SELECT 'GB-65' UNION ALL
+  SELECT 'GC-197 FINISHING' UNION ALL SELECT 'GC-20' UNION ALL
+  SELECT 'GC-78 FINISHING' UNION ALL SELECT 'GC-78 WAREHOUSE' UNION ALL
+  SELECT 'HAWRAH' UNION ALL SELECT 'NEW BUILDING DENIM' UNION ALL
+  SELECT 'NEW BUILDING DENIM-2' UNION ALL SELECT 'NEW BUILDING FINISHING' UNION ALL
+  SELECT 'NEW BUILDING WAREHOUSE' UNION ALL SELECT 'SAMBHAL' UNION ALL SELECT 'TIRANGA'
+) v
+WHERE NOT EXISTS (SELECT 1 FROM departments d WHERE d.name = v.name);

--- a/test/onOrder.test.js
+++ b/test/onOrder.test.js
@@ -89,3 +89,50 @@ test('buildOnOrderMap: unions manual rows on top of real lots', () => {
   assert.strictEqual(res.map.get('KTTTOP374L'), 15); // 10 real + 5 manual
   assert.strictEqual(res.map.get('KTTTOP374M'), 7);
 });
+
+const { computeOnOrderBySku } = require('../utils/onOrder.js');
+
+// Fake pool dispatching by SQL shape (house pattern, cf. test/approvalCorrection.test.js).
+function fakePool(data) {
+  return {
+    queries: [],
+    async query(sql) {
+      this.queries.push(sql.replace(/\s+/g, ' ').trim());
+      if (/FROM pm_open_cutting_lots/.test(sql)) return [data.manual || []];
+      if (/FROM cutting_lots/.test(sql)) return [data.inflight || []];
+      if (/FROM finishing_dispatches/.test(sql)) return [data.dispatched || []];
+      if (/FROM pm_sku_resolution/.test(sql)) return [data.resolution || []];
+      if (/FROM ee_suborders/.test(sql)) return [data.canon || []];
+      throw new Error('unexpected query: ' + sql);
+    },
+  };
+}
+
+test('computeOnOrderBySku: flag OFF uses ONLY the manual table', async () => {
+  delete process.env.PM_CLOSED_LOOP;
+  const pool = fakePool({ manual: [{ sku: 'KTTTOP374L', qty: 12 }] });
+  const res = await computeOnOrderBySku(pool);
+  assert.strictEqual(res.onOrder.get('KTTTOP374L'), 12);
+  assert.deepStrictEqual(res.unresolved, { lots: 0, pieces: 0 });
+  // Only the manual query should have run.
+  assert.strictEqual(pool.queries.some((q) => /FROM cutting_lots/.test(q)), false);
+});
+
+test('computeOnOrderBySku: flag ON nets real lots + unions manual + tallies unresolved', async () => {
+  process.env.PM_CLOSED_LOOP = '1';
+  const pool = fakePool({
+    manual: [{ sku: 'KTTTOP374M', qty: 5 }],
+    inflight: [
+      { lot_no: 'A1', style: 'KTTTOP374', size_label: 'L', cut_pieces: 80 },
+      { lot_no: 'B2', style: 'WEIRDSTYLE', size_label: 'XL', cut_pieces: 30 },
+    ],
+    dispatched: [{ lot_no: 'A1', size_label: 'L', qty: 20 }],
+    resolution: [{ cl_sku: 'KTTTOP374', size_label: 'L', size_sku: 'KTTTOP374L' }],
+    canon: [{ sku: 'KTTTOP374L' }],
+  });
+  const res = await computeOnOrderBySku(pool);
+  assert.strictEqual(res.onOrder.get('KTTTOP374L'), 60); // 80 - 20 dispatched
+  assert.strictEqual(res.onOrder.get('KTTTOP374M'), 5);  // manual
+  assert.deepStrictEqual(res.unresolved, { lots: 1, pieces: 30 }); // WEIRDSTYLE/B2
+  delete process.env.PM_CLOSED_LOOP;
+});

--- a/test/onOrder.test.js
+++ b/test/onOrder.test.js
@@ -1,0 +1,28 @@
+// test/onOrder.test.js
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { resolveSizeSku } = require('../utils/onOrder.js');
+
+test('resolveSizeSku: prefers pm_sku_resolution map', () => {
+  const rmap = new Map([['KTTTOP374||L', 'KTTTOP374L']]);
+  assert.strictEqual(resolveSizeSku('KTTTOP374', 'L', rmap, new Set()), 'KTTTOP374L');
+});
+
+test('resolveSizeSku: falls back to STYLE+LABEL against canon set', () => {
+  const canon = new Set(['KTTTOP374L']);
+  assert.strictEqual(resolveSizeSku('KTTTOP374', 'L', new Map(), canon), 'KTTTOP374L');
+});
+
+test('resolveSizeSku: falls back to STYLE+_+LABEL for numeric sizes', () => {
+  const canon = new Set(['KTTMENSJEANS381_28']);
+  assert.strictEqual(resolveSizeSku('KTTMENSJEANS381', '28', new Map(), canon), 'KTTMENSJEANS381_28');
+});
+
+test('resolveSizeSku: case-insensitive on inputs', () => {
+  const rmap = new Map([['KTTTOP374||L', 'KTTTOP374L']]);
+  assert.strictEqual(resolveSizeSku('ktttop374', 'l', rmap, new Set()), 'KTTTOP374L');
+});
+
+test('resolveSizeSku: returns null when nothing matches', () => {
+  assert.strictEqual(resolveSizeSku('NOPE', 'XL', new Map(), new Set()), null);
+});

--- a/test/onOrder.test.js
+++ b/test/onOrder.test.js
@@ -26,3 +26,66 @@ test('resolveSizeSku: case-insensitive on inputs', () => {
 test('resolveSizeSku: returns null when nothing matches', () => {
   assert.strictEqual(resolveSizeSku('NOPE', 'XL', new Map(), new Set()), null);
 });
+
+const { buildOnOrderMap } = require('../utils/onOrder.js');
+
+const RMAP = new Map([
+  ['KTTTOP374||M', 'KTTTOP374M'],
+  ['KTTTOP374||L', 'KTTTOP374L'],
+]);
+const CANON = new Set(['KTTTOP374M', 'KTTTOP374L']);
+
+test('buildOnOrderMap: nets dispatched pieces off the cut qty', () => {
+  const res = buildOnOrderMap({
+    inFlightRows: [{ lot_no: 'A1', style: 'KTTTOP374', size_label: 'M', cut_pieces: 80 }],
+    dispatchedMap: new Map([['A1||M', 20]]),
+    manualRows: [],
+    resolutionMap: RMAP, canonSet: CANON,
+  });
+  assert.strictEqual(res.map.get('KTTTOP374M'), 60);
+  assert.strictEqual(res.unresolvedLots, 0);
+});
+
+test('buildOnOrderMap: fully dispatched lot-size contributes 0 and is omitted', () => {
+  const res = buildOnOrderMap({
+    inFlightRows: [{ lot_no: 'A1', style: 'KTTTOP374', size_label: 'M', cut_pieces: 50 }],
+    dispatchedMap: new Map([['A1||M', 50]]),
+    manualRows: [], resolutionMap: RMAP, canonSet: CANON,
+  });
+  assert.strictEqual(res.map.has('KTTTOP374M'), false);
+});
+
+test('buildOnOrderMap: sums multiple lots into the same size-SKU', () => {
+  const res = buildOnOrderMap({
+    inFlightRows: [
+      { lot_no: 'A1', style: 'KTTTOP374', size_label: 'M', cut_pieces: 30 },
+      { lot_no: 'A2', style: 'KTTTOP374', size_label: 'M', cut_pieces: 40 },
+    ],
+    dispatchedMap: new Map(), manualRows: [], resolutionMap: RMAP, canonSet: CANON,
+  });
+  assert.strictEqual(res.map.get('KTTTOP374M'), 70);
+});
+
+test('buildOnOrderMap: unresolved size tallied by distinct lot, not dropped silently', () => {
+  const res = buildOnOrderMap({
+    inFlightRows: [
+      { lot_no: 'A1', style: 'WEIRDSTYLE', size_label: 'M', cut_pieces: 25 },
+      { lot_no: 'A1', style: 'WEIRDSTYLE', size_label: 'L', cut_pieces: 15 },
+    ],
+    dispatchedMap: new Map(), manualRows: [], resolutionMap: RMAP, canonSet: CANON,
+  });
+  assert.strictEqual(res.map.size, 0);
+  assert.strictEqual(res.unresolvedLots, 1);   // one distinct lot_no
+  assert.strictEqual(res.unresolvedPieces, 40);
+});
+
+test('buildOnOrderMap: unions manual rows on top of real lots', () => {
+  const res = buildOnOrderMap({
+    inFlightRows: [{ lot_no: 'A1', style: 'KTTTOP374', size_label: 'L', cut_pieces: 10 }],
+    dispatchedMap: new Map(),
+    manualRows: [{ sku: 'KTTTOP374L', qty: 5 }, { sku: 'KTTTOP374M', qty: 7 }],
+    resolutionMap: RMAP, canonSet: CANON,
+  });
+  assert.strictEqual(res.map.get('KTTTOP374L'), 15); // 10 real + 5 manual
+  assert.strictEqual(res.map.get('KTTTOP374M'), 7);
+});

--- a/utils/onOrder.js
+++ b/utils/onOrder.js
@@ -49,4 +49,70 @@ function buildOnOrderMap({ inFlightRows, dispatchedMap, manualRows, resolutionMa
   return { map, unresolvedLots: unresolvedLotSet.size, unresolvedPieces };
 }
 
-module.exports = { resolveSizeSku, buildOnOrderMap, U };
+function flagOn() {
+  const v = String(process.env.PM_CLOSED_LOOP || '').toLowerCase();
+  return v === '1' || v === 'true';
+}
+
+async function loadManualRows(pool) {
+  const [rows] = await pool.query(
+    `SELECT sku, COALESCE(SUM(qty), 0) AS qty FROM pm_open_cutting_lots
+     WHERE closed_at IS NULL GROUP BY sku`
+  );
+  return rows.map((r) => ({ sku: r.sku, qty: Number(r.qty) || 0 }));
+}
+
+// Returns { onOrder: Map<size_sku, qty>, unresolved: { lots, pieces } }.
+// Flag OFF -> manual table only (today's behavior). Flag ON -> union real
+// in-flight lots (cut within windowDays, net of dispatches) with the manual table.
+async function computeOnOrderBySku(pool, { windowDays } = {}) {
+  const manualRows = await loadManualRows(pool);
+
+  if (!flagOn()) {
+    const map = new Map();
+    for (const r of manualRows) map.set(U(r.sku), (map.get(U(r.sku)) || 0) + r.qty);
+    return { onOrder: map, unresolved: { lots: 0, pieces: 0 } };
+  }
+
+  const days = Number(windowDays || process.env.PM_INFLIGHT_WINDOW_DAYS || 120);
+
+  const [inflight] = await pool.query(
+    `SELECT cl.lot_no, cl.sku AS style, cls.size_label,
+            COALESCE(cls.total_pieces, 0) AS cut_pieces
+     FROM cutting_lots cl
+     JOIN cutting_lot_sizes cls ON cls.cutting_lot_id = cl.id
+     WHERE cl.created_at >= DATE_SUB(CURDATE(), INTERVAL ? DAY)`,
+    [days]
+  );
+
+  const [dispatched] = await pool.query(
+    `SELECT lot_no, size_label, COALESCE(SUM(quantity), 0) AS qty
+     FROM finishing_dispatches GROUP BY lot_no, size_label`
+  );
+  const dispatchedMap = new Map(
+    dispatched.map((r) => [U(r.lot_no) + '||' + U(r.size_label), Number(r.qty) || 0])
+  );
+
+  const [resolution] = await pool.query(
+    `SELECT cl_sku, size_label, size_sku FROM pm_sku_resolution
+     WHERE state = 'resolved' AND size_sku IS NOT NULL`
+  );
+  const resolutionMap = new Map(
+    resolution.map((r) => [U(r.cl_sku) + '||' + U(r.size_label), U(r.size_sku)])
+  );
+
+  const [canonRows] = await pool.query(
+    `SELECT DISTINCT UPPER(sku) AS sku FROM ee_suborders WHERE sku IS NOT NULL AND sku <> ''`
+  );
+  const canonSet = new Set(canonRows.map((r) => r.sku));
+
+  const built = buildOnOrderMap({
+    inFlightRows: inflight, dispatchedMap, manualRows, resolutionMap, canonSet,
+  });
+  return {
+    onOrder: built.map,
+    unresolved: { lots: built.unresolvedLots, pieces: built.unresolvedPieces },
+  };
+}
+
+module.exports = { resolveSizeSku, buildOnOrderMap, computeOnOrderBySku, U };

--- a/utils/onOrder.js
+++ b/utils/onOrder.js
@@ -1,0 +1,22 @@
+'use strict';
+
+const U = (s) => String(s == null ? '' : s).toUpperCase().trim();
+
+// Bind a cut lot's (style, size_label) to an EasyEcom size-SKU.
+// Primary: the human-authored pm_sku_resolution map. Fallback: concatenation
+// (letter sizes attach directly, numeric/long sizes via underscore) validated
+// against the canonical ecom SKU set. Returns the size-SKU or null.
+function resolveSizeSku(style, sizeLabel, resolutionMap, canonSet) {
+  const st = U(style);
+  const lbl = U(sizeLabel);
+  if (!st || !lbl) return null;
+  const fromMap = resolutionMap.get(st + '||' + lbl);
+  if (fromMap) return fromMap;
+  const direct = st + lbl;
+  if (canonSet.has(direct)) return direct;
+  const underscored = st + '_' + lbl;
+  if (canonSet.has(underscored)) return underscored;
+  return null;
+}
+
+module.exports = { resolveSizeSku, U };

--- a/utils/onOrder.js
+++ b/utils/onOrder.js
@@ -19,4 +19,34 @@ function resolveSizeSku(style, sizeLabel, resolutionMap, canonSet) {
   return null;
 }
 
-module.exports = { resolveSizeSku, U };
+// Build the size_sku -> on-order qty map. In-flight = cut pieces net of pieces
+// already dispatched (finishing); unresolved sizes are tallied, never dropped
+// silently. The manual pm_open_cutting_lots rows are summed on top (transition).
+function buildOnOrderMap({ inFlightRows, dispatchedMap, manualRows, resolutionMap, canonSet }) {
+  const map = new Map();
+  const unresolvedLotSet = new Set();
+  let unresolvedPieces = 0;
+
+  for (const r of (inFlightRows || [])) {
+    const dispatched = dispatchedMap.get(U(r.lot_no) + '||' + U(r.size_label)) || 0;
+    const net = (Number(r.cut_pieces) || 0) - dispatched;
+    if (net <= 0) continue;
+    const sku = resolveSizeSku(r.style, r.size_label, resolutionMap, canonSet);
+    if (!sku) {
+      unresolvedLotSet.add(U(r.lot_no));
+      unresolvedPieces += net;
+      continue;
+    }
+    map.set(sku, (map.get(sku) || 0) + net);
+  }
+
+  for (const r of (manualRows || [])) {
+    const sku = U(r.sku);
+    if (!sku) continue;
+    map.set(sku, (map.get(sku) || 0) + (Number(r.qty) || 0));
+  }
+
+  return { map, unresolvedLots: unresolvedLotSet.size, unresolvedPieces };
+}
+
+module.exports = { resolveSizeSku, buildOnOrderMap, U };

--- a/views/returnChallanDashboard.ejs
+++ b/views/returnChallanDashboard.ejs
@@ -607,6 +607,7 @@ let currentPage = 1;
 let totalPages = 1;
 let totalCount = 0;
 let searchQuery = '';
+let masterDepartments = [];
 let searchT = null;
 
 // Form image state. Three buckets:
@@ -1027,7 +1028,7 @@ function renderTable() {
       : `<span class="rc-pill unbranded">Unbranded</span>`;
     const editBtn = e.editable
       ? `<button class="rc-mini-btn" onclick='editEntry(${e.id})'>Edit</button>`
-      : `<button class="rc-mini-btn" disabled title="Edit window passed (24h)">Edit</button>`;
+      : `<button class="rc-mini-btn" disabled title="Edit window passed (7 days)">Edit</button>`;
     const customCells = fields.map((f) => {
       const v = (e.custom_data || {})[f.field_key];
       if (v == null || v === '') return '<td>—</td>';
@@ -1086,7 +1087,7 @@ async function editEntry(id) {
 
 // Populate datalists (department, category, brand) from existing entries
 function populateDatalists() {
-  const deps = new Set(), cats = new Set(), brands = new Set();
+  const deps = new Set(masterDepartments), cats = new Set(), brands = new Set();
   for (const e of entries) {
     if (e.department) deps.add(e.department);
     if (e.category) cats.add(e.category);
@@ -1286,6 +1287,10 @@ document.addEventListener('keydown', (e) => {
 });
 
 (async () => {
+  try {
+    const r = await api('GET', '/return-challan/api/departments');
+    masterDepartments = r.departments || [];
+  } catch (_) { /* non-fatal: datalist still fills from existing entries */ }
   await loadActiveFields();
   await loadEntries();
 })();


### PR DESCRIPTION
## What
- **Departments**: seed the 13 standard departments (EROS, GB-65, GC-197 FINISHING, GC-20, GC-78 FINISHING, GC-78 WAREHOUSE, HAWRAH, NEW BUILDING DENIM, NEW BUILDING DENIM-2, NEW BUILDING FINISHING, NEW BUILDING WAREHOUSE, SAMBHAL, TIRANGA) into the `departments` master table and surface them in the return-challan **Department** field. New `GET /return-challan/api/departments` endpoint feeds the datalist (merged with values from existing entries).
- **Edit window**: extend from **24 hours → 7 days** for editing return-challan entries (server-side guard, per-row `editable` flag, and UI tooltip/error wording).

## Post-merge manual step
Run `sql/seed_return_challan_departments.sql` against the **prod DB** so the departments appear (idempotent — skips any that already exist). The dropdown reads from that table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)