### PR TITLE
feat(cutting): start a planned lot from the PM cut-plan (pre-filled, closes the loop)

### DIFF
--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -180,6 +180,41 @@ router.get('/dashboard', isAuthenticated, isCuttingManager, async (req, res) => 
 
     const allowAdhoc = await allowAdhocCuttingEntry();
 
+    // Pre-fill from a PM cut-plan assignment ("Start this lot" on Assigned Cuts).
+    // Only an 'assigned' row that belongs to THIS master, and only a single ≤1500-piece
+    // lot (the planner already caps lots at 1500; a bigger consolidated assignment must be
+    // assigned per-lot from the PM screen). prefill stays null for a normal blank form.
+    let prefill = null;
+    const fromAssignment = parseInt(req.query.from_assignment, 10);
+    if (fromAssignment) {
+      try {
+        const [[a]] = await pool.query(
+          `SELECT id, style, fabric_type, total_pieces FROM pm_cut_assignment
+            WHERE id = ? AND assigned_master_id = ? AND status = 'assigned'`,
+          [fromAssignment, userId]
+        );
+        if (a) {
+          const [sz] = await pool.query(
+            `SELECT size_label, qty FROM pm_cut_assignment_sizes WHERE assignment_id = ? ORDER BY qty DESC`,
+            [fromAssignment]
+          );
+          const totalTarget = sz.reduce((s, r) => s + (Number(r.qty) || 0), 0);
+          prefill = {
+            id: a.id,
+            style: a.style,
+            fabric_type: a.fabric_type || '',
+            sizes: sz.map((r) => ({ size_label: r.size_label, qty: Number(r.qty) || 0 })),
+            total_target: totalTarget,
+            over_cap: totalTarget > 1500, // flag: should have been assigned per-lot
+          };
+        } else {
+          req.flash('error', 'That assigned cut is not available to start (already cut, cancelled, or not yours).');
+        }
+      } catch (e) {
+        if (e.code !== 'ER_NO_SUCH_TABLE') console.error('[cutting-manager] prefill load error:', e.message);
+      }
+    }
+
     res.render('cuttingManagerDashboard', {
       user: req.session.user,
       cuttingLots,
@@ -189,6 +224,7 @@ router.get('/dashboard', isAuthenticated, isCuttingManager, async (req, res) => 
       generatedLotNumber, // Pass the generated lot number
       isDenim,
       allowAdhoc,
+      prefill,
     });
   } catch (err) {
     if (conn) {
@@ -223,6 +259,7 @@ router.post(
       weight_used,
       roll_full_weight,
       roll_remaining_weight,
+      assignment_id, // set when this lot is started from a PM cut-plan assignment
     } = req.body;
     const image = req.file;
 
@@ -444,6 +481,20 @@ router.post(
           'UPDATE cutting_lot_rolls SET total_pieces = layers * ? WHERE cutting_lot_id = ?',
           [sumPatterns, cuttingLotId]
         );
+
+        // If this lot was started from a PM cut-plan assignment, link it back and close
+        // the loop: the assignment now points at the real lot and moves 'assigned' → 'cut',
+        // so it stops showing as "to cut" and the PM's suggestion nets it. Guarded to this
+        // master + still-'assigned' so a stale/duplicate submit can't relink a done row.
+        const assignmentIdNum = parseInt(assignment_id, 10);
+        if (assignmentIdNum) {
+          await conn.query(
+            `UPDATE pm_cut_assignment
+                SET cutting_lot_id = ?, status = 'cut', updated_at = NOW()
+              WHERE id = ? AND assigned_master_id = ? AND status = 'assigned'`,
+            [cuttingLotId, assignmentIdNum, userId]
+          );
+        }
 
         await conn.commit();
         conn.release();

--- a/views/assignedCuts.ejs
+++ b/views/assignedCuts.ejs
@@ -31,6 +31,7 @@
   <div class="page-head">
     <h1><i class="bi bi-scissors"></i> Assigned Cuts</h1>
     <div class="sub">Cuts the production manager has approved and assigned to you. Cut to these quantities — CAD makes the marker.</div>
+    <div style="margin-top:10px;"><a href="/cutting-manager/dashboard" style="color:#93c5fd; text-decoration:none; font-size:.85rem;"><i class="bi bi-arrow-left"></i> Back to dashboard</a></div>
   </div>
 
   <div class="container-fluid" style="max-width:820px;">
@@ -71,6 +72,16 @@
           <% if (a.cutting_lot_id && a.lot_no) { %>
             <div class="mt-2"><i class="bi bi-check2-circle text-success"></i> Cut as lot <strong><%= a.lot_no %></strong>
               — <a href="/cutting-manager/lot-details/<%= a.cutting_lot_id %>">view lot</a></div>
+          <% } else if (a.status === 'assigned') { %>
+            <div class="mt-3">
+              <% if (Number(a.total_pieces) > 1500) { %>
+                <span class="text-warning" style="font-size:.85rem;"><i class="bi bi-exclamation-triangle"></i>
+                  This assignment is <%= a.total_pieces %> pcs (over the 1500/lot cap). Ask the PM to assign it per-lot so each lot is ≤1500.</span>
+              <% } else { %>
+                <a href="/cutting-manager/dashboard?from_assignment=<%= a.id %>" class="btn btn-success btn-sm">
+                  <i class="bi bi-scissors"></i> Start this lot (pre-fills the cutting form)</a>
+              <% } %>
+            </div>
           <% } %>
         </div>
       <% }) %>

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -326,6 +326,9 @@
       <button class="kotty-tab" id="indent-tab" data-bs-toggle="tab" data-bs-target="#indent-panel" type="button" role="tab" aria-controls="indent-panel" aria-selected="false">
         <i class="bi bi-box-seam"></i><span>Raise Indent</span>
       </button>
+      <a class="kotty-tab" href="/cutting-manager/assigned-cuts">
+        <i class="bi bi-scissors"></i><span>Assigned Cuts</span>
+      </a>
       <a class="kotty-tab" href="/manual-lot">
         <i class="bi bi-pencil-square"></i><span>Manual Lot Mapping</span>
       </a>
@@ -407,6 +410,14 @@
           </div>
           <div class="kotty-card-body">
             <form id="lotForm" method="POST" action="/cutting-manager/create-lot" enctype="multipart/form-data">
+              <% if (typeof prefill !== 'undefined' && prefill) { %>
+                <input type="hidden" name="assignment_id" value="<%= prefill.id %>" />
+                <div class="alert alert-info" style="margin-bottom:14px; border-left:4px solid #2563eb;">
+                  <i class="bi bi-scissors"></i> <strong>Starting planned lot for style <%= prefill.style %></strong>
+                  — style, fabric &amp; sizes are pre-filled from the PM cut plan (target <%= prefill.total_target %> pcs).
+                  Enter your physical lot number and rolls; adjust patterns to what you actually lay.
+                </div>
+              <% } %>
               <div class="row g-3">
                 <div class="col-md-4">
                   <label for="lot_no" class="kotty-form-label"><i class="bi bi-hash"></i><span data-i18n="lotNumberGenerated">Lot Number (Generated)</span></label>
@@ -1346,6 +1357,55 @@ document.getElementById('lotForm').addEventListener('submit', function(e) {
 });
 
 loadSkuCategories();
+
+<% if (typeof prefill !== 'undefined' && prefill) { %>
+// ── Pre-fill the create-lot form from a PM cut-plan assignment ("Start this lot").
+// Style, fabric and size labels come from the plan; the cutter still enters the physical
+// lot number, rolls and the actual pattern counts (pieces = patterns × layers).
+(function prefillFromAssignment() {
+  var P = <%- JSON.stringify(prefill) %>;
+  // 1. Jump to the Create Lot tab.
+  var tabBtn = document.getElementById('create-lot-tab');
+  if (tabBtn) tabBtn.click();
+  // 2. SKU = the plan's style (EasyEcom-derived → resolves cleanly). Bypass the builder.
+  var skuHidden = document.getElementById('sku');
+  if (skuHidden) skuHidden.value = P.style;
+  var prev = document.getElementById('skuPreviewText');
+  if (prev) prev.textContent = P.style;
+  ['skuCategory', 'skuCode'].forEach(function (id) {
+    var el = document.getElementById(id);
+    if (el) { el.required = false; }
+  });
+  var builder = document.querySelector('.sku-builder');
+  if (builder) builder.style.display = 'none';
+  // 3. Fabric type — set the hidden value + search box, then fire change to wire rolls.
+  if (P.fabric_type) {
+    var fSearch = document.getElementById('fabric_type_search');
+    var fHidden = document.getElementById('fabric_type');
+    if (fHidden) fHidden.value = P.fabric_type;
+    if (fSearch) fSearch.value = P.fabric_type;
+    if (fHidden) fHidden.dispatchEvent(new Event('change'));
+  }
+  // 4. One size row per planned size, with a target-pieces chip. Cutter sets pattern count.
+  (P.sizes || []).forEach(function (s) {
+    if (typeof addNewSize !== 'function') return;
+    addNewSize();
+    var rows = sizesContainer.querySelectorAll('.size-section:not(.d-none)');
+    var row = rows[rows.length - 1];
+    if (!row) return;
+    var sel = row.querySelector('.sizeLabelSel');
+    if (sel) sel.value = s.size_label;
+    var chip = document.createElement('div');
+    chip.style.cssText = 'margin-top:6px;font-size:.8rem;color:#2563eb;font-weight:600;';
+    chip.textContent = '🎯 plan target: ' + s.qty + ' pcs';
+    row.appendChild(chip);
+  });
+  // 5. Remark links the lot back to the plan for traceability.
+  var rem = document.getElementById('remark');
+  if (rem && !rem.value) rem.value = 'From cut-plan assignment #' + P.id + ' (style ' + P.style + ')';
+  if (typeof updateTotalPieces === 'function') updateTotalPieces();
+})();
+<% } %>
 </script>
 <script src="/public/js/lot-size-expand.js"></script>
 


### PR DESCRIPTION
Lets a cutting master turn a PM cut-plan assignment into a real cutting lot by confirming a **pre-filled** form — closing the assign→cutting_lot gap and eliminating the SKU/size resolution problem for planned lots.

## Flow
1. **Assigned Cuts** tab → each `assigned` ≤1500 lot shows **"Start this lot"**.
2. Opens the existing create-lot form **pre-filled**: SKU = the plan's EasyEcom-derived style (resolves cleanly, no manual SKU builder), fabric type, one size row per planned size with a **"plan target: N pcs"** chip.
3. Cutter enters the **physical lot number + rolls** and lays the **actual** patterns (pieces = patterns × layers) — planned quantities are **editable**, not locked.
4. On submit, `pm_cut_assignment` links back: `cutting_lot_id` = new lot, `status` `assigned → cut` (same transaction, guarded to this master + still-assigned). Counted once (on-order nets real `cutting_lots`). Card flips to **CUT**.

## ≤1500 rule
The planner already hard-caps lots at 1500 and splits bigger demand into several proportional lots. Assignments over 1500 pcs show an **"assign per-lot"** warning instead of a Start button, so a confirm can never create a >1500 lot.

## Lot number
Minted at **confirm** time by the existing `generateLotNumber` (per-master sequence) — no numbers booked ahead for plans that may never be cut.

## Reuse / safety
Reuses the create-lot form, validation, insert path, and lot-number generation. Only new server code: prefill loader + the link-back UPDATE. EJS render-verified for prefill / no-prefill / over-cap.

## Test (browser, with `testcuttinguser`)
1. As PM, assign a style's lot to `testcuttinguser` from cut-planning.
2. Log in as `testcuttinguser` → **Assigned Cuts** → **Start this lot**.
3. Confirm the form is pre-filled; add lot number + rolls; submit.
4. Verify a `cutting_lot` is created and the assignment shows **CUT**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)