### PR TITLE
fix(qc): captures-based dashboard + auto-pass drives Myntra's real Pass button

### DIFF
--- a/frontend/src/qc/App.tsx
+++ b/frontend/src/qc/App.tsx
@@ -54,7 +54,7 @@ export default function App({ username }: AppProps) {
           <ShieldCheck className="size-6 text-primary" />
           <div>
             <h1 className="text-lg font-semibold leading-tight">QC Dashboard</h1>
-            <p className="text-sm text-muted-foreground">Returns QC passes by user</p>
+            <p className="text-sm text-muted-foreground">Returns scanned by user — with pass status</p>
           </div>
         </div>
         <span className="text-sm text-muted-foreground">

--- a/frontend/src/qc/components/PassesTable.tsx
+++ b/frontend/src/qc/components/PassesTable.tsx
@@ -6,15 +6,18 @@ interface PassesTableProps {
 }
 
 const HEADERS: { key: keyof QcPassRow; label: string; className?: string }[] = [
-  { key: "passed_at", label: "Passed at", className: "tabnum whitespace-nowrap" },
+  { key: "captured_at", label: "Scanned at", className: "tabnum whitespace-nowrap" },
   { key: "username", label: "User" },
   { key: "item_barcode", label: "Barcode", className: "tabnum" },
   { key: "tracking_number", label: "Tracking", className: "tabnum" },
   { key: "sku_code", label: "SKU" },
   { key: "style_id", label: "Style" },
+  { key: "product_name", label: "Product" },
   { key: "size", label: "Size" },
   { key: "quality", label: "Quality" },
   { key: "qc_action", label: "QC action" },
+  { key: "return_status", label: "Return" },
+  { key: "logistics_status", label: "Logistics" },
   { key: "warehouse_id", label: "WH" },
 ]
 
@@ -27,7 +30,7 @@ export function PassesTable({ rows }: PassesTableProps) {
   if (rows.length === 0) {
     return (
       <div className="rounded-xl border border-border bg-card p-10 text-center text-sm text-muted-foreground">
-        No QC passes match these filters.
+        No scanned returns match these filters.
       </div>
     )
   }
@@ -40,7 +43,7 @@ export function PassesTable({ rows }: PassesTableProps) {
             {HEADERS.map((h) => (
               <th key={h.key} className="whitespace-nowrap px-3 py-2.5 font-medium">{h.label}</th>
             ))}
-            <th className="whitespace-nowrap px-3 py-2.5 font-medium">Result</th>
+            <th className="whitespace-nowrap px-3 py-2.5 font-medium">Passed</th>
           </tr>
         </thead>
         <tbody>
@@ -49,9 +52,9 @@ export function PassesTable({ rows }: PassesTableProps) {
               {HEADERS.map((h) => (
                 <td key={h.key} className={`px-3 py-2 ${h.className ?? ""}`}>{cell(row[h.key])}</td>
               ))}
-              <td className="px-3 py-2">
+              <td className="px-3 py-2 whitespace-nowrap">
                 {row.pass_success == null ? (
-                  <span className="text-dim">—</span>
+                  <Badge variant="outline" className="text-muted-foreground">not passed</Badge>
                 ) : row.pass_success ? (
                   <Badge variant="success">pass</Badge>
                 ) : (

--- a/frontend/src/qc/components/SummaryBar.tsx
+++ b/frontend/src/qc/components/SummaryBar.tsx
@@ -12,7 +12,7 @@ export function SummaryBar({ summary, total }: SummaryBarProps) {
   return (
     <div className="flex flex-col gap-3">
       <div className="flex items-baseline gap-2">
-        <span className="text-sm text-muted-foreground">Passes in range</span>
+        <span className="text-sm text-muted-foreground">Returns scanned in range</span>
         <span className="tabnum text-2xl font-semibold text-foreground">{total.toLocaleString()}</span>
         <span className="text-sm text-muted-foreground">
           across {summary.length} {summary.length === 1 ? "user" : "users"}

--- a/frontend/src/qc/lib/api.ts
+++ b/frontend/src/qc/lib/api.ts
@@ -11,23 +11,30 @@ export interface QcFilters {
   q: string
 }
 
+// One row = one return item SCANNED by a user (qc_return_captures), with the
+// pass outcome (pass_success/passed_at) LEFT-joined from qc_return_passes.
+// pass_success/passed_at are null when a scanned item was never QC-passed.
 export interface QcPassRow {
-  passed_at: string | null
+  captured_at: string | null
   username: string | null
   item_barcode: string | null
   tracking_number: string | null
   sku_code: string | null
   style_id: string | null
+  product_name: string | null
   size: string | null
   quality: string | null
   qc_action: string | null
+  return_status: string | null
+  logistics_status: string | null
   warehouse_id: string | null
   pass_success: number | null
+  passed_at: string | null
 }
 
 export interface QcSummaryEntry {
   user: string
-  passes: number
+  passes: number // number of returns this user scanned in range
 }
 
 export interface QcPassesResponse {

--- a/qcpass_extension/content.js
+++ b/qcpass_extension/content.js
@@ -78,13 +78,13 @@
 
   // Auto-Pass toggle: OFF = capture/sync only (read-only). ON = also auto-pass each scanned item.
   // State is persisted and pushed to the page-context interceptor (inject.js) via window messages.
-  // Broadcast the full config (toggle + the operator's real desk/quality) to inject.js.
+  // Broadcast the config (toggle + optional Pass-button selector override) to inject.js.
   function pushCfg() {
-    chrome.storage.local.get(['autopass', 'passDesk', 'passQuality'], (r) => {
+    chrome.storage.local.get(['autopass', 'passSelector'], (r) => {
       try {
         window.postMessage({
           __qcCfg: true, autopass: !!(r && r.autopass),
-          passDesk: (r && r.passDesk) || '', passQuality: (r && r.passQuality) || '',
+          passSelector: (r && r.passSelector) || '',
         }, '*');
       } catch (e) {}
     });
@@ -150,11 +150,6 @@
     else if (m.kind === 'pass') {
       markPassed(m.payload);
       chrome.runtime.sendMessage({ type: 'pass', record: m.payload });
-      // remember the operator's real desk/quality so auto-pass uses their actual values
-      const upd = {};
-      if (m.payload.desk_code) upd.passDesk = m.payload.desk_code;
-      if (m.payload.quality) upd.passQuality = m.payload.quality;
-      if (Object.keys(upd).length) chrome.storage.local.set(upd, pushCfg);
     }
   });
 

--- a/qcpass_extension/inject.js
+++ b/qcpass_extension/inject.js
@@ -10,14 +10,14 @@
   const SOURCE_ID = '2297', TENANT_ID = '4019';
 
   // Auto-Pass config, pushed from content.js. OFF = capture only; ON = auto-pass each scanned item.
-  // qcDeskCode/quality come from the operator's own real passes (persisted); default 001/Q1.
-  let AUTOPASS = false, PASS_DESK = '001', PASS_QUALITY = 'Q1';
+  // PASS_SELECTOR (optional) lets an operator pin the exact Pass button via a CSS selector when
+  // the text-based finder isn't enough — set chrome.storage.local.passSelector.
+  let AUTOPASS = false, PASS_SELECTOR = '';
   window.addEventListener('message', (ev) => {
     const m = ev.data;
     if (m && m.__qcCfg === true) {
       AUTOPASS = !!m.autopass;
-      if (m.passDesk) PASS_DESK = m.passDesk;
-      if (m.passQuality) PASS_QUALITY = m.passQuality;
+      if (typeof m.passSelector === 'string') PASS_SELECTOR = m.passSelector.trim();
     }
   });
 
@@ -41,42 +41,72 @@
     return origPrint && origPrint.apply(this, arguments);
   };
 
-  // ---- auto-pass: replay the exact updateReturnRestocked PUT for the scanned item ----
-  const PASS_URL = `${API}/qcSearch/updateReturnRestocked?isColocatedRpc=false`;
-  const passInFlight = new Set();
+  // ---- auto-pass: click the PAGE'S OWN "Pass" button (keeps Myntra's UI in sync) ----
+  // Why not call updateReturnRestocked directly? Doing so passes the item in the backend but
+  // leaves Myntra's React UI unaware — the tracking input stays disabled until a manual refresh,
+  // and a subsequent manual Pass click fails ("already QC'd"). Clicking the real button instead
+  // runs the page's own flow: it re-enables the input for the next scan, and our fetch/XHR hook
+  // below still captures the pass result to the panel/DB. No refresh, no desync.
+  const passHandled = new Set();  // barcodes we've already auto-passed this session (no double-pass)
+
+  function isClickable(el) {
+    if (!el || el.disabled || el.getAttribute('aria-disabled') === 'true') return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0;   // visible
+  }
+
+  // Find the enabled, visible "Pass" control. Explicit selector wins; else match button text.
+  function findPassButton() {
+    if (PASS_SELECTOR) {
+      try { const el = document.querySelector(PASS_SELECTOR); if (isClickable(el)) return el; } catch (e) {}
+    }
+    const cands = document.querySelectorAll('button, [role="button"], input[type="button"], input[type="submit"], a.btn');
+    // exact-label pass first
+    for (const el of cands) {
+      if (!isClickable(el)) continue;
+      const t = (el.innerText || el.textContent || el.value || '').trim().toLowerCase();
+      if (t === 'pass' || t === 'qc pass' || t === 'qcpass') return el;
+    }
+    // looser: a short label containing the word "pass" (excluding lookalikes)
+    for (const el of cands) {
+      if (!isClickable(el)) continue;
+      const t = (el.innerText || el.textContent || el.value || '').trim().toLowerCase();
+      if (t && t.length <= 16 && /\bpass\b/.test(t) && !/bypass|passbook|password/.test(t)) return el;
+    }
+    return null;
+  }
+
+  // Poll for the enabled+visible Pass button up to `timeoutMs` (the page renders it after search).
+  function waitForPassButton(timeoutMs) {
+    return new Promise((resolve) => {
+      const start = Date.now();
+      const tick = () => {
+        const b = findPassButton();
+        if (b) return resolve(b);
+        if (Date.now() - start >= timeoutMs) return resolve(null);
+        setTimeout(tick, 150);
+      };
+      tick();
+    });
+  }
+
   async function doAutoPass(rec) {
     try {
-      if (!rec || !rec.item_barcode || !rec.oms_release_id) return;
-      const wh = Number(rec.return_request_warehouse_id || rec.warehouse_id);
-      if (!wh) return;
-      if (rec.qc_action) return;               // already QC'd — never re-pass
-      if (passInFlight.has(rec.item_barcode)) return;  // de-dupe rapid duplicate searches
-      passInFlight.add(rec.item_barcode);
-      const body = {
-        omsReleaseId: String(rec.oms_release_id),
-        itemBarcode: String(rec.item_barcode),
-        qcActionCode: 'QC_PASS',
-        returnRequestWarehouseId: wh,
-        qcDeskCode: PASS_DESK,
-        quality: PASS_QUALITY,
-      };
+      if (!rec || !rec.item_barcode) return;
+      if (rec.qc_action) return;                      // already QC'd — never re-pass
+      if (passHandled.has(rec.item_barcode)) return;  // de-dupe rapid duplicate searches
+      passHandled.add(rec.item_barcode);
+      const btn = await waitForPassButton(6000);
+      if (!btn) {
+        console.log('%c[QC Capture] auto-pass: Pass button not found — click it manually, or set passSelector', 'color:#f59e0b');
+        passHandled.delete(rec.item_barcode);         // allow a retry on the next search
+        return;
+      }
       armPrintSuppress();
-      const reqId = (window.crypto && crypto.randomUUID) ? crypto.randomUUID() : ('qc-' + Date.now());
-      // NOTE: this goes through our own fetch wrapper below, which captures the response and
-      // posts the 'pass' result to the panel/DB — so we don't call handlePass here.
-      await fetch(PASS_URL, {
-        method: 'PUT', credentials: 'include',
-        headers: {
-          'Accept': 'application/json', 'Content-Type': 'application/json', 'X-Requested-With': 'XMLHttpRequest',
-          'x-myntra-app-name': 'rejoy', 'x-myntra-client-id': 'rejoy', 'x-myntra-module-name': 'QcSearch',
-          'x-myntra-rejoy-service': 'worms.qcSearch.updateReturnRestocked', 'x-myntra-req-id': reqId,
-        },
-        body: JSON.stringify(body),
-      });
+      btn.click();  // page's own pass flow → updateReturnRestocked → captured by our hook below
+      console.log('%c[QC Capture] auto-pass: clicked the page Pass button', 'color:#22c55e');
     } catch (e) {
       post('pass', { item_barcode: String(rec.item_barcode || ''), pass_success: false, pass_error: 'auto-pass error: ' + (e && e.message), passed_at: new Date().toISOString() });
-    } finally {
-      passInFlight.delete(rec.item_barcode);
     }
   }
 

--- a/test/qcDashboard.test.js
+++ b/test/qcDashboard.test.js
@@ -9,7 +9,7 @@ const {
 } = require('../utils/qcDashboard.js');
 
 // ---------------------------------------------------------------------------
-// buildPassesQuery
+// buildPassesQuery  (CAPTURES-based: base table qc_return_captures c)
 // ---------------------------------------------------------------------------
 
 test('buildPassesQuery defaults to today (IST) when no dates given', () => {
@@ -17,9 +17,21 @@ test('buildPassesQuery defaults to today (IST) when no dates given', () => {
   const { sql, params, from, to } = buildPassesQuery({});
   assert.strictEqual(from, today);
   assert.strictEqual(to, today);
-  // date range is the first WHERE predicate, first two params
-  assert.ok(/DATE\(p\.passed_at\) BETWEEN \? AND \?/.test(sql));
+  // date range is on the captured day (captured_at, falling back to ingested_at)
+  assert.ok(/DATE\(COALESCE\(c\.captured_at, c\.ingested_at\)\) BETWEEN \? AND \?/.test(sql));
   assert.deepStrictEqual(params, [today, today]);
+});
+
+test('buildPassesQuery is captures-based and joins passes on item_barcode (not capture_uid)', () => {
+  const { sql } = buildPassesQuery({});
+  assert.ok(/FROM qc_return_captures c/.test(sql), 'base table must be captures');
+  assert.ok(/LEFT JOIN[\s\S]*qc_return_passes[\s\S]*p ON p\.item_barcode = c\.item_barcode/.test(sql),
+    'passes must join on item_barcode');
+  assert.ok(!/c\.capture_uid = p\.capture_uid/.test(sql), 'must NOT join on capture_uid (never matches)');
+  // product detail comes natively from the capture row
+  assert.ok(/c\.sku_code\s+AS sku_code/.test(sql));
+  assert.ok(/c\.tracking_number\s+AS tracking_number/.test(sql));
+  assert.ok(/p\.pass_success\s+AS pass_success/.test(sql));
 });
 
 test('buildPassesQuery honours explicit valid from/to and ignores malformed dates', () => {
@@ -38,9 +50,9 @@ test('buildPassesQuery honours explicit valid from/to and ignores malformed date
 test('buildPassesQuery adds a WHERE + param for each scalar filter', () => {
   const cases = [
     ['user', 'u.username = ?'],
-    ['quality', 'p.quality = ?'],
-    ['qc_action', 'p.qc_action = ?'],
-    ['warehouse', 'p.warehouse_id = ?'],
+    ['quality', 'c.quality = ?'],
+    ['qc_action', 'c.qc_action = ?'],
+    ['warehouse', 'c.return_destination_wh = ?'],
   ];
   for (const [key, clause] of cases) {
     const { sql, params } = buildPassesQuery({ [key]: 'X' });
@@ -56,15 +68,15 @@ test('buildPassesQuery trims filter values and skips empty/whitespace filters', 
   // only `user` should survive; quality/warehouse are blank
   assert.strictEqual(withVal.params.length, 3);
   assert.strictEqual(withVal.params[2], 'alice');
-  assert.ok(!withVal.sql.includes('p.quality = ?'));
-  assert.ok(!withVal.sql.includes('p.warehouse_id = ?'));
+  assert.ok(!withVal.sql.includes('c.quality = ?'));
+  assert.ok(!withVal.sql.includes('c.return_destination_wh = ?'));
 });
 
 test('buildPassesQuery q produces a grouped OR LIKE with five params', () => {
   const { sql, params } = buildPassesQuery({ q: 'abc' });
   assert.ok(
     sql.includes(
-      '(c.sku_code LIKE ? OR c.style_id LIKE ? OR p.item_barcode LIKE ? OR c.tracking_number LIKE ? OR c.product_name LIKE ?)'
+      '(c.sku_code LIKE ? OR c.style_id LIKE ? OR c.item_barcode LIKE ? OR c.tracking_number LIKE ? OR c.product_name LIKE ?)'
     ),
     'q should be a single parenthesized OR group across the 5 searchable columns'
   );
@@ -78,25 +90,26 @@ test('buildPassesQuery combines all filters in order and never inlines user inpu
     from: '2026-01-01',
     to: '2026-01-31',
     user: 'bob',
-    quality: 'good',
-    qc_action: 'restock',
+    quality: 'Q1',
+    qc_action: 'QC_PASS',
     warehouse: 'WH1',
     q: 'jean',
   });
   assert.deepStrictEqual(params, [
     '2026-01-01', '2026-01-31',
-    'bob', 'good', 'restock', 'WH1',
+    'bob', 'Q1', 'QC_PASS', 'WH1',
     '%jean%', '%jean%', '%jean%', '%jean%', '%jean%',
   ]);
   // No raw user values embedded in the SQL text (only placeholders).
-  for (const v of ['bob', 'good', 'restock', 'WH1', 'jean']) {
+  for (const v of ['bob', 'Q1', 'QC_PASS', 'WH1', 'jean']) {
     assert.ok(!sql.includes(v), `value "${v}" must not be string-concatenated into SQL`);
   }
-  assert.ok(sql.trim().endsWith('ORDER BY p.passed_at DESC'));
+  // ordered by the captured timestamp, newest first
+  assert.ok(sql.trim().endsWith('ORDER BY COALESCE(c.captured_at, c.ingested_at) DESC'));
 });
 
 // ---------------------------------------------------------------------------
-// summarizeByUser
+// summarizeByUser  (per-user scan count)
 // ---------------------------------------------------------------------------
 
 test('summarizeByUser groups rows into per-user counts, busiest first', () => {
@@ -128,31 +141,35 @@ test('rowsToCsv emits the header row in the fixed column order', () => {
   const csv = rowsToCsv([]);
   assert.strictEqual(
     csv,
-    'passed_at,username,item_barcode,tracking_number,sku_code,style_id,size,quality,qc_action,warehouse_id,pass_success'
+    'captured_at,username,item_barcode,tracking_number,sku_code,style_id,product_name,size,quality,qc_action,return_status,logistics_status,warehouse_id,pass_success,passed_at'
   );
 });
 
 test('rowsToCsv escapes commas, quotes and newlines; blanks null fields', () => {
   const csv = rowsToCsv([
     {
-      passed_at: '2026-07-01 10:00:00',
+      captured_at: '2026-07-01 10:00:00',
       username: 'alice',
       item_barcode: 'BC,1',
       tracking_number: 'TN"x"',
       sku_code: 'line1\nline2',
       style_id: null,
+      product_name: 'Kotty Jeans',
       size: 'M',
-      quality: 'good',
-      qc_action: 'restock',
+      quality: 'Q1',
+      qc_action: 'QC_PASS',
+      return_status: 'RRC',
+      logistics_status: 'DELIVERED_TO_SELLER',
       warehouse_id: 'WH1',
       pass_success: 1,
+      passed_at: '2026-07-01 10:05:00',
     },
   ]);
   const lines = csv.split('\r\n');
   assert.strictEqual(lines.length, 2);
   assert.strictEqual(
     lines[1],
-    '2026-07-01 10:00:00,alice,"BC,1","TN""x""","line1\nline2",,M,good,restock,WH1,1'
+    '2026-07-01 10:00:00,alice,"BC,1","TN""x""","line1\nline2",,Kotty Jeans,M,Q1,QC_PASS,RRC,DELIVERED_TO_SELLER,WH1,1,2026-07-01 10:05:00'
   );
 });
 

--- a/utils/qcDashboard.js
+++ b/utils/qcDashboard.js
@@ -1,48 +1,70 @@
 // utils/qcDashboard.js
 //
-// Pure (DB-free) logic for the QC dashboard passes API, extracted so it can be
+// Pure (DB-free) logic for the QC dashboard API, extracted so it can be
 // unit-tested without a live database:
 //   - buildPassesQuery(filters)  -> { sql, params }  (parameterized SELECT)
 //   - rowsToCsv(rows)            -> CSV string (RFC-4180-ish escaping)
 //   - summarizeByUser(rows)      -> [{ user, passes }]  (grouped count)
 //   - istToday()                 -> 'YYYY-MM-DD' in IST (default date range)
 //
-// A row in qc_return_passes is one QC pass by user `passed_by`. Product detail
-// (sku_code, style_id, size, product_name, tracking_number) lives in
-// qc_return_captures, joined on capture_uid.
+// CAPTURES-BASED: one row per return item SCANNED by a user (qc_return_captures),
+// which is where the full product detail lives (sku_code, style_id, size,
+// product_name, tracking_number). Whether that item was later QC-passed is
+// LEFT-joined from qc_return_passes ON item_barcode (the physical item key) —
+// NOT on capture_uid, which is derived from different inputs in each table and
+// therefore never matches. `pass_success`/`passed_at` are NULL when a scanned
+// item was never passed.
 
 // Ordered column set the API returns for each detail row. Also the CSV header order.
 const ROW_COLUMNS = [
-  'passed_at',
+  'captured_at',
   'username',
   'item_barcode',
   'tracking_number',
   'sku_code',
   'style_id',
+  'product_name',
   'size',
   'quality',
   'qc_action',
+  'return_status',
+  'logistics_status',
   'warehouse_id',
   'pass_success',
+  'passed_at',
 ];
 
 // SELECT clause that produces exactly ROW_COLUMNS (in order).
+// The passes side is pre-aggregated to ONE row per item_barcode (MAX passed_at /
+// MAX pass_success) so a rare double-pass can't fan a capture into duplicate rows.
 const SELECT_SQL = `
   SELECT
-    DATE_FORMAT(p.passed_at, '%Y-%m-%d %H:%i:%s') AS passed_at,
-    u.username        AS username,
-    p.item_barcode    AS item_barcode,
-    c.tracking_number AS tracking_number,
-    c.sku_code        AS sku_code,
-    c.style_id        AS style_id,
-    c.size            AS size,
-    p.quality         AS quality,
-    p.qc_action       AS qc_action,
-    p.warehouse_id    AS warehouse_id,
-    p.pass_success    AS pass_success
-  FROM qc_return_passes p
-  LEFT JOIN users u ON u.id = p.passed_by
-  LEFT JOIN qc_return_captures c ON c.capture_uid = p.capture_uid`.trim();
+    DATE_FORMAT(COALESCE(c.captured_at, c.ingested_at), '%Y-%m-%d %H:%i:%s') AS captured_at,
+    u.username             AS username,
+    c.item_barcode         AS item_barcode,
+    c.tracking_number      AS tracking_number,
+    c.sku_code             AS sku_code,
+    c.style_id             AS style_id,
+    c.product_name         AS product_name,
+    c.size                 AS size,
+    c.quality              AS quality,
+    c.qc_action            AS qc_action,
+    c.return_status        AS return_status,
+    c.logistics_status     AS logistics_status,
+    c.return_destination_wh AS warehouse_id,
+    p.pass_success         AS pass_success,
+    DATE_FORMAT(p.passed_at, '%Y-%m-%d %H:%i:%s') AS passed_at
+  FROM qc_return_captures c
+  LEFT JOIN users u ON u.id = c.captured_by
+  LEFT JOIN (
+    SELECT item_barcode, MAX(pass_success) AS pass_success, MAX(passed_at) AS passed_at
+    FROM qc_return_passes
+    GROUP BY item_barcode
+  ) p ON p.item_barcode = c.item_barcode`.trim();
+
+// The captured-day / captured-timestamp expressions, reused by WHERE + ORDER BY.
+const CAPTURED_DAY = 'DATE(COALESCE(c.captured_at, c.ingested_at))';
+const CAPTURED_TS = 'COALESCE(c.captured_at, c.ingested_at)';
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
@@ -63,13 +85,14 @@ function nonEmpty(value) {
 }
 
 /**
- * Build the parameterized passes query from user filters. NEVER string-
+ * Build the parameterized captures query from user filters. NEVER string-
  * concatenates user input — every dynamic value goes in `params`.
  *
  * filters: { from, to, user, quality, qc_action, warehouse, q }
- *   from/to  inclusive on DATE(passed_at); default to today (IST) when absent.
- *   user     matches users.username (the passer).
- *   quality / qc_action / warehouse  exact matches on the pass row.
+ *   from/to  inclusive on DATE(captured_at); default to today (IST) when absent.
+ *   user     matches users.username (the operator who scanned).
+ *   quality / qc_action  exact matches on the captured return.
+ *   warehouse            exact match on the return destination warehouse.
  *   q        free-text, grouped OR LIKE across
  *            sku_code / style_id / item_barcode / tracking_number / product_name.
  *
@@ -80,7 +103,7 @@ function buildPassesQuery(filters = {}) {
   const from = sanitizeDate(filters.from, today);
   const to = sanitizeDate(filters.to, today);
 
-  const where = ['DATE(p.passed_at) BETWEEN ? AND ?'];
+  const where = [`${CAPTURED_DAY} BETWEEN ? AND ?`];
   const params = [from, to];
 
   if (nonEmpty(filters.user)) {
@@ -88,30 +111,31 @@ function buildPassesQuery(filters = {}) {
     params.push(String(filters.user).trim());
   }
   if (nonEmpty(filters.quality)) {
-    where.push('p.quality = ?');
+    where.push('c.quality = ?');
     params.push(String(filters.quality).trim());
   }
   if (nonEmpty(filters.qc_action)) {
-    where.push('p.qc_action = ?');
+    where.push('c.qc_action = ?');
     params.push(String(filters.qc_action).trim());
   }
   if (nonEmpty(filters.warehouse)) {
-    where.push('p.warehouse_id = ?');
+    where.push('c.return_destination_wh = ?');
     params.push(String(filters.warehouse).trim());
   }
   if (nonEmpty(filters.q)) {
     const like = `%${String(filters.q).trim()}%`;
     where.push(
-      '(c.sku_code LIKE ? OR c.style_id LIKE ? OR p.item_barcode LIKE ? OR c.tracking_number LIKE ? OR c.product_name LIKE ?)'
+      '(c.sku_code LIKE ? OR c.style_id LIKE ? OR c.item_barcode LIKE ? OR c.tracking_number LIKE ? OR c.product_name LIKE ?)'
     );
     params.push(like, like, like, like, like);
   }
 
-  const sql = `${SELECT_SQL}\n  WHERE ${where.join('\n    AND ')}\n  ORDER BY p.passed_at DESC`;
+  const sql = `${SELECT_SQL}\n  WHERE ${where.join('\n    AND ')}\n  ORDER BY ${CAPTURED_TS} DESC`;
   return { sql, params, from, to };
 }
 
-/** Group rows into a per-user pass count: [{ user, passes }], busiest first. */
+/** Group rows into a per-user scan count: [{ user, passes }], busiest first.
+ *  (`passes` = number of returns that user scanned in range.) */
 function summarizeByUser(rows = []) {
   const counts = new Map();
   for (const r of rows) {


### PR DESCRIPTION
Fixes three issues found while checking the live QC data.

## 1. Dashboard showed "just the barcode"
The dashboard joined `qc_return_passes.capture_uid = qc_return_captures.capture_uid`, but each table derives `capture_uid` from different inputs (`capture|return_id|barcode` vs `pass|barcode|oms_release_id`) — so it matched **0 rows** and every product column (tracking/sku/style/size) came back NULL.

**Fix:** rebuild the dashboard **captures-based** — one row per scanned return (full detail lives natively on the capture), with pass status LEFT-joined on **`item_barcode`** (verified 4/4 match on prod). Now shows **every** scanned return + whether it was passed ("not passed" when it wasn't). Filters (`quality`/`qc_action`/`warehouse` now match capture columns) and CSV export updated to the capture column set.

## 2. "synced 13 but dashboard 4" — not data loss
Different meters. Panel *synced* = all POSTs (captures + passes + re-scans); DB holds 5 captures + 4 passes = 9 unique rows (13−9 = idempotent dedupe). The old dashboard counted passes only. The captures-based view now reflects everything scanned.

## 3. Auto-pass froze Myntra's tracking input until refresh
Auto-pass fired `updateReturnRestocked` directly → item passed in the backend but Myntra's React UI never knew → input stayed disabled, and a later manual Pass click failed "already QC'd".

**Fix:** click the page's **own** Pass button instead (text-based finder + optional `passSelector` override, polls up to 6s for the enabled button). The page runs its own flow, re-enables the input for the next scan, and our fetch/XHR hook still records the pass. No refresh, no desync.

## Verification
- 152 backend + 14 frontend tests pass; qc island builds + typechecks clean.
- New dashboard query run read-only against prod: returns all 5 scanned returns with full detail + correct pass status.
- Auto-pass button-click path needs a live test on the rejoyui QC page (can't exercise Myntra's DOM from CI). If the default text finder misses the button, set `chrome.storage.local.passSelector` to a precise CSS selector.

🤖 Generated with [Claude Code](https://claude.com/claude-code)