### PR TITLE
feat(qc-ext): point extension at prod + login + Export-CSV, drop debug

### DIFF
--- a/qcpass_extension/background.js
+++ b/qcpass_extension/background.js
@@ -1,0 +1,133 @@
+// Service worker: the DURABLE queue + authenticated sync. Every captured record is written to
+// IndexedDB FIRST (survives crashes / reloads / offline), then synced to the kotty-track backend
+// with retries. Nothing is lost: a record only leaves the queue after the backend confirms 200.
+//
+// Config lives in chrome.storage.local:
+//   apiBase — backend base URL (defaults to prod below)
+//   token   — Bearer token from POST /ext/qc/login (set by popup.js)
+//
+// A rolling copy of every record is also kept in a 'log' store so "Export CSV" still works after
+// the records have synced and left the queue (the local safety net for /ext/qc/upload-csv).
+const DEFAULT_API_BASE = 'https://kotty-track-fwlq5ofeza-el.a.run.app';
+const BATCH = 100;
+const LOG_CAP = 10000;
+const DB_NAME = 'qc_capture', STORE = 'queue', LOG = 'log';
+
+function apiBaseClean(base) { return String(base || DEFAULT_API_BASE).replace(/\/+$/, ''); }
+function captureUrl(base) { return apiBaseClean(base) + '/ext/qc/capture'; }
+function getConfig() {
+  return new Promise((resolve) => {
+    chrome.storage.local.get(['apiBase', 'token'], (r) => {
+      resolve({ apiBase: apiBaseClean(r && r.apiBase), token: (r && r.token) || '' });
+    });
+  });
+}
+
+function idb() {
+  return new Promise((resolve, reject) => {
+    const r = indexedDB.open(DB_NAME, 2);
+    r.onupgradeneeded = () => {
+      const db = r.result;
+      if (!db.objectStoreNames.contains(STORE)) db.createObjectStore(STORE, { keyPath: 'k', autoIncrement: true });
+      if (!db.objectStoreNames.contains(LOG)) db.createObjectStore(LOG, { keyPath: 'k', autoIncrement: true });
+    };
+    r.onsuccess = () => resolve(r.result); r.onerror = () => reject(r.error);
+  });
+}
+async function tx(store, mode, fn) { const db = await idb(); return new Promise((res, rej) => { const t = db.transaction(store, mode); const s = t.objectStore(store); const out = fn(s); t.oncomplete = () => res(out); t.onerror = () => rej(t.error); }); }
+const enqueue = (rec) => tx(STORE, 'readwrite', (s) => s.add({ rec, ts: Date.now() }));
+function readAll() { return tx(STORE, 'readonly', (s) => { const out = []; s.openCursor().onsuccess = (e) => { const c = e.target.result; if (c) { out.push({ k: c.key, ...c.value }); c.continue(); } }; return out; }); }
+const remove = (keys) => tx(STORE, 'readwrite', (s) => keys.forEach((k) => s.delete(k)));
+function count() { return tx(STORE, 'readonly', (s) => { let n = 0; s.openCursor().onsuccess = (e) => { const c = e.target.result; if (c) { n++; c.continue(); } }; return n; }); }
+
+// Rolling log (durable copy for CSV export). Appends the record, then trims oldest rows > LOG_CAP.
+function logCount() { return tx(LOG, 'readonly', (s) => { let n = 0; s.openCursor().onsuccess = (e) => { const c = e.target.result; if (c) { n++; c.continue(); } }; return n; }); }
+async function appendLog(rec) {
+  await tx(LOG, 'readwrite', (s) => s.add({ rec, ts: Date.now() }));
+  try {
+    const n = await logCount();
+    const extra = n - LOG_CAP;
+    if (extra > 0) {
+      await tx(LOG, 'readwrite', (s) => {
+        let deleted = 0;
+        s.openCursor().onsuccess = (e) => { const c = e.target.result; if (c && deleted < extra) { c.delete(); deleted++; c.continue(); } };
+      });
+    }
+  } catch (e) { /* trimming is best-effort */ }
+}
+function logAll() { return tx(LOG, 'readonly', (s) => { const out = []; s.openCursor().onsuccess = (e) => { const c = e.target.result; if (c) { out.push(c.value.rec); c.continue(); } }; return out; }); }
+
+let synced = 0, offline = false, needsLogin = false, authMsg = '';
+async function broadcast() {
+  const queued = await count().catch(() => 0);
+  const data = { queued, synced, offline, needsLogin, authMsg };
+  const tabs = await chrome.tabs.query({ url: 'https://rejoyui.myntrainfo.com/*' });
+  for (const t of tabs) chrome.tabs.sendMessage(t.id, { type: 'status', data }).catch(() => {});
+}
+
+let flushing = false;
+async function flush() {
+  if (flushing) return; flushing = true;
+  try {
+    const { apiBase, token } = await getConfig();
+    if (!token) { needsLogin = true; authMsg = 'Please log in to sync captured returns.'; await broadcast(); return; }
+    let items = await readAll();
+    while (items.length) {
+      const batch = items.slice(0, BATCH);
+      let res;
+      try {
+        res = await fetch(captureUrl(apiBase), {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', 'Authorization': 'Bearer ' + token },
+          body: JSON.stringify({ records: batch.map((b) => ({ ...b.rec, _type: b.type || b.rec._type || 'capture' })) }),
+        });
+      } catch (e) {
+        offline = true; await broadcast(); break;            // network down — keep queue, retry later
+      }
+      if (res.status === 401) {
+        needsLogin = true; authMsg = 'Session expired — please log in again.'; await broadcast(); break; // keep queue, stop
+      }
+      if (res.status === 403) {
+        needsLogin = true; authMsg = 'This account lacks QC access (jitrgp role).'; await broadcast(); break; // keep queue, stop
+      }
+      if (!res.ok) { offline = true; await broadcast(); break; } // 5xx / other — keep queue, retry later
+      await remove(batch.map((b) => b.k));
+      synced += batch.length; offline = false; needsLogin = false; authMsg = '';
+      items = items.slice(BATCH);
+      await broadcast();
+    }
+  } finally { flushing = false; }
+}
+
+chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
+  if (!msg) return;
+  if (msg.type === 'capture' || msg.type === 'pass') {
+    const rec = { ...msg.record, _type: msg.type };
+    enqueue(rec).then(() => appendLog(rec)).then(() => { broadcast(); flush(); });
+  } else if (msg.type === 'getStatus') {
+    count().then((queued) => sendResponse({ queued, synced, offline, needsLogin, authMsg })); return true;
+  } else if (msg.type === 'exportRecords') {
+    // return the durable rolling log (falls back to the live queue if the log is empty)
+    logAll().then((recs) => {
+      if (recs && recs.length) return recs;
+      return readAll().then((items) => items.map((i) => i.rec));
+    }).then((records) => sendResponse({ records })).catch(() => sendResponse({ records: [] }));
+    return true;
+  } else if (msg.type === 'flushNow') {
+    needsLogin = false; authMsg = ''; flush(); if (sendResponse) sendResponse({ ok: true });
+  }
+});
+
+// When the popup stores a fresh token, clear the re-login flag and drain the queue immediately.
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === 'local' && (changes.token || changes.apiBase)) {
+    if (changes.token && changes.token.newValue) { needsLogin = false; authMsg = ''; }
+    flush();
+  }
+});
+
+// retry timer so offline/queued records always get delivered
+chrome.alarms.create('flush', { periodInMinutes: 0.5 });
+chrome.alarms.onAlarm.addListener((a) => { if (a.name === 'flush') flush(); });
+chrome.runtime.onStartup.addListener(flush);
+chrome.runtime.onInstalled.addListener(flush);

--- a/qcpass_extension/content.js
+++ b/qcpass_extension/content.js
@@ -1,0 +1,167 @@
+// ISOLATED-world content script: bridges the page-context interceptor (inject.js) to the
+// privileged background worker, and shows the captured product/details on screen so the
+// worker sees exactly what they're processing — like normal, plus the full record + sync status.
+(function () {
+  // ---------- on-screen panel ----------
+  const PANEL_ID = 'qc-capture-panel';
+  let panel, body, statusEl;
+  function ensurePanel() {
+    if (document.getElementById(PANEL_ID)) return;
+    const css = document.createElement('style');
+    css.textContent = `
+      #${PANEL_ID}{position:fixed;bottom:16px;right:16px;width:340px;background:#0f172a;color:#e2e8f0;
+        font:12px/1.45 Segoe UI,Tahoma,sans-serif;border-radius:10px;box-shadow:0 8px 30px rgba(0,0,0,.4);z-index:2147483647}
+      #${PANEL_ID} .h{background:linear-gradient(90deg,#7c3aed,#a855f7);padding:8px 12px;border-radius:10px 10px 0 0;display:flex;justify-content:space-between;align-items:center}
+      #${PANEL_ID} .h b{font-size:13px}
+      #${PANEL_ID} .st{font-size:11px;opacity:.95}
+      #${PANEL_ID} .bd{padding:10px 12px;max-height:340px;overflow:auto}
+      #${PANEL_ID} .row{display:flex;justify-content:space-between;gap:8px;padding:2px 0;border-bottom:1px solid #1e293b}
+      #${PANEL_ID} .k{color:#94a3b8}#${PANEL_ID} .v{color:#fff;font-weight:600;text-align:right;word-break:break-all}
+      #${PANEL_ID} .pass{color:#22c55e}#${PANEL_ID} .warn{color:#f59e0b}
+      #${PANEL_ID} .cfg{display:flex;justify-content:space-between;align-items:center;padding:7px 12px;background:#1e293b;border-bottom:1px solid #334155}
+      #${PANEL_ID} .cfg label{display:flex;gap:7px;align-items:center;cursor:pointer;user-select:none}
+      #${PANEL_ID} .cfg input{width:15px;height:15px;cursor:pointer}
+      #${PANEL_ID} .mode{font-size:10px;font-weight:700;color:#f59e0b}
+      #${PANEL_ID} .mode.on{color:#22c55e}
+      #${PANEL_ID} .auth{padding:6px 12px;font-size:11px;background:#1e293b;border-bottom:1px solid #334155;display:flex;justify-content:space-between;align-items:center;gap:8px}
+      #${PANEL_ID} .auth .who{color:#a855f7;font-weight:700}
+      #${PANEL_ID} .auth.warn{background:#3f1d1d}
+      #${PANEL_ID} .auth .relogin{color:#f87171;font-weight:700}
+      #${PANEL_ID} .bar{display:flex;gap:8px;padding:7px 12px;background:#1e293b;border-top:1px solid #334155;border-radius:0 0 10px 10px}
+      #${PANEL_ID} .bar button{flex:1;padding:6px;border:0;border-radius:6px;background:#334155;color:#fff;font:600 11px/1 Segoe UI,sans-serif;cursor:pointer}
+    `;
+    document.documentElement.appendChild(css);
+    panel = document.createElement('div'); panel.id = PANEL_ID;
+    panel.innerHTML = `<div class="h"><b>QC Capture</b><span class="st" id="qc-st">queued 0 · synced 0</span></div>` +
+      `<div class="auth" id="qc-auth"><span id="qc-who">not signed in</span><span class="relogin" id="qc-relogin" style="display:none">login needed</span></div>` +
+      `<div class="cfg"><label><input type="checkbox" id="qc-autopass"> Auto-Pass on scan</label><span class="mode" id="qc-mode">capture only</span></div>` +
+      `<div class="bd" id="qc-bd"><div class="k">Scan/search a return…</div></div>` +
+      `<div class="bar"><button id="qc-export">Export CSV</button></div>`;
+    document.documentElement.appendChild(panel);
+    body = panel.querySelector('#qc-bd'); statusEl = panel.querySelector('#qc-st');
+    wireAutoPass(panel.querySelector('#qc-autopass'), panel.querySelector('#qc-mode'));
+    wireExport(panel.querySelector('#qc-export'));
+    renderAuth();
+    chrome.storage.onChanged.addListener((ch, area) => { if (area === 'local' && (ch.token || ch.user)) renderAuth(); });
+  }
+
+  // Show who's signed in (from chrome.storage.local, set by the popup) in the panel.
+  function renderAuth() {
+    const whoEl = panel && panel.querySelector('#qc-who');
+    if (!whoEl) return;
+    chrome.storage.local.get(['user'], (r) => {
+      const u = r && r.user;
+      whoEl.textContent = u ? ('signed in: ' + (u.username || ('#' + u.id))) : 'not signed in — open the extension to log in';
+      whoEl.className = 'who';
+    });
+  }
+
+  // Export CSV of the captured records straight from the panel (local backup safety net).
+  function wireExport(btn) {
+    if (!btn) return;
+    btn.addEventListener('click', () => {
+      chrome.runtime.sendMessage({ type: 'exportRecords' }, (resp) => {
+        const records = (resp && resp.records) || [];
+        if (!records.length) { btn.textContent = 'nothing to export'; setTimeout(() => (btn.textContent = 'Export CSV'), 1500); return; }
+        const csv = (self.QCCsv ? self.QCCsv.toCsv(records) : '');
+        const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-');
+        const blob = new Blob([csv], { type: 'text/csv' });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url; a.download = 'qc-capture-' + stamp + '.csv';
+        document.documentElement.appendChild(a); a.click(); a.remove();
+        setTimeout(() => URL.revokeObjectURL(url), 4000);
+        btn.textContent = 'exported ' + records.length; setTimeout(() => (btn.textContent = 'Export CSV'), 1500);
+      });
+    });
+  }
+
+  // Auto-Pass toggle: OFF = capture/sync only (read-only). ON = also auto-pass each scanned item.
+  // State is persisted and pushed to the page-context interceptor (inject.js) via window messages.
+  // Broadcast the full config (toggle + the operator's real desk/quality) to inject.js.
+  function pushCfg() {
+    chrome.storage.local.get(['autopass', 'passDesk', 'passQuality'], (r) => {
+      try {
+        window.postMessage({
+          __qcCfg: true, autopass: !!(r && r.autopass),
+          passDesk: (r && r.passDesk) || '', passQuality: (r && r.passQuality) || '',
+        }, '*');
+      } catch (e) {}
+    });
+  }
+  function wireAutoPass(cb, modeEl) {
+    if (!cb) return;
+    const apply = (on) => {
+      cb.checked = on;
+      modeEl.textContent = on ? 'AUTO-PASS ON' : 'capture only';
+      modeEl.classList.toggle('on', on);
+      pushCfg();
+    };
+    chrome.storage.local.get('autopass', (r) => apply(!!(r && r.autopass)));
+    cb.addEventListener('change', () => { chrome.storage.local.set({ autopass: cb.checked }); apply(cb.checked); });
+  }
+  const FIELDS = [
+    ['Tracking', 'tracking_number'], ['Item Barcode', 'item_barcode'], ['Product', 'product_name'],
+    ['Article No', 'article_no'], ['Style Id', 'style_id'], ['Size', 'size'], ['Price', 'price'],
+    ['Return Type', 'return_type'], ['Return Mode', 'return_mode'], ['Return Status', 'return_status'],
+    ['RMS Status', 'rms_status'], ['QC Action', 'qc_action'], ['Quality', 'quality'],
+    ['Created', 'created_date'], ['Refund', 'refund_date'], ['Received', 'return_received_on'],
+    ['Restock', 'return_restocked_on'], ['Logistics', 'logistics_status'], ['Courier', 'courier_code'],
+    ['Return Hub', 'return_hub'], ['Dispatch WH', 'dispatch_wh'], ['Destination WH', 'return_destination_wh'],
+    ['DC', 'delivery_center'], ['Ship City', 'ship_city'], ['Return Id', 'return_id'],
+    ['OMS Release', 'oms_release_id'], ['SKU Id', 'sku_id'], ['SKU Code', 'sku_code'],
+  ];
+  function renderRecord(rec) {
+    ensurePanel();
+    body.innerHTML = FIELDS.map(([label, key]) => {
+      const v = rec[key] || '—';
+      const cls = key === 'logistics_status' && v === 'DELIVERED_TO_SELLER' ? 'pass' : '';
+      return `<div class="row"><span class="k">${label}</span><span class="v ${cls}">${String(v)}</span></div>`;
+    }).join('');
+  }
+  function markPassed(p) {
+    ensurePanel();
+    const tag = document.createElement('div');
+    tag.className = 'row';
+    tag.innerHTML = `<span class="k">QC PASS</span><span class="v ${p.pass_success ? 'pass' : 'warn'}">${p.pass_success ? 'PASSED → ' + (p.new_status || '') : 'FAILED: ' + (p.pass_error || '')}</span>`;
+    body.prepend(tag);
+  }
+  function setStatus(s) {
+    if (statusEl) statusEl.textContent = `queued ${s.queued || 0} · synced ${s.synced || 0}${s.offline ? ' · OFFLINE' : ''}`;
+    const authEl = panel && panel.querySelector('#qc-auth');
+    const reEl = panel && panel.querySelector('#qc-relogin');
+    if (reEl && authEl) {
+      const need = !!s.needsLogin;
+      reEl.style.display = need ? '' : 'none';
+      reEl.title = s.authMsg || '';
+      reEl.textContent = need ? (s.authMsg || 'login needed') : '';
+      authEl.classList.toggle('warn', need);
+    }
+  }
+
+  // ---------- bridge: page -> background ----------
+  window.addEventListener('message', (ev) => {
+    const m = ev.data;
+    if (!m) return;
+    // inject.js just loaded and asked for the current config → push it.
+    if (m.__qcReady === true) { pushCfg(); return; }
+    if (m.__qcCapture !== true) return;
+    if (m.kind === 'capture') { renderRecord(m.payload); chrome.runtime.sendMessage({ type: 'capture', record: m.payload }); }
+    else if (m.kind === 'pass') {
+      markPassed(m.payload);
+      chrome.runtime.sendMessage({ type: 'pass', record: m.payload });
+      // remember the operator's real desk/quality so auto-pass uses their actual values
+      const upd = {};
+      if (m.payload.desk_code) upd.passDesk = m.payload.desk_code;
+      if (m.payload.quality) upd.passQuality = m.payload.quality;
+      if (Object.keys(upd).length) chrome.storage.local.set(upd, pushCfg);
+    }
+  });
+
+  // ---------- background -> panel (queue/sync status) ----------
+  chrome.runtime.onMessage.addListener((msg) => { if (msg && msg.type === 'status') setStatus(msg.data); });
+  // ask for current status on load
+  try { chrome.runtime.sendMessage({ type: 'getStatus' }, (r) => { if (r) setStatus(r); }); } catch (e) {}
+  document.addEventListener('DOMContentLoaded', ensurePanel);
+  ensurePanel();
+})();

--- a/qcpass_extension/csv.js
+++ b/qcpass_extension/csv.js
@@ -1,0 +1,32 @@
+// Pure CSV serialization for the captured QC records. Kept dependency-free and UMD-wrapped so it
+// can load as a content script / popup script (attaches window.QCCsv) AND be required from a
+// node:test unit test. No DOM, no chrome APIs — just data in, CSV string out.
+(function (root, factory) {
+  const mod = factory();
+  if (typeof module !== 'undefined' && module.exports) module.exports = mod;
+  if (typeof self !== 'undefined') self.QCCsv = mod;
+  else if (typeof globalThis !== 'undefined') globalThis.QCCsv = mod;
+})(typeof self !== 'undefined' ? self : this, function () {
+  function escapeCell(v) {
+    if (v == null) return '';
+    const s = String(v);
+    return /[",\n\r]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
+  }
+  // Union of keys across records, in first-seen order (stable, no keys dropped).
+  function columnsOf(records) {
+    const seen = new Set(), cols = [];
+    for (const r of (records || [])) {
+      if (!r || typeof r !== 'object') continue;
+      for (const k of Object.keys(r)) { if (!seen.has(k)) { seen.add(k); cols.push(k); } }
+    }
+    return cols;
+  }
+  function toCsv(records, columns) {
+    records = Array.isArray(records) ? records : [];
+    const cols = (columns && columns.length) ? columns : columnsOf(records);
+    const lines = [cols.map(escapeCell).join(',')];
+    for (const r of records) lines.push(cols.map((c) => escapeCell(r ? r[c] : '')).join(','));
+    return lines.join('\r\n');
+  }
+  return { toCsv, columnsOf, escapeCell };
+});

--- a/qcpass_extension/csv.test.js
+++ b/qcpass_extension/csv.test.js
@@ -1,0 +1,37 @@
+// Unit test for the pure CSV serializer. Run:  node --test qcpass_extension/csv.test.js
+const test = require('node:test');
+const assert = require('node:assert');
+const { toCsv, columnsOf, escapeCell } = require('./csv.js');
+
+test('escapeCell quotes cells with commas, quotes and newlines', () => {
+  assert.strictEqual(escapeCell('plain'), 'plain');
+  assert.strictEqual(escapeCell('a,b'), '"a,b"');
+  assert.strictEqual(escapeCell('he said "hi"'), '"he said ""hi"""');
+  assert.strictEqual(escapeCell('line1\nline2'), '"line1\nline2"');
+  assert.strictEqual(escapeCell(null), '');
+  assert.strictEqual(escapeCell(undefined), '');
+  assert.strictEqual(escapeCell(0), '0');
+});
+
+test('columnsOf is the first-seen union across records', () => {
+  const rows = [{ a: 1, b: 2 }, { b: 3, c: 4 }];
+  assert.deepStrictEqual(columnsOf(rows), ['a', 'b', 'c']);
+});
+
+test('toCsv writes a header row plus one row per record, CRLF separated', () => {
+  const rows = [
+    { item_barcode: 'X1', size: 'M', note: 'a,b' },
+    { item_barcode: 'X2', size: 'L' },
+  ];
+  const csv = toCsv(rows);
+  const lines = csv.split('\r\n');
+  assert.strictEqual(lines[0], 'item_barcode,size,note');
+  assert.strictEqual(lines[1], 'X1,M,"a,b"');
+  assert.strictEqual(lines[2], 'X2,L,'); // missing key -> empty cell
+  assert.strictEqual(lines.length, 3);
+});
+
+test('toCsv on empty input yields an empty header line', () => {
+  assert.strictEqual(toCsv([]), '');
+  assert.strictEqual(toCsv(null), '');
+});

--- a/qcpass_extension/inject.js
+++ b/qcpass_extension/inject.js
@@ -1,0 +1,279 @@
+// MAIN-world script: runs in the rejoyui page context (uses the live session).
+// It piggybacks on the page's own QC API calls (no extra login, no token juggling):
+//   - searchReturnDetails/search2  -> the page calls this when a worker searches/scans a return
+//   - updateReturnRestocked        -> the page calls this when a worker clicks "Pass"
+// For each searchReturnDetails response it also fires getReturnLMSDetails to add the
+// Logistics Status (DELIVERED_TO_SELLER etc.), assembles the FULL record, and posts it to
+// the isolated content script via window.postMessage.
+(function () {
+  const API = 'https://spectrum-babylon-api.myntrainfo.com/api/rejoyui';
+  const SOURCE_ID = '2297', TENANT_ID = '4019';
+
+  // Auto-Pass config, pushed from content.js. OFF = capture only; ON = auto-pass each scanned item.
+  // qcDeskCode/quality come from the operator's own real passes (persisted); default 001/Q1.
+  let AUTOPASS = false, PASS_DESK = '001', PASS_QUALITY = 'Q1';
+  window.addEventListener('message', (ev) => {
+    const m = ev.data;
+    if (m && m.__qcCfg === true) {
+      AUTOPASS = !!m.autopass;
+      if (m.passDesk) PASS_DESK = m.passDesk;
+      if (m.passQuality) PASS_QUALITY = m.passQuality;
+    }
+  });
+
+  // ---- print-popup suppression ----
+  // Clicking Pass (or our auto-pass) makes the app open a print/label window. Suppress any
+  // window.open / window.print that fires in the ~3s right after a pass, so no print page appears.
+  let suppressOpenUntil = 0;
+  const armPrintSuppress = () => { suppressOpenUntil = Date.now() + 3000; };
+  const origOpen = window.open;
+  window.open = function (...a) {
+    if (Date.now() < suppressOpenUntil) {
+      console.log('%c[QC Capture] print popup suppressed', 'color:#f59e0b');
+      // return a harmless stub so page code like w.document.write(...).print() doesn't throw
+      return { closed: true, close() {}, focus() {}, print() {}, document: { write() {}, close() {}, open() {} }, location: {} };
+    }
+    return origOpen.apply(this, a);
+  };
+  const origPrint = window.print;
+  window.print = function () {
+    if (Date.now() < suppressOpenUntil) { console.log('%c[QC Capture] print() suppressed', 'color:#f59e0b'); return; }
+    return origPrint && origPrint.apply(this, arguments);
+  };
+
+  // ---- auto-pass: replay the exact updateReturnRestocked PUT for the scanned item ----
+  const PASS_URL = `${API}/qcSearch/updateReturnRestocked?isColocatedRpc=false`;
+  const passInFlight = new Set();
+  async function doAutoPass(rec) {
+    try {
+      if (!rec || !rec.item_barcode || !rec.oms_release_id) return;
+      const wh = Number(rec.return_request_warehouse_id || rec.warehouse_id);
+      if (!wh) return;
+      if (rec.qc_action) return;               // already QC'd — never re-pass
+      if (passInFlight.has(rec.item_barcode)) return;  // de-dupe rapid duplicate searches
+      passInFlight.add(rec.item_barcode);
+      const body = {
+        omsReleaseId: String(rec.oms_release_id),
+        itemBarcode: String(rec.item_barcode),
+        qcActionCode: 'QC_PASS',
+        returnRequestWarehouseId: wh,
+        qcDeskCode: PASS_DESK,
+        quality: PASS_QUALITY,
+      };
+      armPrintSuppress();
+      const reqId = (window.crypto && crypto.randomUUID) ? crypto.randomUUID() : ('qc-' + Date.now());
+      // NOTE: this goes through our own fetch wrapper below, which captures the response and
+      // posts the 'pass' result to the panel/DB — so we don't call handlePass here.
+      await fetch(PASS_URL, {
+        method: 'PUT', credentials: 'include',
+        headers: {
+          'Accept': 'application/json', 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest',
+          'x-myntra-app-name': 'rejoy', 'x-myntra-client-id': 'rejoy', 'x-myntra-module-name': 'QcSearch',
+          'x-myntra-rejoy-service': 'worms.qcSearch.updateReturnRestocked', 'x-myntra-req-id': reqId,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch (e) {
+      post('pass', { item_barcode: String(rec.item_barcode || ''), pass_success: false, pass_error: 'auto-pass error: ' + (e && e.message), passed_at: new Date().toISOString() });
+    } finally {
+      passInFlight.delete(rec.item_barcode);
+    }
+  }
+
+  const post = (kind, payload) => {
+    try { window.postMessage({ __qcCapture: true, kind, payload }, '*'); } catch (e) {}
+  };
+
+  function pick(o, ...keys) { for (const k of keys) { if (o && o[k] != null && o[k] !== '') return o[k]; } return ''; }
+  // Dates arrive as epoch-ms (numbers) OR ISO strings ("2026-06-17T06:41:04.000+0000").
+  // Return a clean YYYY-MM-DD (local day) for both; '' when missing.
+  function toDay(v) {
+    if (v == null || v === '') return '';
+    let dt;
+    if (typeof v === 'number' || /^\d+$/.test(String(v))) dt = new Date(Number(v));
+    else dt = new Date(String(v));
+    if (isNaN(dt.getTime())) return '';
+    const p = (n) => String(n).padStart(2, '0');
+    return `${dt.getFullYear()}-${p(dt.getMonth() + 1)}-${p(dt.getDate())}`;
+  }
+
+  // Pull the full field set out of a searchReturnDetails response (mapped from the REAL shape).
+  function extractSearch(j) {
+    const d = (j && j.data) || {};
+    const rd = (d.rmsRetunDetails || [])[0] || {};
+    const it = (d.orderReleaseItemData || [])[0] || {};
+    const pr = (d.productResponse && (d.productResponse['0'] || d.productResponse[0])) || {};
+    const tr = rd.returnTrackingDetailsEntry || {};
+    const oh = rd.returnOnHoldDetailsEntry || {};
+    const qc = rd.returnQcDetailsEntry || {};
+    const refund = rd.returnRefundDetailsEntry || {};
+    const line = (rd.returnLineEntries || [])[0] || {};
+
+    const skuId = String(pick(line, 'skuId') || pick(it, 'skuId'));
+    // SIZE: productOptions lists ALL sizes of the style — pick the one matching THIS item's skuId,
+    // not the first option (that bug showed 26 instead of 32).
+    let size = '', skuCode = '', vendorArticle = '';
+    const opts = pr.productOptions || [];
+    let opt = opts.find((o) => o && String(o.skuId) === skuId);
+    if (!opt) opt = opts.find((o) => o && o.name === 'Size'); // fallback
+    if (opt) {
+      size = String(opt.value || opt.unifiedSize || '');
+      skuCode = opt.skuCode || '';
+      // the article no shown on the QC screen is the per-size VENDOR article (e.g. KTTWOMENSPANT473XL)
+      vendorArticle = opt.vendorArticleNo || opt.vendorArticleNumber || '';
+    }
+
+    return {
+      tracking_number: pick(it, 'trackingNumber') || pick(tr, 'trackingNo'),
+      item_barcode: String(pick(it, 'itemBarcode')),
+      return_id: String(pick(rd, 'id') || pick(it, 'returnId')),
+      oms_release_id: String(pick(it, 'omsReleaseId') || pick(line, 'orderReleaseId')),
+      sku_id: skuId,
+      sku_code: skuCode,
+      style_id: String(pick(line, 'styleId')),
+      rms_status: pick(it, 'status'),
+      status_code: pick(rd, 'statusCode') || pick(line, 'statusCode'),
+      return_status: pick(rd, 'statusCode') || pick(line, 'statusCode'),
+      qc_action: pick(qc, 'qcAction', 'qcActionCode') || pick(it, 'qcActionCode'),
+      quality: pick(qc, 'quality') || pick(it, 'quality'),
+      qc_done_by: pick(qc, 'qcDoneBy') || pick(it, 'qcDoneBy'),
+      return_type: pick(rd, 'returnType') || pick(it, 'returnType'),
+      return_mode: pick(rd, 'returnMode'),
+      supply_type: pick(line, 'supplyType') || pick(it, 'supplyType'),
+      on_hold: (oh.onHold || rd.isOnHold) ? 'Yes' : 'No',
+      store_order_id: String(pick(rd, 'orderId', 'storeOrderId')),
+      display_order_id: pick(rd, 'displayStoreOrderId'),
+      warehouse_id: String(pick(line, 'warehouseId') || pick(it, 'warehouseId') || pick(tr, 'warehouseId')),
+      return_request_warehouse_id: String(pick(it, 'returnRequestWarehouseId')),
+      article_no: vendorArticle || pick(pr, 'articleNumber'),
+      style_article_no: pick(pr, 'articleNumber'),
+      product_name: pick(pr, 'productDisplayName', 'title'),
+      price: String(pick(line, 'unitPrice') || pick(pr, 'price')),
+      size,
+      created_date: toDay(rd.createdOn),
+      refund_date: toDay(refund.refundedOn),
+      refund_amount: String(pick(refund, 'refundAmount')),
+      refund_mode: pick(refund, 'refundMode'),
+      shipped_on: toDay(it.shippedOn),
+      return_received_on: toDay(it.returnReceivedOn) || toDay(tr.receivedOn),
+      return_restocked_on: toDay(rd.lastModifiedOn) || toDay(line.lastModifiedOn),
+      // logistics — filled by getReturnLMSDetails below
+      logistics_status: '', courier_code: '', return_hub: '', return_facility: '',
+      delivery_center: '', dispatch_wh: '', return_destination_wh: '',
+      ship_city: '', ship_state: '', ship_pincode: '', shipment_type: '', active_leg: '',
+      captured_at: new Date().toISOString(),
+    };
+  }
+
+  async function enrichLogistics(rec) {
+    if (!rec.return_id) return rec;
+    try {
+      const res = await fetch(`${API}/qcSearch/getReturnLMSDetails/${rec.return_id}?sourceId=${SOURCE_ID}&tenantId=${TENANT_ID}`, {
+        credentials: 'include',
+        headers: { 'Accept': 'application/json', 'X-Requested-With': 'XMLHttpRequest', 'x-myntra-app-name': 'rejoy', 'x-myntra-client-id': 'rejoy', 'x-myntra-module-name': 'QcSearch', 'x-myntra-rejoy-service': 'lms.qcSearch.getReturnLMSDetails' },
+      });
+      const j = await res.json();
+      const r = (j && j.data && j.data[0]) || null;
+      if (r) {
+        rec.logistics_status = r.shipmentStatus || '';
+        rec.courier_code = r.courierCode || '';
+        rec.return_hub = r.returnHubCode || '';
+        rec.return_facility = String(r.returnFacilityId || '');
+        rec.delivery_center = String(r.deliveryCenterId || '');
+        rec.dispatch_wh = String(r.receivedAtWH || '');
+        rec.return_destination_wh = String(r.returnFacilityId || r.lastReceivedHubCode || '');
+        rec.ship_city = r.city || '';
+        rec.ship_state = r.stateCode || '';
+        rec.ship_pincode = r.pincode || '';
+        rec.shipment_type = r.shipmentType || '';
+        rec.active_leg = r.activeLegType || '';
+      }
+    } catch (e) { /* leave logistics blank; backend still gets the record */ }
+    return rec;
+  }
+
+  async function handleSearch(j) {
+    try {
+      if (!j || (j.status && j.status.statusType && j.status.statusType !== 'SUCCESS')) return;
+      const rec = extractSearch(j);
+      if (!rec.item_barcode && !rec.tracking_number) return;
+      await enrichLogistics(rec);
+      post('capture', rec);
+      if (AUTOPASS) doAutoPass(rec);   // auto-pass the scanned item when the toggle is ON
+    } catch (e) {}
+  }
+
+  function handlePass(j, reqBody) {
+    try {
+      const ok = j && j.status && j.status.statusType === 'SUCCESS';
+      let body = {}; try { body = reqBody ? JSON.parse(reqBody) : {}; } catch (e) {}
+      const newStatus = ok && j.data && j.data[0] ? (j.data[0].status || '') : '';
+      post('pass', {
+        item_barcode: String(body.itemBarcode || ''),
+        oms_release_id: String(body.omsReleaseId || ''),
+        qc_action: body.qcActionCode || '',
+        quality: body.quality || '',
+        desk_code: body.qcDeskCode || '',
+        warehouse_id: String(body.returnRequestWarehouseId || ''),
+        pass_success: !!ok,
+        new_status: newStatus,
+        pass_error: ok ? '' : (j && j.status ? j.status.statusMessage : 'pass failed'),
+        passed_at: new Date().toISOString(),
+      });
+    } catch (e) {}
+  }
+
+  // ---- hook fetch ----
+  const origFetch = window.fetch;
+  window.fetch = function (...args) {
+    const p = origFetch.apply(this, args);
+    try {
+      const url = (typeof args[0] === 'string' ? args[0] : (args[0] && args[0].url)) || '';
+      const init = args[1] || {};
+      if (url.includes('/qcSearch/searchReturnDetails/search2')) {
+        p.then((r) => r.clone().json().then(handleSearch).catch(() => {}));
+      } else if (url.includes('/qcSearch/updateReturnRestocked')) {
+        armPrintSuppress();   // also kill the print popup when the page itself does a pass
+        p.then((r) => r.clone().json().then((j) => handlePass(j, init.body)).catch(() => {}));
+      }
+    } catch (e) {}
+    return p;
+  };
+
+  // ---- hook XHR (page may use axios/XHR) ----
+  const OrigXHR = window.XMLHttpRequest;
+  function PatchedXHR() {
+    const xhr = new OrigXHR();
+    let _url = '', _body = null;
+    const open = xhr.open;
+    xhr.open = function (method, url, ...rest) { _url = url || ''; return open.call(this, method, url, ...rest); };
+    const send = xhr.send;
+    xhr.send = function (body) {
+      _body = body;
+      try {
+        if (_url.includes('/qcSearch/updateReturnRestocked')) {
+          armPrintSuppress();   // also kill the print popup when the page itself does a pass
+        }
+      } catch (e) {}
+      return send.call(this, body);
+    };
+    xhr.addEventListener('load', function () {
+      try {
+        if (xhr.responseType && xhr.responseType !== 'text' && xhr.responseType !== 'json') return;
+        const txt = xhr.responseType === 'json' ? null : xhr.responseText;
+        const j = xhr.responseType === 'json' ? xhr.response : (txt ? JSON.parse(txt) : null);
+        if (!j) return;
+        if (_url.includes('/qcSearch/searchReturnDetails/search2')) handleSearch(j);
+        else if (_url.includes('/qcSearch/updateReturnRestocked')) handlePass(j, _body);
+      } catch (e) {}
+    });
+    return xhr;
+  }
+  PatchedXHR.prototype = OrigXHR.prototype;
+  window.XMLHttpRequest = PatchedXHR;
+
+  // ask content.js for the current Auto-Pass config (handles either load order)
+  try { window.postMessage({ __qcReady: true }, '*'); } catch (e) {}
+
+  console.log('%c[QC Capture] active — capturing full return data on this page', 'color:#a855f7;font-weight:bold');
+})();

--- a/qcpass_extension/manifest.json
+++ b/qcpass_extension/manifest.json
@@ -1,0 +1,31 @@
+{
+  "manifest_version": 3,
+  "name": "QC Capture — Full Return Data",
+  "version": "0.2.0",
+  "description": "On rejoyui QC, captures the FULL return record (search details + logistics) and queues it durably, then syncs it to the kotty-track backend with authentication. Nothing is missed.",
+  "permissions": ["storage", "alarms", "downloads"],
+  "host_permissions": [
+    "https://rejoyui.myntrainfo.com/*",
+    "https://spectrum-babylon-api.myntrainfo.com/*",
+    "https://kotty-track-fwlq5ofeza-el.a.run.app/*"
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "QC Capture — login & sync"
+  },
+  "background": { "service_worker": "background.js" },
+  "content_scripts": [
+    {
+      "matches": ["https://rejoyui.myntrainfo.com/*"],
+      "js": ["inject.js"],
+      "run_at": "document_start",
+      "world": "MAIN"
+    },
+    {
+      "matches": ["https://rejoyui.myntrainfo.com/*"],
+      "js": ["csv.js", "content.js"],
+      "run_at": "document_start",
+      "world": "ISOLATED"
+    }
+  ]
+}

--- a/qcpass_extension/popup.html
+++ b/qcpass_extension/popup.html
@@ -1,0 +1,60 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <style>
+    :root { color-scheme: light dark; }
+    body { width: 300px; margin: 0; font: 13px/1.45 Segoe UI, Tahoma, sans-serif; background: #0f172a; color: #e2e8f0; }
+    .h { background: linear-gradient(90deg, #7c3aed, #a855f7); padding: 10px 14px; font-weight: 700; font-size: 14px; }
+    .bd { padding: 12px 14px; }
+    label { display: block; font-size: 11px; color: #94a3b8; margin: 8px 0 3px; }
+    input { width: 100%; box-sizing: border-box; padding: 7px 9px; border: 1px solid #334155; border-radius: 6px;
+      background: #1e293b; color: #fff; font-size: 13px; }
+    button { width: 100%; margin-top: 10px; padding: 8px; border: 0; border-radius: 6px; cursor: pointer;
+      font-weight: 700; font-size: 13px; background: #7c3aed; color: #fff; }
+    button.sec { background: #334155; }
+    button:disabled { opacity: .6; cursor: default; }
+    .row { display: flex; justify-content: space-between; padding: 3px 0; border-bottom: 1px solid #1e293b; }
+    .k { color: #94a3b8; } .v { color: #fff; font-weight: 600; }
+    .msg { margin-top: 8px; font-size: 12px; min-height: 15px; }
+    .msg.err { color: #f87171; } .msg.ok { color: #22c55e; } .msg.warn { color: #f59e0b; }
+    .who { font-size: 12px; margin-bottom: 6px; }
+    .who b { color: #a855f7; }
+    .adv { margin-top: 10px; font-size: 11px; color: #64748b; }
+    .adv summary { cursor: pointer; }
+    hr { border: 0; border-top: 1px solid #1e293b; margin: 12px 0; }
+  </style>
+</head>
+<body>
+  <div class="h">QC Capture</div>
+  <div class="bd">
+    <!-- logged-out view -->
+    <div id="login-view">
+      <label for="u">Username</label>
+      <input id="u" type="text" autocomplete="username" />
+      <label for="p">Password</label>
+      <input id="p" type="password" autocomplete="current-password" />
+      <button id="login-btn">Log in</button>
+      <details class="adv">
+        <summary>Advanced</summary>
+        <label for="base">Backend URL</label>
+        <input id="base" type="text" placeholder="https://kotty-track-fwlq5ofeza-el.a.run.app" />
+      </details>
+      <div id="login-msg" class="msg"></div>
+    </div>
+
+    <!-- logged-in view -->
+    <div id="account-view" style="display:none">
+      <div class="who">Signed in as <b id="who-name">—</b></div>
+      <div class="row"><span class="k">Queued</span><span class="v" id="s-queued">0</span></div>
+      <div class="row"><span class="k">Synced</span><span class="v" id="s-synced">0</span></div>
+      <div class="row"><span class="k">Status</span><span class="v" id="s-state">—</span></div>
+      <div id="acct-msg" class="msg"></div>
+      <button id="export-btn" class="sec">Export CSV (local backup)</button>
+      <button id="logout-btn" class="sec">Log out</button>
+    </div>
+  </div>
+  <script src="csv.js"></script>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/qcpass_extension/popup.js
+++ b/qcpass_extension/popup.js
@@ -1,0 +1,100 @@
+// Popup: login against /ext/qc/login, persist token+user, show account/sync state, logout,
+// and Export CSV (local backup) of the captured records. Nothing here touches the QC page.
+const DEFAULT_API_BASE = 'https://kotty-track-fwlq5ofeza-el.a.run.app';
+const apiBaseClean = (b) => String(b || DEFAULT_API_BASE).replace(/\/+$/, '');
+
+const $ = (id) => document.getElementById(id);
+const loginView = $('login-view'), acctView = $('account-view');
+
+function getLocal(keys) { return new Promise((r) => chrome.storage.local.get(keys, r)); }
+function setLocal(obj) { return new Promise((r) => chrome.storage.local.set(obj, r)); }
+function removeLocal(keys) { return new Promise((r) => chrome.storage.local.remove(keys, r)); }
+function sendBg(msg) { return new Promise((r) => { try { chrome.runtime.sendMessage(msg, (resp) => { void chrome.runtime.lastError; r(resp); }); } catch (e) { r(null); } }); }
+
+function showMsg(el, text, cls) { el.className = 'msg' + (cls ? ' ' + cls : ''); el.textContent = text || ''; }
+
+async function render() {
+  const { token, user, apiBase } = await getLocal(['token', 'user', 'apiBase']);
+  $('base').value = apiBase || '';
+  if (token && user) {
+    loginView.style.display = 'none';
+    acctView.style.display = 'block';
+    $('who-name').textContent = user.username || ('#' + user.id);
+    refreshStatus();
+  } else {
+    loginView.style.display = 'block';
+    acctView.style.display = 'none';
+  }
+}
+
+async function refreshStatus() {
+  const s = await sendBg({ type: 'getStatus' }) || {};
+  $('s-queued').textContent = s.queued || 0;
+  $('s-synced').textContent = s.synced || 0;
+  let state = 'idle', cls = '';
+  if (s.needsLogin) { state = 're-login needed'; cls = 'warn'; }
+  else if (s.offline) { state = 'offline — retrying'; cls = 'warn'; }
+  else if (s.queued) { state = 'syncing…'; }
+  else { state = 'synced'; cls = 'ok'; }
+  $('s-state').textContent = state;
+  showMsg($('acct-msg'), s.needsLogin ? (s.authMsg || 'Please log in again.') : '', cls === 'ok' ? '' : cls);
+}
+
+async function doLogin() {
+  const username = $('u').value.trim(), password = $('p').value;
+  const base = apiBaseClean($('base').value.trim());
+  if (!username || !password) { showMsg($('login-msg'), 'Enter username and password.', 'err'); return; }
+  $('login-btn').disabled = true;
+  showMsg($('login-msg'), 'Logging in…', '');
+  try {
+    const res = await fetch(base + '/ext/qc/login', {
+      method: 'POST', headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username, password, device_label: 'chrome-ext' }),
+    });
+    let body = {};
+    try { body = await res.json(); } catch (e) {}
+    if (res.status === 403) { showMsg($('login-msg'), 'This account lacks QC access (jitrgp role).', 'err'); return; }
+    if (res.status === 401) { showMsg($('login-msg'), 'Wrong username or password.', 'err'); return; }
+    if (!res.ok || !body.ok || !body.token) { showMsg($('login-msg'), 'Login failed (HTTP ' + res.status + ').', 'err'); return; }
+    await setLocal({ token: body.token, user: body.user || { username }, apiBase: base });
+    $('p').value = '';
+    showMsg($('login-msg'), '', '');
+    await render();
+  } catch (e) {
+    showMsg($('login-msg'), 'Network error: ' + (e && e.message || e), 'err');
+  } finally {
+    $('login-btn').disabled = false;
+  }
+}
+
+async function doLogout() {
+  await removeLocal(['token', 'user']);
+  await render();
+}
+
+async function doExport() {
+  showMsg($('acct-msg'), 'Preparing CSV…', '');
+  const resp = await sendBg({ type: 'exportRecords' }) || {};
+  const records = resp.records || [];
+  if (!records.length) { showMsg($('acct-msg'), 'No captured records to export yet.', 'warn'); return; }
+  const csv = QCCsv.toCsv(records);
+  const stamp = new Date().toISOString().slice(0, 19).replace(/[:T]/g, '-');
+  const name = 'qc-capture-' + stamp + '.csv';
+  const url = 'data:text/csv;charset=utf-8,' + encodeURIComponent(csv);
+  try {
+    chrome.downloads.download({ url, filename: name, saveAs: true }, () => { void chrome.runtime.lastError; });
+    showMsg($('acct-msg'), 'Exported ' + records.length + ' records.', 'ok');
+  } catch (e) {
+    // fallback: anchor download
+    const a = document.createElement('a');
+    a.href = url; a.download = name; document.body.appendChild(a); a.click(); a.remove();
+    showMsg($('acct-msg'), 'Exported ' + records.length + ' records.', 'ok');
+  }
+}
+
+$('login-btn').addEventListener('click', doLogin);
+$('p').addEventListener('keydown', (e) => { if (e.key === 'Enter') doLogin(); });
+$('logout-btn').addEventListener('click', doLogout);
+$('export-btn').addEventListener('click', doExport);
+render();
+setInterval(() => { if (acctView.style.display !== 'none') refreshStatus(); }, 2000);


### PR DESCRIPTION
## What & why
The `qcpass_extension/` Chrome MV3 extension previously POSTed captured QC returns to a hardcoded `http://localhost:8000/api/capture` dev server with no auth, and shipped debug endpoints (`/api/debug-dump`, `/api/debug-pass`) plus a `window.__qcRaw`/`qcDump` console dump. This reworks it to talk to the live, authenticated kotty-track backend and removes the dev leakage.

Scope: **only `qcpass_extension/`** — no backend/frontend changes.

## Changes per file
- **manifest.json** — bump to 0.2.0; drop `localhost`/`127.0.0.1` from `host_permissions`, add the prod host `https://kotty-track-fwlq5ofeza-el.a.run.app/*`; add `downloads` permission; add an `action` with `default_popup: popup.html`; load `csv.js` before `content.js` in the ISOLATED content world.
- **background.js** — capture URL is now `${apiBase}/ext/qc/capture` where `apiBase` (default = prod) and `token` come from `chrome.storage.local`. Every capture POST sends `Authorization: Bearer <token>`. Response handling: **401/403** → set `needsLogin`, stop flushing, broadcast a re-login status, **keep the queue**; **5xx / network** → keep queue and retry (existing behavior); **200** → dequeue as before. Adds a durable rolling `log` IndexedDB store (copy of every record, capped) so Export CSV works after records have synced; `exportRecords`/`flushNow` messages; and an auto-flush when a fresh token is stored.
- **popup.html / popup.js** *(new)* — login form → `POST /ext/qc/login`, stores `token`+`user`(+`apiBase`) in `chrome.storage.local`; shows the signed-in user, live queued/synced/status, a re-login hint, **Logout**, and **Export CSV** (local backup). Handles 401 (bad creds) / 403 (missing `jitrgp` role) distinctly.
- **content.js** — panel now shows the signed-in user, a red **"login needed"** hint when the server rejects auth, and an **Export CSV** button. Capture/auto-pass logic unchanged.
- **inject.js** — removed `debugPost`/`debugPostPass` and their calls, the `window.__qcRaw`/`qcDump` dump, and the now-dead request-header capture code. Capture + auto-pass intact.
- **csv.js / csv.test.js** *(new)* — pure UMD CSV serializer (loads in popup + content world, `require()`-able in node) with `node:test` coverage.

Note: `capture_uid` is left in the records (harmless) — the server derives the dedup key.

## Testing
- `node --check` passes for background.js, content.js, inject.js, popup.js, csv.js.
- `node --test qcpass_extension/csv.test.js` → 4/4 pass.
- **End-to-end testing is manual** (no browser harness):
  1. `chrome://extensions` → enable Developer mode → **Load unpacked** → select `qcpass_extension/`.
  2. Click the toolbar icon → log in as a **jitrgp** user (a non-jitrgp user should get a "lacks QC access" error).
  3. Open `https://rejoyui.myntrainfo.com/…`, search/scan a return → watch the panel show the record and `queued`→`synced` climb.
  4. Confirm the record reached the backend (`/ext/qc/capture`).
  5. Click **Export CSV** (panel or popup) → a `qc-capture-*.csv` downloads with the capture fields.
  6. Log out (or let the token expire) → the panel shows **"login needed"**, flushing stops, and the queue is retained until you log back in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)