### PR TITLE
fix(pm): stop pulling the never-working INVENTORY_AGING_REPORT

### DIFF
--- a/utils/easyecomPullWorker.js
+++ b/utils/easyecomPullWorker.js
@@ -809,14 +809,13 @@ async function runPullWorker(pool, { bootstrap = 'auto', includeProducts } = {})
     }
     // MINI_SALES_REPORT — best-effort cross-check source, rate-limited by EasyEcom
     // (1 report/company/2h). Self-caps its poll wait and is skipped if tried within 2h.
-    // Runs BEFORE the slow aging report so aging can no longer starve it of run budget.
     await eeStep('mini_sales', () => pullMiniSalesReport(pool, runStartedAt, windowDays));
-    // INVENTORY_AGING LAST — the slowest step (EasyEcom is slow to generate it for the
-    // secondary warehouses). Gets a longer dedicated deadline than the generic per-step
-    // cap so it can actually complete instead of being killed at 600s and freezing the
-    // aging feed. pullInventoryAging fetches the warehouses in parallel.
-    const AGING_DEADLINE_MS = Number(process.env.PM_PULL_AGING_DEADLINE_MS || 1500000); // 25 min
-    await eeStep('aging', () => pullInventoryAging(pool, runStartedAt), AGING_DEADLINE_MS);
+    // INVENTORY_AGING_REPORT is intentionally NOT pulled: EasyEcom has never generated it
+    // for our two secondary warehouses (every attempt 429s / times out — ee_inventory_aging
+    // has always been empty), so it only wasted ~20 min of run budget and churned the auth
+    // circuit breaker each night. getDeadStock already falls back to a sales-based
+    // "on-hand but no orders in N days" signal when the aging table is empty, so Dead Stock
+    // is unaffected. pullInventoryAging() is kept for a future PRIMARY-location retry.
   }
 
   // Sales cross-check (orders vs mini sales) — DB-only, safe to run regardless of auth.


### PR DESCRIPTION
## Finding
The aging report has **never returned data**:
- `ee_inventory_aging` is **empty** (0 rows, never populated).
- Every `aging` "ok" for weeks was `rows=0`, and every per-warehouse call failed — 22 Jun `not configured for delhi` + faridabad **429**; 23–26 Jun both **429**; 29 Jun **400** then timeouts; 02 Jul 20-min timeouts. The old code logged a **fake "ok rows=0"**; #475 made it honest, which exposed it.

## Why it's safe to drop
`getDeadStock` uses `ee_inventory_aging` **only if populated**; since it's always been empty, Dead Stock has always run on its **sales-based fallback** ("on-hand but zero orders in N days"). So removing the aging pull changes nothing for Dead Stock.

Meanwhile the step cost **~20 min of run budget every night** (two parallel 20-min timeouts) and churned the EasyEcom auth circuit breaker.

## Change
Remove the `aging` step from `runPullWorker`. `pullInventoryAging()` is kept for a future **PRIMARY-location** retry — the report is account-level (like the inventory snapshot) and likely needs the primary location, not the two secondary warehouses where it 429s/times out.

Pairs with #481 (aging already removed from the freshness banner). `stock_status` also returns `rows=0` from the same warehouses — noted as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)