### PR TITLE
feat(pm): size-wise breakdown of the actual lot in the lot journey

### DIFF
--- a/public/css/pm-suite.css
+++ b/public/css/pm-suite.css
@@ -505,3 +505,10 @@ table.pm-table strong{font-weight:700}
 .ouchip.over::before{background:var(--red)}
 .ouchip.covered{background:var(--green-bg);color:var(--green-ink)}
 .ouchip.covered::before{background:var(--green)}
+
+/* Lot-journey: sizes in the actual lot */
+.lotsz{margin:0 0 16px}
+.lotsz .szrow{display:flex;flex-wrap:wrap;gap:8px}
+.szchip{display:inline-flex;align-items:center;gap:7px;border:1px solid var(--line);border-radius:9px;padding:5px 10px;background:var(--card-2)}
+.szchip .s{font-size:12px;font-weight:700;color:var(--ink)}
+.szchip .q{font-size:13px;font-weight:600;color:var(--ink-2);font-variant-numeric:tabular-nums}

--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -713,10 +713,16 @@ async function lotJourneyCompact(lot) {
   const dispatchedBySize = {};
   for (const r of dr) dispatchedBySize[String(r.size_label || '').trim().toUpperCase()] = Number(r.qty) || 0;
   const dispatch = dispatchSummary(finished, dispatchedBySize);
+  const [szRows] = await pool.query(
+    'SELECT size_label, COALESCE(total_pieces, 0) AS pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ? ORDER BY total_pieces DESC, size_label',
+    [lot.id]
+  );
+  const sizes = szRows.map((r) => ({ size_label: String(r.size_label || ''), pieces: Number(r.pieces) || 0 }));
   return {
     lot_no: lot.lot_no, manual_lot_number: lot.manual_lot_number || '', total_pieces: lot.total_pieces,
     created_at: lot.created_at, flow_type: lot.flow_type || 'unknown',
     current_stage: dispatch.complete ? 'Dispatched' : currentStage(timeline),
+    sizes,
     timeline, dispatch: { finished: dispatch.totalFinished, dispatched: dispatch.totalDispatched, in_stock: dispatch.remaining },
   };
 }

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -353,6 +353,11 @@ function renderLot(idx) {
     ['Dispatched', d.dispatched || 0, 'green'],
     ['In stock', d.in_stock || 0, ''],
   ].map(c => `<div class="dcell"><div class="sz">${c[0]}</div><div class="qty num">${fmtNum(c[1])}</div>${c[2] ? `<div class="st">back in stock</div>` : ''}</div>`).join('');
+  const szchips = (lot.sizes && lot.sizes.length)
+    ? '<div class="lotsz"><div class="cap" style="margin:2px 0 7px">Sizes in this lot</div><div class="szrow">'
+      + lot.sizes.map(s => '<div class="szchip"><span class="s">' + escapeHtml(s.size_label) + '</span><span class="q num">' + fmtNum(s.pieces) + '</span></div>').join('')
+      + '</div></div>'
+    : '';
   $('lotJourney').innerHTML = `
     <div class="grid-2" style="grid-template-columns:1.1fr .9fr;align-items:start;margin-top:14px">
       <div class="chartcard">
@@ -363,6 +368,7 @@ function renderLot(idx) {
           <div class="m"><div class="k">Stage</div><div class="v">${escapeHtml(lot.current_stage)}</div></div>
           <div class="m"><div class="k">Cut on</div><div class="v"><span class="num">${fmtDate(lot.created_at)}</span></div></div>
         </div>
+        ${szchips}
         <div class="timeline">${steps}</div>
       </div>
       <div><div class="chartcard"><h4 style="margin-bottom:4px">Dispatch breakdown</h4><div class="cap" style="margin-bottom:4px">Back as sellable stock</div><div class="dispatch">${dcells}</div></div></div>


### PR DESCRIPTION
## What & why
The lot-journey panel on the style page showed the lot's total pieces and stage timeline, but not **which sizes** are actually in the lot. This adds the real per-size cut breakdown.

## Changes
- **Backend:** `lotJourneyCompact` (`/pm/api/style-lots`) now returns `sizes: [{ size_label, pieces }]` for each lot, from `cutting_lot_sizes`.
- **Frontend:** the lot-journey panel renders a **"Sizes in this lot"** chip row (e.g. lot `ke373` → **XL 448 · XXL 448**).

Frontend reuses the pm-suite chip styling; verified `node --check` on the inline script, `ejs.renderFile` renders, routes load, 115/115 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)