### PR TITLE
fix(qc-ext): natural-key dedup (re-search a return -> one row, latest state)

### DIFF
--- a/docs/plans/01-qcpass-extension.md
+++ b/docs/plans/01-qcpass-extension.md
@@ -192,8 +192,51 @@ stored with the queued record). Without it, retries double-insert.
 - Confirm 401 handling: revoke the token mid-session → panel shows "re-login", queue preserved.
 
 ## Open decisions (need the user)
-1. **Token style**: DB-backed opaque (revocable, audited — recommended) vs stateless JWT (simpler).
+1. **Token style**: DB-backed opaque — DECIDED, built in #486.
 2. **What is the captured data *for* downstream** — pure QC/return audit store, or does it feed
    an RGP reconciliation / report? (Affects whether we build reporting now.)
 3. **Auto-pass in production** — keep the toggle, or capture-only? (It writes to Myntra.)
 4. **Where the extension points in prod** — main Cloud Run host, or a dedicated ingest path.
+
+---
+
+## Addendum (2026-07-03): dashboard, CSV recovery, concurrency, dedup
+
+### Status
+Backend shipped (#486) + natural-key dedup (#487). Tables exist on prod (empty). `jitrgp`
+role exists; **no user granted yet**. Extension client still points at localhost.
+
+### Dedup / re-capture (DONE — #487)
+Idempotency key is derived from the **return item** (`return_id+item_barcode` for captures,
+`item_barcode+oms_release_id` for passes), NOT the search timestamp. Re-searching the same
+return upserts ONE row (latest state); a pass is one event per item, attributed to `passed_by`.
+Server always derives the key → same dedup via API batch or CSV re-upload. Resolves the
+"search, don't pass; later search + pass" scenario cleanly.
+
+### Concurrency guarantee (by design)
+N users passing simultaneously is safe: per-user token, stateless endpoint (any instance),
+one transaction per batch on a pooled connection (pool 50 / queue 250), idempotent single-row
+upserts serializing on the PK in InnoDB. No shared mutable state, no dupes, no deadlock.
+
+### CSV backup + recovery (TO BUILD)
+- **Extension:** an "Export CSV" button dumps the IndexedDB queue / captured records to a local
+  CSV (safety net if the browser/queue is lost).
+- **Server:** `POST /ext/qc/upload-csv` (token + jitrgp) parses the CSV and ingests via the SAME
+  idempotent path → re-uploading is safe (dupes are no-ops). Any record recoverable by re-upload.
+
+### QC dashboard (TO BUILD)
+Session-gated web page (roles: admin + jitrgp + a manager role TBD), separate from the
+token-auth ingestion.
+- **Default view:** *today's* QC passes grouped by the user who passed them (count per user +
+  detail rows), from `qc_return_passes` ⋈ `qc_return_captures` ⋈ `users`.
+- **Filters:** date (single day or range, default today) + **enhanced** — user, quality,
+  qc_action, warehouse, logistics status, free-text on sku/style/barcode/tracking.
+- **CSV download** of the filtered result.
+- **API:** `GET /qc/api/passes?from=&to=&user=&quality=&q=…[&download=csv]`.
+- **Stack decision (open):** build as the first **React island** (target stack) vs a quick EJS
+  page now. Recommendation: React island (new feature = build in target stack).
+
+### Remaining extension-client work
+Point `BACKEND` at prod `/ext/qc/capture`; add login UI (`/ext/qc/login`, store token); handle
+401 (re-login) vs 5xx (retry); add the Export-CSV button; remove the localhost debug endpoints
++ `__qcRaw` dump. `capture_uid` now optional (server derives).

--- a/routes/qcExtensionRoutes.js
+++ b/routes/qcExtensionRoutes.js
@@ -96,7 +96,12 @@ router.post('/capture', requireQcToken, async (req, res) => {
              (capture_uid, passed_by, item_barcode, oms_release_id, qc_action, quality, desk_code,
               warehouse_id, pass_success, new_status, pass_error, passed_at, raw_json)
            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
-           ON DUPLICATE KEY UPDATE ingested_at = ingested_at`,
+           ON DUPLICATE KEY UPDATE
+             passed_by=VALUES(passed_by), qc_action=VALUES(qc_action), quality=VALUES(quality),
+             desk_code=VALUES(desk_code), warehouse_id=VALUES(warehouse_id),
+             pass_success=VALUES(pass_success), new_status=VALUES(new_status),
+             pass_error=VALUES(pass_error), passed_at=VALUES(passed_at),
+             raw_json=VALUES(raw_json), ingested_at=CURRENT_TIMESTAMP`,
           [r.capture_uid, r.passed_by, r.item_barcode, r.oms_release_id, r.qc_action, r.quality,
            r.desk_code, r.warehouse_id, r.pass_success, r.new_status, r.pass_error, r.passed_at, r.raw_json]);
       } else {
@@ -110,7 +115,19 @@ router.post('/capture', requireQcToken, async (req, res) => {
               ship_city, created_date, refund_date, return_received_on, return_restocked_on,
               raw_json, captured_at)
            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-           ON DUPLICATE KEY UPDATE ingested_at = ingested_at`,
+           ON DUPLICATE KEY UPDATE
+             captured_by=VALUES(captured_by), tracking_number=VALUES(tracking_number),
+             oms_release_id=VALUES(oms_release_id), sku_id=VALUES(sku_id), sku_code=VALUES(sku_code),
+             style_id=VALUES(style_id), article_no=VALUES(article_no), product_name=VALUES(product_name),
+             size=VALUES(size), price=VALUES(price), return_type=VALUES(return_type),
+             return_mode=VALUES(return_mode), return_status=VALUES(return_status),
+             rms_status=VALUES(rms_status), qc_action=VALUES(qc_action), quality=VALUES(quality),
+             logistics_status=VALUES(logistics_status), courier_code=VALUES(courier_code),
+             return_hub=VALUES(return_hub), dispatch_wh=VALUES(dispatch_wh),
+             return_destination_wh=VALUES(return_destination_wh), delivery_center=VALUES(delivery_center),
+             ship_city=VALUES(ship_city), created_date=VALUES(created_date), refund_date=VALUES(refund_date),
+             return_received_on=VALUES(return_received_on), return_restocked_on=VALUES(return_restocked_on),
+             raw_json=VALUES(raw_json), captured_at=VALUES(captured_at), ingested_at=CURRENT_TIMESTAMP`,
           [r.capture_uid, r.captured_by, r.return_id, r.item_barcode, r.tracking_number, r.oms_release_id,
            r.sku_id, r.sku_code, r.style_id, r.article_no, r.product_name, r.size, r.price, r.return_type,
            r.return_mode, r.return_status, r.rms_status, r.qc_action, r.quality, r.logistics_status,

--- a/test/qcExtAuth.test.js
+++ b/test/qcExtAuth.test.js
@@ -18,14 +18,20 @@ test('hashToken: deterministic sha256 hex, raw != hash', () => {
   assert.notStrictEqual(hashToken('abc'), hashToken('abd'));
 });
 
-test('deriveCaptureUid: stable per record, capture and pass differ', () => {
-  const cap = { return_id: 'R1', item_barcode: 'B1', captured_at: '2026-07-03T10:00:00Z' };
-  const u1 = deriveCaptureUid({ ...cap, _type: 'capture' });
-  const u2 = deriveCaptureUid({ ...cap, _type: 'capture' });
-  assert.strictEqual(u1, u2);                        // stable → idempotent
-  const pass = deriveCaptureUid({ item_barcode: 'B1', oms_release_id: 'O1', passed_at: 'x', _type: 'pass' });
-  assert.notStrictEqual(u1, pass);                   // different namespace
-  assert.match(u1, /^[0-9a-f]{64}$/);
+test('deriveCaptureUid: keyed on the return item, NOT the timestamp (re-search dedups)', () => {
+  // Same return item searched at two different times -> SAME uid -> upserts one row.
+  const t1 = deriveCaptureUid({ return_id: 'R1', item_barcode: 'B1', captured_at: '2026-07-03T10:00:00Z', _type: 'capture' });
+  const t2 = deriveCaptureUid({ return_id: 'R1', item_barcode: 'B1', captured_at: '2026-07-03T15:30:00Z', _type: 'capture' });
+  assert.strictEqual(t1, t2);                         // timestamp excluded from the key
+  // Different item -> different uid.
+  const other = deriveCaptureUid({ return_id: 'R1', item_barcode: 'B2', _type: 'capture' });
+  assert.notStrictEqual(t1, other);
+  // Pass is a separate namespace, keyed on item_barcode + oms (not passed_at).
+  const p1 = deriveCaptureUid({ item_barcode: 'B1', oms_release_id: 'O1', passed_at: 'x', _type: 'pass' });
+  const p2 = deriveCaptureUid({ item_barcode: 'B1', oms_release_id: 'O1', passed_at: 'y', _type: 'pass' });
+  assert.strictEqual(p1, p2);
+  assert.notStrictEqual(t1, p1);
+  assert.match(t1, /^[0-9a-f]{64}$/);
 });
 
 test('normalizeCapture: maps + truncates fields, derives capture_uid, keeps raw_json', () => {
@@ -44,9 +50,11 @@ test('normalizeCapture: maps + truncates fields, derives capture_uid, keeps raw_
   assert.deepStrictEqual(JSON.parse(r.raw_json).return_id, 'R1');
 });
 
-test('normalizeCapture: uses provided capture_uid when present; null-safe on empty', () => {
-  const r = normalizeCapture({ capture_uid: 'fixed-uid', item_barcode: '' }, 1);
-  assert.strictEqual(r.capture_uid, 'fixed-uid');
+test('normalizeCapture: server derives the key (ignores client capture_uid); null-safe', () => {
+  const withClientUid = normalizeCapture({ capture_uid: 'attacker-supplied', return_id: 'R1', item_barcode: 'B1' }, 1);
+  const derived = deriveCaptureUid({ return_id: 'R1', item_barcode: 'B1', _type: 'capture' });
+  assert.strictEqual(withClientUid.capture_uid, derived); // client uid ignored -> deterministic
+  const r = normalizeCapture({ return_id: 'R', item_barcode: '' }, 1);
   assert.strictEqual(r.item_barcode, null);          // '' -> null
   assert.strictEqual(r.price, null);                 // missing -> null
   assert.strictEqual(r.captured_at, null);

--- a/utils/qcExtAuth.js
+++ b/utils/qcExtAuth.js
@@ -12,13 +12,19 @@ function hashToken(raw) {
   return crypto.createHash('sha256').update(String(raw)).digest('hex');
 }
 
-// Stable idempotency key per record. The extension should send `capture_uid`; if absent we
-// derive a deterministic one from the record's identifying fields so retries never double-insert.
+// Deterministic idempotency key derived from the RETURN ITEM ITSELF (not the search moment),
+// so re-searching the same return upserts one row instead of creating duplicates, and the same
+// record arriving via API batch or CSV re-upload always dedupes to the same key.
+//   capture -> return_id + item_barcode   (one row per return item; latest state wins)
+//   pass    -> item_barcode + oms_release  (one pass event per item)
+// NOTE: timestamps are intentionally excluded from the key (that was the pre-#486-fix bug where
+// searching a return twice made two rows). The server always derives this — client-sent
+// capture_uid is ignored for dedup so a stale/mismatched client formula can't reintroduce dupes.
 function deriveCaptureUid(rec) {
   const type = rec._type === 'pass' ? 'pass' : 'capture';
   const key = type === 'pass'
-    ? [rec.item_barcode, rec.oms_release_id, rec.passed_at].join('|')
-    : [rec.return_id, rec.item_barcode, rec.captured_at].join('|');
+    ? [rec.item_barcode, rec.oms_release_id].join('|')
+    : [rec.return_id, rec.item_barcode].join('|');
   return crypto.createHash('sha256').update(type + '|' + key).digest('hex');
 }
 
@@ -30,7 +36,7 @@ const DT = (v) => { if (!v) return null; const d = new Date(v); return Number.is
 function normalizeCapture(rec, capturedBy) {
   const r = rec || {};
   return {
-    capture_uid: r.capture_uid || deriveCaptureUid({ ...r, _type: 'capture' }),
+    capture_uid: deriveCaptureUid({ ...r, _type: 'capture' }), // server-derived (client uid ignored)
     captured_by: capturedBy,
     return_id: S(r.return_id, 40), item_barcode: S(r.item_barcode, 60),
     tracking_number: S(r.tracking_number, 80), oms_release_id: S(r.oms_release_id, 40),
@@ -53,7 +59,7 @@ function normalizeCapture(rec, capturedBy) {
 function normalizePass(rec, passedBy) {
   const r = rec || {};
   return {
-    capture_uid: r.capture_uid || deriveCaptureUid({ ...r, _type: 'pass' }),
+    capture_uid: deriveCaptureUid({ ...r, _type: 'pass' }), // server-derived (client uid ignored)
     passed_by: passedBy,
     item_barcode: S(r.item_barcode, 60), oms_release_id: S(r.oms_release_id, 40),
     qc_action: S(r.qc_action, 40), quality: S(r.quality, 20), desk_code: S(r.desk_code, 20),


### PR DESCRIPTION
Handles the "search a return, don't pass; later search the same return and pass" scenario, and makes CSV re-upload safe.

**Problem (from #486):** the dedupe id included the capture timestamp, so searching the same return twice created two rows.

**Fix:** key on the **return item itself**, not the search moment —
- capture → `sha256('capture'|return_id|item_barcode)`
- pass → `sha256('pass'|item_barcode|oms_release_id)`

The **server always derives** the key (client-sent `capture_uid` ignored), so the same record dedupes identically via API batch **or** CSV re-upload, and a stale client formula can't reintroduce dupes.

The capture upsert now **updates mutable fields to the latest values** (was a no-op), so re-searching a return reflects its newest state (`qc_action` empty → `QC_PASS`). Net result: **one capture row per return item (latest state) + one pass event per item**, attributed to `passed_by`.

**Concurrency:** single-row upserts serialize on the PK in InnoDB — five users passing at once is safe, no dupes, no deadlock.

Tests updated (uid stable across timestamps; item vs pass namespaces; server ignores client uid). 6 tests pass.

Builds on #486 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)