### PR TITLE
fix(pm): DRR reads orders_api (robust feed) + honest feed status/freshness

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -352,11 +352,14 @@ router.get('/api/summary', async (req, res) => {
     out.inventory = { units: Number(r.units) || 0, as_of: r.as_of };
   } catch (_) { out.inventory = null; }
 
-  // Sales day by day (last 30 days).
+  // Sales day by day (last 30 days). Filter to a single source (orders_api — the DRR feed);
+  // ee_sales_daily holds both orders_api and mini_sales_report rows, so an unfiltered SUM
+  // double-counts every day that has both.
   try {
     const [rows] = await pool.query(
       `SELECT sale_date, SUM(qty) qty FROM ee_sales_daily
-        WHERE sale_date >= CURDATE() - INTERVAL 30 DAY GROUP BY sale_date ORDER BY sale_date`
+        WHERE sale_date >= CURDATE() - INTERVAL 30 DAY AND source = 'orders_api'
+        GROUP BY sale_date ORDER BY sale_date`
     );
     out.sales_by_day = rows.map((r) => ({ date: r.sale_date, qty: Number(r.qty) || 0 }));
   } catch (_) { out.sales_by_day = null; }
@@ -376,8 +379,11 @@ router.get('/api/summary', async (req, res) => {
     );
     const lastOk = {};
     for (const r of okSteps) lastOk[r.step] = r.last_ok;
-    // 'orders_aggregate' is the fresh DRR sales source; fall back to legacy names.
-    const salesAsOf = lastOk['orders_aggregate'] || lastOk['sales_cross_check'] || lastOk['mini_sales'] || null;
+    // 'orders_aggregate' (orders_api) is the feed that actually drives DRR/cuts, so the
+    // banner keys off it. Do NOT fall back to 'sales_cross_check' — that step logs 'partial'
+    // (never 'ok') whenever any day is flagged, so its last 'ok' can be months old and would
+    // make the banner read far staler than reality. mini_sales is the only sane secondary.
+    const salesAsOf = lastOk['orders_aggregate'] || lastOk['mini_sales'] || null;
     const feeds = [salesAsOf, lastOk['stock_status']].filter(Boolean);
     const dataAsOf = feeds.length ? new Date(Math.min(...feeds.map((d) => new Date(d).getTime()))) : null;
     out.freshness = {

--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -623,7 +623,7 @@ async function computeCleanDayMetrics(pool, windowStart) {
      INNER JOIN (
        SELECT DISTINCT sku
        FROM ee_sales_daily
-       WHERE sale_date >= ? AND source = 'mini_sales_report'
+       WHERE sale_date >= ? AND source = 'orders_api'
      ) sold ON sold.sku = s.sku
      WHERE s.snapshot_date >= ?
      GROUP BY s.sku, d
@@ -634,7 +634,7 @@ async function computeCleanDayMetrics(pool, windowStart) {
   const [saleRows] = await pool.query(
     `SELECT sku, DATE_FORMAT(sale_date, '%Y-%m-%d') AS d, SUM(qty) AS qty
      FROM ee_sales_daily
-     WHERE sale_date >= ? AND source = 'mini_sales_report'
+     WHERE sale_date >= ? AND source = 'orders_api'
      GROUP BY sku, d`,
     [windowStart]
   );
@@ -715,7 +715,7 @@ async function getCuttingRecommendations(pool, { periodKey = '30d', shadow = fal
        WHERE snapshot_date >= ? AND qty > 0
        GROUP BY sku
      ) sd ON sd.sku = s.sku
-     WHERE s.sale_date >= ? AND s.source = 'mini_sales_report'
+     WHERE s.sale_date >= ? AND s.source = 'orders_api'
      GROUP BY s.sku`,
     [snapshotStart, snapshotStart]
   );

--- a/utils/easyecomPullWorker.js
+++ b/utils/easyecomPullWorker.js
@@ -546,7 +546,10 @@ async function crossCheckSales(pool, runStartedAt, windowDays) {
               ), 2)
         END AS delta_pct,
         CASE
-          WHEN GREATEST(
+          -- Only flag a genuine discrepancy: BOTH sources must have data for this
+          -- warehouse-day. mini_sales is routinely one-warehouse-only (EasyEcom rate cap),
+          -- so requiring LEAST(...) > 0 stops a missing feed from reading as a 100% delta.
+          WHEN LEAST(
                 SUM(CASE WHEN d.source = 'orders_api' THEN d.qty ELSE 0 END),
                 SUM(CASE WHEN d.source = 'mini_sales_report' THEN d.qty ELSE 0 END)
               ) = 0 THEN 0
@@ -593,6 +596,8 @@ async function crossCheckSales(pool, runStartedAt, windowDays) {
 async function pullStatusWiseStock(pool, runStartedAt) {
   const stepStart = Date.now();
   let totalRows = 0;
+  let okCount = 0;
+  let failCount = 0;
   for (const [warehouseIdStr, warehouseKey] of Object.entries(WAREHOUSE_KEY_BY_ID)) {
     const warehouseId = Number(warehouseIdStr);
     try {
@@ -617,12 +622,20 @@ async function pullStatusWiseStock(pool, runStartedAt) {
         }
       }
       totalRows += upsert.length;
+      okCount += 1;
     } catch (err) {
+      failCount += 1;
       console.error(`[pullWorker] stock-status report failed for ${warehouseKey}:`, err.message);
       await logStep(pool, runStartedAt, `stock_status:${warehouseKey}`, 'error', err.message, Date.now() - stepStart);
     }
   }
-  await logStep(pool, runStartedAt, 'stock_status', 'ok', `rows=${totalRows}`, Date.now() - stepStart);
+  // Honest parent status (mirrors mini_sales): 'ok' only if a warehouse actually delivered,
+  // 'partial' when some failed, 'error' when every warehouse failed. A false 'ok' here would
+  // let the freshness banner advance on a total stock-pull failure while SOH silently rides
+  // the stale ee_inventory_health fallback.
+  const parentStatus = okCount > 0 ? (failCount > 0 ? 'partial' : 'ok') : 'error';
+  await logStep(pool, runStartedAt, 'stock_status', parentStatus,
+    `rows=${totalRows} ok=${okCount} failed=${failCount}`, Date.now() - stepStart);
 }
 
 // ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Wraps up cutting-planning so the dashboard numbers can be trusted. Follows PR #474 (the feed-freeze fix).

## Problem
The DRR that drives *suggested cut* read only `source='mini_sales_report'` — the rate-limited feed that is routinely one-warehouse-only or skipped (EasyEcom 1-report/2h cap). So DRR could silently go stale or collapse to 0 (`suggested_cut ≈ 0` while stock depletes) even though the robust `orders_api` feed we already ingest was current. The freshness banner keyed off the fresh `orders_api`, so it read **green while cuts were stale**.

## Changes
- **DRR → `orders_api`**: `getCuttingRecommendations` + `computeCleanDayMetrics` now read the ±5% `orders_api` feed; `mini_sales_report` stays the independent cross-check only.
- **Honest `stock_status`**: parent step logs `ok`/`partial`/`error` (was always `ok`, even when both warehouses failed and `totalRows=0`), so SOH freshness can't ride a total stock-pull failure on the stale `ee_inventory_health` fallback.
- **Freshness banner**: drops the `sales_cross_check` fallback (that step logs `partial`, never `ok`, so its last-`ok` could be months old — the "18 May / 42d old" symptom).
- **`sales_by_day` KPI**: filters to `source='orders_api'` (was summing both sources → double-count).
- **`sales_cross_check`**: only flags a day when BOTH sources have data (`LEAST>0`), so a normal one-warehouse mini_sales run no longer trips a false 100% delta.

## Test
`node --test` — all suites pass except `test/picSizeReport.test.js`, which fails on clean `main` too (needs a live DB; pre-existing, unrelated).

## Verify after deploy
- `getCuttingRecommendations` DRR non-zero for currently-selling SKUs even when `mini_sales` last logged `partial`.
- `pm_pull_runs` `stock_status` logs real status; `/pm` banner tracks orders_api/stock_status; Sales/day no longer double-counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)