### PR TITLE
feat(cutting): choose denim/hosiery at lot creation

### DIFF
--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -274,6 +274,7 @@ router.post(
       fabric_type,
       remark,
       table_length,
+      flow_type,
       manual_cutting_date,
       size_label,
       pattern_count,
@@ -301,12 +302,17 @@ router.post(
       try {
         await conn.beginTransaction();
 
-        // Get cutter's is_denim_cutter flag to set flow_type
+        // Determine flow_type: honour the cutter's explicit selection on the form
+        // ('denim' or 'hosiery'), otherwise fall back to the is_denim_cutter default.
+        // Safe to set here because no stage events exist yet at lot creation.
         const [[cutter]] = await conn.query(
           'SELECT is_denim_cutter FROM users WHERE id = ?',
           [userId]
         );
-        const flowType = cutter && cutter.is_denim_cutter ? 'denim' : 'hosiery';
+        const defaultFlowType = cutter && cutter.is_denim_cutter ? 'denim' : 'hosiery';
+        const flowType = (flow_type === 'denim' || flow_type === 'hosiery')
+          ? flow_type
+          : defaultFlowType;
 
         // Enforce ad-hoc cutting entry switch
         const allowAdhoc = await allowAdhocCuttingEntry();

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -481,6 +481,13 @@
                   </div>
                 </div>
                 <div class="col-md-4">
+                  <label for="flow_type" class="kotty-form-label"><i class="bi bi-diagram-3"></i><span data-i18n="flowTypeLabel">Flow Type</span></label>
+                  <select id="flow_type" name="flow_type" class="kotty-select">
+                    <option value="denim" <%= isDenim ? 'selected' : '' %>>Denim</option>
+                    <option value="hosiery" <%= isDenim ? '' : 'selected' %>>Hosiery</option>
+                  </select>
+                </div>
+                <div class="col-md-4">
                   <label for="table_length" class="kotty-form-label"><i class="bi bi-rulers"></i><span data-i18n="tableLengthLabel">Table Length</span></label>
                   <input type="number" class="kotty-input" id="table_length" name="table_length" <%= isDenim ? 'required' : '' %> placeholder="<%= isDenim ? 'Table length (required for denim)' : 'Table length (optional)' %>" min="0" step="0.01" />
                 </div>
@@ -611,13 +618,14 @@
 
 <script src="/public/js/cuttingWeight.js"></script>
 <script>
-const IS_DENIM = <%= isDenim ? 'true' : 'false' %>;
-const FLOW_MODE = IS_DENIM ? 'denim' : 'hosiery';
+// Mutable so the Flow Type selector can switch denim/hosiery mode live at lot creation.
+let IS_DENIM = <%= isDenim ? 'true' : 'false' %>;
+let FLOW_MODE = IS_DENIM ? 'denim' : 'hosiery';
 const ALLOW_ADHOC = <%= allowAdhoc ? 'true' : 'false' %>;
 
 const langData = {
-  en: { cuttingManagerDashboardTitle: "Cutting Manager Dashboard", welcomeUser: "Welcome", existingCuttingLots: "Existing Cutting Lots", createNewCuttingLot: "Create New Cutting Lot", idLabel: "ID", lotNumberLabel: "Lot Number", skuLabel: "SKU", fabricTypeLabel: "Fabric Type", tableLengthLabel: "Table Length", remarkLabel: "Remark", imageLabel: "Image", createdByLabel: "Created By", creationTimeLabel: "Creation Time", totalPiecesLabel: "Total Pieces", sizesLabel: "Sizes", actionsLabel: "Actions", noCuttingLotsAvailable: "No cutting lots available.", sizeLabel: "Size", patternCountLabel: "Pattern Count", lotNumberGenerated: "Lot Number (Generated)", createLotBtn: "Create Lot", remove: "Remove", rollNumber: "Roll Number", layersLabel: "Layers", weightUsedLabel: "Weight Used (Calculated)", weightUsageProgress: "Weight Usage Progress", availableLabel: "Available", sizesAndPatterns: "Sizes and Patterns", rollsUsed: "Rolls Used", addNewSize: "Add New Size", addAnotherRoll: "Add Another Roll", totalPiecesCalc: "Total Pieces (Calculated)", fullWeightLabel: "Full Roll Weight", remainingWeightLabel: "Remaining Weight" },
-  hi: { cuttingManagerDashboardTitle: "काटिंग मैनेजर डैशबोर्ड", welcomeUser: "स्वागत हे", existingCuttingLots: "मौजूदा काटिंग लॉट्स", createNewCuttingLot: "नया काटिंग लॉट बनाएं", idLabel: "आईडी", lotNumberLabel: "लॉट नंबर", skuLabel: "एसकेयू", fabricTypeLabel: "फैब्रिक प्रकार", tableLengthLabel: "टेबल लंबाई", remarkLabel: "टिप्पणी", imageLabel: "छवि", createdByLabel: "बनाने वाले", creationTimeLabel: "बनाने का समय", totalPiecesLabel: "कुल पीस", sizesLabel: "साइज़", actionsLabel: "कार्रवाई", noCuttingLotsAvailable: "कोई काटिंग लॉट उपलब्ध नहीं है।", sizeLabel: "साइज़", patternCountLabel: "पैटर्न की संख्या", lotNumberGenerated: "लॉट नंबर (सिस्टम द्वारा तैयार)", createLotBtn: "लॉट तैयार करें", remove: "हटाएं", rollNumber: "रोल नंबर", layersLabel: "लेयर्स", weightUsedLabel: "उपयोग किया गया वज़न (गणना)", weightUsageProgress: "वज़न उपयोग की प्रगति", availableLabel: "उपलब्ध", sizesAndPatterns: "साइज़ और पैटर्न", rollsUsed: "उपयोग किए गए रोल्स", addNewSize: "नया साइज़ जोड़ें", addAnotherRoll: "एक और रोल जोड़ें", totalPiecesCalc: "कुल पीस (हिसाब से)", fullWeightLabel: "रोल का कुल वज़न", remainingWeightLabel: "बचा हुआ वज़न" }
+  en: { cuttingManagerDashboardTitle: "Cutting Manager Dashboard", welcomeUser: "Welcome", existingCuttingLots: "Existing Cutting Lots", createNewCuttingLot: "Create New Cutting Lot", idLabel: "ID", lotNumberLabel: "Lot Number", skuLabel: "SKU", fabricTypeLabel: "Fabric Type", flowTypeLabel: "Flow Type", tableLengthLabel: "Table Length", remarkLabel: "Remark", imageLabel: "Image", createdByLabel: "Created By", creationTimeLabel: "Creation Time", totalPiecesLabel: "Total Pieces", sizesLabel: "Sizes", actionsLabel: "Actions", noCuttingLotsAvailable: "No cutting lots available.", sizeLabel: "Size", patternCountLabel: "Pattern Count", lotNumberGenerated: "Lot Number (Generated)", createLotBtn: "Create Lot", remove: "Remove", rollNumber: "Roll Number", layersLabel: "Layers", weightUsedLabel: "Weight Used (Calculated)", weightUsageProgress: "Weight Usage Progress", availableLabel: "Available", sizesAndPatterns: "Sizes and Patterns", rollsUsed: "Rolls Used", addNewSize: "Add New Size", addAnotherRoll: "Add Another Roll", totalPiecesCalc: "Total Pieces (Calculated)", fullWeightLabel: "Full Roll Weight", remainingWeightLabel: "Remaining Weight" },
+  hi: { cuttingManagerDashboardTitle: "काटिंग मैनेजर डैशबोर्ड", welcomeUser: "स्वागत हे", existingCuttingLots: "मौजूदा काटिंग लॉट्स", createNewCuttingLot: "नया काटिंग लॉट बनाएं", idLabel: "आईडी", lotNumberLabel: "लॉट नंबर", skuLabel: "एसकेयू", fabricTypeLabel: "फैब्रिक प्रकार", flowTypeLabel: "फ्लो प्रकार", tableLengthLabel: "टेबल लंबाई", remarkLabel: "टिप्पणी", imageLabel: "छवि", createdByLabel: "बनाने वाले", creationTimeLabel: "बनाने का समय", totalPiecesLabel: "कुल पीस", sizesLabel: "साइज़", actionsLabel: "कार्रवाई", noCuttingLotsAvailable: "कोई काटिंग लॉट उपलब्ध नहीं है।", sizeLabel: "साइज़", patternCountLabel: "पैटर्न की संख्या", lotNumberGenerated: "लॉट नंबर (सिस्टम द्वारा तैयार)", createLotBtn: "लॉट तैयार करें", remove: "हटाएं", rollNumber: "रोल नंबर", layersLabel: "लेयर्स", weightUsedLabel: "उपयोग किया गया वज़न (गणना)", weightUsageProgress: "वज़न उपयोग की प्रगति", availableLabel: "उपलब्ध", sizesAndPatterns: "साइज़ और पैटर्न", rollsUsed: "उपयोग किए गए रोल्स", addNewSize: "नया साइज़ जोड़ें", addAnotherRoll: "एक और रोल जोड़ें", totalPiecesCalc: "कुल पीस (हिसाब से)", fullWeightLabel: "रोल का कुल वज़न", remainingWeightLabel: "बचा हुआ वज़न" }
 };
 let currentLanguage = "en";
 function setLanguage(lang) {
@@ -851,11 +859,29 @@ function addNewSize() {
   newSize.querySelector('.patternCountInput').addEventListener('input', updateTotalPieces);
 }
 
+// Make a roll's Remaining Weight field match the current flow mode. The template bakes in
+// readonly/value at render time (from the cutter's default), so re-apply on every add and
+// whenever the Flow Type selector switches modes.
+function applyFlowToRoll(rollSection) {
+  const rem = rollSection.querySelector('.remainingWeightInput');
+  if (!rem) return;
+  if (FLOW_MODE === 'denim') {
+    rem.readOnly = true;
+    rem.value = '';
+    rem.placeholder = 'Auto (full − used)';
+  } else {
+    rem.readOnly = false;
+    if (!rem.value) rem.value = '0';
+    rem.placeholder = 'Remaining (default 0)';
+  }
+}
+
 function addNewRoll() {
   const newRoll = rollTemplate.cloneNode(true);
   newRoll.classList.remove('d-none');
   newRoll.removeAttribute('id');
   rollsContainer.appendChild(newRoll);
+  applyFlowToRoll(newRoll);
   newRoll.querySelector('.remove-roll-btn').addEventListener('click', () => { newRoll.remove(); updateTotalPieces(); checkRollsCompletion(); });
   newRoll.querySelector('.layersInput').addEventListener('input', () => {
     updateTotalPieces();
@@ -955,6 +981,30 @@ fabricTypeSel.addEventListener('change', () => {
   checkRollsCompletion();
 });
 
+// Flow Type selector — cutter can override denim/hosiery per lot. Safe: chosen at lot
+// creation, before any stage events exist. Switching modes changes the roll weight rules
+// (denim = auto remaining from table_length+layers; hosiery = manual remaining) and whether
+// table_length is required, so re-drive those and clear any rolls entered under the old mode.
+const flowTypeSel = document.getElementById('flow_type');
+if (flowTypeSel) {
+  flowTypeSel.addEventListener('change', () => {
+    FLOW_MODE = flowTypeSel.value === 'denim' ? 'denim' : 'hosiery';
+    IS_DENIM = FLOW_MODE === 'denim';
+    const tl = document.getElementById('table_length');
+    if (tl) {
+      tl.required = (FLOW_MODE === 'denim');
+      tl.placeholder = (FLOW_MODE === 'denim')
+        ? 'Table length (required for denim)'
+        : 'Table length (optional)';
+    }
+    // Rolls entered under the previous mode used different weight rules — reset them so
+    // freshly added rolls follow the newly selected flow (same reset as changing fabric).
+    rollsContainer.innerHTML = '';
+    updateTotalPieces();
+    checkRollsCompletion();
+  });
+}
+
 addSizeBtn.addEventListener('click', addNewSize);
 addRollBtn.addEventListener('click', addNewRoll);
 
@@ -999,10 +1049,13 @@ function checkRollsCompletion() {
   createLotBtn.disabled = !allFilled;
 }
 
-// Re-run weight computation across every roll when table length changes (denim only)
+// Re-run weight computation across every roll when table length changes (denim only).
+// Attached unconditionally and guarded inside so it still works if the cutter switches
+// the Flow Type selector to denim after page load.
 const tableLengthInput = document.getElementById('table_length');
-if (tableLengthInput && FLOW_MODE === 'denim') {
+if (tableLengthInput) {
   tableLengthInput.addEventListener('input', () => {
+    if (FLOW_MODE !== 'denim') return;
     rollsContainer.querySelectorAll('.roll-section:not(.d-none)').forEach(rs => {
       updateWeightUsed(rs);
       updateWeightProgress(rs);


### PR DESCRIPTION
## What

Adds a **Flow Type** selector (Denim / Hosiery) to the CUTTING MANAGER create-lot form so the cutter can choose the lot's `flow_type` at creation. It defaults to the cutter's current mode (`is_denim_cutter`) but is overridable. This is safe because `flow_type` is set at lot creation, before any stage events exist.

## Changes

- **`views/cuttingManagerDashboard.ejs`**
  - New `<select name="flow_type">` next to the fabric field, defaulting to `isDenim ? 'denim' : 'hosiery'`.
  - `IS_DENIM` / `FLOW_MODE` made mutable (`let`) so the selector drives the live UI mode.
  - Selector `change` listener: toggles `table_length` `required` + placeholder, and resets the rolls section so freshly added rolls follow the newly selected flow (denim = auto remaining from table_length+layers; hosiery = manual remaining). New `applyFlowToRoll()` helper normalizes each roll's remaining-weight field to the current mode on add.
  - `table_length` recompute listener attached unconditionally and guarded inside, so it still works after a mid-session switch to denim.

- **`routes/cuttingManagerRoutes.js`** — `POST /cutting-manager/create-lot`
  - Accepts `req.body.flow_type`: uses it when exactly `'denim'` or `'hosiery'`, otherwise falls back to the existing `is_denim_cutter`-derived default. Inserted into `cutting_lots.flow_type`. Everything else unchanged.

## Scope / safety

- Only the two files above touched. No stage-event tables, no assign/PM flow, no other routes.
- `node -c routes/cuttingManagerRoutes.js` and EJS compile both pass.

Do not merge yet — behavioural change wants a quick live click-through (switch modes, confirm table_length required toggles and rolls reset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)