### PR TITLE
chore: test + CI foundation (backend node:test + frontend Vitest) + roadmap docs

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,6 +2,20 @@
 # Triggered on push to main branch
 
 steps:
+  # Gate the deploy on the backend test suite (node --test). Fails the build on any red test.
+  - name: 'node:20'
+    entrypoint: bash
+    args:
+      - '-c'
+      - 'npm ci && NODE_ENV=test npm test'
+
+  # Gate on the frontend test suite (Vitest). Fails the build on any red test.
+  - name: 'node:20'
+    entrypoint: bash
+    args:
+      - '-c'
+      - 'cd frontend && npm ci && npm run test'
+
   # Build the container image
   - name: 'gcr.io/cloud-builders/docker'
     args:

--- a/config/db.js
+++ b/config/db.js
@@ -88,6 +88,13 @@ async function testConnection() {
   }
 }
 
-testConnection();
+// Skip the connect-on-import probe in tests (NODE_ENV=test) or when explicitly disabled
+// (SKIP_DB_CONNECT). This lets pure logic in DB-coupled modules (which `require` this file
+// at the top) be unit-tested without a live database and without process.exit killing the
+// test runner. The pool is created lazily by mysql2 and is never touched by pure functions.
+const skipConnect = env.NODE_ENV === 'test' || env.SKIP_DB_CONNECT === '1' || env.SKIP_DB_CONNECT === 'true';
+if (!skipConnect) {
+  testConnection();
+}
 
 module.exports = { pool };

--- a/docs/plans/00-PROGRESS.md
+++ b/docs/plans/00-PROGRESS.md
@@ -1,0 +1,80 @@
+# Kotty-Track — Progress & Roadmap Tracker
+
+> Master index. Each initiative has its own detailed plan file in this folder.
+> Update the **Status** and **Last touched** columns as work lands. Anyone picking
+> this up should read this file first, then the relevant `NN-*.md` plan.
+
+_Last updated: 2026-07-03_
+
+---
+
+## Plan files in this folder
+| File | What it covers |
+|------|----------------|
+| `00-PROGRESS.md` | This tracker. |
+| `01-qcpass-extension.md` | Authenticated ingestion of the QC-Capture Chrome extension into the kotty-track DB, restricted to the `jitrgp` role, with the realtime-vs-queue design. |
+| `02-cutting-planning-bugs.md` | The cutting-planning correctness backlog (audit findings), one by one. |
+| `03-ejs-to-react-migration.md` | Effort + benefits + incremental approach for moving the EJS frontend to React. |
+| `04-frontend-best-practices.md` | Frontend issues measured against best practice, with fixes. |
+| `05-architecture-testing-security.md` | Split into separate backend/React projects, full test coverage (backend+frontend), security testing + server/DB hardening, stress/load testing. |
+
+---
+
+## A. Recently shipped (context for whoever continues)
+
+All merged to `main` unless noted. These fixed the production-manager (PM) data feed and reports.
+
+| PR | What |
+|----|------|
+| #473 | Mini-sales freeze fix — single adaptive-window report + resilient polling. |
+| #474 | 429-as-transient in mini-sales; freshness indicator. |
+| #475 | Aging feed: parallelize warehouses, honest status, dedicated deadline (later superseded — see below). |
+| #476 | In-production **size-PIC report** download on the PM style page; extracted shared `utils/picSizeReport.js` from `routes/operatorRoutes.js`. |
+| #477 | Scoped that download to the current style. |
+| #478 | Cloud Run **2Gi + min-instances=1** (durable, in `cloudbuild.yaml`) — stopped OOM + stabilized the EasyEcom auth token → un-froze the feed. |
+| #479 | PIC reports reworked: per-stage **In=approved / Out=completed / In-line=WIP / Pending=handoff** (was In=previous-stage-completed). |
+| #480 | Renamed those download columns to "Approved / Completed". |
+| #481 | Removed **aging** from the freshness banner (it only powers Dead Stock, which has a fallback). |
+| #482 | Stopped pulling `INVENTORY_AGING_REPORT` nightly — it has **never** returned data (EasyEcom won't generate it for our two secondary warehouses); reclaims ~20 min/run. |
+
+### Data repairs done directly on prod (uncommitted scripts, backups kept)
+- Stage-qty corruption repair (37 lots).
+- **Orphan-approve dedup**: deleted 329 duplicate `AUTO_APPROVE_ORPHAN` approve events across 328 lots (241,810 phantom pieces). 9 lots flagged for manual review (benign 0-piece pairs + `ak4972`).
+
+### Verified healthy (2026-07-03, read-only vs prod)
+- Feed fresh: orders/DRR, stock, mini_sales, snapshot all refreshed 03 Jul 04:07.
+- `getCuttingRecommendations`: 26,244 size-SKU rows in 5.2 s; recommendations sane.
+
+---
+
+## B. Open initiatives
+
+| # | Initiative | Status | Plan | Priority |
+|---|-----------|--------|------|----------|
+| 1 | QC-Capture extension → authenticated DB ingestion (`jitrgp`) | **Not started** | `01-qcpass-extension.md` | High (new feature the user is adding) |
+| 2 | Cutting-planning correctness bugs | **Not started** | `02-cutting-planning-bugs.md` | High — one bug hides 107 "cut-soon" styles |
+| 3 | EJS → React migration | **Analysis only** | `03-ejs-to-react-migration.md` | Medium — decision pending |
+| 4 | Frontend best-practices cleanup | **Not started** | `04-frontend-best-practices.md` | Medium |
+
+---
+
+## C. Cutting-planning bug backlog — quick status (details in `02`)
+| ID | Bug / gap | Severity | Status |
+|----|-----------|----------|--------|
+| CP-1 | `orange` vs `amber` trigger mismatch → 107 "cut-soon" styles shown as Covered | **High** | **DONE — PR #483** (107 amber styles now surface) |
+| CP-2 | Closed loop not wired (assign never becomes "cut") | **High (design)** | Open |
+| CP-3 | Marketplace-PO sign (`+ upcomingPoQty`) — verify demand vs supply | High | Open (needs decision) |
+| CP-4 | No transaction in `POST /api/cut-plan/assign` (per-lot mode) | Medium | Open |
+| CP-5 | Style-scope lead-times ignored (only `scope='sku'` loaded) | Medium | Open |
+| CP-6 | CAD size vocabulary not unified (no 5XL/6XL/numeric) | Medium | Open |
+| CP-7 | `deriveStyle` over-strip (base ending in S/M/L/XL) | Medium | Open |
+| CP-8 | Leftover `GET /pm/debug-ee` endpoint | Low | Open |
+| CP-9 | Redundant heavy recompute in assign path | Low | Open |
+| CP-10 | Resolver gap: unresolved in-flight counted, not netted → over-cut | Medium | Open (monitor) |
+
+## D. Known environment facts (so nobody re-discovers them)
+- Prod = GCP `kotty-track-prod`, Cloud Run, deploys from `main` via `cloudbuild.yaml` (2Gi, min-instances=1, timeout 3600).
+- Sessions use **in-process MemoryStore** (not shared across instances, lost on restart) — relevant to the extension auth choice.
+- No token/JWT/API-key auth exists; the only header-secret path is `POST /internal/run-pull` (`x-cron-secret` vs `PM_CRON_SECRET`).
+- Env changes on Cloud Run must use `--update-env-vars` (never `--set/--clear`).
+- Read-only prod inspection: cloud-sql-proxy → `127.0.0.1:3306`, creds from Secret Manager `db-password`.

--- a/docs/plans/01-qcpass-extension.md
+++ b/docs/plans/01-qcpass-extension.md
@@ -1,0 +1,199 @@
+# Plan 01 — QC-Capture Extension → Authenticated DB Ingestion (`jitrgp`)
+
+_Status: Not started. Owner: TBD. Related: `qcpass_extension/`, `routes/`, `middlewares/auth.js`._
+
+## Context — what prompted this
+`qcpass_extension/` is a Manifest-V3 Chrome extension ("QC Capture — Full Return Data")
+that the QC / return-gate-pass team runs on Myntra's return console
+(`rejoyui.myntrainfo.com`). It piggybacks on the page's own session and API calls to:
+- **Capture** the full return record on every scan/search (`searchReturnDetails/search2`),
+  enriched with logistics (`getReturnLMSDetails`) — ~40 fields (tracking, item barcode,
+  return_id, sku, style, size, price, qc_action, quality, dates, courier, warehouses, …).
+- Optionally **auto-pass** each scanned item (`updateReturnRestocked` PUT) and suppress the
+  print popup.
+- Write every record to a **durable IndexedDB queue** and batch-sync to a backend, only
+  removing a record after the backend confirms (survives crashes / reload / offline).
+
+**Current gaps (why this plan exists):**
+1. **No login / no auth.** Anyone who installs it captures and posts data anonymously.
+2. Backend is hardcoded to a throwaway `http://localhost:8000/api/capture` — that endpoint
+   **does not exist in kotty-track**. Data goes nowhere real.
+3. There are leftover **debug endpoints** (`localhost:8000/api/debug-dump`, `/api/debug-pass`)
+   that ship raw Myntra API responses.
+
+**Goal:** only users with the **`jitrgp`** role can use the extension; each captured record
+is attributed to that user and stored in the kotty-track DB, **reliably (no lost or
+duplicated records) whether online, offline, or flaky** — the user explicitly wants the
+best realtime-vs-queue approach.
+
+---
+
+## Key constraints discovered (drive the design)
+- **No token/JWT/API-key auth exists** in the app; everything is `express-session` cookie based.
+- Sessions use **in-process `MemoryStore`** → not shared across Cloud Run instances, lost on
+  restart. The service runs `min-instances=1, max-instances=10`.
+- Session cookie is `httpOnly` + `sameSite=lax` + `secure` → a background-worker cross-site
+  POST **won't reliably carry the cookie**, and extension JS can't read it.
+- **No global CORS** (only `/returns/api` has `cors()`).
+- The one existing machine-to-machine pattern is `POST /internal/run-pull`, gated by
+  `x-cron-secret` header vs `PM_CRON_SECRET`, mounted **before** the session/auth middleware
+  (`app.js:210`, `utils/catchupPull.js:179`). **This is the template.**
+- The **`jitrgp` role does not exist yet** — must be created.
+
+**Conclusion:** session-cookie auth is the wrong tool for a background-worker extension.
+Use a **per-user bearer token**, on an endpoint mounted before the session middleware, that
+resolves the token → user → confirms the `jitrgp` role. Stateless-per-request (any Cloud Run
+instance can serve it), no cookie, so CORS is trivial.
+
+---
+
+## Design
+
+### 1. Role
+Create the role once (seed SQL, mirroring `sql/2026_05_production_manager.sql:70`):
+```sql
+INSERT IGNORE INTO roles (name, description) VALUES ('jitrgp', 'JIT Return Gate Pass — QC capture');
+```
+Grant it to the relevant users (primary `users.role_id` or via `user_roles`). Add a
+`getDashboardForRole('jitrgp')` entry in `routes/authRoutes.js:48` (can point at a simple
+status page) and, if they should log into the web app too, nothing else is needed —
+`allowRoles(['jitrgp'])` already works off `req.session.user.roleName`.
+
+### 2. Token-based auth for the extension (recommended: DB-backed opaque token)
+Two token options — **recommend DB-backed opaque token** for revocability + per-user audit:
+
+**A. DB-backed opaque token (recommended).** New table:
+```sql
+CREATE TABLE qc_ext_tokens (
+  id            INT AUTO_INCREMENT PRIMARY KEY,
+  token_hash    CHAR(64) NOT NULL UNIQUE,   -- sha256 of the random token; never store raw
+  user_id       INT NOT NULL,
+  device_label  VARCHAR(80) NULL,
+  created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  last_used_at  TIMESTAMP NULL,
+  revoked_at    TIMESTAMP NULL,
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+);
+```
+- **Login** `POST /ext/qc/login` (mounted before auth, like `/internal`): body `{username, password, device_label?}`. bcrypt-compare against `users JOIN roles`, **require the user to hold `jitrgp`** (primary role or a `user_roles` row). On success, generate `crypto.randomBytes(32).hex()`, store its sha256 in `qc_ext_tokens`, return the raw token once. Extension saves it in `chrome.storage.local`.
+- **Verify** middleware `requireQcToken`: read `Authorization: Bearer <t>` (or `x-qc-token`), sha256, look up a non-revoked row, join to user+role, confirm `jitrgp`, set `req.qcUser = {id, username}`, bump `last_used_at`. 401 on any failure.
+- Revocable per user/device from an admin action (`UPDATE ... SET revoked_at=NOW()`).
+
+**B. Stateless JWT** (HS256, new `EXT_TOKEN_SECRET`, `exp` ~12 h, payload `{uid, role}`).
+Simpler (no table) but not revocable and needs re-login on expiry. Acceptable fallback.
+
+> Why not "extension logs in via `/api/login` and rides the session cookie"? Because
+> `MemoryStore` isn't shared across instances and the `sameSite=lax`/`httpOnly` cookie won't
+> reliably attach to background POSTs — you'd get intermittent 401s. Tokens avoid all of it.
+
+### 3. Ingestion endpoint
+`POST /ext/qc/capture` (mounted before session middleware, `requireQcToken` gate):
+- Body: `{ records: [ {…, _type:'capture'|'pass', capture_uid } ] }` (≤100, matches the
+  extension's existing batch shape).
+- **Idempotent upsert** into new tables (see §4) keyed on `capture_uid`, all in **one
+  transaction**; respond `200 {ok:true, accepted:n}` **only after commit** — this satisfies
+  the extension's "remove from queue only after backend confirms" contract.
+- Attribute every row to `req.qcUser.id` (server-side, never trust a client-supplied user).
+- On any error → 5xx (no partial state, transaction rolls back) so the extension retries.
+
+### 4. Storage schema (idempotent)
+```sql
+CREATE TABLE qc_return_captures (
+  capture_uid   CHAR(64) NOT NULL PRIMARY KEY,   -- client-stable dedupe id
+  captured_by   INT NOT NULL,
+  return_id     VARCHAR(40), item_barcode VARCHAR(60), tracking_number VARCHAR(80),
+  oms_release_id VARCHAR(40), sku_id VARCHAR(40), sku_code VARCHAR(80),
+  style_id VARCHAR(40), article_no VARCHAR(80), product_name VARCHAR(255),
+  size VARCHAR(20), price DECIMAL(10,2),
+  return_type VARCHAR(40), return_mode VARCHAR(40), return_status VARCHAR(40),
+  rms_status VARCHAR(40), qc_action VARCHAR(40), quality VARCHAR(20),
+  logistics_status VARCHAR(60), courier_code VARCHAR(40),
+  return_hub VARCHAR(40), dispatch_wh VARCHAR(40), return_destination_wh VARCHAR(40),
+  delivery_center VARCHAR(40), ship_city VARCHAR(80),
+  created_date DATE, refund_date DATE, return_received_on DATE, return_restocked_on DATE,
+  raw_json JSON NULL,                       -- keep the full record for anything unmapped
+  captured_at   DATETIME, ingested_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  INDEX (return_id), INDEX (item_barcode), INDEX (captured_by), INDEX (captured_at)
+);
+
+CREATE TABLE qc_return_passes (
+  capture_uid   CHAR(64) NOT NULL PRIMARY KEY,
+  passed_by     INT NOT NULL,
+  item_barcode VARCHAR(60), oms_release_id VARCHAR(40),
+  qc_action VARCHAR(40), quality VARCHAR(20), desk_code VARCHAR(20), warehouse_id VARCHAR(40),
+  pass_success TINYINT(1), new_status VARCHAR(40), pass_error VARCHAR(255),
+  passed_at DATETIME, ingested_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+  INDEX (item_barcode), INDEX (passed_by), INDEX (passed_at)
+);
+```
+Ingest = `INSERT … ON DUPLICATE KEY UPDATE` on `capture_uid` → replays are no-ops. Keep
+`raw_json` so no captured field is ever lost even before it's columnized.
+
+### 5. Realtime vs queue — **the recommended approach**
+**Keep the durable queue; make the server idempotent + transactional. Do NOT switch to
+per-event realtime (WebSocket/SSE).** Reasons and how each failure mode is handled:
+
+| Concern | How this design handles it |
+|--------|----------------------------|
+| Flaky wifi / offline QC desk | IndexedDB queue holds records; `flush()` retries every 30 s + on capture. Nothing lost. |
+| Backend down / deploy / 5xx | Batch stays queued (record removed only on 200-after-commit). |
+| Duplicate delivery (retry after a dropped 200) | `capture_uid` primary key + upsert → exact-once effect. |
+| Out-of-order capture vs pass | Both keyed independently and idempotent; order doesn't matter. |
+| Token expired / revoked | Endpoint returns 401 → extension surfaces "re-login" in the panel and **keeps** the queue until re-auth (must handle 401 distinctly from 5xx — see §6). |
+| Multi-instance Cloud Run | Token auth is stateless → any instance serves ingest (session couldn't). |
+| Volume / bursts | Batches of 100 + back-pressure via the queue; server commits per batch. |
+
+Realtime (WebSocket) would add a persistent connection, server fan-in, and reconnection
+logic while making durability *harder* — the opposite of what's wanted. Near-realtime
+(30 s batch) is already effectively live for a human-paced QC desk.
+
+**Required precondition:** a **stable `capture_uid`.** Add it in the extension when a record
+is created — e.g. `sha256(return_id + '|' + item_barcode + '|' + captured_at)` for captures,
+`sha256(item_barcode + '|' + passed_at)` for passes (or a persisted `crypto.randomUUID()`
+stored with the queued record). Without it, retries double-insert.
+
+---
+
+## Work items
+
+### Extension side (`qcpass_extension/`)
+1. `background.js`: change `BACKEND` from `localhost:8000/api/capture` → the kotty-track URL
+   (`https://<prod-host>/ext/qc/capture`); make it configurable via `chrome.storage.local`.
+2. `background.js`: add `Authorization: Bearer <token>` (from storage) to the POST; add a
+   **stable `capture_uid`** to each queued record; treat **401** specially (set `needsLogin`,
+   stop flushing, surface in panel) vs 5xx (keep retrying).
+3. Add a tiny **login UI** — a popup (add `action`/`default_popup` to the manifest) or a form
+   in the on-screen panel — that calls `POST /ext/qc/login`, stores the token, and shows the
+   logged-in user. Panel status: "logged in as X · queued N · synced M · OFFLINE/RE-LOGIN".
+4. `inject.js`: **remove the debug endpoints** (`debugPost`/`debugPostPass` to localhost) and
+   the `window.__qcRaw` console dump for the prod build (or gate behind a dev flag).
+5. `manifest.json`: replace `localhost` host permissions with the prod host; keep
+   `rejoyui.myntrainfo.com` + `spectrum-babylon-api.myntrainfo.com` (needed for capture).
+6. Decide **auto-pass** policy: keep it as an explicit opt-in toggle (it mutates Myntra state).
+   Document that captures are read-only; auto-pass is a separate, deliberate action.
+
+### Server side (kotty-track)
+1. Seed the `jitrgp` role + grant to users (`sql/…jitrgp.sql`).
+2. New `routes/qcExtensionRoutes.js` with `POST /ext/qc/login` + `POST /ext/qc/capture`,
+   mounted in `app.js` **before** the session/auth block (next to `/internal/run-pull`).
+3. `requireQcToken` middleware + `qc_ext_tokens`, `qc_return_captures`, `qc_return_passes`
+   tables (migration in `sql/`).
+4. `cors()` scoped to `/ext/qc` (token, no cookie → can allow the extension origin; ideally
+   restrict `Origin: chrome-extension://<id>` once the extension id is fixed).
+5. Secrets: `EXT_TOKEN_SECRET` (if JWT) via Secret Manager + `--update-env-vars`.
+6. A minimal admin/report view (later): list `qc_ext_tokens` (issue/revoke) and browse
+   `qc_return_captures`. Optional first cut: reuse the existing admin pages.
+
+### Verification
+- Local: run the app, `POST /ext/qc/login` with a jitrgp user → token; `POST /ext/qc/capture`
+  with a batch twice → second is a no-op (idempotency); non-jitrgp user → 403; bad token → 401.
+- Load the extension against a staging URL, scan a return, pull the plug (offline) → queue
+  grows; restore → syncs; verify rows land once in `qc_return_captures` attributed to the user.
+- Confirm 401 handling: revoke the token mid-session → panel shows "re-login", queue preserved.
+
+## Open decisions (need the user)
+1. **Token style**: DB-backed opaque (revocable, audited — recommended) vs stateless JWT (simpler).
+2. **What is the captured data *for* downstream** — pure QC/return audit store, or does it feed
+   an RGP reconciliation / report? (Affects whether we build reporting now.)
+3. **Auto-pass in production** — keep the toggle, or capture-only? (It writes to Myntra.)
+4. **Where the extension points in prod** — main Cloud Run host, or a dedicated ingest path.

--- a/docs/plans/02-cutting-planning-bugs.md
+++ b/docs/plans/02-cutting-planning-bugs.md
@@ -1,0 +1,125 @@
+# Plan 02 — Cutting-Planning Correctness Backlog
+
+_Status: Not started. Source: end-to-end audit (2026-07-03) of `/pm` cutting planning,
+verified live against prod. Fix these **one by one**, each on its own branch/PR, each with a
+before/after check. Ordered by value/effort._
+
+## How cutting planning works (1-paragraph refresher)
+`getCuttingRecommendations` (`utils/easyecomAnalytics.js:696`) computes, per size-SKU,
+`suggested = max(0, horizon×DRR − SOH − in_flight + upcoming_PO)` where
+`horizon = lead_time + safety_days` (default 12+3=15). DRR = units sold ÷ selling-days
+(calendar-days fallback when <7 selling days). In-flight (cut-but-not-dispatched) netting is
+in `utils/onOrder.js` (flag `PM_CLOSED_LOOP`, **on** in prod). The dashboard rolls size-SKUs
+up to styles (`aggregateStyles`, `routes/productionManagerRoutes.js`), the style page shows
+per-size detail, and "Approve & assign" writes a PM intent row (`pm_cut_assignment`).
+
+Live health (03 Jul): engine returns 26,244 rows in 5.2 s, feed fresh — the engine **works**;
+these are correctness/completeness defects on top.
+
+---
+
+## CP-1 — `orange` vs `amber` trigger mismatch  **[High · one-line fix]**
+**Symptom:** the entire "Cut soon" tier is dead at style/dashboard level. Measured live:
+**282 orange size-SKUs, 107 styles that are orange-only** (no red) show as **GREEN "Covered"**
+and drop off the priority list.
+**Cause:** analytics emits `trigger='orange'` (`easyecomAnalytics.js:851`), but the roll-up
+and filters test `'amber'` (`routes/productionManagerRoutes.js:122`, `:132`, and the
+`/api/styles` trigger filter `:422`; the view uses `value="amber"`).
+**Fix:** unify the vocabulary — simplest is to emit `'amber'` from analytics (rename the one
+literal at `:851`, and the demotion at `:852`), OR map orange→amber in `aggregateStyles`.
+Prefer renaming at the source so per-size and style agree. Grep for every `'orange'`/`'amber'`
+before/after.
+**Verify:** re-run the live count — orange-only styles should now roll up as `amber`/`cut_soon`
+and appear under the "Cut soon" filter.
+
+## CP-2 — Closed loop not wired (assign never becomes "cut")  **[High · design decision]**
+**Symptom:** "Approve & assign" only ever INSERTs `pm_cut_assignment` (+ `_sizes`). Nothing
+ever sets `status='cut'` or links a `cutting_lot_id`. So the "Cut as lot X" link in
+`assignedCuts.ejs` is dead, assignment status is permanently "TO CUT", and every master's
+"cut" count in `/api/analytics` (`master_output`) is structurally **0**. When a cutting
+master actually cuts, `routes/cuttingManagerRoutes.js` inserts `cutting_lots` independently
+with **no back-reference** to the assignment.
+**Decision needed:** is the PM "assign" meant to be (a) just an advisory note, or (b) a real
+work order that gets marked cut? If (b):
+- Add `cutting_lots.source_assignment_id` (nullable FK) — set it when a master cuts a lot that
+  originated from an assignment (surface the assignment on the cutting-master screen so they
+  cut "from" it).
+- On lot creation, `UPDATE pm_cut_assignment SET status='cut', cutting_lot_id=? …`.
+- Then the status pill, "Cut as lot X" link, and master cut-counts all light up.
+**Verify:** assign a style → master cuts → assignment flips to "cut" with the lot linked;
+`master_output.cut` > 0.
+
+## CP-3 — Marketplace-PO sign  **[High · needs confirmation, then trivial]**
+**Symptom/risk:** the formula does `… + upcomingPoQty` (`easyecomAnalytics.js:843`) — upcoming
+PO **increases** the suggested cut. Correct only if `pm_marketplace_po_lines` are **outbound
+demand** POs. If they're **inbound supply**, the sign is inverted (should subtract). Currently
+the table is **empty (0 rows)**, so no live impact — but confirm intent before anyone uploads.
+**Fix:** confirm semantics with the user; keep `+` for demand, switch to `−` (and clamp) for
+supply. Add a code comment stating which it is.
+
+## CP-4 — No transaction in `POST /api/cut-plan/assign`  **[Medium]**
+**Symptom:** header + sizes inserts run on the bare pool; in **per-lot mode** (loop) a mid-loop
+failure leaves partial assignments committed with no rollback (`productionManagerRoutes.js`
+~`:655`, `:690`). Contrast the marketplace upload which is transactional (`:1037`).
+**Fix:** wrap the whole assign (all lots + sizes + snapshots) in one `getConnection` +
+`beginTransaction`/`commit`/`rollback`.
+**Verify:** force a mid-loop error → nothing persists.
+
+## CP-5 — Style-scope lead-times silently ignored  **[Medium]**
+**Symptom:** the live recs path bulk-loads only `pm_style_lead_times WHERE scope='sku'`
+(`easyecomAnalytics.js:756`); any `scope='style'` lead-time/safety/`override_drr` has **no
+effect**, even though `getLeadTimeForSku` supports it. Today the table is empty so no impact,
+but style-level config would silently do nothing.
+**Fix:** also load `scope='style'` rows and resolve SKU→style fallback in `resolveLeadTime`
+(SKU row wins, else style row, else defaults 12/3).
+**Verify:** set a style-level override → recs for that style's SKUs reflect it.
+
+## CP-6 — CAD size vocabulary not unified  **[Medium]**
+**Symptom:** `cadConsumption.js` normalizes only letter sizes (`LETTER_SIZES`, no 5XL/6XL and
+no numeric waist), but `deriveSize` emits 5XL/6XL/2–3-digit numerics. A CAD row for "5XL"/"34"
+won't match, so that size is flagged `missing` in `fabricForCut` and cut **without a fabric
+figure**.
+**Fix:** unify the size grammar — share one `normalizeSize`/`deriveSize` between
+`cadConsumption.js` and `easyecomAnalytics.js` (add 3XL–6XL + numeric to the CAD normalizer).
+**Verify:** upload a CAD sheet with 5XL/6XL/numeric → those sizes get consumption, `missingSizes`
+empty.
+
+## CP-7 — `deriveStyle` over-strip  **[Medium]**
+**Symptom:** `deriveStyle` (`easyecomAnalytics.js:594`) strips a trailing S/M/L/XL/XXL with no
+delimiter, so a style whose base legitimately ends in one of those letters gets mis-read as a
+size → mis-grouped, and `computeStyleCutPlan` drops SKUs whose derived size is null.
+**Fix:** prefer the authored `pm_sku_resolution` map for style/size splitting where available;
+for the regex path, add guards/known-style checks. Lower-risk: log/flag SKUs whose
+`deriveStyle`+`deriveSize` don't round-trip so bad cases are visible.
+**Verify:** pick a style ending in "…L" and confirm it groups correctly.
+
+## CP-8 — Leftover `GET /pm/debug-ee`  **[Low · quick]**
+Admin-only raw EasyEcom probe, self-labeled "remove after debugging"
+(`productionManagerRoutes.js:1165`). **Delete it.**
+
+## CP-9 — Redundant heavy recompute in assign path  **[Low]**
+`computeStyleCutPlan` (→ full `getCuttingRecommendations`) runs 2× for single-master and once
+**per lot** for per-lot mode (`recordCutDecisionSnapshot`). Compute the plan once and pass it
+down.
+
+## CP-10 — Resolver gap (over-cut risk)  **[Medium · monitor]**
+In-flight lots whose size-SKU can't be resolved are **counted but not netted**
+(`onOrder.js:35`), so their already-cut stock is invisible → potential over-cut. Surfaced as
+`in_flight_unresolved` in `/api/styles` but with no threshold/alert.
+**Fix:** (a) add an alert when unresolved pieces exceed a threshold; (b) drive down the gap by
+filling `pm_sku_resolution` (there are resolver-upload endpoints already). Monitor the live
+number after `PM_CLOSED_LOOP` is on.
+
+---
+
+## Also parked (not bugs, but incomplete/unused)
+- **Marketplace POs**: `pm_marketplace_po_lines` empty — feature unused (see CP-3).
+- **Lead-time config**: `pm_style_lead_times` empty — no per-style tuning in use (see CP-5).
+- **Clean-day DRR**: running in `shadow` mode (legacy DRR is the live driver); the cleanday
+  model is computed for diffing but the cutover isn't done (`easyecomAnalytics.js:779`).
+- **Cut-decision audit**: gated behind `PM_CUT_AUDIT` (off) → no `pm_cut_decision_snapshot`
+  rows → the Audit page's decision context is null.
+
+## Suggested order
+CP-1 (today, one line, big UI win) → CP-8 → CP-4 → CP-3 (decision) → CP-2 (decision, biggest)
+→ CP-5 / CP-6 / CP-7 → CP-9 / CP-10.

--- a/docs/plans/03-ejs-to-react-migration.md
+++ b/docs/plans/03-ejs-to-react-migration.md
@@ -1,0 +1,84 @@
+# Plan 03 — EJS → React: Effort, Benefits, Approach
+
+_Status: Analysis / decision pending. This answers "how long, and what gets better."_
+
+## Where we are today
+- **194 `.ejs` files** in `views/` (~157 top-level pages + partials/layouts).
+- Interactivity is **inline**: **132 views contain `<script>` blocks; 83 make `fetch()` calls**
+  straight to per-feature JSON routes. Only **6 shared JS files** in `public/js/` — no SPA,
+  no shared state, no component library on the EJS side.
+- Server coupling is high: every page is `res.render(view, { user, …locals })` reading
+  `req.session.user` + feature data.
+- **A React stack already exists and is proven in prod**: `frontend/` = **Vite 6 + React 18 +
+  TypeScript + Tailwind v4 + shadcn/Radix**, built to `public/tasks/`, bridged into EJS by
+  `utils/viteManifest.js`, mounted by `views/tasks.ejs` passing session via `data-*`, behind
+  session-gated `/tasks/api/*`. The **island migration rails are already laid.**
+
+## Two ways to do it
+
+### Option A — Incremental "islands" (recommended)
+Migrate **feature by feature**, reusing the Tasks pattern: a Vite entry per feature →
+`public/<feature>/` → manifest bridge → thin EJS shell with `data-*` → session-gated JSON API.
+Old EJS pages keep working; you convert the **high-interactivity** pages first and leave
+simple server-rendered pages (static lists, print views, admin CRUD) on EJS possibly forever.
+
+- **Pros:** ship value continuously; no big-bang risk; auth/session unchanged; each island is
+  independently testable; you already have one working.
+- **Cons:** two rendering models coexist for a long time; some duplicated layout/partials.
+
+### Option B — Full SPA rewrite (not recommended now)
+Replace EJS entirely with a React app + a JSON-only backend (React Router, a real session-or-JWT
+API, shared design system).
+- **Pros:** one model, best DX/UX ceiling, shared components/state.
+- **Cons:** months before anything ships; must re-implement **all 194 views + 83 fetch flows +
+  auth/session/flash** at once; high regression risk across every role's daily workflow; freezes
+  feature work. For a live factory ops tool this is the wrong risk profile.
+
+## Rough effort (one experienced full-stack dev)
+Estimates are for migrating a page's UI to a React island **and** hardening its API. Wide
+ranges because complexity varies.
+
+| Page type | Examples | Per page | Count (approx) |
+|-----------|----------|----------|----------------|
+| Simple list/CRUD | units master, config pages | 0.5–1.5 d | many (leave most on EJS) |
+| Interactive dashboard | PM dashboard, operator day-activity, lot-TAT, cutting/washing/finishing dashboards | 3–8 d | ~12–18 |
+| Complex flow | cut-planning approve-&-assign, PIC reports, PO creator, returns | 5–12 d | ~6–10 |
+| Shared foundation (one-time) | design system, auth/session hook, API client, layout shell, CI build step | 10–20 d | once |
+
+- **Recommended subset** (the ~20 high-value interactive pages + foundation): **~3–5 months.**
+- **Everything** (all 194 views): **~9–15 months** and a long two-model period — only worth it
+  if you commit to it as a program, not a side quest.
+
+## What genuinely gets better with React
+1. **No more inline `<script>` sprawl** — 132 pages of ad-hoc DOM code become typed components.
+2. **A real component/design system** (shadcn already in place) → consistent UI, faster new
+   screens, dark-mode/theming for free.
+3. **Type safety** (TS) across the 83 fetch flows → fewer field-name/shape bugs (the kind that
+   caused the `orange`/`amber` mismatch class of defect).
+4. **Client state & optimistic UI** — the production dashboards (live counts, filters, assign)
+   are exactly where React + a data layer (TanStack Query) shines vs full-page reloads.
+5. **Testability** — component + hook tests vs untestable inline scripts.
+6. **Reuse** — the PIC report table, size grids, KPI cards, priority tables recur across
+   dashboards; build once.
+
+## What does NOT need React (keep on EJS)
+Print/label views, simple admin CRUD, one-off report pages, login. Forcing these into React is
+pure cost.
+
+## Prerequisites / things to fix first (independent of React)
+- Add the `frontend` build to CI (`cloudbuild.yaml` currently doesn't run `cd frontend && npm
+  run build` — Tasks assets are built manually). Any island migration needs this automated.
+- Decide the **API auth story** for a growing JSON surface — session cookies work for
+  same-site islands (Tasks proves it), but see the MemoryStore caveat (not shared across
+  instances). Consider a shared session store (Redis/MySQL) before scaling islands, or you'll
+  hit intermittent logouts under `max-instances>1`. (This also matters for Plan 01.)
+
+## Recommendation
+- **Do Option A, opportunistically.** When a dashboard needs real work, migrate it to an island
+  instead of extending its inline script.
+- **First islands to target** (highest interactivity + churn): the **PM cutting-planning**
+  screens (dashboard, style page, approve-&-assign) — they're already the most JS-heavy and are
+  getting active bug-fix work (Plan 02), so you'd get typed models + reuse immediately.
+- **Two hard prerequisites before scaling islands:** (1) CI builds `frontend/`; (2) a shared
+  session store (or token auth) so multi-instance doesn't drop sessions.
+- Treat a full Option-B rewrite as a **separate, staffed program**, not implied by "move to React."

--- a/docs/plans/04-frontend-best-practices.md
+++ b/docs/plans/04-frontend-best-practices.md
@@ -1,0 +1,100 @@
+# Plan 04 — Frontend Issues vs Best Practice (one by one)
+
+_Status: Not started. Each item: **Issue → Best practice → Fix**. Prioritized. These apply to
+the current EJS frontend and are largely independent of the React question (Plan 03); doing
+them makes an eventual React migration easier, not harder._
+
+Baseline (measured): 194 `.ejs` views, **132 with inline `<script>`**, **83 with inline
+`fetch()`**, only 6 shared `public/js/` files, `express-session` on **MemoryStore**, no CI
+build for the `frontend/` island.
+
+---
+
+## FE-1 — Inline `<script>` sprawl  **[High]**
+- **Issue:** 132 views hand-roll DOM logic inline. No reuse, no tests, easy to drift (this is
+  the soil the `orange`/`amber`-class bugs grow in).
+- **Best practice:** keep behavior in versioned, cacheable JS modules (or components), not in
+  server-rendered markup; markup should be declarative.
+- **Fix:** extract repeated inline logic into `public/js/` modules (or React islands per
+  Plan 03) and load with `<script type="module" src>`. Start with the most-duplicated patterns
+  (fetch-render-table, filter chips, modal open/close).
+
+## FE-2 — Inline `fetch()` with no shared client / error handling  **[High]**
+- **Issue:** 83 views call `fetch()` directly; each re-implements JSON parsing, error handling,
+  and loading/empty states inconsistently (many just `.then(r=>r.json())` with no `res.ok`
+  check → silent failures on 401/500).
+- **Best practice:** one thin API client that handles base URL, credentials, `res.ok`, JSON,
+  and a consistent error/toast + auth-redirect on 401.
+- **Fix:** add `public/js/api.js` (`apiGet/apiPost` → throw on !ok, redirect to `/login` on
+  401, surface a toast on 5xx). Migrate the 83 call sites incrementally. In React islands this
+  becomes TanStack Query.
+
+## FE-3 — Unescaped output / XSS surface  **[High · security]**
+- **Issue:** EJS `<%- %>` (unescaped) used with data that can contain user/vendor input renders
+  raw HTML. History shows prior HTML-injection fixes — the pattern still exists in places.
+- **Best practice:** default to escaped `<%= %>`; only use `<%- %>` for trusted server HTML;
+  never interpolate user/DB strings into `<%- %>` or into inline `<script>` as JS literals.
+- **Fix:** audit every `<%- %>` and every `<script>… <%= %> …</script>` interpolation; switch
+  user-derived values to escaped output or pass them via `data-*`/`JSON.stringify` with proper
+  escaping. Add a lint/grep check in review.
+
+## FE-4 — No Content-Security-Policy; inline scripts block one  **[Medium · security]**
+- **Issue:** heavy inline `<script>` makes a strict CSP impossible, so there's no defense-in-
+  depth against injected script.
+- **Best practice:** a CSP that disallows inline script (`script-src 'self'`); externalize JS.
+- **Fix:** FE-1 is the prerequisite; then add `helmet` CSP starting in report-only mode, tighten
+  as inline scripts are removed.
+
+## FE-5 — Session on in-process MemoryStore  **[High · reliability/UX]**
+- **Issue:** `express-session` uses the default MemoryStore → sessions are per-instance and lost
+  on restart. With `max-instances=10`, users get **intermittent logouts** when routed to another
+  instance. (Also blocks scaling React islands and complicates the extension — Plan 01/03.)
+- **Best practice:** a shared, persistent session store.
+- **Fix:** add `express-mysql-session` (reuse the existing MySQL) or Redis; low-risk, big UX win.
+
+## FE-6 — No CI build for the frontend island  **[Medium]**
+- **Issue:** `cloudbuild.yaml` doesn't run `cd frontend && npm run build`; the Tasks island
+  assets are built by hand, so a deploy can ship stale/missing assets.
+- **Best practice:** build all client assets in CI, fail the deploy if the build fails.
+- **Fix:** add a `frontend` install+build step to `cloudbuild.yaml` before the image build (or
+  bake it into the Docker build), and commit `public/tasks` out of git if it's currently tracked.
+
+## FE-7 — Duplicated layout / no shared shell  **[Medium]**
+- **Issue:** partials exist (`views/partials/*`, `layouts/master.ejs`) but many pages re-declare
+  nav/header/styles; inconsistent look across roles.
+- **Best practice:** one layout + shared partials (or one React `AppShell`); design tokens for
+  color/spacing.
+- **Fix:** consolidate onto `layouts/master.ejs` + a single nav partial; define CSS variables
+  for the palette (there's already an amber/red/green trigger vocabulary to standardize).
+
+## FE-8 — Inconsistent loading / empty / error states  **[Medium · UX]**
+- **Issue:** fetch-driven pages often show nothing (or a spinner forever) on error/empty; the
+  PM freshness-banner saga showed how silent staleness misleads users.
+- **Best practice:** every async view has explicit loading, empty, and error states, and
+  surfaces data freshness where relevant.
+- **Fix:** standardize skeleton/empty/error components (ties to FE-2's client); reuse the
+  freshness-banner pattern for any data that can be stale.
+
+## FE-9 — Asset caching / cache-busting  **[Low]**
+- **Issue:** `public/css` + `public/js` served without content-hash filenames → stale assets or
+  aggressive cache-busting via query strings.
+- **Best practice:** hashed filenames (Vite already does this for islands) + long-cache headers;
+  fingerprint the shared `public/js` too.
+- **Fix:** either move shared JS into the Vite pipeline or add a small hashing step +
+  `Cache-Control` in `express.static`.
+
+## FE-10 — Accessibility & mobile  **[Low–Medium]**
+- **Issue:** factory-floor tools are used on phones/tablets; inline-built tables/forms have
+  inconsistent responsive + a11y (labels, focus, contrast).
+- **Best practice:** semantic HTML, labelled controls, keyboard focus, responsive tables.
+- **Fix:** address per island during Plan 03 (shadcn/Radix give a11y primitives); for EJS pages,
+  a pass on the highest-traffic operator screens.
+
+---
+
+## Suggested order
+FE-5 (session store — quick, stops random logouts) → FE-3 (XSS audit — security) → FE-2
+(API client) → FE-1 (externalize scripts) → FE-6 (CI build) → FE-4 (CSP) → FE-7/8 → FE-9/10.
+
+Most of FE-1/2/4/7/8 are naturally absorbed by migrating a page to a React island (Plan 03),
+so sequence them with that work rather than duplicating effort.

--- a/docs/plans/05-architecture-testing-security.md
+++ b/docs/plans/05-architecture-testing-security.md
@@ -1,0 +1,139 @@
+# Plan 05 — Split Architecture, Test Coverage, Security & Stress Testing
+
+_Status: Not started. Captures the cross-cutting program the user added on 2026-07-03:
+"frontend and backend as different projects (React + Vite + Tailwind v4 + shadcn),
+test cases for every feature (backend + frontend), migrate features one by one,
+plus stress testing, security testing, and hardening server/DB access."_
+
+This is a **multi-month program**. It runs alongside Plans 01–04 (extension, cutting bugs,
+migration, FE best-practices) and reframes Plan 03's "islands inside EJS" into a clean split.
+
+---
+
+## 1. Split into two projects
+
+### Target shape
+- **`backend/`** — Node/Express, **JSON API only** (no EJS rendering for migrated features),
+  MySQL, session **or token** auth. Owns all business logic + DB.
+- **`frontend/`** — React 18 + **Vite** + **Tailwind v4** + **shadcn/Radix** SPA (the existing
+  `frontend/` Tasks app is the seed — same stack, expand it into the full app).
+- **`qcpass_extension/`** — stays its own MV3 project (Plan 01).
+
+### Repo strategy (decision needed)
+- **Option A — monorepo** (`/backend`, `/frontend`, `/qcpass_extension` in this repo).
+  Simplest for shared CI, one PR spans API+UI, atomic feature migration. **Recommended.**
+- **Option B — two repos.** Cleaner separation, but cross-cutting features need coordinated PRs
+  and versioned API contracts. More overhead for a small team.
+
+### Auth across the split (decision needed — ties to Plan 01)
+Today: `express-session` + **MemoryStore** (not shared across Cloud Run instances). A separate
+React SPA on its own origin makes cookies harder (CORS + sameSite). Choose ONE:
+- **Session cookie + shared store** (`express-mysql-session`/Redis) + CORS `credentials` for the
+  SPA origin — keeps the current model, fixes multi-instance logouts.
+- **Token auth (JWT/opaque)** for the SPA + extension — cleanest for cross-origin + background
+  workers; bigger change (login, refresh, storage). Aligns with Plan 01's extension token.
+> Recommendation: **token auth** for all programmatic/SPA clients; keep sessions only for any
+> remaining EJS pages during transition. Decide before the first migrated feature.
+
+### CI/CD
+- `cloudbuild.yaml` must build **both** projects (backend image + `frontend` build) and run
+  tests; fail the deploy on any test/build failure. (Today it builds neither the frontend nor
+  runs tests.)
+
+### Migration mechanics (feature by feature)
+For each feature: (1) build/confirm the JSON API in `backend/` with tests; (2) build the React
+screen in `frontend/` with tests; (3) cut traffic over (route the page to the SPA), retire the
+EJS view; (4) update `00-PROGRESS.md`. **One feature per PR.** Keep EJS serving un-migrated
+features until each is ported.
+
+---
+
+## 2. Test coverage — every feature, backend + frontend
+
+Today there are **no meaningful automated tests** (root `package.json` has a `test` placeholder;
+only ~13 ad-hoc tests referenced historically). This is the single biggest risk for a big
+refactor. Establish the harness FIRST, then require tests with every migrated/fixed feature.
+
+### Backend
+- **Framework:** Jest (or Vitest) + **Supertest** for HTTP routes.
+- **DB:** a disposable MySQL (Docker/testcontainers) seeded per suite; never touch prod.
+- **Layers:** unit tests for `utils/*` (the calc chain — `getCuttingRecommendations`, `onOrder`,
+  `cutPlanner`, `picSizeReport`, `stageEvents`), integration tests for each route (auth, role
+  gating, happy-path, validation, idempotency), and regression tests pinning the bugs we fixed
+  (e.g. amber trigger, In=approved report model, orphan-approve dedup invariant).
+- **Coverage gate:** start at a realistic floor, ratchet up per feature.
+
+### Frontend
+- **Framework:** **Vitest** + **React Testing Library**; **Playwright** for end-to-end.
+- **Scope:** component tests (render, states: loading/empty/error), hook/API-client tests
+  (mock fetch), and E2E per feature flow (login → view → action → assert DB effect via API).
+- **Accessibility checks** (axe) baked into component tests.
+
+### "Every single feature" — approach
+Enumerate features from the route map (Plan 00/02 + the 194 views). For each: a backend
+integration test file + a frontend test file, written **as that feature is migrated** (not a
+big-bang test-writing phase). Track per-feature test status in `00-PROGRESS.md`.
+
+---
+
+## 3. Security testing & server/DB access hardening
+
+The user's concern: "if someone could get access to our server or database." Work items:
+
+### AuthN/AuthZ
+- Replace the fragile session model (see §1). Enforce role checks on **every** API route (audit
+  for any unguarded `/api/*`). Rate-limit login + token endpoints (there's already
+  express-rate-limit in the app — extend it).
+- Extension/token endpoints: short-lived or revocable tokens, per-user attribution, no secrets
+  in client code (the extension currently has none, but the localhost debug endpoints must go).
+
+### Input / injection
+- Audit all raw SQL for parameterization (the codebase uses `pool.query(?, [..])` widely — verify
+  no string-concatenated user input). Add a lint rule / review checklist.
+- XSS: the EJS `<%- %>` unescaped-output audit (Plan 04 FE-3). CSP (FE-4).
+- File uploads (XLSX importers): validate type/size, parse in a sandbox, cap rows.
+
+### Secrets & infra
+- Confirm no secrets in the repo/history; all via Secret Manager (there are API keys in Cloud
+  Run env today — review least-privilege). Rotate anything that's been in logs.
+- **DB access:** the app connects as `kotty_user` — verify it has only needed grants (no
+  SUPER/FILE); restrict Cloud SQL to the Cloud Run service account + the proxy; no public IP.
+- Cloud Run: `--no-allow-unauthenticated` is NOT possible (public app), so WAF/Cloud Armor +
+  rate limiting at the edge; lock down `/internal/*` and `/ext/*` to secret/token only.
+- Dependency scanning (`npm audit` / Dependabot — already surfaced by GitHub), and CI SAST.
+
+### Testing
+- **Security tests:** automated checks for authz bypass (hit protected routes without/with wrong
+  role → expect 401/403), SQLi/XSS payloads in test suites, and a periodic dependency + secret
+  scan in CI. Consider a pentest pass before/after the split.
+
+---
+
+## 4. Stress / load testing
+- **Tooling:** k6 (or Artillery) scripts per critical endpoint — the recommendation engine
+  (`/pm/api/*` — 26k-row compute, currently ~5 s), the report downloads (PIC size — large XLSX),
+  the extension ingest (`/ext/qc/capture` — batched writes), and login.
+- **Goals:** find the p95 latency + breakpoint under N concurrent QC desks / PM users; verify the
+  pull worker + API coexist on 2Gi/min-instances=1; validate DB connection-pool limits and the
+  Cloud Run 32 MiB response cap (already a known gotcha for big reports).
+- **Where:** against a **staging** environment, never prod. Add a staging Cloud Run service +
+  Cloud SQL (or a smaller instance) as part of this program.
+- **Outputs:** a baseline report + autoscaling/pool tuning; re-run after each big feature.
+
+---
+
+## Sequencing (high level)
+0. **Now:** cutting-planning bugs (Plan 02) on the current stack — safe, high value, no rearchitecture.
+1. **Foundation:** test harness (backend Jest+Supertest, frontend Vitest+RTL+Playwright), CI
+   builds both + runs tests, staging env, shared session store or token auth (decision).
+2. **Extension (Plan 01):** first real token-auth + ingest feature — good pilot for the split.
+3. **Feature-by-feature migration** (Plan 03 reframed as the split): start with the PM
+   cutting-planning screens (most active), each with backend + frontend tests.
+4. **Security + stress passes** continuous, with a formal review gate before cutover of each
+   high-risk feature.
+
+## Decisions needed before Foundation
+1. Repo: monorepo (recommended) vs two repos.
+2. Auth: token (recommended) vs session+shared-store.
+3. Test stack: Jest vs Vitest (backend); confirm Vitest+RTL+Playwright (frontend).
+4. Staging environment budget (needed for stress + safe security testing).

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,13 +26,91 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
+        "happy-dom": "^20.10.6",
         "tailwindcss": "^4.0.0",
         "typescript": "^5.6.3",
-        "vite": "^6.0.7"
+        "vite": "^6.0.7",
+        "vitest": "^4.1.9"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -268,6 +346,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -314,6 +402,158 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.6.tgz",
+      "integrity": "sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "optional": true,
+      "peer": true,
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1988,6 +2228,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -2260,6 +2507,102 @@
         "vite": "^5.2.0 || ^6 || ^7 || ^8"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2305,12 +2648,40 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.0.tgz",
+      "integrity": "sha512-O0A1G3xPGy4w7AgQdAQYUlQ+BKk2Oovw8eRpofyp5KdBZULnbe+WqaOVNrm705SHphCiG4XHsACrSmPu1f+Kgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
@@ -2340,6 +2711,23 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2361,6 +2749,154 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.9.tgz",
+      "integrity": "sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.9.tgz",
+      "integrity": "sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.9.tgz",
+      "integrity": "sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.9.tgz",
+      "integrity": "sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.9",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.9.tgz",
+      "integrity": "sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.9.tgz",
+      "integrity": "sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.9.tgz",
+      "integrity": "sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.9",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/aria-hidden": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
@@ -2371,6 +2907,26 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -2384,6 +2940,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -2420,6 +2988,19 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-image-size": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/buffer-image-size/-/buffer-image-size-0.6.4.tgz",
+      "integrity": "sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001797",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001797.tgz",
@@ -2440,6 +3021,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -2485,12 +3076,93 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2510,6 +3182,25 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2524,6 +3215,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
@@ -2546,6 +3244,28 @@
       "engines": {
         "node": ">=10.13.0"
       }
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.0.tgz",
+      "integrity": "sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -2597,6 +3317,26 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fdir": {
@@ -2658,6 +3398,129 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/happy-dom": {
+      "version": "20.10.6",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.10.6.tgz",
+      "integrity": "sha512-6QD0ilzDDt93tX44y8tbmZdAcdTRYDhUP+Asgi6pC8Pp5IA3cvaZGyoVN/EGtlq9ziT65iPuBBn3ASLr6hCgVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": ">=20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "@types/ws": "^8.18.1",
+        "buffer-image-size": "^0.6.4",
+        "entities": "^7.0.1",
+        "whatwg-mimetype": "^3.0.0",
+        "ws": "^8.21.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/happy-dom/node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
     "node_modules/jiti": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
@@ -2673,6 +3536,48 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.0.1.tgz",
+      "integrity": "sha512-SNSQteBL1IlV2zqhwwolaG9CwhIhTvVHWg3kTss/cLE7H/X4644mtPQqYvCfsSrGQWt9hSZcgOXX8bOZaMN+kA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@asamuzakjp/dom-selector": "^6.7.2",
+        "cssstyle": "^5.3.1",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2992,6 +3897,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3000,6 +3915,25 @@
       "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/ms": {
@@ -3037,6 +3971,42 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/obug": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.3.tgz",
+      "integrity": "sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -3087,6 +4057,33 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3111,6 +4108,13 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",
@@ -3191,6 +4195,32 @@
         }
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rollup": {
       "version": "4.61.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.61.1.tgz",
@@ -3236,6 +4266,39 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3255,6 +4318,13 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3264,6 +4334,42 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/tailwind-merge": {
       "version": "3.6.0",
@@ -3296,6 +4402,23 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -3311,6 +4434,70 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.6.tgz",
+      "integrity": "sha512-rbP0Gyx8b3Ae9yO//CU2wbSnQNoQ66m1nJdSbSHmnwKwzkkz/u8mERYU8T2rmlmy+bJvRNn84yNCW8gYqox44Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tldts-core": "^7.4.6"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.6.tgz",
+      "integrity": "sha512-TkQNGJIhlEphpHCjKodMTSe23egUZr/g+flI2qkLgiJ/maAzSgXypSLRTNH3nCmqgayEmtcJBiLcfODSAr1xoA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/tslib": {
@@ -3332,6 +4519,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -3481,6 +4675,227 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.9.tgz",
+      "integrity": "sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.9",
+        "@vitest/mocker": "4.1.9",
+        "@vitest/pretty-format": "4.1.9",
+        "@vitest/runner": "4.1.9",
+        "@vitest/snapshot": "4.1.9",
+        "@vitest/spy": "4.1.9",
+        "@vitest/utils": "4.1.9",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.9",
+        "@vitest/browser-preview": "4.1.9",
+        "@vitest/browser-webdriverio": "4.1.9",
+        "@vitest/coverage-istanbul": "4.1.9",
+        "@vitest/coverage-v8": "4.1.9",
+        "@vitest/ui": "4.1.9",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-avatar": "^1.1.12",
@@ -28,11 +30,17 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",
+    "happy-dom": "^20.10.6",
     "tailwindcss": "^4.0.0",
     "typescript": "^5.6.3",
-    "vite": "^6.0.7"
+    "vite": "^6.0.7",
+    "vitest": "^4.1.9"
   }
 }

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from 'vitest'
+import { cn } from './utils'
+
+describe('cn (className merge)', () => {
+  it('joins class names', () => {
+    expect(cn('a', 'b')).toBe('a b')
+  })
+  it('lets the last conflicting tailwind class win', () => {
+    expect(cn('p-2', 'p-4')).toBe('p-4')
+  })
+  it('drops falsy values', () => {
+    expect(cn('a', false && 'x', null, undefined, 'c')).toBe('a c')
+  })
+})

--- a/frontend/src/test/render.test.tsx
+++ b/frontend/src/test/render.test.tsx
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+
+// Smoke test proving the jsdom + React Testing Library wiring works. Real component
+// tests will replace this as features are migrated (Plan 05).
+function Hello({ name }: { name: string }) {
+  return <h1>Hello {name}</h1>
+}
+
+describe('RTL smoke', () => {
+  it('renders a component into jsdom', () => {
+    render(<Hello name="QC" />)
+    expect(screen.getByRole('heading')).toHaveTextContent('Hello QC')
+  })
+})

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom'

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,18 @@
+/// <reference types="vitest" />
+import { defineConfig } from 'vitest/config'
+import react from '@vitejs/plugin-react'
+import path from 'node:path'
+
+// Test-only config (kept separate from vite.config.ts so the island build is untouched).
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: { '@': path.resolve(__dirname, './src') },
+  },
+  test: {
+    environment: 'happy-dom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+  },
+})

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "node app.js",
     "start:dev": "node --watch app.js",
-    "test": "node --test"
+    "test": "NODE_ENV=test node --test",
+    "test:watch": "NODE_ENV=test node --test --watch"
   },
   "keywords": [],
   "author": "",

--- a/test/picSizeReport.test.js
+++ b/test/picSizeReport.test.js
@@ -1,0 +1,87 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+// Requires config/db at import; NODE_ENV=test (set by `npm test`) skips the DB connect.
+const { buildEnhancedRow } = require('../utils/picSizeReport.js');
+
+// Regression guard for the approved/completed stage model (PR #479):
+//   In      = this stage's APPROVED
+//   Out     = this stage's COMPLETED
+//   In-line = approved - completed (WIP on the machine)
+//   Pending = completed - NEXT stage's approved (done, not yet picked up);
+//             for terminal Finishing, completed - dispatched.
+
+const LOT = { lot_no: 'test1', sku: 'KTTX', manual_lot_number: 'm1', remark: '', created_at: new Date() };
+const NO_ASSIGNS = { stAssign: null, asmAssign: null, washAssign: null, washInAssign: null, finAssign: null };
+
+test('denim: 100-piece assembly→washing handoff shows as Assembly Pending', () => {
+  const row = buildEnhancedRow({
+    lot: LOT, isDenim: true, totalCut: 1000,
+    sums:     { stitchedQty: 1000, assembledQty: 1000, washedQty: 900, washingInQty: 0, finishedQty: 0 },
+    approved: { stitchApproved: 1000, assemblyApproved: 1000, washingApproved: 900, washInApproved: 0, finishingApproved: 0 },
+    assigns: NO_ASSIGNS, dispatched: 0,
+  });
+  // stitching: all handed to assembly
+  assert.strictEqual(row.stitchInQty, 1000);
+  assert.strictEqual(row.stitchOutQty, 1000);
+  assert.strictEqual(row.stitchInline, 0);
+  assert.strictEqual(row.stitchPendingQty, 0); // 1000 completed - 1000 assembly-approved
+  // assembly: finished 1000 but washing only took 900 → 100 pending at the handoff
+  assert.strictEqual(row.assemblyInQty, 1000);
+  assert.strictEqual(row.assemblyOutQty, 1000);
+  assert.strictEqual(row.assemblyPendingQty, 100);
+  // washing: In = approved (900), not assembly's 1000
+  assert.strictEqual(row.washingInQty_in, 900);
+  assert.strictEqual(row.washingOutQty, 900);
+  assert.strictEqual(row.washingPendingQty, 900); // 900 completed - 0 wash-in approved
+  assert.strictEqual(row.washingStatus, 'Completed');
+});
+
+test('WIP: approved but not yet completed shows as In-line, not Pending', () => {
+  const row = buildEnhancedRow({
+    lot: LOT, isDenim: true, totalCut: 1000,
+    sums:     { stitchedQty: 1000, assembledQty: 1000, washedQty: 500, washingInQty: 0, finishedQty: 0 },
+    approved: { stitchApproved: 1000, assemblyApproved: 1000, washingApproved: 900, washInApproved: 0, finishingApproved: 0 },
+    assigns: NO_ASSIGNS, dispatched: 0,
+  });
+  assert.strictEqual(row.washingInQty_in, 900);   // In = approved
+  assert.strictEqual(row.washingOutQty, 500);     // Out = completed
+  assert.strictEqual(row.washingInline, 400);     // 900 - 500 on the machine
+  assert.strictEqual(row.washingPendingQty, 500); // 500 - 0 next-approved
+  assert.strictEqual(row.washingStatus, 'In Progress');
+});
+
+test('finishing (terminal): Pending = completed - dispatched', () => {
+  const row = buildEnhancedRow({
+    lot: LOT, isDenim: true, totalCut: 200,
+    sums:     { stitchedQty: 200, assembledQty: 200, washedQty: 200, washingInQty: 200, finishedQty: 200 },
+    approved: { stitchApproved: 200, assemblyApproved: 200, washingApproved: 200, washInApproved: 200, finishingApproved: 200 },
+    assigns: NO_ASSIGNS, dispatched: 150,
+  });
+  assert.strictEqual(row.finishingInQty, 200);
+  assert.strictEqual(row.finishingOutQty, 200);
+  assert.strictEqual(row.finishingPendingQty, 50); // 200 finished - 150 dispatched
+});
+
+test('hosiery: assembly/washing/wash-in are N/A; stitch pends against finishing', () => {
+  const row = buildEnhancedRow({
+    lot: LOT, isDenim: false, totalCut: 300,
+    sums:     { stitchedQty: 300, assembledQty: 0, washedQty: 0, washingInQty: 0, finishedQty: 100 },
+    approved: { stitchApproved: 300, assemblyApproved: 0, washingApproved: 0, washInApproved: 0, finishingApproved: 250 },
+    assigns: NO_ASSIGNS, dispatched: 0,
+  });
+  assert.strictEqual(row.assemblyInQty, '—');
+  assert.strictEqual(row.washingInQty_in, '—');
+  assert.strictEqual(row.stitchInQty, 300);
+  assert.strictEqual(row.stitchPendingQty, 50); // 300 stitched - 250 finishing-approved
+});
+
+test('inline/pending never go negative (corrupt data: completed > approved)', () => {
+  const row = buildEnhancedRow({
+    lot: LOT, isDenim: true, totalCut: 100,
+    sums:     { stitchedQty: 100, assembledQty: 0, washedQty: 0, washingInQty: 0, finishedQty: 0 },
+    approved: { stitchApproved: 80, assemblyApproved: 0, washingApproved: 0, washInApproved: 0, finishingApproved: 0 },
+    assigns: NO_ASSIGNS, dispatched: 0,
+  });
+  assert.strictEqual(row.stitchInline, 0);       // max(0, 80 - 100)
+  assert.ok(row.stitchPendingQty >= 0);
+});


### PR DESCRIPTION
Stands up the **test + CI foundation** the program needs before feature migration, and commits the **`docs/plans/` roadmap**.

## CI test gate (the missing piece)
Neither `cloudbuild.yaml` nor the Dockerfile ran the existing tests — nothing gated a deploy. Now two `node:20` steps run **before** the image build and fail the build on any red test:
- `npm ci && NODE_ENV=test npm test` (backend)
- `cd frontend && npm ci && npm run test` (frontend)

## Backend (`node --test`, zero-dep)
- `config/db.js` skips the connect-on-import probe under `NODE_ENV=test`/`SKIP_DB_CONNECT`, so pure logic in DB-coupled modules is unit-testable without a live DB (previously the import called `process.exit` and killed the runner).
- `package.json`: `test` → `NODE_ENV=test node --test` (+ `test:watch`).
- **New `test/picSizeReport.test.js`** — regression guard for the approved/completed stage model (#479): In=approved, Out=completed, In-line=WIP, Pending=handoff (finishing = completed−dispatched), hosiery N/A, non-negative clamping. **120 tests pass locally.**

## Frontend (`frontend/`)
- Vitest + `@testing-library/react` + **happy-dom** (jsdom hit an ESM/CJS css-parser bug).
- `vitest.config.ts` (separate from the build config), setup, and first tests (`cn()` + an RTL render smoke test). **`npm run test` → 4 pass.**

## Roadmap docs (`docs/plans/`)
`00-PROGRESS` + five initiative plans (qcpass extension, cutting-planning bugs, EJS→React, frontend best-practices, split-architecture/tests/security/stress) so the program can be picked up anywhere.

## Decisions captured (from today)
Monorepo · token auth · real work-order closed loop · foundation-first. Next after this merges: the monorepo split scaffolding + first migrated feature with tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)