### PR TITLE
feat(qc-ext): CSV re-upload recovery for QC ingestion

### DIFF
--- a/docs/plans/01-qcpass-extension.md
+++ b/docs/plans/01-qcpass-extension.md
@@ -192,8 +192,51 @@ stored with the queued record). Without it, retries double-insert.
 - Confirm 401 handling: revoke the token mid-session → panel shows "re-login", queue preserved.
 
 ## Open decisions (need the user)
-1. **Token style**: DB-backed opaque (revocable, audited — recommended) vs stateless JWT (simpler).
+1. **Token style**: DB-backed opaque — DECIDED, built in #486.
 2. **What is the captured data *for* downstream** — pure QC/return audit store, or does it feed
    an RGP reconciliation / report? (Affects whether we build reporting now.)
 3. **Auto-pass in production** — keep the toggle, or capture-only? (It writes to Myntra.)
 4. **Where the extension points in prod** — main Cloud Run host, or a dedicated ingest path.
+
+---
+
+## Addendum (2026-07-03): dashboard, CSV recovery, concurrency, dedup
+
+### Status
+Backend shipped (#486) + natural-key dedup (#487). Tables exist on prod (empty). `jitrgp`
+role exists; **no user granted yet**. Extension client still points at localhost.
+
+### Dedup / re-capture (DONE — #487)
+Idempotency key is derived from the **return item** (`return_id+item_barcode` for captures,
+`item_barcode+oms_release_id` for passes), NOT the search timestamp. Re-searching the same
+return upserts ONE row (latest state); a pass is one event per item, attributed to `passed_by`.
+Server always derives the key → same dedup via API batch or CSV re-upload. Resolves the
+"search, don't pass; later search + pass" scenario cleanly.
+
+### Concurrency guarantee (by design)
+N users passing simultaneously is safe: per-user token, stateless endpoint (any instance),
+one transaction per batch on a pooled connection (pool 50 / queue 250), idempotent single-row
+upserts serializing on the PK in InnoDB. No shared mutable state, no dupes, no deadlock.
+
+### CSV backup + recovery (TO BUILD)
+- **Extension:** an "Export CSV" button dumps the IndexedDB queue / captured records to a local
+  CSV (safety net if the browser/queue is lost).
+- **Server:** `POST /ext/qc/upload-csv` (token + jitrgp) parses the CSV and ingests via the SAME
+  idempotent path → re-uploading is safe (dupes are no-ops). Any record recoverable by re-upload.
+
+### QC dashboard (TO BUILD)
+Session-gated web page (roles: admin + jitrgp + a manager role TBD), separate from the
+token-auth ingestion.
+- **Default view:** *today's* QC passes grouped by the user who passed them (count per user +
+  detail rows), from `qc_return_passes` ⋈ `qc_return_captures` ⋈ `users`.
+- **Filters:** date (single day or range, default today) + **enhanced** — user, quality,
+  qc_action, warehouse, logistics status, free-text on sku/style/barcode/tracking.
+- **CSV download** of the filtered result.
+- **API:** `GET /qc/api/passes?from=&to=&user=&quality=&q=…[&download=csv]`.
+- **Stack decision (open):** build as the first **React island** (target stack) vs a quick EJS
+  page now. Recommendation: React island (new feature = build in target stack).
+
+### Remaining extension-client work
+Point `BACKEND` at prod `/ext/qc/capture`; add login UI (`/ext/qc/login`, store token); handle
+401 (re-login) vs 5xx (retry); add the Export-CSV button; remove the localhost debug endpoints
++ `__qcRaw` dump. `capture_uid` now optional (server derives).

--- a/routes/qcExtensionRoutes.js
+++ b/routes/qcExtensionRoutes.js
@@ -4,12 +4,17 @@
 const express = require('express');
 const bcrypt = require('bcryptjs');
 const cors = require('cors');
+const multer = require('multer');
 const { pool } = require('../config/db');
 const { generateToken, hashToken, normalizeCapture, normalizePass } = require('../utils/qcExtAuth');
+const { parseCsv, rowsToRecords } = require('../utils/qcCsv');
 
 const router = express.Router();
 const REQUIRED_ROLE = 'jitrgp';
 const MAX_BATCH = 500;
+const MAX_CSV_ROWS = 5000;
+
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 25 * 1024 * 1024 } });
 
 // Token auth carries no cookie, so there's nothing to CSRF/steal — allow the extension origin.
 // Tighten to the fixed chrome-extension://<id> once the extension is published.
@@ -76,6 +81,63 @@ async function requireQcToken(req, res, next) {
   }
 }
 
+// Normalize + idempotently upsert each record on an open connection (inside the caller's
+// transaction). Server-derived dedupe keys make this safe to replay, so both the live /capture
+// batch and the CSV re-upload recovery path share ONE implementation. Returns the accepted count.
+async function ingestRecords(conn, records, userId) {
+  let accepted = 0;
+  for (const rec of records) {
+    if (rec && rec._type === 'pass') {
+      const r = normalizePass(rec, userId);
+      await conn.query(
+        `INSERT INTO qc_return_passes
+           (capture_uid, passed_by, item_barcode, oms_release_id, qc_action, quality, desk_code,
+            warehouse_id, pass_success, new_status, pass_error, passed_at, raw_json)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
+         ON DUPLICATE KEY UPDATE
+           passed_by=VALUES(passed_by), qc_action=VALUES(qc_action), quality=VALUES(quality),
+           desk_code=VALUES(desk_code), warehouse_id=VALUES(warehouse_id),
+           pass_success=VALUES(pass_success), new_status=VALUES(new_status),
+           pass_error=VALUES(pass_error), passed_at=VALUES(passed_at),
+           raw_json=VALUES(raw_json), ingested_at=CURRENT_TIMESTAMP`,
+        [r.capture_uid, r.passed_by, r.item_barcode, r.oms_release_id, r.qc_action, r.quality,
+         r.desk_code, r.warehouse_id, r.pass_success, r.new_status, r.pass_error, r.passed_at, r.raw_json]);
+    } else {
+      const r = normalizeCapture(rec, userId);
+      await conn.query(
+        `INSERT INTO qc_return_captures
+           (capture_uid, captured_by, return_id, item_barcode, tracking_number, oms_release_id,
+            sku_id, sku_code, style_id, article_no, product_name, size, price, return_type,
+            return_mode, return_status, rms_status, qc_action, quality, logistics_status,
+            courier_code, return_hub, dispatch_wh, return_destination_wh, delivery_center,
+            ship_city, created_date, refund_date, return_received_on, return_restocked_on,
+            raw_json, captured_at)
+         VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
+         ON DUPLICATE KEY UPDATE
+           captured_by=VALUES(captured_by), tracking_number=VALUES(tracking_number),
+           oms_release_id=VALUES(oms_release_id), sku_id=VALUES(sku_id), sku_code=VALUES(sku_code),
+           style_id=VALUES(style_id), article_no=VALUES(article_no), product_name=VALUES(product_name),
+           size=VALUES(size), price=VALUES(price), return_type=VALUES(return_type),
+           return_mode=VALUES(return_mode), return_status=VALUES(return_status),
+           rms_status=VALUES(rms_status), qc_action=VALUES(qc_action), quality=VALUES(quality),
+           logistics_status=VALUES(logistics_status), courier_code=VALUES(courier_code),
+           return_hub=VALUES(return_hub), dispatch_wh=VALUES(dispatch_wh),
+           return_destination_wh=VALUES(return_destination_wh), delivery_center=VALUES(delivery_center),
+           ship_city=VALUES(ship_city), created_date=VALUES(created_date), refund_date=VALUES(refund_date),
+           return_received_on=VALUES(return_received_on), return_restocked_on=VALUES(return_restocked_on),
+           raw_json=VALUES(raw_json), captured_at=VALUES(captured_at), ingested_at=CURRENT_TIMESTAMP`,
+        [r.capture_uid, r.captured_by, r.return_id, r.item_barcode, r.tracking_number, r.oms_release_id,
+         r.sku_id, r.sku_code, r.style_id, r.article_no, r.product_name, r.size, r.price, r.return_type,
+         r.return_mode, r.return_status, r.rms_status, r.qc_action, r.quality, r.logistics_status,
+         r.courier_code, r.return_hub, r.dispatch_wh, r.return_destination_wh, r.delivery_center,
+         r.ship_city, r.created_date, r.refund_date, r.return_received_on, r.return_restocked_on,
+         r.raw_json, r.captured_at]);
+    }
+    accepted += 1;
+  }
+  return accepted;
+}
+
 // POST /ext/qc/capture  { records:[{ _type:'capture'|'pass', capture_uid, ... }] } -> { ok, accepted }
 // Idempotent (capture_uid PK + no-op upsert) and transactional — responds 200 only after commit,
 // which satisfies the extension's "remove from queue only after the backend confirms" contract.
@@ -87,58 +149,42 @@ router.post('/capture', requireQcToken, async (req, res) => {
   const conn = await pool.getConnection();
   try {
     await conn.beginTransaction();
-    let accepted = 0;
-    for (const rec of records) {
-      if (rec && rec._type === 'pass') {
-        const r = normalizePass(rec, req.qcUser.id);
-        await conn.query(
-          `INSERT INTO qc_return_passes
-             (capture_uid, passed_by, item_barcode, oms_release_id, qc_action, quality, desk_code,
-              warehouse_id, pass_success, new_status, pass_error, passed_at, raw_json)
-           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
-           ON DUPLICATE KEY UPDATE
-             passed_by=VALUES(passed_by), qc_action=VALUES(qc_action), quality=VALUES(quality),
-             desk_code=VALUES(desk_code), warehouse_id=VALUES(warehouse_id),
-             pass_success=VALUES(pass_success), new_status=VALUES(new_status),
-             pass_error=VALUES(pass_error), passed_at=VALUES(passed_at),
-             raw_json=VALUES(raw_json), ingested_at=CURRENT_TIMESTAMP`,
-          [r.capture_uid, r.passed_by, r.item_barcode, r.oms_release_id, r.qc_action, r.quality,
-           r.desk_code, r.warehouse_id, r.pass_success, r.new_status, r.pass_error, r.passed_at, r.raw_json]);
-      } else {
-        const r = normalizeCapture(rec, req.qcUser.id);
-        await conn.query(
-          `INSERT INTO qc_return_captures
-             (capture_uid, captured_by, return_id, item_barcode, tracking_number, oms_release_id,
-              sku_id, sku_code, style_id, article_no, product_name, size, price, return_type,
-              return_mode, return_status, rms_status, qc_action, quality, logistics_status,
-              courier_code, return_hub, dispatch_wh, return_destination_wh, delivery_center,
-              ship_city, created_date, refund_date, return_received_on, return_restocked_on,
-              raw_json, captured_at)
-           VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-           ON DUPLICATE KEY UPDATE
-             captured_by=VALUES(captured_by), tracking_number=VALUES(tracking_number),
-             oms_release_id=VALUES(oms_release_id), sku_id=VALUES(sku_id), sku_code=VALUES(sku_code),
-             style_id=VALUES(style_id), article_no=VALUES(article_no), product_name=VALUES(product_name),
-             size=VALUES(size), price=VALUES(price), return_type=VALUES(return_type),
-             return_mode=VALUES(return_mode), return_status=VALUES(return_status),
-             rms_status=VALUES(rms_status), qc_action=VALUES(qc_action), quality=VALUES(quality),
-             logistics_status=VALUES(logistics_status), courier_code=VALUES(courier_code),
-             return_hub=VALUES(return_hub), dispatch_wh=VALUES(dispatch_wh),
-             return_destination_wh=VALUES(return_destination_wh), delivery_center=VALUES(delivery_center),
-             ship_city=VALUES(ship_city), created_date=VALUES(created_date), refund_date=VALUES(refund_date),
-             return_received_on=VALUES(return_received_on), return_restocked_on=VALUES(return_restocked_on),
-             raw_json=VALUES(raw_json), captured_at=VALUES(captured_at), ingested_at=CURRENT_TIMESTAMP`,
-          [r.capture_uid, r.captured_by, r.return_id, r.item_barcode, r.tracking_number, r.oms_release_id,
-           r.sku_id, r.sku_code, r.style_id, r.article_no, r.product_name, r.size, r.price, r.return_type,
-           r.return_mode, r.return_status, r.rms_status, r.qc_action, r.quality, r.logistics_status,
-           r.courier_code, r.return_hub, r.dispatch_wh, r.return_destination_wh, r.delivery_center,
-           r.ship_city, r.created_date, r.refund_date, r.return_received_on, r.return_restocked_on,
-           r.raw_json, r.captured_at]);
-      }
-      accepted += 1;
-    }
+    const accepted = await ingestRecords(conn, records, req.qcUser.id);
     await conn.commit();
     return res.json({ ok: true, accepted });
+  } catch (e) {
+    await conn.rollback().catch(() => {});
+    return res.status(500).json({ ok: false, error: e.message });
+  } finally {
+    conn.release();
+  }
+});
+
+// POST /ext/qc/upload-csv  (multipart, field "file") -> { ok, accepted, parsed }
+// Recovery path: the extension keeps a local CSV of everything it captured; re-uploading it here
+// re-runs ingestion. Because dedupe keys are server-derived, replays are no-ops, so this can be
+// run repeatedly without creating duplicates.
+router.post('/upload-csv', requireQcToken, upload.single('file'), async (req, res) => {
+  if (!req.file || !req.file.buffer) {
+    return res.status(400).json({ ok: false, error: 'file required (multipart field "file")' });
+  }
+  let records;
+  try {
+    const rows = parseCsv(req.file.buffer.toString('utf8'));
+    records = rowsToRecords(rows);
+  } catch (e) {
+    return res.status(400).json({ ok: false, error: `could not parse CSV: ${e.message}` });
+  }
+  const parsed = records.length;
+  if (parsed === 0) return res.status(400).json({ ok: false, error: 'no data rows found in CSV' });
+  if (parsed > MAX_CSV_ROWS) return res.status(413).json({ ok: false, error: `too many rows (max ${MAX_CSV_ROWS})` });
+
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+    const accepted = await ingestRecords(conn, records, req.qcUser.id);
+    await conn.commit();
+    return res.json({ ok: true, accepted, parsed });
   } catch (e) {
     await conn.rollback().catch(() => {});
     return res.status(500).json({ ok: false, error: e.message });

--- a/routes/qcExtensionRoutes.js
+++ b/routes/qcExtensionRoutes.js
@@ -96,7 +96,12 @@ router.post('/capture', requireQcToken, async (req, res) => {
              (capture_uid, passed_by, item_barcode, oms_release_id, qc_action, quality, desk_code,
               warehouse_id, pass_success, new_status, pass_error, passed_at, raw_json)
            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)
-           ON DUPLICATE KEY UPDATE ingested_at = ingested_at`,
+           ON DUPLICATE KEY UPDATE
+             passed_by=VALUES(passed_by), qc_action=VALUES(qc_action), quality=VALUES(quality),
+             desk_code=VALUES(desk_code), warehouse_id=VALUES(warehouse_id),
+             pass_success=VALUES(pass_success), new_status=VALUES(new_status),
+             pass_error=VALUES(pass_error), passed_at=VALUES(passed_at),
+             raw_json=VALUES(raw_json), ingested_at=CURRENT_TIMESTAMP`,
           [r.capture_uid, r.passed_by, r.item_barcode, r.oms_release_id, r.qc_action, r.quality,
            r.desk_code, r.warehouse_id, r.pass_success, r.new_status, r.pass_error, r.passed_at, r.raw_json]);
       } else {
@@ -110,7 +115,19 @@ router.post('/capture', requireQcToken, async (req, res) => {
               ship_city, created_date, refund_date, return_received_on, return_restocked_on,
               raw_json, captured_at)
            VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)
-           ON DUPLICATE KEY UPDATE ingested_at = ingested_at`,
+           ON DUPLICATE KEY UPDATE
+             captured_by=VALUES(captured_by), tracking_number=VALUES(tracking_number),
+             oms_release_id=VALUES(oms_release_id), sku_id=VALUES(sku_id), sku_code=VALUES(sku_code),
+             style_id=VALUES(style_id), article_no=VALUES(article_no), product_name=VALUES(product_name),
+             size=VALUES(size), price=VALUES(price), return_type=VALUES(return_type),
+             return_mode=VALUES(return_mode), return_status=VALUES(return_status),
+             rms_status=VALUES(rms_status), qc_action=VALUES(qc_action), quality=VALUES(quality),
+             logistics_status=VALUES(logistics_status), courier_code=VALUES(courier_code),
+             return_hub=VALUES(return_hub), dispatch_wh=VALUES(dispatch_wh),
+             return_destination_wh=VALUES(return_destination_wh), delivery_center=VALUES(delivery_center),
+             ship_city=VALUES(ship_city), created_date=VALUES(created_date), refund_date=VALUES(refund_date),
+             return_received_on=VALUES(return_received_on), return_restocked_on=VALUES(return_restocked_on),
+             raw_json=VALUES(raw_json), captured_at=VALUES(captured_at), ingested_at=CURRENT_TIMESTAMP`,
           [r.capture_uid, r.captured_by, r.return_id, r.item_barcode, r.tracking_number, r.oms_release_id,
            r.sku_id, r.sku_code, r.style_id, r.article_no, r.product_name, r.size, r.price, r.return_type,
            r.return_mode, r.return_status, r.rms_status, r.qc_action, r.quality, r.logistics_status,

--- a/test/qcCsv.test.js
+++ b/test/qcCsv.test.js
@@ -1,0 +1,83 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { parseCsv, rowsToRecords } = require('../utils/qcCsv.js');
+
+test('parseCsv handles quoted fields containing commas and quotes', () => {
+  const rows = parseCsv('a,"b,c","she said ""hi"""\n1,2,3');
+  assert.deepStrictEqual(rows, [
+    ['a', 'b,c', 'she said "hi"'],
+    ['1', '2', '3'],
+  ]);
+});
+
+test('parseCsv handles a quoted field spanning newlines', () => {
+  const rows = parseCsv('x,y\n"line1\nline2",z');
+  assert.deepStrictEqual(rows, [
+    ['x', 'y'],
+    ['line1\nline2', 'z'],
+  ]);
+});
+
+test('parseCsv treats CRLF and LF identically and drops a trailing newline', () => {
+  const lf = parseCsv('a,b\n1,2\n');
+  const crlf = parseCsv('a,b\r\n1,2\r\n');
+  assert.deepStrictEqual(lf, [['a', 'b'], ['1', '2']]);
+  assert.deepStrictEqual(crlf, lf);
+});
+
+test('parseCsv strips a leading UTF-8 BOM', () => {
+  const rows = parseCsv('﻿return_id,item_barcode\nR1,B1');
+  assert.strictEqual(rows[0][0], 'return_id');
+});
+
+test('rowsToRecords maps header-driven rows and defaults _type to capture', () => {
+  const rows = parseCsv('return_id,item_barcode,size\nR1,B1,M');
+  const recs = rowsToRecords(rows);
+  assert.strictEqual(recs.length, 1);
+  assert.strictEqual(recs[0]._type, 'capture');
+  assert.strictEqual(recs[0].return_id, 'R1');
+  assert.strictEqual(recs[0].item_barcode, 'B1');
+  assert.strictEqual(recs[0].size, 'M');
+});
+
+test('rowsToRecords honours an explicit _type column (pass) case-insensitively', () => {
+  const rows = parseCsv('_type,item_barcode,oms_release_id\nPASS,B9,OMS9\ncapture,B1,OMS1');
+  const recs = rowsToRecords(rows);
+  assert.strictEqual(recs[0]._type, 'pass');
+  assert.strictEqual(recs[1]._type, 'capture');
+});
+
+test('rowsToRecords is header case-insensitive and maps known fields', () => {
+  const rows = parseCsv('Return_ID,Item_Barcode\nR1,B1');
+  const recs = rowsToRecords(rows);
+  assert.strictEqual(recs[0].return_id, 'R1');
+  assert.strictEqual(recs[0].item_barcode, 'B1');
+});
+
+test('rowsToRecords sets missing known columns to null and empty cells to null', () => {
+  const rows = parseCsv('return_id,item_barcode,size\nR1,,');
+  const recs = rowsToRecords(rows);
+  // present-but-empty cells -> null
+  assert.strictEqual(recs[0].item_barcode, null);
+  assert.strictEqual(recs[0].size, null);
+  // known fields not in the header -> null
+  assert.strictEqual(recs[0].qc_action, null);
+  assert.strictEqual(recs[0].quality, null);
+  assert.strictEqual(recs[0].oms_release_id, null);
+  // populated cell survives
+  assert.strictEqual(recs[0].return_id, 'R1');
+});
+
+test('rowsToRecords skips fully-empty rows (blank lines / all-empty cells)', () => {
+  const rows = parseCsv('return_id,item_barcode\nR1,B1\n\n,,\nR2,B2\n');
+  const recs = rowsToRecords(rows);
+  assert.strictEqual(recs.length, 2);
+  assert.strictEqual(recs[0].return_id, 'R1');
+  assert.strictEqual(recs[1].return_id, 'R2');
+});
+
+test('rowsToRecords returns [] for empty input or header-only input', () => {
+  assert.deepStrictEqual(rowsToRecords([]), []);
+  assert.deepStrictEqual(rowsToRecords(parseCsv('')), []);
+  assert.deepStrictEqual(rowsToRecords(parseCsv('return_id,item_barcode')), []);
+});

--- a/test/qcExtAuth.test.js
+++ b/test/qcExtAuth.test.js
@@ -18,14 +18,20 @@ test('hashToken: deterministic sha256 hex, raw != hash', () => {
   assert.notStrictEqual(hashToken('abc'), hashToken('abd'));
 });
 
-test('deriveCaptureUid: stable per record, capture and pass differ', () => {
-  const cap = { return_id: 'R1', item_barcode: 'B1', captured_at: '2026-07-03T10:00:00Z' };
-  const u1 = deriveCaptureUid({ ...cap, _type: 'capture' });
-  const u2 = deriveCaptureUid({ ...cap, _type: 'capture' });
-  assert.strictEqual(u1, u2);                        // stable → idempotent
-  const pass = deriveCaptureUid({ item_barcode: 'B1', oms_release_id: 'O1', passed_at: 'x', _type: 'pass' });
-  assert.notStrictEqual(u1, pass);                   // different namespace
-  assert.match(u1, /^[0-9a-f]{64}$/);
+test('deriveCaptureUid: keyed on the return item, NOT the timestamp (re-search dedups)', () => {
+  // Same return item searched at two different times -> SAME uid -> upserts one row.
+  const t1 = deriveCaptureUid({ return_id: 'R1', item_barcode: 'B1', captured_at: '2026-07-03T10:00:00Z', _type: 'capture' });
+  const t2 = deriveCaptureUid({ return_id: 'R1', item_barcode: 'B1', captured_at: '2026-07-03T15:30:00Z', _type: 'capture' });
+  assert.strictEqual(t1, t2);                         // timestamp excluded from the key
+  // Different item -> different uid.
+  const other = deriveCaptureUid({ return_id: 'R1', item_barcode: 'B2', _type: 'capture' });
+  assert.notStrictEqual(t1, other);
+  // Pass is a separate namespace, keyed on item_barcode + oms (not passed_at).
+  const p1 = deriveCaptureUid({ item_barcode: 'B1', oms_release_id: 'O1', passed_at: 'x', _type: 'pass' });
+  const p2 = deriveCaptureUid({ item_barcode: 'B1', oms_release_id: 'O1', passed_at: 'y', _type: 'pass' });
+  assert.strictEqual(p1, p2);
+  assert.notStrictEqual(t1, p1);
+  assert.match(t1, /^[0-9a-f]{64}$/);
 });
 
 test('normalizeCapture: maps + truncates fields, derives capture_uid, keeps raw_json', () => {
@@ -44,9 +50,11 @@ test('normalizeCapture: maps + truncates fields, derives capture_uid, keeps raw_
   assert.deepStrictEqual(JSON.parse(r.raw_json).return_id, 'R1');
 });
 
-test('normalizeCapture: uses provided capture_uid when present; null-safe on empty', () => {
-  const r = normalizeCapture({ capture_uid: 'fixed-uid', item_barcode: '' }, 1);
-  assert.strictEqual(r.capture_uid, 'fixed-uid');
+test('normalizeCapture: server derives the key (ignores client capture_uid); null-safe', () => {
+  const withClientUid = normalizeCapture({ capture_uid: 'attacker-supplied', return_id: 'R1', item_barcode: 'B1' }, 1);
+  const derived = deriveCaptureUid({ return_id: 'R1', item_barcode: 'B1', _type: 'capture' });
+  assert.strictEqual(withClientUid.capture_uid, derived); // client uid ignored -> deterministic
+  const r = normalizeCapture({ return_id: 'R', item_barcode: '' }, 1);
   assert.strictEqual(r.item_barcode, null);          // '' -> null
   assert.strictEqual(r.price, null);                 // missing -> null
   assert.strictEqual(r.captured_at, null);

--- a/utils/qcCsv.js
+++ b/utils/qcCsv.js
@@ -1,0 +1,94 @@
+// Pure CSV parsing/mapping for the QC-Capture recovery upload (routes/qcExtensionRoutes.js).
+// No DB, no I/O — takes CSV text, returns the same record shape the /capture endpoint accepts
+// (fed through normalizeCapture/normalizePass). Unit-tested in test/qcCsv.test.js.
+
+// Field names normalizeCapture/normalizePass read. Always present on the output record (null when
+// the column is absent) so downstream normalization is uniform and "missing column" is explicit.
+const KNOWN_FIELDS = [
+  // capture
+  'return_id', 'item_barcode', 'tracking_number', 'oms_release_id', 'sku_id', 'sku_code',
+  'style_id', 'article_no', 'product_name', 'size', 'price', 'return_type', 'return_mode',
+  'return_status', 'rms_status', 'qc_action', 'quality', 'logistics_status', 'courier_code',
+  'return_hub', 'dispatch_wh', 'return_destination_wh', 'delivery_center', 'ship_city',
+  'created_date', 'refund_date', 'return_received_on', 'return_restocked_on', 'captured_at',
+  // pass-only
+  'desk_code', 'warehouse_id', 'pass_success', 'new_status', 'pass_error', 'passed_at',
+];
+
+// Robust RFC-4180-ish parser: quoted fields (with commas, newlines and "" escapes), CRLF or LF
+// line endings, and a leading UTF-8 BOM. Returns a rectangular-ish string[][] (rows of cells).
+function parseCsv(text) {
+  let s = text == null ? '' : String(text);
+  if (s.charCodeAt(0) === 0xFEFF) s = s.slice(1); // strip BOM
+  const rows = [];
+  let row = [];
+  let field = '';
+  let inQuotes = false;
+  const n = s.length;
+  for (let i = 0; i < n; i++) {
+    const c = s[i];
+    if (inQuotes) {
+      if (c === '"') {
+        if (s[i + 1] === '"') { field += '"'; i++; } // escaped quote
+        else inQuotes = false;
+      } else {
+        field += c;
+      }
+      continue;
+    }
+    if (c === '"') { inQuotes = true; continue; }
+    if (c === ',') { row.push(field); field = ''; continue; }
+    if (c === '\r') {
+      row.push(field); field = '';
+      rows.push(row); row = [];
+      if (s[i + 1] === '\n') i++; // CRLF
+      continue;
+    }
+    if (c === '\n') {
+      row.push(field); field = '';
+      rows.push(row); row = [];
+      continue;
+    }
+    field += c;
+  }
+  // Flush the final field/row unless the input ended exactly on a line break (no trailing content).
+  if (field !== '' || row.length > 0) {
+    row.push(field);
+    rows.push(row);
+  }
+  return rows;
+}
+
+function isEmptyRow(row) {
+  return !Array.isArray(row) || row.every((c) => c == null || String(c).trim() === '');
+}
+
+// Header-driven mapping: first non-empty row is the header (case-insensitive, trimmed). Each
+// subsequent non-empty row becomes a record keyed by header. Empty cells -> null. `_type` defaults
+// to 'capture' (only an explicit 'pass' selects the pass path). Tolerant of missing columns.
+function rowsToRecords(rows) {
+  if (!Array.isArray(rows) || rows.length === 0) return [];
+  let h = 0;
+  while (h < rows.length && isEmptyRow(rows[h])) h++;
+  if (h >= rows.length) return [];
+  const header = rows[h].map((x) => String(x == null ? '' : x).trim().toLowerCase());
+
+  const records = [];
+  for (let i = h + 1; i < rows.length; i++) {
+    const row = rows[i];
+    if (isEmptyRow(row)) continue;
+    const rec = {};
+    for (let c = 0; c < header.length; c++) {
+      const key = header[c];
+      if (!key) continue;
+      const raw = row[c] == null ? '' : String(row[c]).trim();
+      rec[key] = raw === '' ? null : raw;
+    }
+    rec._type = String(rec._type || '').toLowerCase() === 'pass' ? 'pass' : 'capture';
+    for (const f of KNOWN_FIELDS) if (!(f in rec)) rec[f] = null;
+    records.push(rec);
+  }
+  return records;
+}
+
+module.exports = { parseCsv, rowsToRecords, KNOWN_FIELDS };

--- a/utils/qcExtAuth.js
+++ b/utils/qcExtAuth.js
@@ -12,13 +12,19 @@ function hashToken(raw) {
   return crypto.createHash('sha256').update(String(raw)).digest('hex');
 }
 
-// Stable idempotency key per record. The extension should send `capture_uid`; if absent we
-// derive a deterministic one from the record's identifying fields so retries never double-insert.
+// Deterministic idempotency key derived from the RETURN ITEM ITSELF (not the search moment),
+// so re-searching the same return upserts one row instead of creating duplicates, and the same
+// record arriving via API batch or CSV re-upload always dedupes to the same key.
+//   capture -> return_id + item_barcode   (one row per return item; latest state wins)
+//   pass    -> item_barcode + oms_release  (one pass event per item)
+// NOTE: timestamps are intentionally excluded from the key (that was the pre-#486-fix bug where
+// searching a return twice made two rows). The server always derives this — client-sent
+// capture_uid is ignored for dedup so a stale/mismatched client formula can't reintroduce dupes.
 function deriveCaptureUid(rec) {
   const type = rec._type === 'pass' ? 'pass' : 'capture';
   const key = type === 'pass'
-    ? [rec.item_barcode, rec.oms_release_id, rec.passed_at].join('|')
-    : [rec.return_id, rec.item_barcode, rec.captured_at].join('|');
+    ? [rec.item_barcode, rec.oms_release_id].join('|')
+    : [rec.return_id, rec.item_barcode].join('|');
   return crypto.createHash('sha256').update(type + '|' + key).digest('hex');
 }
 
@@ -30,7 +36,7 @@ const DT = (v) => { if (!v) return null; const d = new Date(v); return Number.is
 function normalizeCapture(rec, capturedBy) {
   const r = rec || {};
   return {
-    capture_uid: r.capture_uid || deriveCaptureUid({ ...r, _type: 'capture' }),
+    capture_uid: deriveCaptureUid({ ...r, _type: 'capture' }), // server-derived (client uid ignored)
     captured_by: capturedBy,
     return_id: S(r.return_id, 40), item_barcode: S(r.item_barcode, 60),
     tracking_number: S(r.tracking_number, 80), oms_release_id: S(r.oms_release_id, 40),
@@ -53,7 +59,7 @@ function normalizeCapture(rec, capturedBy) {
 function normalizePass(rec, passedBy) {
   const r = rec || {};
   return {
-    capture_uid: r.capture_uid || deriveCaptureUid({ ...r, _type: 'pass' }),
+    capture_uid: deriveCaptureUid({ ...r, _type: 'pass' }), // server-derived (client uid ignored)
     passed_by: passedBy,
     item_barcode: S(r.item_barcode, 60), oms_release_id: S(r.oms_release_id, 40),
     qc_action: S(r.qc_action, 40), quality: S(r.quality, 20), desk_code: S(r.desk_code, 20),


### PR DESCRIPTION
## What

Adds a CSV recovery upload to the QC-Capture extension ingestion API. The extension keeps a local CSV of everything it captured; this endpoint lets a user re-upload that CSV so nothing is lost. Because dedupe keys are server-derived, re-uploading is idempotent — dupes are no-ops.

## Changes (only 3 files touched)

- **`routes/qcExtensionRoutes.js`**
  - Refactored the per-record normalize+upsert loop out of `POST /capture` into a reusable `async ingestRecords(conn, records, userId)` (returns accepted count). `/capture` now calls it — behavior unchanged.
  - Added `POST /ext/qc/upload-csv`, gated by `requireQcToken`, using `multer` memoryStorage (`upload.single('file')`). Parses the CSV, maps rows to records, runs `ingestRecords` inside ONE transaction, and responds `{ ok, accepted, parsed }`. Caps at 5000 rows (413 if larger).
- **`utils/qcCsv.js`** (new) — pure parse/map, no DB/IO:
  - `parseCsv(text) -> string[][]`: quoted fields with commas, embedded newlines, `""` escapes, CRLF/LF, and leading BOM.
  - `rowsToRecords(rows) -> record[]`: header-driven (case-insensitive), `_type` defaults to `capture`, missing/empty cells → null, fully-empty rows skipped.
- **`test/qcCsv.test.js`** (new) — 10 `node:test` cases covering quoted fields, CRLF/LF, BOM, `_type` defaulting/`pass`, missing columns → nulls, empty-row skip, and empty/header-only input.

No changes to app.js, cloudbuild.yaml, frontend/, qcpass_extension/, or productionManagerRoutes.js. Reuses `requireQcToken` and the existing normalize/upsert SQL via the shared `ingestRecords` (no duplicated SQL).

## Tests

`NODE_ENV=test node --test` is green — 136 tests pass (10 new).

## Dependency

Stacks on / depends on **#487** (`fix/qc-ingest-natural-key`) — branched off that branch for the natural-key dedup, and targets `main`. Merge #487 first (or rebase this once #487 lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)