### PR TITLE
fix(deploy): deploy immutable per-commit SHA image tag, not mutable :v2

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,6 +20,10 @@ steps:
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
+      # Immutable, per-commit tag — this is the ONLY tag we deploy from, so the running
+      # revision always matches the exact commit that triggered the build (no mutable-tag race).
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${SHORT_SHA}'
       - '-t'
       - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${_TAG}'
       - '-t'
@@ -40,8 +44,10 @@ steps:
       - 'run'
       - 'deploy'
       - '${_SERVICE_NAME}'
+      # Deploy the immutable SHA tag (NOT the mutable :${_TAG}/:latest) so concurrent merges
+      # can't race a stale image onto the running revision.
       - '--image'
-      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${_TAG}'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${SHORT_SHA}'
       - '--region'
       - '${_REGION}'
       - '--platform'
@@ -89,6 +95,7 @@ substitutions:
 
 # Store images in Artifact Registry
 images:
+  - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${SHORT_SHA}'
   - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:${_TAG}'
   - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO_NAME}/${_SERVICE_NAME}:latest'
 


### PR DESCRIPTION
## Problem: mutable-tag deploy race

`cloudbuild.yaml` built/pushed a **mutable** tag (`:${_TAG}`, default `:v2`) plus `:latest`, and deployed Cloud Run with `--image ...:${_TAG}`.

When several PRs merge within a short window, their triggered builds run concurrently and all write the **same** `:v2` tag. Whichever `docker push` lands last wins the tag, and the `gcloud run deploy` that resolves `:v2` can therefore pin an **older** commit's image onto the running revision. We just hit this in prod — a freshly merged route wasn't live because a racing build re-pointed `:v2`.

## Fix: deploy an immutable per-commit SHA tag

Cloud Build provides `$SHORT_SHA` for trigger-based builds (this is the `deploy-main-on-push` GitHub trigger, so it's always populated). We now build, push, and — critically — **deploy** the image by its commit SHA:

- **Build:** additionally tag `...:${SHORT_SHA}` (still also tags `:${_TAG}` and `:latest`).
- **Push:** unchanged (`--all-tags` pushes all three).
- **Deploy:** `--image ...:${SHORT_SHA}` instead of `:${_TAG}` — the running revision now always matches the exact commit that triggered the build. No two concurrent builds share this tag, so the race is gone.
- **`images:`** now lists the SHA tag so it's retained in Artifact Registry.

`:${_TAG}`/`:latest` are still pushed for humans but are never what gets deployed.

Everything else is unchanged: backend + frontend test-gate steps, `--memory`, `--min-instances`, secrets, `--update-env-vars`, region, timeout, substitutions. Only `cloudbuild.yaml` changed; no app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)