### PR TITLE
fix(pm): exclude aging from the freshness banner (feeds only Dead Stock)

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -362,8 +362,13 @@ router.get('/api/summary', async (req, res) => {
   } catch (_) { out.sales_by_day = null; }
 
   // Data freshness: when the numbers behind the dashboard were last refreshed. We take
-  // the OLDEST of the critical feeds (sales / stock / aging) so the homepage line
-  // reflects true staleness, not whichever table was touched most recently.
+  // the OLDEST of the DECISION-CRITICAL feeds (sales/DRR + stock) so the homepage line
+  // reflects true staleness. Aging is deliberately EXCLUDED from this: it only powers the
+  // Dead Stock view (via getDeadStock, which has a sales-based fallback), it's slow-moving
+  // (stock age vs a 45-day threshold), and EasyEcom's INVENTORY_AGING_REPORT has been
+  // failing to generate for the secondary warehouses — so letting it gate the banner kept
+  // it permanently "stale" even when the real data was current. Aging's own as-of date is
+  // still exposed under feeds.aging below.
   try {
     const [okSteps] = await pool.query(
       `SELECT step, MAX(run_started_at) AS last_ok FROM pm_pull_runs
@@ -373,7 +378,7 @@ router.get('/api/summary', async (req, res) => {
     for (const r of okSteps) lastOk[r.step] = r.last_ok;
     // 'orders_aggregate' is the fresh DRR sales source; fall back to legacy names.
     const salesAsOf = lastOk['orders_aggregate'] || lastOk['sales_cross_check'] || lastOk['mini_sales'] || null;
-    const feeds = [salesAsOf, lastOk['stock_status'], lastOk['aging']].filter(Boolean);
+    const feeds = [salesAsOf, lastOk['stock_status']].filter(Boolean);
     const dataAsOf = feeds.length ? new Date(Math.min(...feeds.map((d) => new Date(d).getTime()))) : null;
     out.freshness = {
       data_as_of: dataAsOf,

--- a/views/productionManagerDashboard.ejs
+++ b/views/productionManagerDashboard.ejs
@@ -275,7 +275,15 @@ function renderFreshness(f) {
   const asOf = new Date(f.data_as_of);
   const ageH = (Date.now() - asOf.getTime()) / 3.6e6;
   const stale = ageH > 24;
-  el.textContent = `Data last refreshed: ${fmtDateTime(asOf)}${stale ? ` · ${Math.round(ageH / 24)}d old — feed may be stale` : ''}`;
+  let txt = `Data last refreshed: ${fmtDateTime(asOf)}${stale ? ` · ${Math.round(ageH / 24)}d old — feed may be stale` : ''}`;
+  // Aging (dead-stock age signal) is tracked separately and does NOT gate the banner
+  // above — surface its own age only when it's noticeably behind.
+  const agingRaw = f.feeds && f.feeds.aging;
+  if (agingRaw) {
+    const agingAgeH = (Date.now() - new Date(agingRaw).getTime()) / 3.6e6;
+    if (agingAgeH > 48) txt += ` · aging report ${Math.round(agingAgeH / 24)}d old`;
+  }
+  el.textContent = txt;
   el.style.color = stale ? '#b45309' : '';
 }
 


### PR DESCRIPTION
## Problem
The Overview banner still showed **"30 Jun 03:57 · 3d old — feed may be stale"** even though the feed recovered. The 02 Jul nightly run refreshed everything — auth ✅, snapshot ✅, orders ✅, DRR/orders_aggregate ✅, stock ✅, mini_sales ✅ — **except `aging`**, which errors because EasyEcom's `INVENTORY_AGING_REPORT` won't generate for the two secondary warehouses (each poll times out at 20 min; failing since ~29 Jun).

The banner takes the **oldest** of sales/stock/**aging**, so aging (stuck at 29 Jun) dragged the whole line to "stale."

## Why aging shouldn't gate the banner
Aging is read in exactly one place — `getDeadStock` — powering only the **Dead Stock** view, which has a **sales-based fallback** and is slow-moving against a 45-day threshold. It does **not** feed cutting recommendations, DRR, open lots, or POs.

## Change
- `data_as_of` = oldest of **sales/DRR + stock** only (aging removed from the min).
- Aging still pulled best-effort and still powers Dead Stock; `feeds.aging` is still returned and the dashboard shows a separate **"· aging report Nd old"** note (only when >2 days behind) so its staleness stays visible.

## Effect
With sales+stock current (02 Jul), the banner goes green/current instead of falsely red. Verified live: `pm_pull_runs` last-ok for orders_aggregate/stock_status = 02 Jul 22:37; aging = 29 Jun (now shown separately).

## Not included (follow-up)
Chasing why EasyEcom stopped generating the aging report (and the `stock_status rows=0` empty-report oddity) — separate EasyEcom-side investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)