### PR TITLE
fix(deploy): Cloud Run 2Gi + min-instances=1 to keep the PM feed alive

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -62,9 +62,14 @@ substitutions:
   _BUCKET_NAME: 'kotty-track-uploads'
   _DB_USER: 'kotty_user'
   _DB_NAME: 'kotty_db'
-  _MEMORY: '1Gi'
+  # 2Gi matches NODE_OPTIONS=--max-old-space-size=1536 (set via update-env-vars) so the
+  # nightly EasyEcom pull worker doesn't OOM on the orders/aging steps. Do not drop to 1Gi.
+  _MEMORY: '2Gi'
   _CPU: '1'
-  _MIN_INSTANCES: '0'
+  # Keep one warm instance so the in-memory EasyEcom JWT token (cached ~23h) survives
+  # instead of re-authing on every scale-to-zero cold start — cold-start auth churn was
+  # tripping EasyEcom's /access/token "Limit Exceeded" rate cap and freezing the PM feed.
+  _MIN_INSTANCES: '1'
   _MAX_INSTANCES: '10'
   _TAG: 'v2'
 


### PR DESCRIPTION
## Problem
The PM freshness banner froze again ("30 Jun 03:57 · 2d old") even though the aging fix (#475) is deployed. Root cause was **config**, in `cloudbuild.yaml`:

1. **`--memory 1Gi`** (hardcoded via `_MEMORY`) — every deploy reverted the 2Gi bump applied on 01 Jul. With `NODE_OPTIONS=--max-old-space-size=1536` still set, that's an OOM trap for the nightly pull (32k+ orders + aging), so runs died mid-pull.
2. **`--min-instances 0`** — the service scales to zero, dropping the in-memory EasyEcom JWT cache on every cold start. A day of deploy churn (~6 merges) re-authenticated on each cold start and tripped EasyEcom's `/access/token` **"Limit Exceeded"** rate cap. After that, `runPullWorker`'s auth gate logged `auth: error` and **skipped all EasyEcom steps** (aging, orders, stock) — freezing the feed.

## Fix
- `_MEMORY: 1Gi → 2Gi` (matches the heap ceiling; no more OOM).
- `_MIN_INSTANCES: 0 → 1` (one warm instance keeps the ~23h token, ending the re-auth churn and making the in-process pull cron reliable).

Both values were already applied live via `gcloud run services update` (revision `00396`, verified: memory 2Gi / min-instances 1 / timeout 3600). This PR makes them **durable** so the next deploy doesn't revert them again.

## Verify after merge/deploy
- `gcloud run services describe` shows `memory=2Gi`, `min-instances=1`.
- `pm_pull_runs` newest rows: `auth: ok`, `aging: ok` (rows>0), `orders`/`stock_status` timestamps at today.
- Logs: no `Limit Exceeded`, no `heap out of memory`. Banner advances to the current day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)