### PR TITLE
fix(qc-ext): make local log actually cap (rolling 10k) + fix queued count

### DIFF
--- a/qcpass_extension/background.js
+++ b/qcpass_extension/background.js
@@ -38,10 +38,18 @@ async function tx(store, mode, fn) { const db = await idb(); return new Promise(
 const enqueue = (rec) => tx(STORE, 'readwrite', (s) => s.add({ rec, ts: Date.now() }));
 function readAll() { return tx(STORE, 'readonly', (s) => { const out = []; s.openCursor().onsuccess = (e) => { const c = e.target.result; if (c) { out.push({ k: c.key, ...c.value }); c.continue(); } }; return out; }); }
 const remove = (keys) => tx(STORE, 'readwrite', (s) => keys.forEach((k) => s.delete(k)));
-function count() { return tx(STORE, 'readonly', (s) => { let n = 0; s.openCursor().onsuccess = (e) => { const c = e.target.result; if (c) { n++; c.continue(); } }; return n; }); }
+// O(1) row count. NOTE: tx() resolves whatever fn(s) *returns*, so we must return a by-reference
+// holder that the count request fills in — returning a primitive `n` would resolve its value at
+// call time (0), before the request completes. (That old bug made the LOG_CAP trim never fire and
+// the queue count always read 0.)
+function storeCount(store) {
+  return tx(store, 'readonly', (s) => { const req = s.count(); const h = { n: 0 }; req.onsuccess = () => { h.n = req.result; }; return h; })
+    .then((h) => h.n);
+}
+const count = () => storeCount(STORE);
 
 // Rolling log (durable copy for CSV export). Appends the record, then trims oldest rows > LOG_CAP.
-function logCount() { return tx(LOG, 'readonly', (s) => { let n = 0; s.openCursor().onsuccess = (e) => { const c = e.target.result; if (c) { n++; c.continue(); } }; return n; }); }
+const logCount = () => storeCount(LOG);
 async function appendLog(rec) {
   await tx(LOG, 'readwrite', (s) => s.add({ rec, ts: Date.now() }));
   try {


### PR DESCRIPTION
Stranded after #494 merged (this commit was pushed just after the merge).

`tx()` resolves whatever `fn(s)` returns. `count()`/`logCount()` returned the primitive `n` captured at call time (**0**, before the cursor ran), so both always resolved 0. `readAll` only worked because it returns an array by reference that the cursor fills in.

Consequences:
- `logCount()` always returned 0 → `extra = 0 - 10000 < 0` → the **LOG_CAP=10000 trim never fired** → the local `log` store grew **unbounded** (a real problem at ~3000 scans/day).
- `count()` always returned 0 → the panel's "queued" always showed 0.

Fix: use IndexedDB's O(1) `count()` via a by-reference holder so the real count is returned. The rolling log now trims to the most recent 10k, and queued reflects the true backlog. The server DB remains the full archive.

Extension-only change → live on extension reload (no deploy needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)