### PR TITLE
feat(qc-ext): token-auth ingestion backend for the QC-Capture extension

### DIFF
--- a/app.js
+++ b/app.js
@@ -208,6 +208,12 @@ app.use('/health', healthRoutes);
 // Mounted before auth: the endpoint authenticates via the x-cron-secret header.
 const { catchupMiddleware, internalRunPullHandler } = require('./utils/catchupPull');
 app.post('/internal/run-pull', internalRunPullHandler);
+
+// QC-Capture extension ingestion — token-auth (no session). Mounted before catchupMiddleware
+// and the session-gated routes so any Cloud Run instance can serve it. See docs/plans/01.
+const qcExtensionRoutes = require('./routes/qcExtensionRoutes');
+app.use('/ext/qc', qcExtensionRoutes.router);
+
 app.use(catchupMiddleware);
 
 app.use('/', authRoutes);

--- a/routes/qcExtensionRoutes.js
+++ b/routes/qcExtensionRoutes.js
@@ -1,0 +1,133 @@
+// QC-Capture extension ingestion API (docs/plans/01-qcpass-extension.md).
+// Token-based (no session/cookie), mounted BEFORE the session middleware in app.js so any
+// Cloud Run instance can serve it. Restricted to users holding the `jitrgp` role.
+const express = require('express');
+const bcrypt = require('bcryptjs');
+const cors = require('cors');
+const { pool } = require('../config/db');
+const { generateToken, hashToken, normalizeCapture, normalizePass } = require('../utils/qcExtAuth');
+
+const router = express.Router();
+const REQUIRED_ROLE = 'jitrgp';
+const MAX_BATCH = 500;
+
+// Token auth carries no cookie, so there's nothing to CSRF/steal — allow the extension origin.
+// Tighten to the fixed chrome-extension://<id> once the extension is published.
+router.use(cors({ origin: true, methods: ['POST', 'OPTIONS'], allowedHeaders: ['Content-Type', 'Authorization', 'x-qc-token'] }));
+
+// A user "has" the role via their primary role_id OR a user_roles grant.
+async function userHasRole(userId, roleName) {
+  const [rows] = await pool.query(
+    `SELECT 1 FROM users u JOIN roles r ON r.id = u.role_id WHERE u.id = ? AND r.name = ?
+      UNION
+     SELECT 1 FROM user_roles ur JOIN roles r ON r.id = ur.role_id WHERE ur.user_id = ? AND r.name = ?
+      LIMIT 1`,
+    [userId, roleName, userId, roleName]
+  );
+  return rows.length > 0;
+}
+
+// POST /ext/qc/login  { username, password, device_label? } -> { ok, token, user }
+router.post('/login', async (req, res) => {
+  try {
+    const username = String(req.body.username || '').trim();
+    const password = String(req.body.password || '');
+    if (!username || !password) return res.status(400).json({ ok: false, error: 'username and password required' });
+
+    const [users] = await pool.query(
+      'SELECT id, username, password FROM users WHERE username = ? AND is_active = TRUE', [username]);
+    const user = users[0];
+    const ok = user && (await bcrypt.compare(password, user.password));
+    if (!ok) return res.status(401).json({ ok: false, error: 'invalid credentials' });
+    if (!(await userHasRole(user.id, REQUIRED_ROLE))) {
+      return res.status(403).json({ ok: false, error: `role '${REQUIRED_ROLE}' required` });
+    }
+    const raw = generateToken();
+    await pool.query(
+      'INSERT INTO qc_ext_tokens (token_hash, user_id, device_label) VALUES (?, ?, ?)',
+      [hashToken(raw), user.id, String(req.body.device_label || '').slice(0, 80) || null]);
+    return res.json({ ok: true, token: raw, user: { id: user.id, username: user.username } });
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+});
+
+// Bearer / x-qc-token -> req.qcUser. 401 (token) is distinct from 403 (role) so the extension
+// can tell "re-login" from "not authorized".
+async function requireQcToken(req, res, next) {
+  try {
+    const auth = req.get('authorization') || '';
+    const raw = auth.startsWith('Bearer ') ? auth.slice(7) : (req.get('x-qc-token') || '');
+    if (!raw) return res.status(401).json({ ok: false, error: 'missing token' });
+    const [rows] = await pool.query(
+      `SELECT t.id, t.user_id, u.username FROM qc_ext_tokens t
+         JOIN users u ON u.id = t.user_id
+        WHERE t.token_hash = ? AND t.revoked_at IS NULL AND u.is_active = TRUE`,
+      [hashToken(raw)]);
+    if (!rows.length) return res.status(401).json({ ok: false, error: 'invalid or revoked token' });
+    if (!(await userHasRole(rows[0].user_id, REQUIRED_ROLE))) {
+      return res.status(403).json({ ok: false, error: `role '${REQUIRED_ROLE}' required` });
+    }
+    req.qcUser = { id: rows[0].user_id, username: rows[0].username, tokenId: rows[0].id };
+    pool.query('UPDATE qc_ext_tokens SET last_used_at = NOW() WHERE id = ?', [rows[0].id]).catch(() => {});
+    return next();
+  } catch (e) {
+    return res.status(500).json({ ok: false, error: e.message });
+  }
+}
+
+// POST /ext/qc/capture  { records:[{ _type:'capture'|'pass', capture_uid, ... }] } -> { ok, accepted }
+// Idempotent (capture_uid PK + no-op upsert) and transactional — responds 200 only after commit,
+// which satisfies the extension's "remove from queue only after the backend confirms" contract.
+router.post('/capture', requireQcToken, async (req, res) => {
+  const records = Array.isArray(req.body.records) ? req.body.records : null;
+  if (!records) return res.status(400).json({ ok: false, error: 'records[] required' });
+  if (records.length > MAX_BATCH) return res.status(413).json({ ok: false, error: `batch too large (max ${MAX_BATCH})` });
+
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+    let accepted = 0;
+    for (const rec of records) {
+      if (rec && rec._type === 'pass') {
+        const r = normalizePass(rec, req.qcUser.id);
+        await conn.query(
+          `INSERT INTO qc_return_passes
+             (capture_uid, passed_by, item_barcode, oms_release_id, qc_action, quality, desk_code,
+              warehouse_id, pass_success, new_status, pass_error, passed_at, raw_json)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+           ON DUPLICATE KEY UPDATE ingested_at = ingested_at`,
+          [r.capture_uid, r.passed_by, r.item_barcode, r.oms_release_id, r.qc_action, r.quality,
+           r.desk_code, r.warehouse_id, r.pass_success, r.new_status, r.pass_error, r.passed_at, r.raw_json]);
+      } else {
+        const r = normalizeCapture(rec, req.qcUser.id);
+        await conn.query(
+          `INSERT INTO qc_return_captures
+             (capture_uid, captured_by, return_id, item_barcode, tracking_number, oms_release_id,
+              sku_id, sku_code, style_id, article_no, product_name, size, price, return_type,
+              return_mode, return_status, rms_status, qc_action, quality, logistics_status,
+              courier_code, return_hub, dispatch_wh, return_destination_wh, delivery_center,
+              ship_city, created_date, refund_date, return_received_on, return_restocked_on,
+              raw_json, captured_at)
+           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+           ON DUPLICATE KEY UPDATE ingested_at = ingested_at`,
+          [r.capture_uid, r.captured_by, r.return_id, r.item_barcode, r.tracking_number, r.oms_release_id,
+           r.sku_id, r.sku_code, r.style_id, r.article_no, r.product_name, r.size, r.price, r.return_type,
+           r.return_mode, r.return_status, r.rms_status, r.qc_action, r.quality, r.logistics_status,
+           r.courier_code, r.return_hub, r.dispatch_wh, r.return_destination_wh, r.delivery_center,
+           r.ship_city, r.created_date, r.refund_date, r.return_received_on, r.return_restocked_on,
+           r.raw_json, r.captured_at]);
+      }
+      accepted += 1;
+    }
+    await conn.commit();
+    return res.json({ ok: true, accepted });
+  } catch (e) {
+    await conn.rollback().catch(() => {});
+    return res.status(500).json({ ok: false, error: e.message });
+  } finally {
+    conn.release();
+  }
+});
+
+module.exports = { router, requireQcToken };

--- a/sql/2026_07_qc_extension.sql
+++ b/sql/2026_07_qc_extension.sql
@@ -1,0 +1,74 @@
+-- QC-Capture extension ingestion (see docs/plans/01-qcpass-extension.md).
+-- The `jitrgp` role already exists; login gates on it. Tokens are DB-backed + revocable.
+
+CREATE TABLE IF NOT EXISTS qc_ext_tokens (
+  id            INT AUTO_INCREMENT PRIMARY KEY,
+  token_hash    CHAR(64) NOT NULL UNIQUE,      -- sha256 of the raw token; raw is never stored
+  user_id       INT NOT NULL,
+  device_label  VARCHAR(80) NULL,
+  created_at    TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  last_used_at  TIMESTAMP NULL,
+  revoked_at    TIMESTAMP NULL,
+  INDEX idx_qet_user (user_id),
+  CONSTRAINT fk_qet_user FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS qc_return_captures (
+  capture_uid   CHAR(64) NOT NULL PRIMARY KEY, -- client-stable dedupe id (idempotent upsert)
+  captured_by   INT NOT NULL,
+  return_id     VARCHAR(40) NULL,
+  item_barcode  VARCHAR(60) NULL,
+  tracking_number VARCHAR(80) NULL,
+  oms_release_id VARCHAR(40) NULL,
+  sku_id        VARCHAR(40) NULL,
+  sku_code      VARCHAR(80) NULL,
+  style_id      VARCHAR(40) NULL,
+  article_no    VARCHAR(80) NULL,
+  product_name  VARCHAR(255) NULL,
+  size          VARCHAR(20) NULL,
+  price         DECIMAL(10,2) NULL,
+  return_type   VARCHAR(40) NULL,
+  return_mode   VARCHAR(40) NULL,
+  return_status VARCHAR(40) NULL,
+  rms_status    VARCHAR(40) NULL,
+  qc_action     VARCHAR(40) NULL,
+  quality       VARCHAR(20) NULL,
+  logistics_status VARCHAR(60) NULL,
+  courier_code  VARCHAR(40) NULL,
+  return_hub    VARCHAR(40) NULL,
+  dispatch_wh   VARCHAR(40) NULL,
+  return_destination_wh VARCHAR(40) NULL,
+  delivery_center VARCHAR(40) NULL,
+  ship_city     VARCHAR(80) NULL,
+  created_date  DATE NULL,
+  refund_date   DATE NULL,
+  return_received_on DATE NULL,
+  return_restocked_on DATE NULL,
+  raw_json      JSON NULL,                      -- full record, so nothing is lost pre-columnization
+  captured_at   DATETIME NULL,
+  ingested_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_qrc_return (return_id),
+  INDEX idx_qrc_barcode (item_barcode),
+  INDEX idx_qrc_by (captured_by),
+  INDEX idx_qrc_at (captured_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE IF NOT EXISTS qc_return_passes (
+  capture_uid   CHAR(64) NOT NULL PRIMARY KEY,
+  passed_by     INT NOT NULL,
+  item_barcode  VARCHAR(60) NULL,
+  oms_release_id VARCHAR(40) NULL,
+  qc_action     VARCHAR(40) NULL,
+  quality       VARCHAR(20) NULL,
+  desk_code     VARCHAR(20) NULL,
+  warehouse_id  VARCHAR(40) NULL,
+  pass_success  TINYINT(1) NULL,
+  new_status    VARCHAR(40) NULL,
+  pass_error    VARCHAR(255) NULL,
+  passed_at     DATETIME NULL,
+  raw_json      JSON NULL,
+  ingested_at   DATETIME DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_qrp_barcode (item_barcode),
+  INDEX idx_qrp_by (passed_by),
+  INDEX idx_qrp_at (passed_at)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/test/qcExtAuth.test.js
+++ b/test/qcExtAuth.test.js
@@ -1,0 +1,63 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  generateToken, hashToken, deriveCaptureUid, normalizeCapture, normalizePass,
+} = require('../utils/qcExtAuth.js');
+
+test('generateToken: 64 hex chars, unique per call', () => {
+  const a = generateToken();
+  const b = generateToken();
+  assert.match(a, /^[0-9a-f]{64}$/);
+  assert.notStrictEqual(a, b);
+});
+
+test('hashToken: deterministic sha256 hex, raw != hash', () => {
+  assert.strictEqual(hashToken('abc'), hashToken('abc'));
+  assert.match(hashToken('abc'), /^[0-9a-f]{64}$/);
+  assert.notStrictEqual(hashToken('abc'), 'abc');
+  assert.notStrictEqual(hashToken('abc'), hashToken('abd'));
+});
+
+test('deriveCaptureUid: stable per record, capture and pass differ', () => {
+  const cap = { return_id: 'R1', item_barcode: 'B1', captured_at: '2026-07-03T10:00:00Z' };
+  const u1 = deriveCaptureUid({ ...cap, _type: 'capture' });
+  const u2 = deriveCaptureUid({ ...cap, _type: 'capture' });
+  assert.strictEqual(u1, u2);                        // stable → idempotent
+  const pass = deriveCaptureUid({ item_barcode: 'B1', oms_release_id: 'O1', passed_at: 'x', _type: 'pass' });
+  assert.notStrictEqual(u1, pass);                   // different namespace
+  assert.match(u1, /^[0-9a-f]{64}$/);
+});
+
+test('normalizeCapture: maps + truncates fields, derives capture_uid, keeps raw_json', () => {
+  const rec = {
+    return_id: 'R1', item_barcode: 'B1', price: '499.5', size: 'XL',
+    product_name: 'x'.repeat(400), created_date: '2026-07-01T00:00:00Z', captured_at: '2026-07-03T10:00:00Z',
+    qc_action: 'QC_PASS', logistics_status: 'DELIVERED_TO_SELLER',
+  };
+  const r = normalizeCapture(rec, 42);
+  assert.strictEqual(r.captured_by, 42);
+  assert.match(r.capture_uid, /^[0-9a-f]{64}$/);
+  assert.strictEqual(r.price, 499.5);
+  assert.strictEqual(r.product_name.length, 255);    // truncated to column width
+  assert.strictEqual(r.created_date, '2026-07-01');  // DATE only
+  assert.ok(r.captured_at instanceof Date);
+  assert.deepStrictEqual(JSON.parse(r.raw_json).return_id, 'R1');
+});
+
+test('normalizeCapture: uses provided capture_uid when present; null-safe on empty', () => {
+  const r = normalizeCapture({ capture_uid: 'fixed-uid', item_barcode: '' }, 1);
+  assert.strictEqual(r.capture_uid, 'fixed-uid');
+  assert.strictEqual(r.item_barcode, null);          // '' -> null
+  assert.strictEqual(r.price, null);                 // missing -> null
+  assert.strictEqual(r.captured_at, null);
+});
+
+test('normalizePass: pass_success coerced to 1/0, fields mapped', () => {
+  const ok = normalizePass({ item_barcode: 'B1', pass_success: true, new_status: 'RESTOCKED', passed_at: '2026-07-03T10:00:00Z' }, 7);
+  assert.strictEqual(ok.passed_by, 7);
+  assert.strictEqual(ok.pass_success, 1);
+  assert.strictEqual(ok.new_status, 'RESTOCKED');
+  const bad = normalizePass({ item_barcode: 'B1', pass_success: false }, 7);
+  assert.strictEqual(bad.pass_success, 0);
+  assert.match(ok.capture_uid, /^[0-9a-f]{64}$/);
+});

--- a/utils/qcExtAuth.js
+++ b/utils/qcExtAuth.js
@@ -1,0 +1,66 @@
+// Pure helpers for the QC-Capture extension ingestion (docs/plans/01-qcpass-extension.md).
+// No DB here — token hashing, dedupe-id derivation, and record normalization are all pure
+// and unit-tested (test/qcExtAuth.test.js).
+const crypto = require('crypto');
+
+// Raw bearer token given to the extension once at login (64 hex chars).
+function generateToken() {
+  return crypto.randomBytes(32).toString('hex');
+}
+// Only the hash is stored server-side; the raw token is never persisted.
+function hashToken(raw) {
+  return crypto.createHash('sha256').update(String(raw)).digest('hex');
+}
+
+// Stable idempotency key per record. The extension should send `capture_uid`; if absent we
+// derive a deterministic one from the record's identifying fields so retries never double-insert.
+function deriveCaptureUid(rec) {
+  const type = rec._type === 'pass' ? 'pass' : 'capture';
+  const key = type === 'pass'
+    ? [rec.item_barcode, rec.oms_release_id, rec.passed_at].join('|')
+    : [rec.return_id, rec.item_barcode, rec.captured_at].join('|');
+  return crypto.createHash('sha256').update(type + '|' + key).digest('hex');
+}
+
+const S = (v, n) => (v == null || v === '' ? null : String(v).slice(0, n));
+const NUM = (v) => { const x = Number(v); return Number.isFinite(x) ? x : null; };
+const DAY = (v) => { if (!v) return null; const s = String(v).slice(0, 10); return /^\d{4}-\d{2}-\d{2}$/.test(s) ? s : null; };
+const DT = (v) => { if (!v) return null; const d = new Date(v); return Number.isNaN(d.getTime()) ? null : d; };
+
+function normalizeCapture(rec, capturedBy) {
+  const r = rec || {};
+  return {
+    capture_uid: r.capture_uid || deriveCaptureUid({ ...r, _type: 'capture' }),
+    captured_by: capturedBy,
+    return_id: S(r.return_id, 40), item_barcode: S(r.item_barcode, 60),
+    tracking_number: S(r.tracking_number, 80), oms_release_id: S(r.oms_release_id, 40),
+    sku_id: S(r.sku_id, 40), sku_code: S(r.sku_code, 80), style_id: S(r.style_id, 40),
+    article_no: S(r.article_no, 80), product_name: S(r.product_name, 255),
+    size: S(r.size, 20), price: NUM(r.price),
+    return_type: S(r.return_type, 40), return_mode: S(r.return_mode, 40),
+    return_status: S(r.return_status, 40), rms_status: S(r.rms_status, 40),
+    qc_action: S(r.qc_action, 40), quality: S(r.quality, 20),
+    logistics_status: S(r.logistics_status, 60), courier_code: S(r.courier_code, 40),
+    return_hub: S(r.return_hub, 40), dispatch_wh: S(r.dispatch_wh, 40),
+    return_destination_wh: S(r.return_destination_wh, 40), delivery_center: S(r.delivery_center, 40),
+    ship_city: S(r.ship_city, 80),
+    created_date: DAY(r.created_date), refund_date: DAY(r.refund_date),
+    return_received_on: DAY(r.return_received_on), return_restocked_on: DAY(r.return_restocked_on),
+    raw_json: JSON.stringify(r), captured_at: DT(r.captured_at),
+  };
+}
+
+function normalizePass(rec, passedBy) {
+  const r = rec || {};
+  return {
+    capture_uid: r.capture_uid || deriveCaptureUid({ ...r, _type: 'pass' }),
+    passed_by: passedBy,
+    item_barcode: S(r.item_barcode, 60), oms_release_id: S(r.oms_release_id, 40),
+    qc_action: S(r.qc_action, 40), quality: S(r.quality, 20), desk_code: S(r.desk_code, 20),
+    warehouse_id: S(r.warehouse_id, 40),
+    pass_success: r.pass_success ? 1 : 0, new_status: S(r.new_status, 40),
+    pass_error: S(r.pass_error, 255), passed_at: DT(r.passed_at), raw_json: JSON.stringify(r),
+  };
+}
+
+module.exports = { generateToken, hashToken, deriveCaptureUid, normalizeCapture, normalizePass };


### PR DESCRIPTION
First feature of the split (docs/plans/01) — the backend the QC-Capture Chrome extension needs to send its data into kotty-track, **restricted to the `jitrgp` role**, using **DB-backed opaque token auth** (your choices).

## Endpoints (mounted at `/ext/qc`, before the session middleware — token, no cookie)
- **`POST /ext/qc/login`** `{username,password,device_label?}` → bcrypt verify + require `jitrgp` (primary role or `user_roles`) → returns a raw bearer token (only its sha256 is stored).
- **`requireQcToken`** middleware → **401** (bad/missing token) vs **403** (missing role) so the extension can tell "re-login" from "not authorized".
- **`POST /ext/qc/capture`** `{records:[{_type,capture_uid,…}]}` → **idempotent upsert** (`capture_uid` PK, no-op on replay) inside **one transaction**; responds **200 only after commit** — matching the extension's "remove from queue only after the backend confirms" contract. Batch cap 500.

## Storage (`sql/2026_07_qc_extension.sql`)
`qc_ext_tokens` (revocable), `qc_return_captures`, `qc_return_passes` — each keeps `raw_json` so nothing is lost pre-columnization.

## Pure + tested
`utils/qcExtAuth.js` (token hash, stable `deriveCaptureUid`, record normalization) is fully pure and unit-tested (`test/qcExtAuth.test.js`, 6 tests). **121 tests pass.**

## Before it's live (follow-ups)
1. Apply the migration (additive, `CREATE TABLE IF NOT EXISTS`).
2. Grant `jitrgp` to a user.
3. Smoke-test `login` → `capture` (idempotency: same batch twice → second is a no-op).
4. Point the extension at `/ext/qc` + add its login UI + `capture_uid` + drop the localhost debug endpoints (next PR).

Depends on the test gate in #484.

🤖 Generated with [Claude Code](https://claude.com/claude-code)