### PR TITLE
fix(pm): fabric unit (kg/m) not hardcoded m + consumption width column

### DIFF
--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -816,7 +816,8 @@ router.get('/assigned-cuts', isAuthenticated, isCuttingManager, async (req, res)
       const [rows] = await pool.query(
         `SELECT a.id, a.style, a.fabric_type, a.total_pieces, a.lot_count, a.total_fabric_meters,
                 a.fabric_complete, a.status, a.cutting_lot_id, a.note, a.created_at,
-                cl.lot_no
+                cl.lot_no,
+                (SELECT c.consumption_unit FROM pm_style_consumption c WHERE c.style = a.style LIMIT 1) AS fabric_unit
            FROM pm_cut_assignment a
       LEFT JOIN cutting_lots cl ON cl.id = a.cutting_lot_id
           WHERE a.assigned_master_id = ? AND a.status <> 'cancelled'

--- a/sql/2026_07_pm_consumption_width.sql
+++ b/sql/2026_07_pm_consumption_width.sql
@@ -1,0 +1,13 @@
+-- Fabric width (inches) the CAD marker / consumption figure was derived at.
+--
+-- Reference metadata, NOT an input to the fabric-needed calc:
+--   * When consumption is a per-piece WEIGHT (consumption_unit='KG'), the weight of fabric
+--     in one garment = pattern area x GSM, which is independent of the roll width. So the
+--     fabric-needed math (sum(qty x consumption_per_piece)) works without width.
+--   * Width only changes per-piece LENGTH (consumption_unit='METER'): a wider roll fits more
+--     pieces across the marker, so fewer running metres per piece. A metre figure is only
+--     valid at the width it was markered on.
+-- We store width so we can (a) validate the roll being cut is the width the CAD assumed,
+-- (b) later convert KG<->METER (needs GSM too), and (c) keep the CAD input for audit.
+ALTER TABLE pm_style_consumption
+  ADD COLUMN width DECIMAL(6,2) NULL AFTER fabric_type;

--- a/views/assignedCuts.ejs
+++ b/views/assignedCuts.ejs
@@ -62,7 +62,8 @@
           <div class="fabric">
             <i class="bi bi-rulers"></i>
             <% if (a.total_fabric_meters != null) { %>
-              Issue ~<strong><%= Number(a.total_fabric_meters).toFixed(1) %> m</strong> of <%= a.fabric_type || 'fabric' %>
+              <% var fu = a.fabric_unit === 'KG' ? 'kg' : 'm'; %>
+              Issue ~<strong><%= Number(a.total_fabric_meters).toFixed(1) %> <%= fu %></strong> of <%= a.fabric_type || 'fabric' %>
               <% if (!a.fabric_complete) { %><span class="text-warning">(some sizes have no CAD figure yet)</span><% } %>
             <% } else { %>
               <span class="text-muted">Fabric: no CAD consumption for this style yet.</span>

--- a/views/cutPlanning.ejs
+++ b/views/cutPlanning.ejs
@@ -61,6 +61,7 @@ async function loadPlan() {
   if (!j.ok) { status.textContent = j.warning || j.error || 'failed'; return; }
   if (!j.totalPieces) { status.textContent = 'No suggested cut for "' + style + '" right now (stock is covered).'; return; }
   status.style.display = 'none';
+  const fu = j.fabric_unit === 'KG' ? 'kg' : 'm'; // fabric unit label (weight vs length)
   const sizes = Object.entries(j.demand).sort((a, b) => b[1] - a[1]);
   const opts = MASTERS.map(m => '<option value="' + m.id + '">' + esc(m.username) + '</option>').join('');
   out.innerHTML =
@@ -73,7 +74,7 @@ async function loadPlan() {
         '<div class="ratioline">Ratio · <b>' + sizeRatio(j.demand) + '</b></div>' +
         (j.missingSizes && j.missingSizes.length ? '<div style="color:var(--amber-ink);font-size:12.5px;margin-top:10px">No CAD consumption yet for: ' + j.missingSizes.map(esc).join(', ') + '</div>' : '') +
         '<span class="fieldlab" style="margin-top:16px">Lot split · 1,500 hard cap — assign each lot to a master</span>' +
-        '<div class="lotlist">' + j.lots.map(function (l, i) { var sz = Object.entries(l.sizes || {}).sort(function (a, b) { return b[1] - a[1]; }).map(function (e) { return '<div class="chip-sz"><span class="s">' + esc(e[0]) + '</span><span class="q num">' + fmtNum(e[1]) + '</span></div>'; }).join(''); return '<div class="lotrow"><div class="lotid">Lot ' + (i + 1) + ' <small><span class="num">' + fmtNum(l.total) + '</span> pcs' + (l.fabricMeters != null ? ' · ' + Number(l.fabricMeters).toFixed(0) + ' m' : '') + '</small></div><div class="lotsizes">' + sz + '</div><select class="select lotmaster">' + (opts || '<option value="">no masters</option>') + '</select></div>'; }).join('') + '</div>' +
+        '<div class="lotlist">' + j.lots.map(function (l, i) { var sz = Object.entries(l.sizes || {}).sort(function (a, b) { return b[1] - a[1]; }).map(function (e) { return '<div class="chip-sz"><span class="s">' + esc(e[0]) + '</span><span class="q num">' + fmtNum(e[1]) + '</span></div>'; }).join(''); return '<div class="lotrow"><div class="lotid">Lot ' + (i + 1) + ' <small><span class="num">' + fmtNum(l.total) + '</span> pcs' + (l.fabricMeters != null ? ' · ' + Number(l.fabricMeters).toFixed(0) + ' ' + fu : '') + '</small></div><div class="lotsizes">' + sz + '</div><select class="select lotmaster">' + (opts || '<option value="">no masters</option>') + '</select></div>'; }).join('') + '</div>' +
       '</div>' +
       '<div class="assignbar">' +
         '<span style="font-size:12.5px;color:var(--ink-2)">One master can take several lots — same master for all is fine.</span>' +


### PR DESCRIPTION
Fabric consumption can be KG (weight) or METER (length); the UI hardcoded "m". Now cut-planning and Assigned Cuts show the real unit. Adds nullable pm_style_consumption.width (reference metadata — width-independent for KG consumption; kept for roll-width validation + future KG↔m conversion). Migration applied to prod; KTTWOMENSPANT990 (Valentino, KG) width=56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)