### PR TITLE
fix(auth): map jitrgp -> /qc/dashboard (fixes login redirect loop)

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -86,6 +86,7 @@ function getDashboardForRole(roleName) {
     'returns_operator': '/return-grn/dashboard',
     'returnchallan': '/return-challan',
     'production_manager': '/pm',
+    'jitrgp': '/qc/dashboard',
   };
 
   // If role not found, log it for debugging and return a safe default


### PR DESCRIPTION
**Bug:** logging in as a `jitrgp` user (e.g. jituser1) gives **ERR_TOO_MANY_REDIRECTS**.

**Cause:** `getDashboardForRole` (routes/authRoutes.js) has no `jitrgp` entry, so it falls back to `/operator/dashboard`. A jitrgp user isn't an operator, so `isOperator` bounces them → `/` → fallback → `/operator/dashboard` → … redirect loop.

**Fix:** map `jitrgp` → `/qc/dashboard` (the QC dashboard from #491, which allows `admin`+`jitrgp`). jitrgp users now land there directly.

One line. `node --check` clean. Merge + let it deploy (wait for the build) and the loop is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)