### PR TITLE
feat(pm): style page — inline (in-production) qty + over/undercut

### DIFF
--- a/docs/superpowers/specs/2026-06-22-pm-inline-overundercut-design.md
+++ b/docs/superpowers/specs/2026-06-22-pm-inline-overundercut-design.md
@@ -1,0 +1,82 @@
+# PM Style Page — inline (in-production) qty + over/undercut (Feature D)
+
+*Date: 2026-06-22. Status: design approved, ready for implementation plan.*
+*Branch `feat/pm-inline-overundercut` off `main` (B/C/A merged). Frontend-only.*
+
+## Context / Problem
+
+The style page shows per-size SOH / Days-left / Suggested and a "Suggested cut" total, but it
+doesn't show how much of a size is **already in production** (the in-flight/"inline" qty), nor
+whether each size is **under- or over-cut** relative to what's actually needed. The owner wants the
+inline quantity surfaced — total in the Suggested-cut card and per-size in the Size breakdown — with
+a clear undercut/overcut indicator.
+
+## Goal
+
+On `views/productionManagerStyle.ejs` (frontend only — no endpoint change), using fields
+`/pm/api/sizes` already returns per size (`soh`, `drr`, `lead_time`, `safety_days`,
+`upcoming_po_qty`, `open_lot_qty`, `suggested_cut_qty`):
+
+1. **Size breakdown** — each size card shows **"In production: N"** (N = `open_lot_qty`) and a status
+   chip: **Undercut · need X** / **Overcut · Y extra** / **Covered**.
+2. **Suggested-cut card** — a roll-up sub-line: **"In production {total} · Undercut {U} · Overcut {O}"**.
+
+## Definitions (owner-approved: compare inline to the cut requirement)
+
+Per size, from the `/api/sizes` row `r`:
+- `inline = open_lot_qty`
+- `under = suggested_cut_qty` — the authoritative undercut amount (the server already computes
+  `suggested = max(0, horizon×DRR − SOH − open_lot_qty + PO)`, i.e. the remaining gap after inline).
+- `over` (only when `under === 0`): `req = (lead_time + safety_days)×DRR − SOH + upcoming_po_qty`;
+  `over = max(0, round(inline − req))` — how much more is in production than the horizon requires.
+- Status: `under > 0` → **Undercut**; else `over > 0` → **Overcut**; else **Covered**.
+
+Using the server's `suggested_cut_qty` for the undercut amount keeps the per-size number identical to
+the displayed "Suggested", and `over` is derived only in the covered/overstocked case — a size is
+never both under and over.
+
+## Design
+
+All changes are in the inline `<script>` of `views/productionManagerStyle.ejs`, plus a few CSS chips
+in `public/css/pm-suite.css`. Straight ASCII quotes only (inline-script must pass `node --check`).
+
+### 1. Pure helper `sizeOverUnder(r)`
+
+Returns `{ inline, under, over, status }` per the definitions above. `status ∈ 'under'|'over'|'covered'`.
+
+### 2. Size breakdown (`loadSizes`, the `SIZES.map` card render at ~line 136)
+
+Each `.sizecard` gains, below the existing Suggested row:
+- an **"In production"** row showing `inline` (omit/― when 0 is fine to still show "0"),
+- a status chip: amber `Undercut · need {under}` / red `Overcut · {over} extra` / green `Covered`.
+
+### 3. Suggested-cut card roll-up
+
+`loadSizes` already computes `SUGGESTED_TOTAL` (= Σ`suggested_cut_qty` = Σ under) and `IN_PROD`
+(= Σ`open_lot_qty`). Add `TOTAL_OVER = Σ over`. Render a sub-line inside the "Suggested cut" `.scard`
+(a new `<div class="sub" id="kSuggestedSub">` under `#kSuggested`):
+**"In production {IN_PROD} · Undercut {SUGGESTED_TOTAL} · Overcut {TOTAL_OVER}"** (hide the zero
+segments to stay clean, e.g. show "Covered" if both totals are 0).
+
+### CSS (`public/css/pm-suite.css`)
+
+Small chip styles `.ouchip` with `.under` (amber), `.over` (red), `.covered` (green), mirroring the
+existing pill/`pm-pill` token usage; and `.scard .sub` (muted, 12.5px) for the roll-up line.
+
+## Reuse / out of scope
+
+Reuses `/api/sizes` (no backend change), the `pm-suite` color tokens, `fmtNum`. **Out of scope:**
+any endpoint/data change; `PM_CLOSED_LOOP`/`PM_CUT_AUDIT` enablement; resolver coverage. Note the
+inline numbers are small while `PM_CLOSED_LOOP` is off (manual table only) and become the real
+in-flight totals once it's on — the UI simply reflects `open_lot_qty`.
+
+## Verification (manual)
+
+1. Open `/pm/style/<style>`: each size card shows "In production: N" and exactly one chip
+   (Undercut/Overcut/Covered); the Undercut amount equals that size's "Suggested".
+2. The Suggested-cut card shows the roll-up; `Undercut` total == the "Suggested cut" big number;
+   `In production` total == Σ per-size inline.
+3. A size with `suggested_cut_qty = 0` and high `open_lot_qty`/SOH shows **Overcut · Y extra** with a
+   sensible Y; a covered size with no inline shows **Covered**.
+4. Inline `<script>` passes `node --check`; `ejs.renderFile` renders the page; `node --test` stays
+   green (no test targets the view).

--- a/public/css/pm-suite.css
+++ b/public/css/pm-suite.css
@@ -493,3 +493,15 @@ table.pm-table strong{font-weight:700}
 .pm-collapse>summary::after{content:'\25BE';margin-left:auto;color:var(--ink-3);transition:transform .15s}
 .pm-collapse[open]>summary::after{transform:rotate(180deg)}
 .pm-collapse .link{font-weight:500}
+
+/* Style-page inline qty + over/undercut chips (Feature D) */
+.scard .sub{font-size:12px;color:var(--ink-3);margin-top:3px;font-weight:500}
+.sizecard .oubar{margin-top:8px}
+.ouchip{display:inline-flex;align-items:center;gap:6px;font-size:11.5px;font-weight:600;padding:3px 9px;border-radius:999px}
+.ouchip::before{content:"";width:6px;height:6px;border-radius:50%}
+.ouchip.under{background:var(--amber-bg);color:var(--amber-ink)}
+.ouchip.under::before{background:var(--amber)}
+.ouchip.over{background:var(--red-bg);color:var(--red-ink)}
+.ouchip.over::before{background:var(--red)}
+.ouchip.covered{background:var(--green-bg);color:var(--green-ink)}
+.ouchip.covered::before{background:var(--green)}

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -38,7 +38,7 @@
 
     <!-- Summary cards -->
     <section class="summary" id="summaryCards">
-      <div class="scard"><div class="ico" style="background:var(--neutral);color:var(--blue)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M20 4 8.12 15.88M14.47 14.48 20 20M8.12 8.12 12 12"/></svg></div><div><div class="label">Suggested cut</div><div class="big" id="kSuggested">—</div></div></div>
+      <div class="scard"><div class="ico" style="background:var(--neutral);color:var(--blue)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="6" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M20 4 8.12 15.88M14.47 14.48 20 20M8.12 8.12 12 12"/></svg></div><div><div class="label">Suggested cut</div><div class="big" id="kSuggested">—</div><div class="sub" id="kSuggestedSub"></div></div></div>
       <div class="scard"><div class="ico" style="background:var(--neutral);color:var(--green)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M3 7l9-4 9 4-9 4-9-4z"/><path d="M3 7v10l9 4 9-4V7"/><path d="M12 11v10"/></svg></div><div><div class="label">Fabric to issue</div><div class="big" id="kFabric">—</div></div></div>
       <div class="scard"><div class="ico" style="background:var(--neutral);color:var(--ink-2)"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M12 2 2 7l10 5 10-5-10-5z"/><path d="m2 17 10 5 10-5M2 12l10 5 10-5"/></svg></div><div><div class="label">Lots (≤1,500 each)</div><div class="big" id="kLots">—</div></div></div>
     </section>
@@ -108,10 +108,32 @@ function sizeRatio(obj) {
   return ents.map(([s, q]) => `${s}:${Math.round(q / g)}`).join('  ');
 }
 
+// In-production (inline) qty vs the cut requirement, per size.
+// under = suggested_cut_qty (server-authoritative gap after inline); over only when under is 0:
+// over = max(0, inline - (horizon*DRR - SOH + PO)).
+function sizeOverUnder(r) {
+  const inline = Number(r.open_lot_qty) || 0;
+  const under = Number(r.suggested_cut_qty) || 0;
+  let over = 0;
+  if (under === 0) {
+    const horizon = (Number(r.lead_time) || 0) + (Number(r.safety_days) || 0);
+    const req = horizon * (Number(r.drr) || 0) - (Number(r.soh) || 0) + (Number(r.upcoming_po_qty) || 0);
+    over = Math.max(0, Math.round(inline - req));
+  }
+  const status = under > 0 ? 'under' : (over > 0 ? 'over' : 'covered');
+  return { inline, under, over, status };
+}
+function ouChip(ou) {
+  if (ou.status === 'under') return '<span class="ouchip under">Undercut · need ' + fmtNum(ou.under) + '</span>';
+  if (ou.status === 'over') return '<span class="ouchip over">Overcut · ' + fmtNum(ou.over) + ' extra</span>';
+  return '<span class="ouchip covered">Covered</span>';
+}
+
 // ── Sizes → header chip, subtitle, size grid ──────────────────────────
 let SIZES = [];
 let SUGGESTED_TOTAL = 0;
 let IN_PROD = 0;
+let TOTAL_OVER = 0;
 async function loadSizes() {
   const grid = $('sizeGrid');
   try {
@@ -131,18 +153,30 @@ async function loadSizes() {
     // (matches the dashboard). Fabric/lots come from the CAD planner separately.
     SUGGESTED_TOTAL = SIZES.reduce((s, r) => s + (Number(r.suggested_cut_qty) || 0), 0);
     IN_PROD = SIZES.reduce((s, r) => s + (Number(r.open_lot_qty) || 0), 0);
+    TOTAL_OVER = SIZES.reduce((s, r) => s + sizeOverUnder(r).over, 0);
     $('kSuggested').innerHTML = `<span class="num">${fmtNum(SUGGESTED_TOTAL)}</span> <small>pcs</small>`;
+    const subEl = $('kSuggestedSub');
+    if (subEl) {
+      const parts = ['In production ' + fmtNum(IN_PROD)];
+      if (SUGGESTED_TOTAL > 0) parts.push('Undercut ' + fmtNum(SUGGESTED_TOTAL));
+      if (TOTAL_OVER > 0) parts.push('Overcut ' + fmtNum(TOTAL_OVER));
+      if (SUGGESTED_TOTAL === 0 && TOTAL_OVER === 0) parts.push('Covered');
+      subEl.textContent = parts.join(' · ');
+    }
     if (!SIZES.length) { grid.innerHTML = `<div class="pm-empty">No sizes for this style.</div>`; return; }
     grid.innerHTML = SIZES.map(r => {
       const sug = Number(r.suggested_cut_qty) || 0;
       const dohRed = (r.trigger || 'green') === 'red';
+      const ou = sizeOverUnder(r);
       return `<div class="sizecard ${sug > 0 ? '' : 'dim'}">
         <div class="sz">${escapeHtml(r.size)}</div>
         <div class="rows">
           <div class="r"><span class="k">Stock</span><span class="v num">${fmtNum(r.soh)}</span></div>
           <div class="r"><span class="k">Days left</span><span class="v num ${dohRed ? 'red' : ''}">${r.doh == null ? '—' : Math.round(r.doh) + 'd'}</span></div>
+          <div class="r"><span class="k">In production</span><span class="v num">${fmtNum(ou.inline)}</span></div>
         </div>
         <div class="sug"><span class="k">Suggested</span><span class="v num">${sug ? fmtNum(sug) : '0'}</span></div>
+        <div class="oubar">${ouChip(ou)}</div>
       </div>`;
     }).join('');
   } catch (err) { grid.innerHTML = `<div class="pm-empty">Error: ${escapeHtml(err.message)}</div>`; }


### PR DESCRIPTION
## What & why
On the style detail page, surface how much of each size is **already in production** (the inline / in-flight qty) and whether each size is **under- or over-cut** vs what's actually needed.

## Changes (frontend-only, `views/productionManagerStyle.ejs` + a few CSS chips)
- **Size breakdown:** each size card gains an **"In production: N"** row (`open_lot_qty`) and one chip — **Undercut · need X** / **Overcut · Y extra** / **Covered**.
- **Suggested-cut card:** a roll-up sub-line — **"In production {total} · Undercut {U} · Overcut {O}"**.
- Math (owner-approved, consistent with the suggested-cut formula): `under = suggested_cut_qty` (the server-authoritative gap after inline); `over = max(0, inline − (horizon×DRR − SOH + PO))` only when suggested is 0. A size is never both.

No backend change — reuses fields `/pm/api/sizes` already returns. The inline numbers are small while `PM_CLOSED_LOOP` is off (manual table) and become real in-flight totals once it's on.

Verified: `node --check` on the inline script (no smart-quote regression), `ejs.renderFile` renders, over/under math sanity-checked, 115/115 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)