### PR TITLE
feat(pm): assign lots one at a time; each lot its own per-lot assignment

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -638,23 +638,27 @@ router.post('/api/cut-plan/assign', async (req, res) => {
     const lots = (plan && plan.lots) || [];
     if (!lots.length) return res.status(400).json({ ok: false, error: 'No cut plan to assign.' });
 
-    // Resolve which master each lot goes to.
-    const perLot = Array.isArray(req.body.lots) && req.body.lots.length;
-    let lotMasterIds;
-    if (perLot) {
-      if (req.body.lots.length !== lots.length) {
-        return res.status(400).json({ ok: false, error: `Expected ${lots.length} lot assignment(s), got ${req.body.lots.length}.` });
-      }
-      lotMasterIds = req.body.lots.map((l) => parseInt(l.master_id, 10));
-    } else {
+    // Build the set of lots to assign as {index, masterId}. Two payload shapes:
+    //   { lots: [{ index, master_id }, ...] } -> assign ONLY those lots — a SUBSET is fine, so
+    //       you can assign one lot at a time and leave the rest for later.
+    //   { master_id }                          -> assign every lot to that one master.
+    // Either way EACH lot becomes its OWN per-lot assignment (<=1500 pcs, startable) — the plan
+    // is never collapsed into a single whole-style row.
+    let picks;
+    if (Array.isArray(req.body.lots) && req.body.lots.length) {
+      picks = req.body.lots.map((l) => ({ index: parseInt(l.index, 10), masterId: parseInt(l.master_id, 10) }));
+    } else if (req.body.master_id) {
       const m = parseInt(req.body.master_id, 10);
-      if (!m) return res.status(400).json({ ok: false, error: 'master_id (or per-lot lots[]) is required' });
-      lotMasterIds = lots.map(() => m);
+      picks = lots.map((_, i) => ({ index: i, masterId: m }));
+    } else {
+      return res.status(400).json({ ok: false, error: 'Pick a master for at least one lot.' });
     }
-    if (lotMasterIds.some((m) => !m)) return res.status(400).json({ ok: false, error: 'Every lot needs a cutting master.' });
+    picks = picks.filter((p) => Number.isInteger(p.index) && p.index >= 0 && p.index < lots.length);
+    if (!picks.length) return res.status(400).json({ ok: false, error: 'Pick a master for at least one lot.' });
+    if (picks.some((p) => !p.masterId)) return res.status(400).json({ ok: false, error: 'Each selected lot needs a cutting master.' });
 
     // Validate all chosen masters in one query.
-    const uniqueIds = [...new Set(lotMasterIds)];
+    const uniqueIds = [...new Set(picks.map((p) => p.masterId))];
     const [mrows] = await pool.query(
       `SELECT u.id, u.username FROM users u JOIN roles r ON u.role_id = r.id
         WHERE u.id IN (?) AND r.name = 'cutting_manager' AND u.is_active = TRUE`,
@@ -691,39 +695,23 @@ router.post('/api/cut-plan/assign', async (req, res) => {
 
     try {
       await conn.beginTransaction();
-      let payload;
       const snapshots = []; // {assignmentId, sizes} — audit records, written best-effort AFTER commit
-
-      if (!perLot || uniqueIds.length === 1) {
-        // Single-master (all lots same OR legacy master_id): one consolidated row.
-        const masterId = lotMasterIds[0];
-        const { demand, plan: fullPlan, fabricType: ft } = await computeStyleCutPlan(style);
+      const created = [];
+      const n = lots.length;
+      // One per-lot assignment per pick — each lot's own size split, each <=1500 and startable.
+      for (const p of picks) {
+        const lot = lots[p.index];
         const { header, sizes } = buildAssignmentPayload({
-          style, fabricType: ft, masterId, masterName: nameById.get(masterId),
-          demand, plan: fullPlan, createdBy,
+          style, fabricType, masterId: p.masterId, masterName: nameById.get(p.masterId),
+          demand: lot.sizes,
+          plan: { lotCount: 1, totalFabricMeters: lot.fabricMeters, fabricComplete: lot.fabricComplete },
+          createdBy,
         });
-        const id = await insertAssignment(header, sizes, null);
+        const id = await insertAssignment(header, sizes, `Lot ${p.index + 1}/${n}`);
         snapshots.push({ assignmentId: id, sizes });
-        payload = { ok: true, assignment_id: id, count: 1, assigned_to: nameById.get(masterId) };
-      } else {
-        // Per-lot: one row per lot, each to its own master, using the lot's own size split.
-        const n = lots.length;
-        const created = [];
-        for (let i = 0; i < n; i++) {
-          const lot = lots[i];
-          const masterId = lotMasterIds[i];
-          const { header, sizes } = buildAssignmentPayload({
-            style, fabricType, masterId, masterName: nameById.get(masterId),
-            demand: lot.sizes,
-            plan: { lotCount: 1, totalFabricMeters: lot.fabricMeters, fabricComplete: lot.fabricComplete },
-            createdBy,
-          });
-          const id = await insertAssignment(header, sizes, `Lot ${i + 1}/${n}`);
-          snapshots.push({ assignmentId: id, sizes });
-          created.push({ assignment_id: id, lot: i + 1, pieces: header.total_pieces, master: nameById.get(masterId) });
-        }
-        payload = { ok: true, count: created.length, assignments: created, assigned_to: [...new Set(created.map((c) => c.master))].join(', ') };
+        created.push({ assignment_id: id, lot: p.index + 1, pieces: header.total_pieces, master: nameById.get(p.masterId) });
       }
+      const payload = { ok: true, count: created.length, assignments: created, assigned_to: [...new Set(created.map((c) => c.master))].join(', ') };
 
       await conn.commit();
       // Decision snapshots are audit-only + best-effort; write them after the assignment commits.

--- a/views/cutPlanning.ejs
+++ b/views/cutPlanning.ejs
@@ -55,7 +55,7 @@ async function loadAssignments() {
 async function loadPlan() {
   const style = document.getElementById('style').value.trim();
   const status = document.getElementById('status'); const out = document.getElementById('plan');
-  out.innerHTML = ''; if (!style) return;
+  out.innerHTML = ''; assignedLots.clear(); if (!style) return;
   status.style.display = 'block'; status.textContent = 'Loading…';
   const j = await (await fetch('/pm/api/cut-plan?style=' + encodeURIComponent(style))).json();
   if (!j.ok) { status.textContent = j.warning || j.error || 'failed'; return; }
@@ -86,23 +86,29 @@ async function loadPlan() {
 }
 
 let assignInFlight = false;
+const assignedLots = new Set(); // lot indices already assigned in this render (avoids re-assign)
 async function assign(style) {
   if (assignInFlight) return; // guard: a double-click can't fire a second submit
-  const sels = Array.from(document.querySelectorAll('.lotmaster'));
   const msg = document.getElementById('assignMsg');
-  const ids = sels.map(s => s.value);
-  if (!ids.length || ids.some(v => !v)) { msg.innerHTML = '<span style="color:var(--red)">pick a master for every lot</span>'; return; }
+  const sels = Array.from(document.querySelectorAll('.lotmaster'));
+  // Assign only the lots that HAVE a master picked and aren't already assigned. A subset is
+  // fine — you can do one lot at a time and leave the rest on "— select —" for later.
+  const chosen = sels.map((s, i) => ({ index: i, master_id: s.value, el: s }))
+    .filter(x => x.master_id && !assignedLots.has(x.index));
+  if (!chosen.length) { msg.innerHTML = '<span style="color:var(--red)">pick a master for a lot to assign</span>'; return; }
   assignInFlight = true;
   const btn = document.querySelector('.assignbar .btn.primary'); if (btn) btn.disabled = true;
   msg.textContent = 'Assigning…';
   try {
-    const allSame = ids.every(v => v === ids[0]);
-    const body = allSame ? { style, master_id: ids[0] } : { style, lots: ids.map(v => ({ master_id: v })) };
+    const body = { style, lots: chosen.map(c => ({ index: c.index, master_id: c.master_id })) };
     const d = await (await fetch('/pm/api/cut-plan/assign', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })).json();
-    if (d.ok) { msg.innerHTML = '<span style="color:var(--green-ink)">✓ Assigned to ' + esc(d.assigned_to) + '</span>'; loadAssignments(); } // leave the button disabled: this plan is now assigned
-    else { msg.innerHTML = '<span style="color:var(--red)">' + esc(d.error || 'failed') + '</span>'; if (btn) btn.disabled = false; }
-  } catch (e) { msg.innerHTML = '<span style="color:var(--red)">' + esc(e.message) + '</span>'; if (btn) btn.disabled = false; }
-  finally { assignInFlight = false; }
+    if (d.ok) {
+      chosen.forEach(c => { assignedLots.add(c.index); c.el.disabled = true; const row = c.el.closest('.lotrow'); if (row) row.style.opacity = '0.55'; });
+      msg.innerHTML = '<span style="color:var(--green-ink)">✓ Assigned ' + d.count + ' lot(s) to ' + esc(d.assigned_to) + '</span>';
+      loadAssignments();
+    } else { msg.innerHTML = '<span style="color:var(--red)">' + esc(d.error || 'failed') + '</span>'; }
+  } catch (e) { msg.innerHTML = '<span style="color:var(--red)">' + esc(e.message) + '</span>'; }
+  finally { assignInFlight = false; if (btn) btn.disabled = false; } // re-enable for the remaining lots
 }
 
 (async () => { await loadMasters(); loadAssignments(); if (document.getElementById('style').value.trim()) loadPlan(); })();

--- a/views/productionManagerStyle.ejs
+++ b/views/productionManagerStyle.ejs
@@ -188,6 +188,7 @@ async function loadSizes() {
 let MASTERS = [];
 async function loadAssignPanel() {
   const body = $('assignBody');
+  assignedLots.clear(); // fresh plan render → nothing assigned yet in this view
   try {
     const [planRes, mastersRes, asgRes] = await Promise.all([
       fetch('/pm/api/cut-plan?style=' + encodeURIComponent(STYLE)).then(r => r.json()),
@@ -270,23 +271,28 @@ function assignmentsHtml(items) {
 }
 
 let assignInFlight = false;
+const assignedLots = new Set(); // lot indices already assigned in this render (avoids re-assign)
 async function doAssign() {
   if (assignInFlight) return; // guard: a double-click can't fire a second submit
-  const sels = Array.from(document.querySelectorAll('.lotmaster'));
   const msg = $('assignMsg');
-  const ids = sels.map(s => s.value);
-  if (!ids.length || ids.some(v => !v)) { msg.innerHTML = '<span style="color:var(--red)">pick a master for every lot</span>'; return; }
+  const sels = Array.from(document.querySelectorAll('.lotmaster'));
+  // Assign only the lots with a master picked that aren't already assigned — a subset is fine,
+  // so you can do one lot at a time and leave the rest on "— select —" for later.
+  const chosen = sels.map((s, i) => ({ index: i, master_id: s.value, el: s }))
+    .filter(x => x.master_id && !assignedLots.has(x.index));
+  if (!chosen.length) { msg.innerHTML = '<span style="color:var(--red)">pick a master for a lot to assign</span>'; return; }
   assignInFlight = true;
   const btn = document.querySelector('.assignbar .btn.primary'); if (btn) btn.disabled = true;
   msg.textContent = 'Assigning…';
-  const allSame = ids.every(v => v === ids[0]);
-  const body = allSame ? { style: STYLE, master_id: ids[0] } : { style: STYLE, lots: ids.map(v => ({ master_id: v })) };
   try {
+    const body = { style: STYLE, lots: chosen.map(c => ({ index: c.index, master_id: c.master_id })) };
     const d = await (await fetch('/pm/api/cut-plan/assign', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })).json();
-    if (d.ok) { msg.innerHTML = `<span style="color:var(--green-ink)">✓ Assigned to ${escapeHtml(d.assigned_to)}</span>`; loadAssignPanel(); } // leave disabled: assigned
-    else { msg.innerHTML = `<span style="color:var(--red)">${escapeHtml(d.error || 'failed')}</span>`; if (btn) btn.disabled = false; }
-  } catch (err) { msg.innerHTML = `<span style="color:var(--red)">${escapeHtml(err.message)}</span>`; if (btn) btn.disabled = false; }
-  finally { assignInFlight = false; }
+    if (d.ok) {
+      chosen.forEach(c => { assignedLots.add(c.index); c.el.disabled = true; const row = c.el.closest('.lotrow'); if (row) row.style.opacity = '0.55'; });
+      msg.innerHTML = `<span style="color:var(--green-ink)">✓ Assigned ${d.count} lot(s) to ${escapeHtml(d.assigned_to)}</span>`;
+    } else { msg.innerHTML = `<span style="color:var(--red)">${escapeHtml(d.error || 'failed')}</span>`; }
+  } catch (err) { msg.innerHTML = `<span style="color:var(--red)">${escapeHtml(err.message)}</span>`; }
+  finally { assignInFlight = false; if (btn) btn.disabled = false; } // re-enable for the remaining lots
 }
 // Init: sizes first (sets Suggested cut), then the CAD plan / assign panel.
 (async () => { await loadSizes(); loadAssignPanel(); })();


### PR DESCRIPTION
Assign a subset of lots (one at a time, leave the rest for later) and stop consolidating same-master lots into one over-cap whole-style row. Every lot becomes its own ≤1500 startable assignment. Client sends only picked lots, marks them assigned on success (can't re-send), keeps the button live for the rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)