### PR TITLE
fix(pm): scope in-production PIC download to the current style

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -191,13 +191,16 @@ router.get('/style/:style', async (req, res) => {
 // Download the size-wise PIC report of ALL in-production lots (every style):
 // a lot cut within the last 120 days that still has undispatched pieces. Identical
 // format to the operator dashboard's /dashboard/pic-size-report (shared builder in
-// utils/picSizeReport.js). Exposed on the PM style page's "Download in-production report".
+// utils/picSizeReport.js). Scoped to ?style= when provided (the PM style page passes
+// its style); omit it for an all-styles report.
 router.get('/reports/pic-size', async (req, res) => {
   try {
-    const rows = await buildPicSizeRows({ inProductionOnly: true });
+    const style = String(req.query.style || '').trim();
+    const rows = await buildPicSizeRows({ inProductionOnly: true, style });
     const workbook = buildPicSizeWorkbook(rows);
+    const safeStyle = (style || 'AllStyles').replace(/[^A-Za-z0-9._-]/g, '_');
     res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
-    res.setHeader('Content-Disposition', 'attachment; filename="PICReport-InProduction-BySize.xlsx"');
+    res.setHeader('Content-Disposition', `attachment; filename="PICReport-InProduction-${safeStyle}-BySize.xlsx"`);
     await workbook.xlsx.write(res);
     res.end();
   } catch (err) {

--- a/utils/picSizeReport.js
+++ b/utils/picSizeReport.js
@@ -7,6 +7,7 @@
 const { pool } = require('../config/db');
 const { cache } = require('../utils/cache');
 const ExcelJS = require('exceljs');
+const { deriveStyle } = require('./easyecomAnalytics');
 
 function isDenimLot(lotOrLotNo, isDenimCutter = null, flowType = null) {
   // If called with lot object that has flow_type or is_denim_cutter
@@ -970,11 +971,16 @@ async function buildPicSizeRows({
   endDate = '',
   inProductionOnly = false,
   inProductionWindowDays = 120,
+  style = '',
 } = {}) {
   // Row cap: the operator (date-windowed) path keeps its historical 5000 cap; the
   // "all in-production" path needs headroom so it doesn't silently drop older
   // in-production lots (the 120d window is ~6.5k lot×size rows and growing).
   const rowLimit = inProductionOnly ? 50000 : 5000;
+  // Optional style scope (e.g. the PM style page). Matches via deriveStyle() so both
+  // style-level and size-suffixed cutting_lots.sku values resolve correctly — the SQL
+  // LIKE is a prefilter; the exact match happens per-row in the assembly loop below.
+  const styleUpper = String(style || '').trim().toUpperCase();
   let dateWhere = '';
   const dateParams = [];
 
@@ -1013,6 +1019,13 @@ async function buildPicSizeRows({
         dateParams.push(sd, ed);
       }
     }
+  }
+
+  // Style scope prefilter (exact match happens per-row via deriveStyle below).
+  // Appended after the date clause so params stay in query order.
+  if (styleUpper) {
+    dateWhere += ' AND cl.sku LIKE ? ';
+    dateParams.push(`${styleUpper}%`);
   }
 
   let lotTypeClause = '';
@@ -1110,6 +1123,10 @@ async function buildPicSizeRows({
 
   const finalData = [];
   for (const row of rows) {
+    // Exact style scope: the SQL LIKE prefilter can over-match (e.g. KTT677 vs KTT6770),
+    // so confirm the derived style equals the requested one — same semantics as the
+    // dashboard's r.style === style filtering.
+    if (styleUpper && deriveStyle(row.sku) !== styleUpper) continue;
     const lotNo = row.lot_no;
     const sizeLabel = row.size_label;
     const totalCut = parseFloat(row.total_pieces) || 0;

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -9,7 +9,7 @@
     </div>
     <div class="actions">
       <a class="pm-btn" href="/pm/api/recommendations.csv?style=<%= encodeURIComponent(style) %>">Export CSV</a>
-      <a class="pm-btn" href="/pm/reports/pic-size" title="Download the size-wise PIC report of all lots currently in production (every style)">Download in-production report</a>
+      <a class="pm-btn" href="/pm/reports/pic-size?style=<%= encodeURIComponent(style) %>" title="Download the size-wise PIC report of this style's lots currently in production">Download in-production report</a>
       <% if (typeof userRole !== 'undefined' && userRole === 'admin') { %><a class="pm-btn primary" href="/pm">Run pull</a><% } %>
     </div>
   </header>


### PR DESCRIPTION
Follow-up to #476 (already merged). That PR shipped the "Download in-production report" button but exported **all** in-production lots across every style. This scopes the download to **only the style whose page is open**.

Single commit on top of the merged #476.

## Changes
- `buildPicSizeRows()` gains a `style` option: SQL `cl.sku LIKE 'style%'` prefilter + exact per-row `deriveStyle(row.sku) === style` check (same semantics as the dashboard's `r.style === style`; handles style-level and size-suffixed SKUs). `deriveStyle` imported from `utils/easyecomAnalytics.js`.
- `GET /pm/reports/pic-size` reads `?style=` and names the file `PICReport-InProduction-<style>-BySize.xlsx`. Omitting the param still returns all styles (back-compat).
- Style-page button passes `?style=<current style>`.

## Verified (read-only vs prod)
- `KTTWOMENSPANT677` → 265 rows / 82 lots (0 wrong-style)
- `KTTWOMENSPANT975` → 37 rows / 13 lots
- no `?style=` → 6,395 (all styles, back-compat)
- nonexistent style → 0 rows, valid empty workbook
- prefix over-match guard holds (0 leaked); no circular dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)