### PR TITLE
feat(pm): skew-aware lot split + readable size ratio

### DIFF
--- a/test/cutPlanner.test.js
+++ b/test/cutPlanner.test.js
@@ -1,6 +1,6 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { fabricForCut, splitIntoLots, planCut } = require('../utils/cutPlanner.js');
+const { fabricForCut, splitIntoLots, groupSizesByRatio, planCut } = require('../utils/cutPlanner.js');
 
 // Owner ruling 2026-06-18: CAD per-size consumption is the fabric truth.
 // fabric = sum(size_qty * CAD consumption). CAD owns the marker; we only do quantities+lots.
@@ -45,6 +45,40 @@ test('splitIntoLots may dip below 1200 but never exceeds 1500', () => {
 test('splitIntoLots: empty/zero demand -> no lots', () => {
   assert.deepStrictEqual(splitIntoLots({}), []);
   assert.deepStrictEqual(splitIntoLots({ M: 0 }), []);
+});
+
+test('groupSizesByRatio keeps volume-similar sizes together, peels off trivial ones', () => {
+  const g = groupSizesByRatio({ '6XL': 1151, '5XL': 701, '4XL': 496, '3XL': 171, XXL: 10 }, 8);
+  // 6XL..3XL are within 8x of the group max (1151/171 = 6.7); XXL (115x) splits off.
+  assert.strictEqual(g.length, 2);
+  assert.deepStrictEqual(g[0], { '6XL': 1151, '5XL': 701, '4XL': 496, '3XL': 171 });
+  assert.deepStrictEqual(g[1], { XXL: 10 });
+});
+
+test('splitIntoLots: extreme skew isolates the trivial size, never smears it across lots', () => {
+  const lots = splitIntoLots({ '6XL': 1151, '5XL': 701, '4XL': 496, '3XL': 171, XXL: 10 });
+  // big sizes -> proportional lots (group 2519 -> 2 lots); XXL -> its own single-size lot.
+  const xxlLots = lots.filter((l) => Object.keys(l.sizes).length === 1 && l.sizes.XXL);
+  assert.strictEqual(xxlLots.length, 1);
+  assert.strictEqual(xxlLots[0].sizes.XXL, 10);
+  assert.ok(lots.filter((l) => l.sizes['6XL']).every((l) => !('XXL' in l.sizes)));
+  for (const l of lots) assert.ok(l.total <= 1500);
+  // per-size totals exactly conserved across all lots
+  const tot = {};
+  for (const l of lots) for (const [s, q] of Object.entries(l.sizes)) tot[s] = (tot[s] || 0) + q;
+  assert.deepStrictEqual(tot, { '6XL': 1151, '5XL': 701, '4XL': 496, '3XL': 171, XXL: 10 });
+});
+
+test('splitIntoLots: modest skew (<=8x) stays one proportional group (unchanged behaviour)', () => {
+  const lots = splitIntoLots({ M: 1300, L: 900, XL: 400, XXL: 200 }); // 6.5x -> one group, 2 lots
+  assert.strictEqual(lots.length, 2);
+  assert.deepStrictEqual(lots[0].sizes, { M: 650, L: 450, XL: 200, XXL: 100 });
+});
+
+test('splitIntoLots skewAware:false forces a single proportional split', () => {
+  const lots = splitIntoLots({ '6XL': 1151, XXL: 10 }, { skewAware: false }); // 1161 -> 1 lot, both sizes
+  assert.strictEqual(lots.length, 1);
+  assert.deepStrictEqual(lots[0].sizes, { '6XL': 1151, XXL: 10 });
 });
 
 test('planCut: lots + per-lot fabric from CAD consumption', () => {

--- a/utils/cutPlanner.js
+++ b/utils/cutPlanner.js
@@ -28,16 +28,39 @@ function fabricForCut(sizesQty, consumptionBySize) {
 }
 
 const MAX_LOT = 1500;
+// Within one marker/lot, the largest size qty should be at most this many times the
+// smallest. Beyond it the marker's size ratio is impractical to cut (e.g. 115:1 when a hot
+// size sits next to a trivial one), so those sizes are split into separate lots instead of
+// smeared proportionally across every lot. Volume-similar sizes stay together (good nesting);
+// a trivial size peels off on its own. Env-overridable via PM_MARKER_MAX_RATIO.
+const MAX_MARKER_RATIO = Number(process.env.PM_MARKER_MAX_RATIO) || 8;
 
 function sumSizes(sizes) {
   return Object.values(sizes || {}).reduce((s, q) => s + (Number(q) || 0), 0);
 }
 
-// Split per-size demand into lots, each total <= maxLot, sizes PROPORTIONAL in every lot.
-// n = ceil(total / maxLot); 1,500 is a hard cap (never above), a lot may dip below 1,200.
-// Rounding remainders go to the earliest lots so per-size totals are exactly conserved.
-function splitIntoLots(demandBySize, opts = {}) {
-  const maxLot = opts.maxLot || MAX_LOT;
+// Group sizes by volume similarity. Walking largest -> smallest, keep adding to the current
+// group while (groupMax / size) <= maxRatio; otherwise start a new group. So a dominant size
+// stays with its near-volume neighbours (nesting stays good) while a trivial size (far below
+// the group's max) peels into its own group instead of distorting the marker ratio.
+function groupSizesByRatio(demandBySize, maxRatio) {
+  const entries = Object.entries(demandBySize)
+    .map(([s, q]) => [s, Number(q) || 0])
+    .filter(([, q]) => q > 0)
+    .sort((a, b) => b[1] - a[1]);
+  const groups = []; // [{ sizes: {size:qty}, max }]
+  for (const [s, q] of entries) {
+    const last = groups[groups.length - 1];
+    if (last && last.max / q <= maxRatio) last.sizes[s] = q;
+    else groups.push({ sizes: { [s]: q }, max: q });
+  }
+  return groups.map((g) => g.sizes);
+}
+
+// Proportional split of ONE size-map into <= maxLot lots (sizes proportional in every lot).
+// n = ceil(total / maxLot); 1,500 is a hard cap (never above). Rounding remainders go to the
+// earliest lots so per-size totals are exactly conserved.
+function proportionalSplit(demandBySize, maxLot) {
   const total = sumSizes(demandBySize);
   if (total <= 0) return [];
   const n = Math.ceil(total / maxLot);
@@ -53,6 +76,19 @@ function splitIntoLots(demandBySize, opts = {}) {
       if (give > 0) { lots[i].sizes[size] = (lots[i].sizes[size] || 0) + give; lots[i].total += give; }
     }
   }
+  return lots;
+}
+
+// Split per-size demand into cutting lots. SKEW-AWARE: sizes of wildly different volume don't
+// share a marker — they're grouped by volume similarity first, then each group is split
+// proportionally, every lot <= maxLot. Pass skewAware:false for a single proportional split
+// across all sizes (legacy behaviour). Per-size totals are always exactly conserved.
+function splitIntoLots(demandBySize, opts = {}) {
+  const maxLot = opts.maxLot || MAX_LOT;
+  const maxRatio = opts.maxRatio || MAX_MARKER_RATIO;
+  const groups = opts.skewAware === false ? [demandBySize] : groupSizesByRatio(demandBySize, maxRatio);
+  const lots = [];
+  for (const group of groups) lots.push(...proportionalSplit(group, maxLot));
   return lots;
 }
 
@@ -82,4 +118,4 @@ function planCut(demandBySize, opts = {}) {
   };
 }
 
-module.exports = { fabricForCut, splitIntoLots, planCut, sumSizes, MAX_LOT };
+module.exports = { fabricForCut, splitIntoLots, groupSizesByRatio, proportionalSplit, planCut, sumSizes, MAX_LOT, MAX_MARKER_RATIO };

--- a/views/cutPlanning.ejs
+++ b/views/cutPlanning.ejs
@@ -37,7 +37,7 @@ const esc = s => String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&': '&am
 const fmtDate = d => d ? new Date(d).toLocaleDateString('en-IN', { day: '2-digit', month: 'short' }) : '';
 const fmtNum = v => (v == null || Number.isNaN(Number(v))) ? '—' : Number(v).toLocaleString('en-IN');
 function gcd(a, b) { a = Math.abs(a); b = Math.abs(b); while (b) { const t = b; b = a % b; a = t; } return a || 1; }
-function sizeRatio(obj) { const e = Object.entries(obj || {}).map(([s, q]) => [s, Number(q) || 0]).filter(([, q]) => q > 0); if (!e.length) return ''; const g = e.reduce((a, [, q]) => gcd(a, q), 0) || 1; return e.map(([s, q]) => s + ':' + Math.round(q / g)).join('  '); }
+function sizeRatio(obj) { const e = Object.entries(obj || {}).map(([s, q]) => [s, Number(q) || 0]).filter(([, q]) => q > 0); if (!e.length) return ''; const mn = Math.min(...e.map(([, q]) => q)) || 1; return e.map(([s, q]) => { const v = q / mn; return s + ':' + (v < 9.95 ? Math.round(v * 10) / 10 : Math.round(v)); }).join('  '); }
 
 async function loadMasters() {
   const d = await (await fetch('/pm/api/cut-masters')).json();

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -105,8 +105,10 @@ function gcd(a, b) { a = Math.abs(a); b = Math.abs(b); while (b) { const t = b; 
 function sizeRatio(obj) {
   const ents = Object.entries(obj || {}).map(([s, q]) => [s, Number(q) || 0]).filter(([, q]) => q > 0);
   if (!ents.length) return '';
-  const g = ents.reduce((acc, [, q]) => gcd(acc, q), 0) || 1;
-  return ents.map(([s, q]) => `${s}:${Math.round(q / g)}`).join('  ');
+  // Normalize to the smallest size (…:1) so the ratio is readable even when quantities are
+  // coprime (e.g. 115:70:50:17:1 instead of 1151:701:496:171:10). One decimal below 10.
+  const mn = Math.min(...ents.map(([, q]) => q)) || 1;
+  return ents.map(([s, q]) => { const v = q / mn; return `${s}:${v < 9.95 ? Math.round(v * 10) / 10 : Math.round(v)}`; }).join('  ');
 }
 
 // In-production (inline) qty vs the cut requirement, per size.


### PR DESCRIPTION
Highly skewed demand (6XL 1151 vs XXL 10) produced impractical markers because every size was smeared into every lot. Now sizes are grouped by volume similarity (≤8× within a marker) then split proportionally under the 1500 cap — trivial sizes get their own lot, volume-similar sizes stay together (good nesting). Also: size-ratio line normalizes to the smallest size (115:70:50:17:1) instead of showing raw coprime numbers. Tests added; totals conserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)