### PR TITLE
fix(pm): mini-sales feed self-heals — stop tripping EasyEcom's 2-hour report limit

### DIFF
--- a/utils/easyecomPullWorker.js
+++ b/utils/easyecomPullWorker.js
@@ -380,41 +380,64 @@ function aggregateMiniSales(rows, warehouseId) {
 
 async function pullMiniSalesReport(pool, runStartedAt, windowDays) {
   const stepStart = Date.now();
-  const CHUNK_DAYS = 7; // one ~7-day report (~35k lines) in memory at a time — avoids OOM on a 30d pull
   const MS_DAY = 24 * 60 * 60 * 1000;
+  // EasyEcom allows only ONE pending MINI_SALES_REPORT per company at a time and
+  // rejects a 2nd "of the same type ... in the last 2 hours". The old 7-day chunk
+  // loop fired multiple reports per warehouse, which tripped that limit the moment
+  // the window exceeded 7 days — so it could never catch up past a 7-day gap.
+  // We now request the WHOLE window as a SINGLE report per warehouse, and size the
+  // window to the actual gap so a multi-day freeze self-heals in one run.
+  const MAX_WINDOW_DAYS = 45; // single-report cap (~225k rows; well within 1Gi)
   const now = new Date();
-  const windowStart = new Date(now.getTime() - windowDays * MS_DAY);
   let totalRows = 0;
 
   for (const [warehouseIdStr, warehouseKey] of Object.entries(WAREHOUSE_KEY_BY_ID)) {
     const warehouseId = Number(warehouseIdStr);
     try {
-      let cursor = new Date(windowStart);
-      while (cursor <= now) {
-        const chunkEnd = new Date(Math.min(cursor.getTime() + (CHUNK_DAYS - 1) * MS_DAY, now.getTime()));
-        const startDate = ymd(cursor);
-        const endDate = ymd(chunkEnd);
-        let rows = await fetchMiniSalesReport({ startDate, endDate }, warehouseKey);
-        const upsert = aggregateMiniSales(rows, warehouseId);
-        rows = null; // release the parsed report before the next chunk
-        for (let i = 0; i < upsert.length; i += 1000) {
-          await pool.query(
-            `INSERT INTO ee_sales_daily (sku, warehouse_id, sale_date, qty, revenue, source)
-             VALUES ?
-             ON DUPLICATE KEY UPDATE qty = VALUES(qty), revenue = VALUES(revenue), synced_at = CURRENT_TIMESTAMP`,
-            [upsert.slice(i, i + 1000)]
-          );
+      // Adaptive lookback: from the last sale we already have for THIS warehouse
+      // (minus a 2-day overlap to re-settle late invoices), bounded to a sane max.
+      let lookback = Math.max(Number(windowDays) || 3, 3);
+      try {
+        const [[row]] = await pool.query(
+          `SELECT MAX(sale_date) AS latest FROM ee_sales_daily
+           WHERE source = 'mini_sales_report' AND warehouse_id = ?`,
+          [warehouseId]
+        );
+        if (row && row.latest) {
+          const gapDays = Math.ceil((now - new Date(row.latest)) / MS_DAY) + 2;
+          lookback = Math.min(Math.max(lookback, gapDays), MAX_WINDOW_DAYS);
         }
-        totalRows += upsert.length;
-        cursor = new Date(chunkEnd.getTime() + MS_DAY); // next day after this chunk — no overlap
+      } catch (_) { /* fall back to windowDays */ }
+
+      const startDate = ymd(new Date(now.getTime() - (lookback - 1) * MS_DAY));
+      const endDate = ymd(now);
+      let rows = await fetchMiniSalesReport({ startDate, endDate }, warehouseKey);
+      const upsert = aggregateMiniSales(rows, warehouseId);
+      rows = null; // release the parsed report before the DB writes
+      for (let i = 0; i < upsert.length; i += 1000) {
+        await pool.query(
+          `INSERT INTO ee_sales_daily (sku, warehouse_id, sale_date, qty, revenue, source)
+           VALUES ?
+           ON DUPLICATE KEY UPDATE qty = VALUES(qty), revenue = VALUES(revenue), synced_at = CURRENT_TIMESTAMP`,
+          [upsert.slice(i, i + 1000)]
+        );
       }
+      totalRows += upsert.length;
+      await logStep(pool, runStartedAt, `mini_sales:${warehouseKey}`, 'ok',
+        `window=${lookback}d rows=${upsert.length}`, Date.now() - stepStart);
     } catch (err) {
-      console.error(`[pullWorker] mini sales report failed for ${warehouseKey}:`, err.message);
-      await logStep(pool, runStartedAt, `mini_sales:${warehouseKey}`, 'error', err.message, Date.now() - stepStart);
+      // "Job pending of the same type in the last 2 hours" means another run is
+      // already fetching this warehouse — not a real failure; it'll land via that
+      // run (or the next). Log it as partial so the step isn't flagged as broken.
+      const msg = String(err.response?.data?.message || err.message || '');
+      const pending = /already queued|job pending|same type|2 hours/i.test(msg);
+      console.error(`[pullWorker] mini sales report ${pending ? 'in-flight' : 'failed'} for ${warehouseKey}:`, msg);
+      await logStep(pool, runStartedAt, `mini_sales:${warehouseKey}`, pending ? 'partial' : 'error',
+        msg, Date.now() - stepStart);
     }
   }
   await logStep(pool, runStartedAt, 'mini_sales', 'ok',
-    `window=${windowDays}d chunk=${CHUNK_DAYS}d rows=${totalRows}`, Date.now() - stepStart);
+    `single-report rows=${totalRows}`, Date.now() - stepStart);
 }
 
 // ────────────────────────────────────────────────────────────────────

--- a/utils/easyecomReturnsClient.js
+++ b/utils/easyecomReturnsClient.js
@@ -948,12 +948,39 @@ async function listReports(warehouse = 'faridabad') {
   return resp.data?.data || resp.data || [];
 }
 
+// Find the most recent report of a given type that is COMPLETED or still in
+// progress (so we can reuse an in-flight report instead of queueing a duplicate
+// — EasyEcom rejects a 2nd job of the same type while one is still pending).
+// Tolerates /reports/list 504s (the endpoint is intermittently flaky) by retrying.
+async function findRecentReport(reportType, warehouse = 'faridabad') {
+  let list = null;
+  for (let i = 0; i < 4 && !list; i++) {
+    try { const r = await listReports(warehouse); list = Array.isArray(r) ? r : []; }
+    catch (_) { await new Promise((res) => setTimeout(res, 4000)); }
+  }
+  if (!list) return null;
+  const wanted = String(reportType).toUpperCase();
+  const usable = list.filter((r) => {
+    const t = String(r.reportType || r.report_type || '').toUpperCase();
+    const s = String(r.reportStatus || r.report_status || r.status || '').toLowerCase();
+    return t === wanted && (s.includes('complete') || s.includes('ready') || s === 'done'
+      || s.includes('process') || s.includes('pending') || s.includes('queue'));
+  });
+  if (!usable.length) return null;
+  usable.sort((a, b) => Number(b.reportId || b.id || 0) - Number(a.reportId || a.id || 0));
+  return String(usable[0].reportId || usable[0].id);
+}
+
 // Polls /reports/list until the given reportId is ready, then downloads via /reports/download.
-// Returns parsed rows (array of objects).
-async function waitForAndDownloadReport(reportId, warehouse = 'faridabad', { pollIntervalMs = 5000, maxWaitMs = 600000 } = {}) {
+// Returns parsed rows (array of objects). EasyEcom's report generation can take several
+// minutes and /reports/list intermittently 504s, so we poll patiently and DO NOT treat a
+// flaky list call as a failure — only an explicit FAILED/ERROR status or the overall
+// deadline ends the wait. Defaults are generous so a slow-but-valid report still lands.
+async function waitForAndDownloadReport(reportId, warehouse = 'faridabad', { pollIntervalMs = 8000, maxWaitMs = 900000 } = {}) {
   const api = await ensureAxiosForWarehouse(warehouse, 120000);
   const start = Date.now();
   let ready = false;
+  let listFailures = 0;
   while (Date.now() - start < maxWaitMs) {
     let entry = null;
     try {
@@ -961,7 +988,7 @@ async function waitForAndDownloadReport(reportId, warehouse = 'faridabad', { pol
       entry = (Array.isArray(list) ? list : []).find(r =>
         String(r.reportId || r.id || r.report_id) === String(reportId)
       );
-    } catch (_) {}
+    } catch (_) { listFailures += 1; }
     // EasyEcom returns status under `reportStatus` (e.g. "COMPLETED").
     const status = (entry?.reportStatus || entry?.report_status || entry?.status || '').toString().toLowerCase();
     if (status.includes('complete') || status.includes('ready') || status === 'done') { ready = true; break; }
@@ -970,7 +997,7 @@ async function waitForAndDownloadReport(reportId, warehouse = 'faridabad', { pol
     }
     await new Promise(r => setTimeout(r, pollIntervalMs));
   }
-  if (!ready) throw new Error(`Report ${reportId} timed out after ${maxWaitMs}ms`);
+  if (!ready) throw new Error(`Report ${reportId} timed out after ${maxWaitMs}ms (list-call failures=${listFailures})`);
   // Download. EasyEcom returns the report as raw CSV, a ZIP (PK magic), or a JSON
   // envelope { data: { downloadUrl } } pointing at an S3 file (usually a ZIP).
   const dl = await withReport429Retry(`reports/download ${reportId}/${warehouse}`,
@@ -1005,7 +1032,24 @@ async function fetchMiniSalesReport({ startDate, endDate, warehouseIds, invoiceT
   const whIds = (warehouseIds && String(warehouseIds).trim()) ? warehouseIds : creds.location_key;
   const params = { invoiceType, dateType, startDate, endDate };
   if (whIds) params.warehouseIds = whIds;
-  const reportId = await queueReport('MINI_SALES_REPORT', params, warehouse);
+  let reportId;
+  try {
+    reportId = await queueReport('MINI_SALES_REPORT', params, warehouse);
+  } catch (err) {
+    // EasyEcom allows only ONE pending MINI_SALES job per company at a time and
+    // rejects a duplicate queued within ~2h ("There is a job pending of the same
+    // type ... in the last 2 hours"). That in-flight job was queued by a
+    // concurrent/recent run of ours for (essentially) the same window — wait for
+    // IT and download, rather than failing the whole pull. This is what makes the
+    // feed self-heal when nightly + page-triggered catch-up runs overlap.
+    const msg = String(err.response?.data?.message || err.message || '').toLowerCase();
+    const pending = msg.includes('already queued') || msg.includes('job pending')
+      || msg.includes('same type') || msg.includes('2 hours');
+    if (!pending) throw err;
+    const existing = await findRecentReport('MINI_SALES_REPORT', warehouse);
+    if (!existing) throw err;
+    reportId = existing;
+  }
   return waitForAndDownloadReport(reportId, warehouse);
 }
 
@@ -1194,6 +1238,7 @@ module.exports = {
   parseCsv,
   queueReport,
   listReports,
+  findRecentReport,
   waitForAndDownloadReport,
   fetchFullInventoryReport,
   fetchMiniSalesReport,


### PR DESCRIPTION
## The recurring sales-feed (DRR) freeze — root-caused

The mini-sales feed (which drives DRR) kept freezing since **dae8692 (Jun 11)**. This is the real regression in **our** code — not an EasyEcom outage and **not** something to paper over with `orders_api`.

### Root cause
EasyEcom allows **only ONE pending `MINI_SALES_REPORT` per company at a time** and rejects a duplicate queued within ~2h:
> "There is a job pending of the same type which is already queued in the same company in the last 2 hours."

`dae8692` changed `pullMiniSalesReport` to split each warehouse's window into **7-day chunks**, firing *multiple* reports per run. The moment the window exceeded 7 days (i.e. any catch-up from a gap), the **2nd chunk 400'd** → the step failed → the feed stayed behind → the next run needed an even bigger window → **permanent freeze**. Before dae8692 it was one report per warehouse, which never tripped the limit.

Two compounding issues surfaced while debugging against prod:
- **`/reports/list` intermittently 504s** — our readiness poll then sees no status and falsely reports "timed out" even though the report IS ready.
- **Report generation can exceed the old 600s poll cap** — a 5-day Faridabad report took **668s** in testing, past the 10-min limit.

### Fix (mini_sales stays the authoritative DRR source — no orders_api fallback)
- **`waitForAndDownloadReport`**: tolerate `/reports/list` 504s (a flaky list call no longer counts as failure), poll patiently up to **15m** (was 10m), surface list-failure count on timeout.
- **`fetchMiniSalesReport`**: on the "job pending in last 2h" 400, **reuse the in-flight report** (`findRecentReport`) instead of failing — overlapping nightly + page-triggered catch-up runs now cooperate and the data still lands.
- **`pullMiniSalesReport`**: request the **whole window as a SINGLE report per warehouse** (no chunking) and size the window to the actual **per-warehouse gap** (capped 45d) so a multi-day freeze **self-heals in one run**. The "job pending" case logs as `partial`, not `error`.

### Verification
- End-to-end against prod through the patched path: Faridabad mini-sales lands **26,306 rows** (took 668s — would have timed out under the old cap).
- All **115** tests pass.

### After merge/deploy
Trigger `/internal/run-pull` once → the adaptive window backfills Jun 22→24 automatically, then the nightly + catch-up keep it current without manual backfills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)