### PR TITLE
feat(pm): lot journey shows who currently holds the lot

### DIFF
--- a/public/css/pm-suite.css
+++ b/public/css/pm-suite.css
@@ -512,3 +512,13 @@ table.pm-table strong{font-weight:700}
 .szchip{display:inline-flex;align-items:center;gap:7px;border:1px solid var(--line);border-radius:9px;padding:5px 10px;background:var(--card-2)}
 .szchip .s{font-size:12px;font-weight:700;color:var(--ink)}
 .szchip .q{font-size:13px;font-weight:600;color:var(--ink-2);font-variant-numeric:tabular-nums}
+
+/* Lot-journey: who currently holds the lot */
+.lotholder{display:flex;align-items:center;gap:12px;background:var(--blue-bg);border:1px solid var(--line);border-radius:11px;padding:11px 16px;margin-top:14px}
+.lotholder .hk{font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;color:var(--blue-ink)}
+.lotholder .hv{font-size:15px;font-weight:700;color:var(--ink)}
+.lotholder .hv small{font-weight:500;color:var(--ink-2)}
+.lotholder.wait{background:var(--amber-bg)}
+.lotholder.wait .hk{color:var(--amber-ink)}
+.lotholder.done{background:var(--green-bg)}
+.lotholder.done .hk{color:var(--green-ink)}

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -364,7 +364,18 @@ function renderLot(idx) {
       + lot.sizes.map(s => '<div class="szchip"><span class="s">' + escapeHtml(s.size_label) + '</span><span class="q num">' + fmtNum(s.pieces) + '</span></div>').join('')
       + '</div></div>'
     : '';
+  // Who currently holds the lot — the master on the active (in-progress) stage.
+  const activeStep = (lot.timeline || []).find(t => t.status === 'in_progress');
+  let holderHtml;
+  if (lot.current_stage === 'Dispatched') {
+    holderHtml = '<div class="lotholder done"><span class="hk">Status</span><span class="hv">Dispatched · back as sellable stock</span></div>';
+  } else if (activeStep && activeStep.master) {
+    holderHtml = '<div class="lotholder"><span class="hk">Currently with</span><span class="hv">' + escapeHtml(activeStep.master) + ' <small>· ' + escapeHtml(activeStep.label) + '</small></span></div>';
+  } else {
+    holderHtml = '<div class="lotholder wait"><span class="hk">Awaiting</span><span class="hv">' + escapeHtml(lot.current_stage || '—') + ' <small>· not started</small></span></div>';
+  }
   $('lotJourney').innerHTML = `
+    ${holderHtml}
     <div class="grid-2" style="grid-template-columns:1.1fr .9fr;align-items:start;margin-top:14px">
       <div class="chartcard">
         <div class="lotmeta" style="margin-top:0;margin-bottom:18px">


### PR DESCRIPTION
Adds a clear **"Currently with"** banner to the lot journey so you instantly see who's holding a lot.

- **Currently with: `<master>` · `<stage>`** — driven by the active (in-progress) stage's master (the user who has started it, per the "once they've started" rule).
- Reads **"Awaiting `<stage>`"** when the lot has reached a stage but no one has started it yet, and **"Dispatched"** when complete.
- Per-stage masters continue to show on each timeline step (so every stage shows who did it).

Frontend-only — uses the master already on each timeline step (from the stage's approve event); no backend/query change. `node --check` clean, ejs renders, 115/115 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)