### PR TITLE
feat(qc): QC dashboard (React island) + passes API

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@ frontend/node_modules
 
 # Built island assets — provided by the frontend-builder stage, never from local
 public/tasks
+public/qc
 
 # VCS / local / runtime
 .git

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ uploads/
 # Tasks React island: deps + built bundle (built in CI / Docker, not committed)
 frontend/node_modules/
 public/tasks/
+public/qc/
 
 # GCP
 *.json.key

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,14 +13,15 @@ COPY package*.json ./
 RUN npm ci --only=production && npm cache clean --force
 
 # Frontend island builder stage (React + Vite + Tailwind + shadcn)
-# Builds the Tasks UI bundle into /app/public/tasks (per frontend/vite.config.ts
-# build.outDir). Kept separate so the runtime image never ships front-end tooling.
+# Builds the Tasks UI bundle into /app/public/tasks (vite.config.ts) and the QC
+# dashboard bundle into /app/public/qc (vite.qc.config.ts). Kept separate so the
+# runtime image never ships front-end tooling.
 FROM node:20-alpine AS frontend-builder
 WORKDIR /app/frontend
 COPY frontend/package*.json ./
 RUN npm ci
 COPY frontend/ ./
-RUN npm run build
+RUN npm run build && npm run build:qc
 
 # Production stage
 FROM node:20-alpine
@@ -40,10 +41,11 @@ COPY --from=builder /app/node_modules ./node_modules
 # Copy application files
 COPY --chown=nodejs:nodejs . .
 
-# Bring in the built Tasks island AFTER `COPY . .` so it isn't shadowed by the
-# (gitignored / dockerignored) local public/tasks. This is the only source of
-# the built bundle in the image.
+# Bring in the built islands AFTER `COPY . .` so they aren't shadowed by the
+# (gitignored / dockerignored) local public/*. This is the only source of the
+# built bundles in the image.
 COPY --from=frontend-builder --chown=nodejs:nodejs /app/public/tasks ./public/tasks
+COPY --from=frontend-builder --chown=nodejs:nodejs /app/public/qc ./public/qc
 
 # Remove development files (drop frontend/ source + node_modules from the runtime image)
 RUN rm -rf .git .gitignore .env* docs/*.md tests frontend

--- a/app.js
+++ b/app.js
@@ -268,6 +268,7 @@ app.use('/easyecom', easyecomUiRoutes);
 app.use('/', featuresRoutes);
 app.use('/indent', indentRoutes);
 app.use('/tasks', require('./routes/taskRoutes'));   // mohitteam: personal to-dos + task assignment
+app.use('/qc', require('./routes/qcDashboardRoutes')); // admin + jitrgp: QC passes dashboard (React island)
 app.use('/po-creator', poCreatorRoutes);
 app.use('/nowi-po', nowiPoRoutes);
 app.use('/vendor-files', vendorFilesRoutes);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
   "description": "React + shadcn/ui island for the kotty-track Tasks feature (mounted into views/tasks.ejs)",
   "scripts": {
     "dev": "vite",
+    "dev:qc": "vite --config vite.qc.config.ts",
     "build": "vite build",
+    "build:qc": "vite build --config vite.qc.config.ts",
     "preview": "vite preview",
     "test": "vitest run",
     "test:watch": "vitest"

--- a/frontend/src/qc/App.tsx
+++ b/frontend/src/qc/App.tsx
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { ShieldCheck, AlertCircle } from "lucide-react"
+import { FilterBar } from "./components/FilterBar"
+import { SummaryBar } from "./components/SummaryBar"
+import { PassesTable } from "./components/PassesTable"
+import {
+  fetchPasses,
+  passesUrl,
+  istToday,
+  type QcFilters,
+  type QcPassesResponse,
+} from "./lib/api"
+
+interface AppProps {
+  meId: number
+  role: string
+  username: string
+}
+
+function defaultFilters(): QcFilters {
+  const today = istToday()
+  return { from: today, to: today, user: "", quality: "", qc_action: "", warehouse: "", q: "" }
+}
+
+export default function App({ username }: AppProps) {
+  const defaults = useMemo(defaultFilters, [])
+  const [applied, setApplied] = useState<QcFilters>(defaults)
+  const [data, setData] = useState<QcPassesResponse | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async (filters: QcFilters) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetchPasses(filters)
+      setData(res)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load QC passes.")
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => { load(applied) }, [applied, load])
+
+  const csvHref = useMemo(() => passesUrl(applied, { download: "csv" }), [applied])
+  const total = data?.rows.length ?? 0
+
+  return (
+    <div className="mx-auto flex min-h-screen max-w-[1400px] flex-col gap-6 px-4 py-6 sm:px-6 lg:px-8">
+      <header className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <ShieldCheck className="size-6 text-primary" />
+          <div>
+            <h1 className="text-lg font-semibold leading-tight">QC Dashboard</h1>
+            <p className="text-sm text-muted-foreground">Returns QC passes by user</p>
+          </div>
+        </div>
+        <span className="text-sm text-muted-foreground">
+          Signed in as <span className="font-medium text-foreground">{username}</span>
+        </span>
+      </header>
+
+      <FilterBar
+        value={applied}
+        defaults={defaults}
+        csvHref={csvHref}
+        loading={loading}
+        onApply={setApplied}
+      />
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-lg border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          <AlertCircle className="size-4 shrink-0" />
+          {error}
+        </div>
+      )}
+
+      <SummaryBar summary={data?.summary ?? []} total={total} />
+
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>
+          {applied.from === applied.to ? applied.from : `${applied.from} → ${applied.to}`}
+        </span>
+        {loading && <span>Loading…</span>}
+      </div>
+
+      <PassesTable rows={data?.rows ?? []} />
+    </div>
+  )
+}

--- a/frontend/src/qc/components/FilterBar.test.tsx
+++ b/frontend/src/qc/components/FilterBar.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { FilterBar } from "./FilterBar"
+import type { QcFilters } from "@/qc/lib/api"
+
+const defaults: QcFilters = {
+  from: "2026-07-01",
+  to: "2026-07-01",
+  user: "",
+  quality: "",
+  qc_action: "",
+  warehouse: "",
+  q: "",
+}
+
+function setup(overrides: Partial<QcFilters> = {}) {
+  const value = { ...defaults, ...overrides }
+  const onApply = vi.fn()
+  render(
+    <FilterBar
+      value={value}
+      defaults={defaults}
+      csvHref="/qc/api/passes?from=2026-07-01&to=2026-07-01&download=csv"
+      onApply={onApply}
+    />
+  )
+  return { onApply }
+}
+
+describe("FilterBar", () => {
+  it("renders the date range and filter fields", () => {
+    setup()
+    expect(screen.getByLabelText("From")).toHaveValue("2026-07-01")
+    expect(screen.getByLabelText("To")).toHaveValue("2026-07-01")
+    expect(screen.getByLabelText("User")).toBeInTheDocument()
+    expect(screen.getByLabelText("Quality")).toBeInTheDocument()
+    expect(screen.getByLabelText("QC action")).toBeInTheDocument()
+    expect(screen.getByLabelText("Warehouse")).toBeInTheDocument()
+    expect(screen.getByLabelText("Search")).toBeInTheDocument()
+  })
+
+  it("applies edited filters when Apply is clicked", async () => {
+    const user = userEvent.setup()
+    const { onApply } = setup()
+
+    await user.type(screen.getByLabelText("Search"), "jean")
+    await user.type(screen.getByLabelText("User"), "alice")
+    await user.click(screen.getByRole("button", { name: /apply/i }))
+
+    expect(onApply).toHaveBeenCalledTimes(1)
+    expect(onApply).toHaveBeenCalledWith(
+      expect.objectContaining({ q: "jean", user: "alice", from: "2026-07-01", to: "2026-07-01" })
+    )
+  })
+
+  it("resets to the default filters", async () => {
+    const user = userEvent.setup()
+    const { onApply } = setup({ q: "shirt", user: "bob" })
+
+    await user.click(screen.getByRole("button", { name: /reset/i }))
+
+    expect(onApply).toHaveBeenCalledWith(defaults)
+  })
+
+  it("exposes the CSV download link", () => {
+    setup()
+    const link = screen.getByRole("link", { name: /download csv/i })
+    expect(link).toHaveAttribute(
+      "href",
+      "/qc/api/passes?from=2026-07-01&to=2026-07-01&download=csv"
+    )
+  })
+})

--- a/frontend/src/qc/components/FilterBar.tsx
+++ b/frontend/src/qc/components/FilterBar.tsx
@@ -1,0 +1,106 @@
+import { useEffect, useState } from "react"
+import { Search, Download, RotateCcw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import type { QcFilters } from "@/qc/lib/api"
+
+interface FilterBarProps {
+  value: QcFilters
+  defaults: QcFilters
+  csvHref: string
+  loading?: boolean
+  onApply: (filters: QcFilters) => void
+}
+
+// Small labelled field wrapper for consistent spacing.
+function Field({ id, label, children }: { id: string; label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <Label htmlFor={id} className="text-xs text-muted-foreground">{label}</Label>
+      {children}
+    </div>
+  )
+}
+
+/**
+ * Filter bar for the QC dashboard: date range (defaults to today), the enhanced
+ * filters (user / quality / qc_action / warehouse), a free-text search, plus
+ * Apply / Reset / Download CSV. Holds an editable draft; the parent stays the
+ * source of truth for the *applied* filters (and thus the CSV link).
+ */
+export function FilterBar({ value, defaults, csvHref, loading, onApply }: FilterBarProps) {
+  const [draft, setDraft] = useState<QcFilters>(value)
+
+  // Keep the draft in sync when the parent replaces the applied filters (e.g. Reset).
+  useEffect(() => { setDraft(value) }, [value])
+
+  function set<K extends keyof QcFilters>(key: K, v: QcFilters[K]) {
+    setDraft((d) => ({ ...d, [key]: v }))
+  }
+
+  function submit(e: React.FormEvent) {
+    e.preventDefault()
+    onApply(draft)
+  }
+
+  return (
+    <form onSubmit={submit} aria-label="QC pass filters" className="flex flex-col gap-4">
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-6">
+        <Field id="qc-from" label="From">
+          <Input id="qc-from" type="date" value={draft.from} onChange={(e) => set("from", e.target.value)} />
+        </Field>
+        <Field id="qc-to" label="To">
+          <Input id="qc-to" type="date" value={draft.to} onChange={(e) => set("to", e.target.value)} />
+        </Field>
+        <Field id="qc-user" label="User">
+          <Input id="qc-user" placeholder="username" value={draft.user} onChange={(e) => set("user", e.target.value)} />
+        </Field>
+        <Field id="qc-quality" label="Quality">
+          <Input id="qc-quality" placeholder="e.g. good" value={draft.quality} onChange={(e) => set("quality", e.target.value)} />
+        </Field>
+        <Field id="qc-action" label="QC action">
+          <Input id="qc-action" placeholder="e.g. restock" value={draft.qc_action} onChange={(e) => set("qc_action", e.target.value)} />
+        </Field>
+        <Field id="qc-warehouse" label="Warehouse">
+          <Input id="qc-warehouse" placeholder="warehouse id" value={draft.warehouse} onChange={(e) => set("warehouse", e.target.value)} />
+        </Field>
+      </div>
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+        <div className="flex-1">
+          <Field id="qc-q" label="Search">
+            <div className="relative">
+              <Search className="pointer-events-none absolute left-2.5 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                id="qc-q"
+                className="pl-8"
+                placeholder="sku, style, barcode, tracking, product…"
+                value={draft.q}
+                onChange={(e) => set("q", e.target.value)}
+              />
+            </div>
+          </Field>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button type="submit" disabled={loading}>
+            {loading ? "Loading…" : "Apply"}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onApply(defaults)}
+            disabled={loading}
+          >
+            <RotateCcw /> Reset
+          </Button>
+          <Button asChild variant="secondary">
+            <a href={csvHref} download>
+              <Download /> Download CSV
+            </a>
+          </Button>
+        </div>
+      </div>
+    </form>
+  )
+}

--- a/frontend/src/qc/components/PassesTable.tsx
+++ b/frontend/src/qc/components/PassesTable.tsx
@@ -1,0 +1,67 @@
+import { Badge } from "@/components/ui/badge"
+import type { QcPassRow } from "@/qc/lib/api"
+
+interface PassesTableProps {
+  rows: QcPassRow[]
+}
+
+const HEADERS: { key: keyof QcPassRow; label: string; className?: string }[] = [
+  { key: "passed_at", label: "Passed at", className: "tabnum whitespace-nowrap" },
+  { key: "username", label: "User" },
+  { key: "item_barcode", label: "Barcode", className: "tabnum" },
+  { key: "tracking_number", label: "Tracking", className: "tabnum" },
+  { key: "sku_code", label: "SKU" },
+  { key: "style_id", label: "Style" },
+  { key: "size", label: "Size" },
+  { key: "quality", label: "Quality" },
+  { key: "qc_action", label: "QC action" },
+  { key: "warehouse_id", label: "WH" },
+]
+
+function cell(v: QcPassRow[keyof QcPassRow]) {
+  return v == null || v === "" ? <span className="text-dim">—</span> : String(v)
+}
+
+/** Detail table of individual QC passes. Horizontal scroll on narrow viewports. */
+export function PassesTable({ rows }: PassesTableProps) {
+  if (rows.length === 0) {
+    return (
+      <div className="rounded-xl border border-border bg-card p-10 text-center text-sm text-muted-foreground">
+        No QC passes match these filters.
+      </div>
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto rounded-xl border border-border">
+      <table className="w-full border-collapse text-sm">
+        <thead>
+          <tr className="border-b border-border bg-elevated text-left text-xs uppercase tracking-wide text-muted-foreground">
+            {HEADERS.map((h) => (
+              <th key={h.key} className="whitespace-nowrap px-3 py-2.5 font-medium">{h.label}</th>
+            ))}
+            <th className="whitespace-nowrap px-3 py-2.5 font-medium">Result</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, i) => (
+            <tr key={`${row.item_barcode ?? "row"}-${i}`} className="border-b border-border/60 last:border-0 hover:bg-accent/40">
+              {HEADERS.map((h) => (
+                <td key={h.key} className={`px-3 py-2 ${h.className ?? ""}`}>{cell(row[h.key])}</td>
+              ))}
+              <td className="px-3 py-2">
+                {row.pass_success == null ? (
+                  <span className="text-dim">—</span>
+                ) : row.pass_success ? (
+                  <Badge variant="success">pass</Badge>
+                ) : (
+                  <Badge variant="outline" className="text-destructive">fail</Badge>
+                )}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/frontend/src/qc/components/SummaryBar.tsx
+++ b/frontend/src/qc/components/SummaryBar.tsx
@@ -1,0 +1,36 @@
+import { Card, CardContent } from "@/components/ui/card"
+import { Badge } from "@/components/ui/badge"
+import type { QcSummaryEntry } from "@/qc/lib/api"
+
+interface SummaryBarProps {
+  summary: QcSummaryEntry[]
+  total: number
+}
+
+/** Per-user pass counts for the selected range, plus the grand total. */
+export function SummaryBar({ summary, total }: SummaryBarProps) {
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-baseline gap-2">
+        <span className="text-sm text-muted-foreground">Passes in range</span>
+        <span className="tabnum text-2xl font-semibold text-foreground">{total.toLocaleString()}</span>
+        <span className="text-sm text-muted-foreground">
+          across {summary.length} {summary.length === 1 ? "user" : "users"}
+        </span>
+      </div>
+
+      {summary.length > 0 && (
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6">
+          {summary.map((s) => (
+            <Card key={s.user} className="overflow-hidden">
+              <CardContent className="flex items-center justify-between gap-2 p-3">
+                <span className="truncate text-sm font-medium" title={s.user}>{s.user}</span>
+                <Badge variant="default" className="tabnum shrink-0">{s.passes}</Badge>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/qc/index.css
+++ b/frontend/src/qc/index.css
@@ -1,0 +1,101 @@
+/*
+ * QC dashboard island — dark-first, shares the Tasks design tokens but scoped to
+ * #qc-root so it can coexist with (and never leak into) the Tasks island.
+ */
+@import "tailwindcss";
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-elevated: var(--elevated);
+  --color-sidebar: var(--sidebar);
+  --color-card: var(--card);
+  --color-card-foreground: var(--foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-dim: var(--dim);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--foreground);
+  --color-destructive: var(--danger);
+  --color-destructive-foreground: #ffffff;
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
+  --color-input: var(--border-strong);
+  --color-ring: var(--primary);
+  --color-success: var(--success);
+  --color-danger: var(--danger);
+  --color-warning: var(--warning);
+
+  --radius-lg: var(--radius);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-sm: calc(var(--radius) - 3px);
+
+  --font-sans: "Geist", ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono: "Geist Mono", ui-monospace, "SFMono-Regular", monospace;
+}
+
+:root {
+  --background: #08090a;
+  --sidebar: #0b0b0d;
+  --elevated: #0f1011;
+  --card: #121315;
+  --popover: #161719;
+  --secondary: #18191c;
+
+  --border: #1c1d20;
+  --border-strong: #26272b;
+
+  --foreground: #ededee;
+  --muted-foreground: #8a8d94;
+  --dim: #5d6068;
+
+  --muted: #161719;
+  --accent: #1a1b1e;
+
+  --primary: #7c84f2;
+  --primary-foreground: #0a0a0c;
+
+  --success: #4cb782;
+  --danger: #e5484d;
+  --warning: #e0b13c;
+
+  --radius: 0.5rem;
+
+  color-scheme: dark;
+}
+
+* { border-color: var(--border); }
+
+html, body {
+  background: var(--background);
+  color: var(--foreground);
+}
+
+#qc-root {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.45;
+  color: var(--foreground);
+  background: var(--background);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  font-feature-settings: "cv01", "cv03", "ss01";
+}
+
+#qc-root *::-webkit-scrollbar { width: 10px; height: 10px; }
+#qc-root *::-webkit-scrollbar-thumb {
+  background: #2a2b2f; border-radius: 999px; border: 3px solid transparent; background-clip: padding-box;
+}
+#qc-root *::-webkit-scrollbar-thumb:hover { background: #38393e; background-clip: padding-box; }
+#qc-root *::-webkit-scrollbar-track { background: transparent; }
+
+#qc-root ::selection { background: color-mix(in oklab, var(--primary) 30%, transparent); }
+
+/* Numeric columns read cleaner in the mono face */
+.tabnum { font-variant-numeric: tabular-nums; font-family: var(--font-mono); }

--- a/frontend/src/qc/lib/api.ts
+++ b/frontend/src/qc/lib/api.ts
@@ -1,0 +1,101 @@
+// QC dashboard API client + pure querystring helpers (the helpers are unit-tested
+// in qs.test.ts so the URL contract stays stable without a live backend).
+
+export interface QcFilters {
+  from: string
+  to: string
+  user: string
+  quality: string
+  qc_action: string
+  warehouse: string
+  q: string
+}
+
+export interface QcPassRow {
+  passed_at: string | null
+  username: string | null
+  item_barcode: string | null
+  tracking_number: string | null
+  sku_code: string | null
+  style_id: string | null
+  size: string | null
+  quality: string | null
+  qc_action: string | null
+  warehouse_id: string | null
+  pass_success: number | null
+}
+
+export interface QcSummaryEntry {
+  user: string
+  passes: number
+}
+
+export interface QcPassesResponse {
+  ok: boolean
+  from: string
+  to: string
+  summary: QcSummaryEntry[]
+  rows: QcPassRow[]
+}
+
+// Filter keys sent to the API (order fixed so URLs are deterministic/testable).
+const FILTER_KEYS: (keyof QcFilters)[] = [
+  "from",
+  "to",
+  "user",
+  "quality",
+  "qc_action",
+  "warehouse",
+  "q",
+]
+
+/**
+ * Build the querystring for /qc/api/passes from filters. Blank/whitespace-only
+ * values are omitted. `extra` (e.g. { download: 'csv' }) is appended last.
+ * Pure — no fetch — so it can be unit-tested.
+ */
+export function passesQueryString(
+  filters: Partial<QcFilters>,
+  extra: Record<string, string> = {}
+): string {
+  const qs = new URLSearchParams()
+  for (const key of FILTER_KEYS) {
+    const raw = filters[key]
+    if (raw != null && String(raw).trim() !== "") {
+      qs.set(key, String(raw).trim())
+    }
+  }
+  for (const [k, v] of Object.entries(extra)) qs.set(k, v)
+  return qs.toString()
+}
+
+/** Full URL to the passes endpoint (used for both fetch + the Download CSV link). */
+export function passesUrl(
+  filters: Partial<QcFilters>,
+  extra: Record<string, string> = {}
+): string {
+  const qs = passesQueryString(filters, extra)
+  return qs ? `/qc/api/passes?${qs}` : `/qc/api/passes`
+}
+
+export async function fetchPasses(filters: Partial<QcFilters>): Promise<QcPassesResponse> {
+  const res = await fetch(passesUrl(filters), {
+    credentials: "same-origin",
+    headers: { Accept: "application/json" },
+  })
+  if (res.status === 401) {
+    window.location.href = "/login"
+    throw new Error("Unauthorized")
+  }
+  const data = await res.json().catch(() => ({}))
+  if (!res.ok || (data as QcPassesResponse).ok === false) {
+    throw new Error((data as { error?: string })?.error || `Request failed (${res.status})`)
+  }
+  return data as QcPassesResponse
+}
+
+/** Today's date in IST as YYYY-MM-DD (matches the backend default range). */
+export function istToday(now = new Date()): string {
+  const ist = new Date(now.getTime() + 5.5 * 60 * 60 * 1000)
+  return ist.toISOString().slice(0, 10)
+}

--- a/frontend/src/qc/lib/qs.test.ts
+++ b/frontend/src/qc/lib/qs.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest"
+import { passesQueryString, passesUrl } from "./api"
+
+describe("passesQueryString", () => {
+  it("omits blank and whitespace-only filters", () => {
+    expect(passesQueryString({})).toBe("")
+    expect(passesQueryString({ user: "", q: "   " })).toBe("")
+  })
+
+  it("includes and trims non-empty filters in a stable order", () => {
+    const qs = passesQueryString({
+      from: "2026-06-01",
+      to: "2026-06-30",
+      user: "  alice  ",
+      q: "jean",
+    })
+    expect(qs).toBe("from=2026-06-01&to=2026-06-30&user=alice&q=jean")
+  })
+
+  it("url-encodes special characters", () => {
+    expect(passesQueryString({ q: "a&b c" })).toBe("q=a%26b+c")
+  })
+
+  it("appends extras like download=csv last", () => {
+    expect(passesQueryString({ from: "2026-06-01" }, { download: "csv" })).toBe(
+      "from=2026-06-01&download=csv"
+    )
+  })
+})
+
+describe("passesUrl", () => {
+  it("returns a bare path when there are no params", () => {
+    expect(passesUrl({})).toBe("/qc/api/passes")
+  })
+
+  it("builds a full CSV download URL", () => {
+    expect(passesUrl({ from: "2026-06-01", to: "2026-06-01" }, { download: "csv" })).toBe(
+      "/qc/api/passes?from=2026-06-01&to=2026-06-01&download=csv"
+    )
+  })
+})

--- a/frontend/src/qc/main.tsx
+++ b/frontend/src/qc/main.tsx
@@ -1,0 +1,16 @@
+import { StrictMode } from "react"
+import { createRoot } from "react-dom/client"
+import "./index.css"
+import App from "./App"
+
+const el = document.getElementById("qc-root")
+if (el) {
+  const meId = Number(el.dataset.userId)
+  const role = el.dataset.userRole || ""
+  const username = el.dataset.username || "user"
+  createRoot(el).render(
+    <StrictMode>
+      <App meId={meId} role={role} username={username} />
+    </StrictMode>
+  )
+}

--- a/frontend/vite.qc.config.ts
+++ b/frontend/vite.qc.config.ts
@@ -1,0 +1,28 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import path from 'node:path'
+
+// Second island: the QC dashboard. Builds to ../public/qc so Express serves it
+// via app.use('/public', express.static(...)). base must match that URL prefix.
+// Kept in a separate config so the Tasks build (vite.config.ts) is untouched.
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: { '@': path.resolve(__dirname, './src') },
+  },
+  base: '/public/qc/',
+  build: {
+    outDir: path.resolve(__dirname, '../public/qc'),
+    emptyOutDir: true,
+    manifest: true, // -> ../public/qc/.vite/manifest.json (read by utils/viteManifest.js qcAssetTags)
+    rollupOptions: {
+      input: path.resolve(__dirname, 'src/qc/main.tsx'),
+    },
+  },
+  server: {
+    port: 5174,
+    // Dev only: proxy API calls to the Express app so the session cookie works.
+    proxy: { '/qc/api': 'http://localhost:8080' },
+  },
+})

--- a/routes/qcDashboardRoutes.js
+++ b/routes/qcDashboardRoutes.js
@@ -1,0 +1,82 @@
+// routes/qcDashboardRoutes.js
+//
+// QC Dashboard. Mounted at /qc, gated to admin + jitrgp (session-authenticated,
+// NOT the token auth the qcpass extension uses). GET /qc/dashboard renders an
+// EJS shell that mounts a React island; the island talks to GET /qc/api/passes.
+//
+// A row in qc_return_passes is one QC pass by user `passed_by`. Product detail
+// (sku_code, style_id, size, product_name, tracking_number) is joined from
+// qc_return_captures on capture_uid. All pure/DB-free logic lives in
+// utils/qcDashboard.js (unit-tested in test/qcDashboard.test.js).
+
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, allowRoles } = require('../middlewares/auth');
+const { qcAssetTags } = require('../utils/viteManifest');
+const {
+  buildPassesQuery,
+  summarizeByUser,
+  rowsToCsv,
+} = require('../utils/qcDashboard');
+
+const gate = [isAuthenticated, allowRoles(['admin', 'jitrgp'])];
+
+// ---------------------------------------------------------------------------
+// Page shell (React island)
+// ---------------------------------------------------------------------------
+router.get('/dashboard', gate, (req, res) => {
+  try {
+    const { jsTag, cssTags } = qcAssetTags();
+    res.render('qcDashboard', { user: req.session.user, jsTag, cssTags });
+  } catch (err) {
+    console.error('Error GET /qc/dashboard (island not built?):', err.message);
+    res
+      .status(500)
+      .send('QC dashboard UI is not built yet. Run: cd frontend && npm install && npm run build:qc');
+  }
+});
+
+// ---------------------------------------------------------------------------
+// JSON / CSV API
+// ---------------------------------------------------------------------------
+// GET /qc/api/passes?from=&to=&user=&quality=&qc_action=&warehouse=&q=&download=csv
+router.get('/api/passes', gate, async (req, res) => {
+  try {
+    const { sql, params, from, to } = buildPassesQuery({
+      from: req.query.from,
+      to: req.query.to,
+      user: req.query.user,
+      quality: req.query.quality,
+      qc_action: req.query.qc_action,
+      warehouse: req.query.warehouse,
+      q: req.query.q,
+    });
+
+    const [rows] = await pool.query(sql, params);
+
+    if (req.query.download === 'csv') {
+      const csv = rowsToCsv(rows);
+      res.setHeader('Content-Type', 'text/csv; charset=utf-8');
+      res.setHeader(
+        'Content-Disposition',
+        `attachment; filename="qc-passes-${from}_${to}.csv"`
+      );
+      // Prepend a BOM so Excel opens UTF-8 correctly.
+      return res.send('﻿' + csv);
+    }
+
+    res.json({
+      ok: true,
+      from,
+      to,
+      summary: summarizeByUser(rows),
+      rows,
+    });
+  } catch (err) {
+    console.error('Error GET /qc/api/passes:', err);
+    res.status(500).json({ ok: false, error: 'Failed to load QC passes.' });
+  }
+});
+
+module.exports = router;

--- a/test/qcDashboard.test.js
+++ b/test/qcDashboard.test.js
@@ -1,0 +1,165 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  buildPassesQuery,
+  summarizeByUser,
+  rowsToCsv,
+  csvField,
+  istToday,
+} = require('../utils/qcDashboard.js');
+
+// ---------------------------------------------------------------------------
+// buildPassesQuery
+// ---------------------------------------------------------------------------
+
+test('buildPassesQuery defaults to today (IST) when no dates given', () => {
+  const today = istToday();
+  const { sql, params, from, to } = buildPassesQuery({});
+  assert.strictEqual(from, today);
+  assert.strictEqual(to, today);
+  // date range is the first WHERE predicate, first two params
+  assert.ok(/DATE\(p\.passed_at\) BETWEEN \? AND \?/.test(sql));
+  assert.deepStrictEqual(params, [today, today]);
+});
+
+test('buildPassesQuery honours explicit valid from/to and ignores malformed dates', () => {
+  const ok = buildPassesQuery({ from: '2026-06-01', to: '2026-06-30' });
+  assert.strictEqual(ok.from, '2026-06-01');
+  assert.strictEqual(ok.to, '2026-06-30');
+  assert.deepStrictEqual(ok.params, ['2026-06-01', '2026-06-30']);
+
+  // A malformed date falls back to today rather than being interpolated.
+  const bad = buildPassesQuery({ from: "2026-06-01'; DROP TABLE x;--", to: 'nope' });
+  const today = istToday();
+  assert.strictEqual(bad.from, today);
+  assert.strictEqual(bad.to, today);
+});
+
+test('buildPassesQuery adds a WHERE + param for each scalar filter', () => {
+  const cases = [
+    ['user', 'u.username = ?'],
+    ['quality', 'p.quality = ?'],
+    ['qc_action', 'p.qc_action = ?'],
+    ['warehouse', 'p.warehouse_id = ?'],
+  ];
+  for (const [key, clause] of cases) {
+    const { sql, params } = buildPassesQuery({ [key]: 'X' });
+    assert.ok(sql.includes(clause), `expected clause "${clause}" for filter "${key}"`);
+    // two date params + this one
+    assert.strictEqual(params.length, 3, `filter "${key}" should add exactly one param`);
+    assert.strictEqual(params[2], 'X');
+  }
+});
+
+test('buildPassesQuery trims filter values and skips empty/whitespace filters', () => {
+  const withVal = buildPassesQuery({ user: '  alice  ', quality: '', warehouse: '   ' });
+  // only `user` should survive; quality/warehouse are blank
+  assert.strictEqual(withVal.params.length, 3);
+  assert.strictEqual(withVal.params[2], 'alice');
+  assert.ok(!withVal.sql.includes('p.quality = ?'));
+  assert.ok(!withVal.sql.includes('p.warehouse_id = ?'));
+});
+
+test('buildPassesQuery q produces a grouped OR LIKE with five params', () => {
+  const { sql, params } = buildPassesQuery({ q: 'abc' });
+  assert.ok(
+    sql.includes(
+      '(c.sku_code LIKE ? OR c.style_id LIKE ? OR p.item_barcode LIKE ? OR c.tracking_number LIKE ? OR c.product_name LIKE ?)'
+    ),
+    'q should be a single parenthesized OR group across the 5 searchable columns'
+  );
+  // two date params + five LIKE params, each wrapped with %...%
+  assert.strictEqual(params.length, 7);
+  assert.deepStrictEqual(params.slice(2), ['%abc%', '%abc%', '%abc%', '%abc%', '%abc%']);
+});
+
+test('buildPassesQuery combines all filters in order and never inlines user input', () => {
+  const { sql, params } = buildPassesQuery({
+    from: '2026-01-01',
+    to: '2026-01-31',
+    user: 'bob',
+    quality: 'good',
+    qc_action: 'restock',
+    warehouse: 'WH1',
+    q: 'jean',
+  });
+  assert.deepStrictEqual(params, [
+    '2026-01-01', '2026-01-31',
+    'bob', 'good', 'restock', 'WH1',
+    '%jean%', '%jean%', '%jean%', '%jean%', '%jean%',
+  ]);
+  // No raw user values embedded in the SQL text (only placeholders).
+  for (const v of ['bob', 'good', 'restock', 'WH1', 'jean']) {
+    assert.ok(!sql.includes(v), `value "${v}" must not be string-concatenated into SQL`);
+  }
+  assert.ok(sql.trim().endsWith('ORDER BY p.passed_at DESC'));
+});
+
+// ---------------------------------------------------------------------------
+// summarizeByUser
+// ---------------------------------------------------------------------------
+
+test('summarizeByUser groups rows into per-user counts, busiest first', () => {
+  const rows = [
+    { username: 'alice' },
+    { username: 'bob' },
+    { username: 'alice' },
+    { username: 'alice' },
+    { username: 'bob' },
+  ];
+  assert.deepStrictEqual(summarizeByUser(rows), [
+    { user: 'alice', passes: 3 },
+    { user: 'bob', passes: 2 },
+  ]);
+});
+
+test('summarizeByUser labels missing usernames and handles empty input', () => {
+  assert.deepStrictEqual(summarizeByUser([]), []);
+  assert.deepStrictEqual(summarizeByUser([{ username: null }]), [
+    { user: '(unknown)', passes: 1 },
+  ]);
+});
+
+// ---------------------------------------------------------------------------
+// rowsToCsv / csvField
+// ---------------------------------------------------------------------------
+
+test('rowsToCsv emits the header row in the fixed column order', () => {
+  const csv = rowsToCsv([]);
+  assert.strictEqual(
+    csv,
+    'passed_at,username,item_barcode,tracking_number,sku_code,style_id,size,quality,qc_action,warehouse_id,pass_success'
+  );
+});
+
+test('rowsToCsv escapes commas, quotes and newlines; blanks null fields', () => {
+  const csv = rowsToCsv([
+    {
+      passed_at: '2026-07-01 10:00:00',
+      username: 'alice',
+      item_barcode: 'BC,1',
+      tracking_number: 'TN"x"',
+      sku_code: 'line1\nline2',
+      style_id: null,
+      size: 'M',
+      quality: 'good',
+      qc_action: 'restock',
+      warehouse_id: 'WH1',
+      pass_success: 1,
+    },
+  ]);
+  const lines = csv.split('\r\n');
+  assert.strictEqual(lines.length, 2);
+  assert.strictEqual(
+    lines[1],
+    '2026-07-01 10:00:00,alice,"BC,1","TN""x""","line1\nline2",,M,good,restock,WH1,1'
+  );
+});
+
+test('csvField quotes only when needed and doubles embedded quotes', () => {
+  assert.strictEqual(csvField('plain'), 'plain');
+  assert.strictEqual(csvField('a,b'), '"a,b"');
+  assert.strictEqual(csvField('he said "hi"'), '"he said ""hi"""');
+  assert.strictEqual(csvField(null), '');
+  assert.strictEqual(csvField(0), '0');
+});

--- a/utils/qcDashboard.js
+++ b/utils/qcDashboard.js
@@ -1,0 +1,153 @@
+// utils/qcDashboard.js
+//
+// Pure (DB-free) logic for the QC dashboard passes API, extracted so it can be
+// unit-tested without a live database:
+//   - buildPassesQuery(filters)  -> { sql, params }  (parameterized SELECT)
+//   - rowsToCsv(rows)            -> CSV string (RFC-4180-ish escaping)
+//   - summarizeByUser(rows)      -> [{ user, passes }]  (grouped count)
+//   - istToday()                 -> 'YYYY-MM-DD' in IST (default date range)
+//
+// A row in qc_return_passes is one QC pass by user `passed_by`. Product detail
+// (sku_code, style_id, size, product_name, tracking_number) lives in
+// qc_return_captures, joined on capture_uid.
+
+// Ordered column set the API returns for each detail row. Also the CSV header order.
+const ROW_COLUMNS = [
+  'passed_at',
+  'username',
+  'item_barcode',
+  'tracking_number',
+  'sku_code',
+  'style_id',
+  'size',
+  'quality',
+  'qc_action',
+  'warehouse_id',
+  'pass_success',
+];
+
+// SELECT clause that produces exactly ROW_COLUMNS (in order).
+const SELECT_SQL = `
+  SELECT
+    DATE_FORMAT(p.passed_at, '%Y-%m-%d %H:%i:%s') AS passed_at,
+    u.username        AS username,
+    p.item_barcode    AS item_barcode,
+    c.tracking_number AS tracking_number,
+    c.sku_code        AS sku_code,
+    c.style_id        AS style_id,
+    c.size            AS size,
+    p.quality         AS quality,
+    p.qc_action       AS qc_action,
+    p.warehouse_id    AS warehouse_id,
+    p.pass_success    AS pass_success
+  FROM qc_return_passes p
+  LEFT JOIN users u ON u.id = p.passed_by
+  LEFT JOIN qc_return_captures c ON c.capture_uid = p.capture_uid`.trim();
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** Current date in IST (Asia/Kolkata) as 'YYYY-MM-DD'. */
+function istToday(now = new Date()) {
+  // IST is a fixed +05:30 offset (no DST); shift the epoch and read UTC parts.
+  const ist = new Date(now.getTime() + 5.5 * 60 * 60 * 1000);
+  return ist.toISOString().slice(0, 10);
+}
+
+/** Return `value` if it is a YYYY-MM-DD string, else `fallback`. */
+function sanitizeDate(value, fallback) {
+  return typeof value === 'string' && DATE_RE.test(value) ? value : fallback;
+}
+
+function nonEmpty(value) {
+  return value != null && String(value).trim() !== '';
+}
+
+/**
+ * Build the parameterized passes query from user filters. NEVER string-
+ * concatenates user input — every dynamic value goes in `params`.
+ *
+ * filters: { from, to, user, quality, qc_action, warehouse, q }
+ *   from/to  inclusive on DATE(passed_at); default to today (IST) when absent.
+ *   user     matches users.username (the passer).
+ *   quality / qc_action / warehouse  exact matches on the pass row.
+ *   q        free-text, grouped OR LIKE across
+ *            sku_code / style_id / item_barcode / tracking_number / product_name.
+ *
+ * Returns { sql, params, from, to }.
+ */
+function buildPassesQuery(filters = {}) {
+  const today = istToday();
+  const from = sanitizeDate(filters.from, today);
+  const to = sanitizeDate(filters.to, today);
+
+  const where = ['DATE(p.passed_at) BETWEEN ? AND ?'];
+  const params = [from, to];
+
+  if (nonEmpty(filters.user)) {
+    where.push('u.username = ?');
+    params.push(String(filters.user).trim());
+  }
+  if (nonEmpty(filters.quality)) {
+    where.push('p.quality = ?');
+    params.push(String(filters.quality).trim());
+  }
+  if (nonEmpty(filters.qc_action)) {
+    where.push('p.qc_action = ?');
+    params.push(String(filters.qc_action).trim());
+  }
+  if (nonEmpty(filters.warehouse)) {
+    where.push('p.warehouse_id = ?');
+    params.push(String(filters.warehouse).trim());
+  }
+  if (nonEmpty(filters.q)) {
+    const like = `%${String(filters.q).trim()}%`;
+    where.push(
+      '(c.sku_code LIKE ? OR c.style_id LIKE ? OR p.item_barcode LIKE ? OR c.tracking_number LIKE ? OR c.product_name LIKE ?)'
+    );
+    params.push(like, like, like, like, like);
+  }
+
+  const sql = `${SELECT_SQL}\n  WHERE ${where.join('\n    AND ')}\n  ORDER BY p.passed_at DESC`;
+  return { sql, params, from, to };
+}
+
+/** Group rows into a per-user pass count: [{ user, passes }], busiest first. */
+function summarizeByUser(rows = []) {
+  const counts = new Map();
+  for (const r of rows) {
+    const user = r.username || '(unknown)';
+    counts.set(user, (counts.get(user) || 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([user, passes]) => ({ user, passes }))
+    .sort((a, b) => b.passes - a.passes || a.user.localeCompare(b.user));
+}
+
+/** Escape one CSV field: quote when it contains comma, quote, CR or LF. */
+function csvField(value) {
+  if (value == null) return '';
+  const s = String(value);
+  if (/[",\r\n]/.test(s)) {
+    return `"${s.replace(/"/g, '""')}"`;
+  }
+  return s;
+}
+
+/** Serialize rows to CSV (header + one line per row, in ROW_COLUMNS order). */
+function rowsToCsv(rows = []) {
+  const lines = [ROW_COLUMNS.map(csvField).join(',')];
+  for (const row of rows) {
+    lines.push(ROW_COLUMNS.map((col) => csvField(row[col])).join(','));
+  }
+  return lines.join('\r\n');
+}
+
+module.exports = {
+  ROW_COLUMNS,
+  buildPassesQuery,
+  summarizeByUser,
+  rowsToCsv,
+  csvField,
+  istToday,
+  sanitizeDate,
+};

--- a/utils/viteManifest.js
+++ b/utils/viteManifest.js
@@ -1,51 +1,67 @@
 // utils/viteManifest.js
 //
-// Bridges the Vite-built React island (frontend/) into the EJS shell. After
-// `vite build`, the bundle lives in public/tasks/ with hashed filenames, and a
-// manifest at public/tasks/.vite/manifest.json maps the source entry to them.
-// This helper reads that manifest and returns ready-to-print HTML tags so the
-// shell view can inject the correct <script type="module"> + <link> for the
+// Bridges Vite-built React islands (frontend/) into the EJS shells. After
+// `vite build`, each bundle lives in public/<island>/ with hashed filenames and
+// a manifest at public/<island>/.vite/manifest.json mapping the source entry to
+// them. This helper reads that manifest and returns ready-to-print HTML tags so
+// the shell view can inject the correct <script type="module"> + <link> for the
 // current build without hardcoding hashes.
+//
+// Two islands share this module:
+//   - Tasks: entry src/main.tsx    -> public/tasks, base /public/tasks/
+//   - QC:    entry src/qc/main.tsx  -> public/qc,    base /public/qc/
 
 const fs = require('fs');
 const path = require('path');
 
-// Vite 5/6 writes the manifest under a `.vite/` subdirectory of the out dir.
-const MANIFEST_PATH = path.join(__dirname, '..', 'public', 'tasks', '.vite', 'manifest.json');
-// Must match rollupOptions.input in frontend/vite.config.ts.
-const ENTRY = 'src/main.tsx';
-// Must match `base` in frontend/vite.config.ts (served via app.use('/public', ...)).
-const ASSET_BASE = '/public/tasks/';
+// Cache per-island; only in production (dev --watch changes hashes each build).
+const caches = new Map();
 
-let cache = null;
-
-function loadManifest() {
-  // Cache only in production; in dev (--watch) the hashes change between builds.
-  if (cache && process.env.NODE_ENV === 'production') return cache;
-  const raw = fs.readFileSync(MANIFEST_PATH, 'utf8');
+function loadManifest(manifestPath) {
+  if (process.env.NODE_ENV === 'production' && caches.has(manifestPath)) {
+    return caches.get(manifestPath);
+  }
+  const raw = fs.readFileSync(manifestPath, 'utf8');
   const parsed = JSON.parse(raw);
-  cache = parsed;
+  caches.set(manifestPath, parsed);
   return parsed;
 }
 
 /**
- * Returns { jsTag, cssTags } HTML strings for the tasks island entry.
- * Throws if the manifest/entry is missing (i.e. the frontend build hasn't run)
- * so the route can render a friendly "not built" message instead of a blank page.
+ * Generic tag builder for a Vite island.
+ * @param {string} outDir   directory name under public/ (e.g. 'tasks', 'qc')
+ * @param {string} entry    manifest entry key (source path, e.g. 'src/main.tsx')
+ * @returns {{ jsTag: string, cssTags: string }}
+ * Throws if the manifest/entry is missing (build hasn't run) so the route can
+ * render a friendly "not built" message instead of a blank page.
  */
-function taskAssetTags() {
-  const manifest = loadManifest();
-  const entry = manifest[ENTRY];
-  if (!entry || !entry.file) {
-    throw new Error(`Vite manifest missing entry "${ENTRY}" — run the frontend build.`);
+function assetTags(outDir, entry) {
+  const manifestPath = path.join(__dirname, '..', 'public', outDir, '.vite', 'manifest.json');
+  const assetBase = `/public/${outDir}/`;
+  const manifest = loadManifest(manifestPath);
+  const record = manifest[entry];
+  if (!record || !record.file) {
+    throw new Error(`Vite manifest missing entry "${entry}" — run the frontend build.`);
   }
 
-  const jsTag = `<script type="module" src="${ASSET_BASE}${entry.file}"></script>`;
-  const cssTags = (entry.css || [])
-    .map((href) => `<link rel="stylesheet" href="${ASSET_BASE}${href}">`)
+  const jsTag = `<script type="module" src="${assetBase}${record.file}"></script>`;
+  const cssTags = (record.css || [])
+    .map((href) => `<link rel="stylesheet" href="${assetBase}${href}">`)
     .join('\n');
 
   return { jsTag, cssTags };
 }
 
-module.exports = { taskAssetTags, MANIFEST_PATH };
+// Tasks island (must match frontend/vite.config.ts input + base).
+function taskAssetTags() {
+  return assetTags('tasks', 'src/main.tsx');
+}
+
+// QC island (must match frontend/vite.qc.config.ts input + base).
+function qcAssetTags() {
+  return assetTags('qc', 'src/qc/main.tsx');
+}
+
+const MANIFEST_PATH = path.join(__dirname, '..', 'public', 'tasks', '.vite', 'manifest.json');
+
+module.exports = { taskAssetTags, qcAssetTags, assetTags, MANIFEST_PATH };

--- a/views/qcDashboard.ejs
+++ b/views/qcDashboard.ejs
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="dark">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+  <meta name="color-scheme" content="dark" />
+  <title>QC Dashboard · Kotty</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Geist:wght@300;400;500;600;700&family=Geist+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+
+  <style>
+    html, body { margin: 0; padding: 0; min-height: 100%; background: #08090a; }
+    #qc-root { min-height: 100vh; min-height: 100dvh; }
+  </style>
+
+  <!-- Vite-built island stylesheet(s) -->
+  <%- cssTags %>
+</head>
+<body>
+  <div id="qc-root"
+       data-user-id="<%= user.id %>"
+       data-user-role="<%= user.roleName || user.role || '' %>"
+       data-username="<%= user.username %>"></div>
+
+  <%- jsTag %>
+</body>
+</html>


### PR DESCRIPTION
## Summary
A session-authenticated **QC Dashboard** (React island + JSON/CSV API) for viewing returns QC passes by user. Gated to `admin` + `jitrgp`. Built as a **second** Vite island alongside Tasks (Tasks build untouched).

## Backend
- **`utils/qcDashboard.js`** (pure, DB-free): `buildPassesQuery(filters) -> { sql, params, from, to }` (fully parameterized — never string-concatenates user input), `summarizeByUser(rows)`, `rowsToCsv(rows)`, `istToday()`.
- **`routes/qcDashboardRoutes.js`** mounted at `/qc` in `app.js`:
  - `GET /qc/dashboard` — renders `views/qcDashboard.ejs` (mounts the island).
  - `GET /qc/api/passes?from&to&user&quality&qc_action&warehouse&q&download=csv` — passes joined from `qc_return_passes` → `qc_return_captures` (product detail) → `users` (passer). Default range = today (IST), inclusive on `DATE(passed_at)`. `download=csv` streams a CSV with `Content-Disposition: attachment; filename="qc-passes-<from>_<to>.csv"`.
- **`utils/viteManifest.js`** generalized to serve multiple islands; adds `qcAssetTags()` (existing `taskAssetTags()` preserved).

### API contract — `GET /qc/api/passes`
```json
{ "ok": true, "from": "YYYY-MM-DD", "to": "YYYY-MM-DD",
  "summary": [{ "user": "alice", "passes": 12 }],
  "rows": [{ "passed_at","username","item_barcode","tracking_number","sku_code",
             "style_id","size","quality","qc_action","warehouse_id","pass_success" }] }
```

## Frontend (second island)
- **`frontend/vite.qc.config.ts`** + `build:qc` script → `../public/qc`, base `/public/qc/`, `manifest: true`.
- **`frontend/src/qc/*`**: `App.tsx` + `FilterBar` (date range default today, user/quality/qc_action/warehouse filters, free-text search, Download CSV) + `SummaryBar` (per-user counts) + `PassesTable`, reusing the shared shadcn components. Pure querystring builder in `lib/api.ts`.
- **Dockerfile** builds both islands (`npm run build && npm run build:qc`); `.gitignore`/`.dockerignore` cover `public/qc`.

## Tests
- **Backend** (`node --test`): 11 new cases in `test/qcDashboard.test.js` (default-today, each filter adds the right WHERE+param, grouped OR-LIKE for `q`, CSV header + comma/quote/newline escaping). Full suite **137 pass / 0 fail**.
- **Frontend** (`npm run test`): `qs.test.ts` (6) + `FilterBar.test.tsx` (4). Full suite **14 pass / 0 fail**.
- No new npm deps (package-lock unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)