### PR TITLE
fix(pm): emit 'amber' trigger so "Cut soon" styles surface (CP-1)

### DIFF
--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -846,10 +846,13 @@ async function getCuttingRecommendations(pool, { periodKey = '30d', shadow = fal
     const doh = drr > 0 ? soh / drr : null;
     // Thin-sample SKUs (clean_days < 7) aren't trustworthy cut targets in cleanday mode.
     const lowConfidence = DRR_MODE === 'cleanday' && cd && (cd.data_quality === 'low_sample' || cd.data_quality === 'no_clean_days');
+    // Trigger vocabulary is 'amber' (matches aggregateStyles, cutPrioritySummary, and the PM
+    // dashboard/style/analytics views/filters). Emitting 'orange' here silently dropped the
+    // entire "Cut soon" tier at the style roll-up (orange never matched 'amber').
     let trigger = 'green';
     if (doh !== null && doh <= lt.lead_time) trigger = 'red';
-    else if (doh !== null && doh <= horizon) trigger = 'orange';
-    if (lowConfidence && trigger === 'red') trigger = 'orange'; // demote noisy thin-sample reds
+    else if (doh !== null && doh <= horizon) trigger = 'amber';
+    if (lowConfidence && trigger === 'red') trigger = 'amber'; // demote noisy thin-sample reds
 
     const drrDiffPct = legacyDrr > 0 ? ((cleandayDrr - legacyDrr) / legacyDrr) * 100 : (cleandayDrr > 0 ? Infinity : 0);
     results.push({


### PR DESCRIPTION
First of the cutting-planning audit fixes (CP-1).

**Bug:** `getCuttingRecommendations` emitted `trigger='orange'`, but every consumer keys on `'amber'` (`aggregateStyles`, `pmAnalytics.cutPrioritySummary`, and the PM dashboard/style/analytics views + the "Cut soon" filter). So an orange (cut-soon) size never propagated — `any_amber` stayed false and the style collapsed to red-or-green.

**Impact (measured live):** 282 amber size-SKUs → **107 "Cut soon" styles that were shown as GREEN "Covered"** and dropped off the priority list.

**Fix:** two literals at `easyecomAnalytics.js:851-852`, `'orange'` → `'amber'`. (Line 171's `'orange'` is the unrelated legacy inventory-health status used by easyecomOps — untouched.)

**Verify:** live re-run — style rollup now `{red:1023, amber:107, green:7790}`; the 107 amber styles now appear under "Cut soon".

🤖 Generated with [Claude Code](https://claude.com/claude-code)