### PR TITLE
fix(pm): show per-size quantities instead of a ratio

### DIFF
--- a/views/cutPlanning.ejs
+++ b/views/cutPlanning.ejs
@@ -37,7 +37,7 @@ const esc = s => String(s == null ? '' : s).replace(/[&<>"]/g, c => ({ '&': '&am
 const fmtDate = d => d ? new Date(d).toLocaleDateString('en-IN', { day: '2-digit', month: 'short' }) : '';
 const fmtNum = v => (v == null || Number.isNaN(Number(v))) ? '—' : Number(v).toLocaleString('en-IN');
 function gcd(a, b) { a = Math.abs(a); b = Math.abs(b); while (b) { const t = b; b = a % b; a = t; } return a || 1; }
-function sizeRatio(obj) { const e = Object.entries(obj || {}).map(([s, q]) => [s, Number(q) || 0]).filter(([, q]) => q > 0); if (!e.length) return ''; const mn = Math.min(...e.map(([, q]) => q)) || 1; return e.map(([s, q]) => { const v = q / mn; return s + ':' + (v < 9.95 ? Math.round(v * 10) / 10 : Math.round(v)); }).join('  '); }
+function sizeRatio(obj) { const e = Object.entries(obj || {}).map(([s, q]) => [s, Number(q) || 0]).filter(([, q]) => q > 0); if (!e.length) return ''; return e.map(([s, q]) => s + ':' + fmtNum(q)).join('  '); }
 
 async function loadMasters() {
   const d = await (await fetch('/pm/api/cut-masters')).json();
@@ -71,7 +71,7 @@ async function loadPlan() {
       '<div class="plan-body" style="display:block">' +
         '<span class="fieldlab">Suggested size split · ' + fmtNum(j.totalPieces) + ' pcs total</span>' +
         '<div class="chips">' + sizes.map(([s, q]) => '<div class="chip-sz"><span class="s">' + esc(s) + '</span><span class="q num">' + fmtNum(q) + '</span></div>').join('') + '</div>' +
-        '<div class="ratioline">Ratio · <b>' + sizeRatio(j.demand) + '</b></div>' +
+        '<div class="ratioline">Qty · <b>' + sizeRatio(j.demand) + '</b></div>' +
         (j.missingSizes && j.missingSizes.length ? '<div style="color:var(--amber-ink);font-size:12.5px;margin-top:10px">No CAD consumption yet for: ' + j.missingSizes.map(esc).join(', ') + '</div>' : '') +
         '<span class="fieldlab" style="margin-top:16px">Lot split · 1,500 hard cap — assign each lot to a master</span>' +
         '<div class="lotlist">' + j.lots.map(function (l, i) { var sz = Object.entries(l.sizes || {}).sort(function (a, b) { return b[1] - a[1]; }).map(function (e) { return '<div class="chip-sz"><span class="s">' + esc(e[0]) + '</span><span class="q num">' + fmtNum(e[1]) + '</span></div>'; }).join(''); return '<div class="lotrow"><div class="lotid">Lot ' + (i + 1) + ' <small><span class="num">' + fmtNum(l.total) + '</span> pcs' + (l.fabricMeters != null ? ' · ' + Number(l.fabricMeters).toFixed(0) + ' ' + fu : '') + '</small></div><div class="lotsizes">' + sz + '</div><select class="select lotmaster"><option value="" selected>' + (opts ? '— select master —' : 'no masters') + '</option>' + opts + '</select></div>'; }).join('') + '</div>' +

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -105,10 +105,7 @@ function gcd(a, b) { a = Math.abs(a); b = Math.abs(b); while (b) { const t = b; 
 function sizeRatio(obj) {
   const ents = Object.entries(obj || {}).map(([s, q]) => [s, Number(q) || 0]).filter(([, q]) => q > 0);
   if (!ents.length) return '';
-  // Normalize to the smallest size (…:1) so the ratio is readable even when quantities are
-  // coprime (e.g. 115:70:50:17:1 instead of 1151:701:496:171:10). One decimal below 10.
-  const mn = Math.min(...ents.map(([, q]) => q)) || 1;
-  return ents.map(([s, q]) => { const v = q / mn; return `${s}:${v < 9.95 ? Math.round(v * 10) / 10 : Math.round(v)}`; }).join('  ');
+  return ents.map(([s, q]) => `${s}:${fmtNum(q)}`).join('  ');
 }
 
 // In-production (inline) qty vs the cut requirement, per size.
@@ -229,7 +226,7 @@ async function loadAssignPanel() {
     body.innerHTML = `
       <span class="fieldlab">Suggested size split · ${fmtNum(planRes.totalPieces)} pcs total</span>
       <div class="chips">${sizes.map(([s, q]) => `<div class="chip-sz"><span class="s">${escapeHtml(s)}</span><span class="q num">${fmtNum(q)}</span></div>`).join('')}</div>
-      <div class="ratioline">Ratio · <b>${sizeRatio(planRes.demand)}</b></div>
+      <div class="ratioline">Qty · <b>${sizeRatio(planRes.demand)}</b></div>
       ${(planRes.missingSizes && planRes.missingSizes.length) ? `<div style="color:var(--amber-ink);font-size:12.5px;margin-top:10px">No CAD consumption yet for: ${planRes.missingSizes.map(escapeHtml).join(', ')}</div>` : ''}
       <span class="fieldlab" style="margin-top:16px">Lot split · 1,500 hard cap — assign each lot to a master</span>
       <div class="lotlist">


### PR DESCRIPTION
Owner preference: the size line shows actual piece counts (labelled 'Qty ·') instead of a normalized ratio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)