### PR TITLE
feat(cutting): manual cutting date on lots + PIC report

### DIFF
--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -215,6 +215,7 @@ router.post(
       fabric_type,
       remark,
       table_length,
+      manual_cutting_date,
       size_label,
       pattern_count,
       roll_no,
@@ -262,9 +263,9 @@ router.post(
         const [result] = await conn.query(
           `
           INSERT INTO cutting_lots
-            (lot_no, manual_lot_number, sku, fabric_type, remark, table_length, image_url, user_id, total_pieces, flow_type)
+            (lot_no, manual_lot_number, sku, fabric_type, remark, table_length, manual_cutting_date, image_url, user_id, total_pieces, flow_type)
           VALUES
-            (?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
+            (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ?)
         `,
           [
             lot_no,
@@ -273,6 +274,7 @@ router.post(
             fabric_type,
             remark || null,
             table_length ? parseFloat(table_length) : null,
+            (manual_cutting_date && String(manual_cutting_date).trim()) ? String(manual_cutting_date).trim() : null,
             image ? image.path : null,
             userId,
             flowType,

--- a/routes/editcuttinglots.js
+++ b/routes/editcuttinglots.js
@@ -249,7 +249,7 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
   try {
     const [[lotRows], [sizes], [rolls], [assignments], [stitchingUsers], [downstream]] = await Promise.all([
       pool.query(
-        `SELECT l.id, l.lot_no, l.manual_lot_number, l.sku, l.fabric_type, l.remark, l.total_pieces, l.table_length, l.flow_type, l.created_at, u.username AS created_by
+        `SELECT l.id, l.lot_no, l.manual_lot_number, l.sku, l.fabric_type, l.remark, l.total_pieces, l.table_length, l.manual_cutting_date, l.flow_type, l.created_at, u.username AS created_by
          FROM cutting_lots l
          JOIN users u ON l.user_id = u.id
          WHERE l.id = ? AND l.user_id = ?`,
@@ -373,6 +373,10 @@ router.get('/editcuttinglots/edit-form', isAuthenticated, isOperator, async (req
                   <div class="mb-3">
                     <label class="form-label">Manual Lot Number</label>
                     <input type="text" class="form-control" name="manual_lot_number" value="${String(lot.manual_lot_number || '').replace(/"/g, '&quot;')}" maxlength="64" placeholder="Manual lot number">
+                  </div>
+                  <div class="mb-3">
+                    <label class="form-label">Manual Cutting Date</label>
+                    <input type="date" class="form-control" name="manual_cutting_date" value="${lot.manual_cutting_date ? (lot.manual_cutting_date instanceof Date ? lot.manual_cutting_date.toISOString().slice(0, 10) : String(lot.manual_cutting_date).slice(0, 10)) : ''}">
                   </div>
                   <div class="mb-3">
                     <label class="form-label">SKU</label>
@@ -559,6 +563,8 @@ router.post('/editcuttinglots/update', isAuthenticated, isOperator, upload.none(
   const { sku, fabric_type, remark } = req.body;
   // Manual lot number is operator-editable; store NULL when cleared.
   const manualLotNumber = (req.body.manual_lot_number || '').trim() || null;
+  // Manual cutting date (actual cut day, may differ from created_at); NULL when cleared.
+  const manualCuttingDate = (req.body.manual_cutting_date || '').trim() || null;
   let { size_id, pattern_count, size_label, orig_size_label, size_pieces } = req.body;
   if (!Array.isArray(size_id)) {
     size_id = [size_id];
@@ -583,8 +589,8 @@ router.post('/editcuttinglots/update', isAuthenticated, isOperator, upload.none(
   try {
     await conn.beginTransaction();
     await conn.query(
-      `UPDATE cutting_lots SET sku = ?, fabric_type = ?, remark = ?, manual_lot_number = ? WHERE id = ?`,
-      [sku, fabric_type, remark, manualLotNumber, lotId]
+      `UPDATE cutting_lots SET sku = ?, fabric_type = ?, remark = ?, manual_lot_number = ?, manual_cutting_date = ? WHERE id = ?`,
+      [sku, fabric_type, remark, manualLotNumber, manualCuttingDate, lotId]
     );
 
     // Need the lot_no to cascade size renames into the legacy data tables.

--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -1142,6 +1142,9 @@ function buildEnhancedRow({
     createdAt: lot.created_at
       ? new Date(lot.created_at).toLocaleDateString('en-GB', { timeZone: 'Asia/Kolkata' }).replace(/\//g, '-')
       : '',
+    manualCuttingDate: lot.manual_cutting_date
+      ? new Date(lot.manual_cutting_date).toLocaleDateString('en-GB', { timeZone: 'Asia/Kolkata' }).replace(/\//g, '-')
+      : '',
     daysSinceCreated: daysSince(lot.created_at),
     totalCut,
     remark: lot.remark || '',
@@ -1226,6 +1229,7 @@ const PIC_REPORT_V2_COLUMNS = [
   { header: 'SKU',                 key: 'sku',               width: 22 },
   { header: 'Lot Type',            key: 'lotType',           width: 9  },
   { header: 'Created At',          key: 'createdAt',         width: 12 },
+  { header: 'Manual Cutting Date', key: 'manualCuttingDate', width: 14 },
   { header: 'Days Since Created',  key: 'daysSinceCreated',  width: 10 },
   { header: 'Total Cut',           key: 'totalCut',          width: 10 },
   { header: 'Current Stage',       key: 'currentStage',      width: 14 },
@@ -1989,7 +1993,7 @@ router.get("/dashboard/pic-report", isAuthenticated, isOperator, async (req, res
 
     // 2) Fetch all lots (ONE QUERY)
     const baseQuery = `
-      SELECT cl.lot_no, cl.manual_lot_number, cl.sku, cl.fabric_type, cl.total_pieces, cl.created_at, cl.remark, cl.flow_type,
+      SELECT cl.lot_no, cl.manual_lot_number, cl.sku, cl.fabric_type, cl.total_pieces, cl.created_at, cl.manual_cutting_date, cl.remark, cl.flow_type,
              u.username AS created_by, u.is_denim_cutter
         FROM cutting_lots cl
         JOIN users u ON cl.user_id = u.id

--- a/sql/cutting_manual_cutting_date_migration.sql
+++ b/sql/cutting_manual_cutting_date_migration.sql
@@ -1,0 +1,6 @@
+-- Manual cutting date: the actual day the lot was cut, which can differ from
+-- created_at (cutters sometimes cut on one day and upload on another).
+-- Cutting-only field — surfaced at lot creation, the operator edit-lot form,
+-- and the PIC report. Nullable.
+ALTER TABLE cutting_lots
+  ADD COLUMN manual_cutting_date DATE NULL AFTER manual_lot_number;

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -416,6 +416,10 @@
                   <label for="manual_lot_number" class="kotty-form-label"><i class="bi bi-pencil-square"></i><span data-i18n="manualLotNumber">Manual Lot Number</span></label>
                   <input type="text" class="kotty-input" id="manual_lot_number" name="manual_lot_number" required placeholder="Handwritten / physical lot number" />
                 </div>
+                <div class="col-md-4">
+                  <label for="manual_cutting_date" class="kotty-form-label"><i class="bi bi-calendar-event"></i><span data-i18n="manualCuttingDate">Manual Cutting Date</span></label>
+                  <input type="date" class="kotty-input" id="manual_cutting_date" name="manual_cutting_date" placeholder="Actual date the lot was cut" />
+                </div>
                 <!-- SKU Builder -->
                 <div class="col-md-8">
                   <label class="kotty-form-label"><i class="bi bi-barcode"></i><span>SKU Builder</span></label>


### PR DESCRIPTION
A cutter sometimes cuts on one day but uploads on another, so `created_at` ≠ the real cut date. Adds an optional **manual cutting date** to cutting lots — **cutting-only**, nothing downstream.

- **New column** `cutting_lots.manual_cutting_date DATE NULL` (`sql/cutting_manual_cutting_date_migration.sql`, **already applied to prod**).
- **Cutting create form** (cutting_manager): a "Manual Cutting Date" date input, written on the lot INSERT.
- **Operator edit-lot**: the date is shown and editable (so a wrong/forgotten date can be corrected).
- **PIC report**: a "Manual Cutting Date" column, right after "Created At".

Scoped strictly to cutting — no stitching/washing/finishing or other reports touched. All routes load, 115/115 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)