### PR TITLE
feat(ops): cross-stage 'who handled this lot' chain on every stage card

### DIFF
--- a/routes/finishingRoutes.js
+++ b/routes/finishingRoutes.js
@@ -7,6 +7,7 @@ const { pool } = require('../config/db');
 const { isAuthenticated, isFinishingMaster } = require('../middlewares/auth');
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
+const { getLotStageUsers } = require('../utils/lotStageUsers');
 
 /* ---------------------------------------------------
    MULTER FOR IMAGE UPLOAD & BULK EXCEL UPLOAD
@@ -703,6 +704,8 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isFinishingMaster,
     const upstreamSizes  = await fUpstreamSizes(pool, lot);
     const upstreamTotal  = upstreamSizes.reduce((a, s) => a + s.available, 0);
 
+    const stageUsers = await getLotStageUsers(pool, { id: lot.id, flow_type: lot.flow_type, cutter_name: lot.cutting_master });
+
     res.json({
       lot,
       flow_kind: isHosieryLot(lot) ? 'hosiery' : 'denim',
@@ -711,6 +714,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isFinishingMaster,
       upstream_sizes: upstreamSizes,
       upstream_total_available: upstreamTotal,
       open_approvals: openApprovals,
+      stage_users: stageUsers,
     });
   } catch (err) {
     console.error('[ERROR] GET /finishing/event/lot-state =>', err);

--- a/routes/jeansAssemblyRoutes.js
+++ b/routes/jeansAssemblyRoutes.js
@@ -8,6 +8,7 @@ const { pool } = require('../config/db');
 const { isAuthenticated, isJeansAssemblyMaster } = require('../middlewares/auth');
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
+const { getLotStageUsers } = require('../utils/lotStageUsers');
 
 // -------------------------------------
 // MULTER for Image Upload
@@ -1229,6 +1230,8 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isJeansAssemblyMas
     const upstreamSizes   = await jaUpstreamSizes(pool, lotId, lot.lot_no);
     const upstreamTotal   = upstreamSizes.reduce((a, s) => a + s.available, 0);
 
+    const stageUsers = await getLotStageUsers(pool, { id: lot.id, flow_type: lot.flow_type, cutter_name: lot.cutting_master });
+
     res.json({
       lot,
       stage_aggregates: aggregates,
@@ -1236,6 +1239,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isJeansAssemblyMas
       upstream_sizes: upstreamSizes,
       upstream_total_available: upstreamTotal,
       open_approvals: openApprovals,
+      stage_users: stageUsers,
     });
   } catch (err) {
     console.error('[ERROR] GET /event/lot-state =>', err);

--- a/routes/stitchingRoutes.js
+++ b/routes/stitchingRoutes.js
@@ -7,6 +7,7 @@ const { pool } = require('../config/db');
 const { isAuthenticated, isStitchingMaster } = require('../middlewares/auth');
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
+const { getLotStageUsers } = require('../utils/lotStageUsers');
 
 // ----------------------------
 // MULTER SETUP (for image uploads)
@@ -206,6 +207,11 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isStitchingMaster,
     });
     const upstreamTotalAvailable = upstreamSizes.reduce((acc, s) => acc + s.available, 0);
 
+    // Cross-stage "who handled this lot" for the card (cut / stitch / wash / finish …).
+    const stageUsers = await getLotStageUsers(pool, {
+      id: lot.id, flow_type: lot.flow_type, cutter_name: lot.cutting_master,
+    });
+
     res.json({
       lot,
       stage_aggregates: aggregates,
@@ -213,6 +219,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isStitchingMaster,
       upstream_sizes: upstreamSizes,
       upstream_total_available: upstreamTotalAvailable,
       open_approvals: openApprovals,
+      stage_users: stageUsers,
     });
   } catch (err) {
     console.error('[ERROR] GET /event/lot-state =>', err);

--- a/routes/washingInRoutes.js
+++ b/routes/washingInRoutes.js
@@ -12,6 +12,7 @@ const { pool } = require('../config/db');
 const { isAuthenticated, isWashingInMaster } = require('../middlewares/auth');
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
+const { getLotStageUsers } = require('../utils/lotStageUsers');
 
 // ----------------------------------------------
 // MULTER SETUP (for optional image uploads)
@@ -533,6 +534,8 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isWashingInMaster,
     const upstreamSizes  = await wiUpstreamSizes(pool, lotId, lot.lot_no);
     const upstreamTotal  = upstreamSizes.reduce((a, s) => a + s.available, 0);
 
+    const stageUsers = await getLotStageUsers(pool, { id: lot.id, flow_type: lot.flow_type, cutter_name: lot.cutting_master });
+
     res.json({
       lot,
       stage_aggregates: aggregates,
@@ -540,6 +543,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isWashingInMaster,
       upstream_sizes: upstreamSizes,
       upstream_total_available: upstreamTotal,
       open_approvals: openApprovals,
+      stage_users: stageUsers,
     });
   } catch (err) {
     console.error('[ERROR] GET /washingin/event/lot-state =>', err);

--- a/routes/washingRoutes.js
+++ b/routes/washingRoutes.js
@@ -8,6 +8,7 @@ const { pool } = require('../config/db');
 const { isAuthenticated, isWashingMaster } = require('../middlewares/auth');
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
+const { getLotStageUsers } = require('../utils/lotStageUsers');
 
 // MULTER SETUP
 const storage = multer.diskStorage({
@@ -1094,6 +1095,8 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isWashingMaster, a
     const upstreamSizes  = await wUpstreamSizes(pool, lotId, lot.lot_no);
     const upstreamTotal  = upstreamSizes.reduce((a, s) => a + s.available, 0);
 
+    const stageUsers = await getLotStageUsers(pool, { id: lot.id, flow_type: lot.flow_type, cutter_name: lot.cutting_master });
+
     res.json({
       lot,
       stage_aggregates: aggregates,
@@ -1101,6 +1104,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isWashingMaster, a
       upstream_sizes: upstreamSizes,
       upstream_total_available: upstreamTotal,
       open_approvals: openApprovals,
+      stage_users: stageUsers,
     });
   } catch (err) {
     console.error('[ERROR] GET /washing/event/lot-state =>', err);

--- a/utils/lotStageUsers.js
+++ b/utils/lotStageUsers.js
@@ -1,0 +1,64 @@
+// Cross-stage "who handled this lot" for a single cutting lot.
+//
+// Returns the accountable operator for EVERY stage in the lot's flow (denim or hosiery),
+// so any stage's search card can show "Cut by X · Stitched by Y · Washed by Z · Finished by W"
+// instead of only the cutting master. The accountable operator for a stage is the operator of
+// its first `approve` event (mirrors routes/lotJourneyRoutes.stageTiming); cutting comes from
+// cutting_lots.user_id. Read-only, safe to call anywhere.
+
+const { orderedStages } = require('./lotJourney');
+
+const EVENT_TABLE = {
+  stitching: 'stitching_events',
+  jeans_assembly: 'jeans_assembly_events',
+  washing: 'washing_events',
+  washing_in: 'washing_in_events',
+  finishing: 'finishing_events',
+};
+
+const STAGE_LABEL = {
+  cutting: 'Cut',
+  stitching: 'Stitch',
+  jeans_assembly: 'Assembly',
+  washing: 'Wash',
+  washing_in: 'Wash-in',
+  finishing: 'Finish',
+};
+
+// lot: { id, flow_type, cutter_name, created_at? }
+// -> [{ stage, label, master, entered, completedAt, hasRows }] in flow order (cutting first).
+async function getLotStageUsers(pool, lot) {
+  const stages = orderedStages(lot && lot.flow_type);
+  const out = [];
+  for (const stage of stages) {
+    if (stage === 'cutting') {
+      out.push({
+        stage, label: STAGE_LABEL.cutting,
+        master: (lot && lot.cutter_name) || null,
+        entered: (lot && lot.created_at) || null,
+        completedAt: (lot && lot.created_at) || null,
+        hasRows: true,
+      });
+      continue;
+    }
+    let master = null; let entered = null; let completedAt = null; let hasRows = false;
+    try {
+      const [rows] = await pool.query(
+        `SELECT e.event_type, e.created_at, u.username
+           FROM \`${EVENT_TABLE[stage]}\` e LEFT JOIN users u ON u.id = e.operator_id
+          WHERE e.cutting_lot_id = ? ORDER BY e.created_at`,
+        [lot.id]
+      );
+      hasRows = rows.length > 0;
+      for (const r of rows) {
+        if (!entered) entered = r.created_at;
+        if (r.event_type === 'approve' && !master) master = r.username;
+        if (r.event_type === 'complete') completedAt = r.created_at;
+      }
+    } catch (_) { /* stage table absent / query error -> leave stage blank */ }
+    out.push({ stage, label: STAGE_LABEL[stage] || stage, master, entered, completedAt, hasRows });
+  }
+  return out;
+}
+
+module.exports = { getLotStageUsers, EVENT_TABLE, STAGE_LABEL };

--- a/views/finishingEvents.ejs
+++ b/views/finishingEvents.ejs
@@ -988,6 +988,7 @@
       <span class="label">From cutting</span>
       <span class="text" id="cuttingRemarkText"></span>
     </div>
+    <div class="sx-journey" id="lotJourneyUsers" style="display:none;"></div>
 
     <div class="sx-stats">
       <div class="sx-stat"><div class="l">Approved</div><div class="v" id="aggApproved">0</div></div>
@@ -1190,6 +1191,22 @@ async function refreshState() {
   } catch (err) { toast('Could not load lot: ' + err.message, 'error'); }
 }
 
+function renderStageUsers(su) {
+  const ju = document.getElementById('lotJourneyUsers');
+  if (!ju) return;
+  su = su || [];
+  if (!su.length) { ju.style.display = 'none'; return; }
+  const esc = (v) => String(v == null ? '' : v).replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]));
+  ju.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin:8px 0 2px;';
+  ju.innerHTML = su.map((s) => {
+    const who = s.master ? esc(s.master) : '—';
+    const col = s.master ? '#0f172a' : '#94a3b8';
+    return '<span style="display:inline-flex;flex-direction:column;line-height:1.15;padding:3px 9px;border-radius:8px;background:#f1f5f9;">'
+      + '<span style="font-size:.62rem;text-transform:uppercase;letter-spacing:.3px;color:#64748b;">' + esc(s.label) + '</span>'
+      + '<span style="font-size:.82rem;font-weight:600;color:' + col + ';">' + who + '</span></span>';
+  }).join('<span style="color:#cbd5e1;font-weight:700;">›</span>');
+}
+
 function renderState() {
   if (!currentState) return;
   const { lot, stage_aggregates: agg, upstream_sizes, open_approvals: open } = currentState;
@@ -1201,6 +1218,8 @@ function renderState() {
   const flowEl = el('lotFlow');
   flowEl.className = 'sx-flow ' + (isDenim ? 'denim' : 'hosiery');
   flowEl.textContent = isDenim ? 'denim' : 'hosiery';
+
+  renderStageUsers(currentState.stage_users);
 
   const remarkNote = el('cuttingRemarkNote');
   if (lot.cutting_remark) {

--- a/views/jeansAssemblyEvents.ejs
+++ b/views/jeansAssemblyEvents.ejs
@@ -988,6 +988,7 @@
       <span class="label">From cutting</span>
       <span class="text" id="cuttingRemarkText"></span>
     </div>
+    <div class="sx-journey" id="lotJourneyUsers" style="display:none;"></div>
 
     <div class="sx-stats">
       <div class="sx-stat"><div class="l">Approved</div><div class="v" id="aggApproved">0</div></div>
@@ -1184,6 +1185,22 @@ async function refreshState() {
   } catch (err) { toast('Could not load lot: ' + err.message, 'error'); }
 }
 
+function renderStageUsers(su) {
+  const ju = document.getElementById('lotJourneyUsers');
+  if (!ju) return;
+  su = su || [];
+  if (!su.length) { ju.style.display = 'none'; return; }
+  const esc = (v) => String(v == null ? '' : v).replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]));
+  ju.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin:8px 0 2px;';
+  ju.innerHTML = su.map((s) => {
+    const who = s.master ? esc(s.master) : '—';
+    const col = s.master ? '#0f172a' : '#94a3b8';
+    return '<span style="display:inline-flex;flex-direction:column;line-height:1.15;padding:3px 9px;border-radius:8px;background:#f1f5f9;">'
+      + '<span style="font-size:.62rem;text-transform:uppercase;letter-spacing:.3px;color:#64748b;">' + esc(s.label) + '</span>'
+      + '<span style="font-size:.82rem;font-weight:600;color:' + col + ';">' + who + '</span></span>';
+  }).join('<span style="color:#cbd5e1;font-weight:700;">›</span>');
+}
+
 function renderState() {
   if (!currentState) return;
   const { lot, stage_aggregates: agg, upstream_sizes, open_approvals: open } = currentState;
@@ -1195,6 +1212,8 @@ function renderState() {
   const flowEl = el('lotFlow');
   flowEl.className = 'sx-flow ' + (isDenim ? 'denim' : 'hosiery');
   flowEl.textContent = isDenim ? 'denim' : 'hosiery';
+
+  renderStageUsers(currentState.stage_users);
 
   const remarkNote = el('cuttingRemarkNote');
   if (lot.cutting_remark) {

--- a/views/stitchingEvents.ejs
+++ b/views/stitchingEvents.ejs
@@ -988,6 +988,7 @@
       <span class="label">From cutting</span>
       <span class="text" id="cuttingRemarkText"></span>
     </div>
+    <div class="sx-journey" id="lotJourneyUsers" style="display:none;"></div>
 
     <div class="sx-stats">
       <div class="sx-stat"><div class="l">Approved</div><div class="v" id="aggApproved">0</div></div>
@@ -1190,6 +1191,22 @@ async function refreshState() {
   } catch (err) { toast('Could not load lot: ' + err.message, 'error'); }
 }
 
+function renderStageUsers(su) {
+  const ju = document.getElementById('lotJourneyUsers');
+  if (!ju) return;
+  su = su || [];
+  if (!su.length) { ju.style.display = 'none'; return; }
+  const esc = (v) => String(v == null ? '' : v).replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]));
+  ju.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin:8px 0 2px;';
+  ju.innerHTML = su.map((s) => {
+    const who = s.master ? esc(s.master) : '—';
+    const col = s.master ? '#0f172a' : '#94a3b8';
+    return '<span style="display:inline-flex;flex-direction:column;line-height:1.15;padding:3px 9px;border-radius:8px;background:#f1f5f9;">'
+      + '<span style="font-size:.62rem;text-transform:uppercase;letter-spacing:.3px;color:#64748b;">' + esc(s.label) + '</span>'
+      + '<span style="font-size:.82rem;font-weight:600;color:' + col + ';">' + who + '</span></span>';
+  }).join('<span style="color:#cbd5e1;font-weight:700;">›</span>');
+}
+
 function renderState() {
   if (!currentState) return;
   const { lot, stage_aggregates: agg, upstream_sizes, open_approvals: open } = currentState;
@@ -1201,6 +1218,9 @@ function renderState() {
   const flowEl = el('lotFlow');
   flowEl.className = 'sx-flow ' + (isDenim ? 'denim' : 'hosiery');
   flowEl.textContent = isDenim ? 'denim' : 'hosiery';
+
+  // Cross-stage "who handled this lot" chain (cut → stitch → wash → finish …).
+  renderStageUsers(currentState.stage_users);
 
   const remarkNote = el('cuttingRemarkNote');
   if (lot.cutting_remark) {

--- a/views/washingEvents.ejs
+++ b/views/washingEvents.ejs
@@ -988,6 +988,7 @@
       <span class="label">From cutting</span>
       <span class="text" id="cuttingRemarkText"></span>
     </div>
+    <div class="sx-journey" id="lotJourneyUsers" style="display:none;"></div>
 
     <div class="sx-stats">
       <div class="sx-stat"><div class="l">Approved</div><div class="v" id="aggApproved">0</div></div>
@@ -1184,6 +1185,22 @@ async function refreshState() {
   } catch (err) { toast('Could not load lot: ' + err.message, 'error'); }
 }
 
+function renderStageUsers(su) {
+  const ju = document.getElementById('lotJourneyUsers');
+  if (!ju) return;
+  su = su || [];
+  if (!su.length) { ju.style.display = 'none'; return; }
+  const esc = (v) => String(v == null ? '' : v).replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]));
+  ju.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin:8px 0 2px;';
+  ju.innerHTML = su.map((s) => {
+    const who = s.master ? esc(s.master) : '—';
+    const col = s.master ? '#0f172a' : '#94a3b8';
+    return '<span style="display:inline-flex;flex-direction:column;line-height:1.15;padding:3px 9px;border-radius:8px;background:#f1f5f9;">'
+      + '<span style="font-size:.62rem;text-transform:uppercase;letter-spacing:.3px;color:#64748b;">' + esc(s.label) + '</span>'
+      + '<span style="font-size:.82rem;font-weight:600;color:' + col + ';">' + who + '</span></span>';
+  }).join('<span style="color:#cbd5e1;font-weight:700;">›</span>');
+}
+
 function renderState() {
   if (!currentState) return;
   const { lot, stage_aggregates: agg, upstream_sizes, open_approvals: open } = currentState;
@@ -1195,6 +1212,8 @@ function renderState() {
   const flowEl = el('lotFlow');
   flowEl.className = 'sx-flow ' + (isDenim ? 'denim' : 'hosiery');
   flowEl.textContent = isDenim ? 'denim' : 'hosiery';
+
+  renderStageUsers(currentState.stage_users);
 
   const remarkNote = el('cuttingRemarkNote');
   if (lot.cutting_remark) {

--- a/views/washingInEvents.ejs
+++ b/views/washingInEvents.ejs
@@ -988,6 +988,7 @@
       <span class="label">From cutting</span>
       <span class="text" id="cuttingRemarkText"></span>
     </div>
+    <div class="sx-journey" id="lotJourneyUsers" style="display:none;"></div>
 
     <div class="sx-stats">
       <div class="sx-stat"><div class="l">Approved</div><div class="v" id="aggApproved">0</div></div>
@@ -1184,6 +1185,22 @@ async function refreshState() {
   } catch (err) { toast('Could not load lot: ' + err.message, 'error'); }
 }
 
+function renderStageUsers(su) {
+  const ju = document.getElementById('lotJourneyUsers');
+  if (!ju) return;
+  su = su || [];
+  if (!su.length) { ju.style.display = 'none'; return; }
+  const esc = (v) => String(v == null ? '' : v).replace(/[<>&]/g, (c) => ({ '<': '&lt;', '>': '&gt;', '&': '&amp;' }[c]));
+  ju.style.cssText = 'display:flex;flex-wrap:wrap;gap:6px;align-items:center;margin:8px 0 2px;';
+  ju.innerHTML = su.map((s) => {
+    const who = s.master ? esc(s.master) : '—';
+    const col = s.master ? '#0f172a' : '#94a3b8';
+    return '<span style="display:inline-flex;flex-direction:column;line-height:1.15;padding:3px 9px;border-radius:8px;background:#f1f5f9;">'
+      + '<span style="font-size:.62rem;text-transform:uppercase;letter-spacing:.3px;color:#64748b;">' + esc(s.label) + '</span>'
+      + '<span style="font-size:.82rem;font-weight:600;color:' + col + ';">' + who + '</span></span>';
+  }).join('<span style="color:#cbd5e1;font-weight:700;">›</span>');
+}
+
 function renderState() {
   if (!currentState) return;
   const { lot, stage_aggregates: agg, upstream_sizes, open_approvals: open } = currentState;
@@ -1195,6 +1212,8 @@ function renderState() {
   const flowEl = el('lotFlow');
   flowEl.className = 'sx-flow ' + (isDenim ? 'denim' : 'hosiery');
   flowEl.textContent = isDenim ? 'denim' : 'hosiery';
+
+  renderStageUsers(currentState.stage_users);
 
   const remarkNote = el('cuttingRemarkNote');
   if (lot.cutting_remark) {


### PR DESCRIPTION
Every stage search card now shows the accountable operator for all stages in the lot's flow (cut/stitch/assembly/wash/wash-in/finish), not just the cutting master. New read-only helper utils/lotStageUsers, wired into all 5 stage lot-state endpoints + cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)