### PR TITLE
feat(operator): Lot Admin — guarded denim/hosiery flow change + audit log

### DIFF
--- a/app.js
+++ b/app.js
@@ -221,6 +221,7 @@ app.use('/', launcherRoutes);                       // /launcher + /switch-role
 app.use('/my-lots', require('./routes/myLotsRoutes'));
 app.use('/operator/lot-tat', require('./routes/operatorLotTatRoutes'));
 app.use('/operator/lot-journey', require('./routes/lotJourneyRoutes'));
+app.use('/operator/lot-admin', require('./routes/lotAdminRoutes'));
 app.use('/admin/user-roles', adminUserRolesRoutes); // mohitOperator-only
 app.use('/return-challan', returnChallanRoutes);    // returnchallan role
 app.use('/admin', adminRoutes);

--- a/routes/lotAdminRoutes.js
+++ b/routes/lotAdminRoutes.js
@@ -1,0 +1,108 @@
+/**
+ * Operator "Lot Admin" — search a lot and perform guarded interventions:
+ *   #2 change denim/hosiery flow_type  (only while the lot hasn't progressed past stitching)
+ *   #3 reverse a lot to its previous stage  (added later)
+ *   #4 edit per-size quantities            (added later)
+ * Every intervention is written to pm_lot_audit_log (utils/lotAudit) so the full history is
+ * reconstructable. Operator-gated.
+ */
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isOperator } = require('../middlewares/auth');
+const { EVENT_TABLE } = require('../utils/lotStageUsers');
+const { canChangeFlow } = require('../utils/lotFlowChange');
+const { writeLotAudit } = require('../utils/lotAudit');
+
+async function resolveLot(q) {
+  const exact = q.trim();
+  const like = `%${exact}%`;
+  const [rows] = await pool.query(
+    `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.flow_type,
+            cl.created_at, u.username AS cutter_name
+       FROM cutting_lots cl LEFT JOIN users u ON u.id = cl.user_id
+      WHERE cl.lot_no = ? OR cl.manual_lot_number = ?
+            OR cl.lot_no LIKE ? OR cl.manual_lot_number LIKE ? OR cl.sku LIKE ?
+   ORDER BY (cl.lot_no = ?) DESC, (cl.manual_lot_number = ?) DESC, cl.created_at DESC
+      LIMIT 25`,
+    [exact, exact, like, like, like, exact, exact]
+  );
+  return rows;
+}
+
+async function eventCounts(db, lotId) {
+  const counts = {};
+  for (const [stage, table] of Object.entries(EVENT_TABLE)) {
+    try {
+      const [[r]] = await db.query(`SELECT COUNT(*) AS c FROM \`${table}\` WHERE cutting_lot_id = ?`, [lotId]);
+      counts[stage] = Number(r.c) || 0;
+    } catch (_) { counts[stage] = 0; }
+  }
+  return counts;
+}
+
+router.get('/', isAuthenticated, isOperator, (req, res) => res.render('lotAdmin', { user: req.session.user }));
+
+// GET /operator/lot-admin/lot?q=... -> best-match lot + its per-stage event counts + eligibility.
+router.get('/lot', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const q = String(req.query.q || '').trim();
+    if (!q) return res.json({ ok: false, error: 'Enter a lot number or SKU.' });
+    const rows = await resolveLot(q);
+    if (!rows.length) return res.json({ ok: false, error: 'No matching lot found.' });
+    const lot = rows[0];
+    const counts = await eventCounts(pool, lot.id);
+    res.json({
+      ok: true,
+      lot: {
+        id: lot.id, lot_no: lot.lot_no, manual_lot_number: lot.manual_lot_number,
+        sku: lot.sku, total_pieces: lot.total_pieces, flow_type: lot.flow_type || null,
+        cutter_name: lot.cutter_name || null,
+      },
+      event_counts: counts,
+      flow_change: canChangeFlow(counts),
+      matches: rows.length,
+    });
+  } catch (err) {
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// POST /operator/lot-admin/flow-change  { cutting_lot_id, flow_type }
+router.post('/flow-change', isAuthenticated, isOperator, async (req, res) => {
+  const conn = await pool.getConnection();
+  try {
+    const lotId = parseInt(req.body.cutting_lot_id, 10);
+    const target = String(req.body.flow_type || '').toLowerCase();
+    if (!lotId || (target !== 'denim' && target !== 'hosiery')) {
+      return res.status(400).json({ ok: false, error: 'A lot and flow_type (denim|hosiery) are required.' });
+    }
+    const [[lot]] = await conn.query('SELECT id, lot_no, flow_type FROM cutting_lots WHERE id = ?', [lotId]);
+    if (!lot) return res.status(404).json({ ok: false, error: 'Lot not found.' });
+    if ((lot.flow_type || '').toLowerCase() === target) {
+      return res.json({ ok: true, unchanged: true, message: `Lot is already ${target}.` });
+    }
+    // Guard: only safe while the lot hasn't diverged (no events past stitching).
+    const counts = await eventCounts(conn, lotId);
+    const guard = canChangeFlow(counts);
+    if (!guard.ok) return res.status(409).json({ ok: false, error: guard.reason, blockedStages: guard.blockedStages });
+
+    await conn.beginTransaction();
+    await conn.query('UPDATE cutting_lots SET flow_type = ? WHERE id = ?', [target, lotId]);
+    await writeLotAudit(conn, {
+      cutting_lot_id: lotId, lot_no: lot.lot_no, action: 'flow_change',
+      detail: { from: lot.flow_type || null, to: target, event_counts: counts },
+      performed_by: req.session?.user?.id || null,
+      performed_by_name: req.session?.user?.username || null,
+    });
+    await conn.commit();
+    res.json({ ok: true, from: lot.flow_type || null, to: target });
+  } catch (err) {
+    await conn.rollback().catch(() => {});
+    res.status(500).json({ ok: false, error: err.message });
+  } finally {
+    conn.release();
+  }
+});
+
+module.exports = router;

--- a/sql/2026_07_pm_lot_audit_log.sql
+++ b/sql/2026_07_pm_lot_audit_log.sql
@@ -1,0 +1,19 @@
+-- Generic production audit trail for operator lot interventions:
+--   flow_change   — denim/hosiery flow_type changed
+--   stage_reversal — a lot pushed back to its previous stage (events/payments undone)
+--   qty_edit      — per-size quantities edited at a stage
+-- `detail` holds an action-specific before/after snapshot (JSON) so a developer can fully
+-- reconstruct what happened. Append-only; never updated.
+CREATE TABLE IF NOT EXISTS pm_lot_audit_log (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  cutting_lot_id INT NULL,
+  lot_no VARCHAR(50) NULL,
+  action VARCHAR(40) NOT NULL,
+  detail JSON NULL,
+  performed_by INT NULL,
+  performed_by_name VARCHAR(100) NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_lot (cutting_lot_id),
+  INDEX idx_action (action),
+  INDEX idx_created (created_at)
+);

--- a/test/lotFlowChange.test.js
+++ b/test/lotFlowChange.test.js
@@ -1,0 +1,23 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { canChangeFlow } = require('../utils/lotFlowChange');
+
+test('allows flow change with no progress or only cutting/stitching events', () => {
+  assert.strictEqual(canChangeFlow({}).ok, true);
+  assert.strictEqual(canChangeFlow({ stitching: 5 }).ok, true);
+  assert.deepStrictEqual(canChangeFlow({ stitching: 5 }).blockedStages, []);
+});
+
+test('blocks flow change once the lot is past stitching', () => {
+  assert.strictEqual(canChangeFlow({ stitching: 5, jeans_assembly: 1 }).ok, false);
+  assert.strictEqual(canChangeFlow({ washing: 2 }).ok, false);
+  assert.strictEqual(canChangeFlow({ washing_in: 1 }).ok, false);
+  assert.deepStrictEqual(canChangeFlow({ finishing: 3 }).blockedStages, ['finishing']);
+});
+
+test('reports every blocking stage', () => {
+  const r = canChangeFlow({ jeans_assembly: 1, washing: 1, finishing: 1 });
+  assert.strictEqual(r.ok, false);
+  assert.deepStrictEqual(r.blockedStages, ['jeans_assembly', 'washing', 'finishing']);
+  assert.match(r.reason, /reverse the lot back to stitching/i);
+});

--- a/utils/lotAudit.js
+++ b/utils/lotAudit.js
@@ -1,0 +1,24 @@
+// Append a row to pm_lot_audit_log (the generic operator-intervention trail). Best-effort:
+// a logging failure must never abort the operation it's recording, but callers that need the
+// audit to be part of the same transaction can pass the transaction connection as `db`.
+async function writeLotAudit(db, { cutting_lot_id, lot_no, action, detail, performed_by, performed_by_name }) {
+  try {
+    await db.query(
+      `INSERT INTO pm_lot_audit_log
+         (cutting_lot_id, lot_no, action, detail, performed_by, performed_by_name)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [
+        cutting_lot_id || null,
+        lot_no || null,
+        String(action),
+        detail == null ? null : JSON.stringify(detail),
+        performed_by || null,
+        performed_by_name || null,
+      ]
+    );
+  } catch (err) {
+    console.error('[lotAudit] write failed:', err.message);
+  }
+}
+
+module.exports = { writeLotAudit };

--- a/utils/lotFlowChange.js
+++ b/utils/lotFlowChange.js
@@ -1,0 +1,29 @@
+// Pure safety guard: is it safe to change a lot's denim/hosiery flow_type given how far it
+// has already progressed?
+//
+// Denim and hosiery share cutting + stitching, then diverge:
+//   denim:   … stitching → jeans_assembly → washing → washing_in → finishing
+//   hosiery: … stitching → finishing
+// Once a lot has events in a divergent stage (jeans_assembly / washing / washing_in), or in
+// finishing (whose UPSTREAM differs by flow), switching flow_type would orphan that stage's
+// data and flip which worker gets paid at the next hand-off. So we only allow the change while
+// the lot has progressed no further than stitching (cutting/stitching events are fine — both
+// flows share them). No DB here so it's unit-tested.
+
+const BLOCKING_STAGES = ['jeans_assembly', 'washing', 'washing_in', 'finishing'];
+
+// eventCounts: { stitching, jeans_assembly, washing, washing_in, finishing } row counts.
+function canChangeFlow(eventCounts) {
+  const counts = eventCounts || {};
+  const blockedStages = BLOCKING_STAGES.filter((s) => (Number(counts[s]) || 0) > 0);
+  if (blockedStages.length) {
+    return {
+      ok: false,
+      blockedStages,
+      reason: `This lot has already moved into ${blockedStages.join(', ')}. Changing denim/hosiery now would orphan that stage's data and mis-pay a worker — reverse the lot back to stitching first.`,
+    };
+  }
+  return { ok: true, blockedStages: [] };
+}
+
+module.exports = { canChangeFlow, BLOCKING_STAGES };

--- a/views/lotAdmin.ejs
+++ b/views/lotAdmin.ejs
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Lot Admin</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <style>
+    :root{ --ink:#0f172a; --ink2:#64748b; --line:#e5e7eb; --bg:#f6f7fb; --card:#fff;
+           --blue:#2563eb; --blue-bg:#eff6ff; --green:#16a34a; --green-bg:#dcfce7;
+           --amber:#b45309; --amber-bg:#fef3c7; --red:#b91c1c; }
+    *{box-sizing:border-box}
+    body{margin:0;background:var(--bg);color:var(--ink);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;}
+    .head{background:#0f172a;color:#fff;padding:18px 16px;}
+    .head h1{margin:0;font-size:1.2rem;font-weight:650;}
+    .head p{margin:4px 0 0;color:#94a3b8;font-size:.85rem;}
+    .wrap{max-width:680px;margin:0 auto;padding:16px;}
+    .search{display:flex;gap:8px;margin-bottom:16px;}
+    .search input{flex:1;padding:12px 14px;border:1px solid var(--line);border-radius:10px;font-size:1rem;}
+    .btn{border:0;border-radius:10px;padding:12px 16px;font-size:.95rem;font-weight:600;cursor:pointer;}
+    .btn.primary{background:var(--blue);color:#fff;}
+    .btn:disabled{opacity:.5;cursor:not-allowed;}
+    .card{background:var(--card);border:1px solid var(--line);border-radius:14px;padding:16px;margin-bottom:14px;}
+    .lot-no{font-size:1.25rem;font-weight:700;}
+    .meta{color:var(--ink2);font-size:.86rem;margin-top:2px;}
+    .flow{display:inline-block;font-size:.72rem;font-weight:700;padding:3px 10px;border-radius:999px;text-transform:uppercase;letter-spacing:.3px;}
+    .flow.denim{background:var(--blue-bg);color:var(--blue);}
+    .flow.hosiery{background:var(--green-bg);color:var(--green);}
+    .journey{display:flex;flex-wrap:wrap;gap:6px;margin:14px 0;}
+    .step{display:inline-flex;flex-direction:column;line-height:1.2;padding:5px 10px;border-radius:9px;background:#f1f5f9;min-width:64px;}
+    .step .s{font-size:.62rem;text-transform:uppercase;letter-spacing:.3px;color:var(--ink2);}
+    .step .v{font-size:.95rem;font-weight:700;}
+    .step.has{background:var(--blue-bg);} .step.has .v{color:var(--blue);}
+    .sec-h{font-size:.8rem;font-weight:700;text-transform:uppercase;letter-spacing:.3px;color:var(--ink2);margin:6px 0 8px;}
+    .flow-pick{display:flex;gap:8px;}
+    .flow-pick .opt{flex:1;padding:12px;border:1.5px solid var(--line);border-radius:10px;text-align:center;font-weight:600;cursor:pointer;background:#fff;}
+    .flow-pick .opt.active{border-color:var(--blue);background:var(--blue-bg);color:var(--blue);}
+    .note{font-size:.85rem;padding:10px 12px;border-radius:9px;margin-top:10px;}
+    .note.warn{background:var(--amber-bg);color:var(--amber);}
+    .note.ok{background:var(--green-bg);color:var(--green);}
+    .note.err{background:#fee2e2;color:var(--red);}
+    .empty{color:var(--ink2);text-align:center;padding:30px;}
+  </style>
+</head>
+<body>
+  <div class="head">
+    <h1>Lot Admin</h1>
+    <p>Search a lot to change its denim/hosiery flow (only before it moves past stitching). Every change is logged.</p>
+  </div>
+  <div class="wrap">
+    <div class="search">
+      <input id="q" placeholder="Lot no, manual lot, or SKU…" autocomplete="off" />
+      <button class="btn primary" id="searchBtn">Search</button>
+    </div>
+    <div id="result"><div class="empty">Search for a lot to begin.</div></div>
+  </div>
+
+<script>
+var lotState = null;
+function esc(v){ return String(v==null?'':v).replace(/[<>&]/g,function(c){return {'<':'&lt;','>':'&gt;','&':'&amp;'}[c];}); }
+var STAGE_LABELS = { stitching:'Stitch', jeans_assembly:'Assembly', washing:'Wash', washing_in:'Wash-in', finishing:'Finish' };
+
+async function search(){
+  var q = document.getElementById('q').value.trim();
+  var box = document.getElementById('result');
+  if(!q){ box.innerHTML = '<div class="empty">Enter a lot number or SKU.</div>'; return; }
+  box.innerHTML = '<div class="empty">Loading…</div>';
+  try{
+    var r = await (await fetch('/operator/lot-admin/lot?q=' + encodeURIComponent(q))).json();
+    if(!r.ok){ box.innerHTML = '<div class="empty">' + esc(r.error) + '</div>'; return; }
+    lotState = r;
+    box.innerHTML = renderLot(r);
+  }catch(e){ box.innerHTML = '<div class="empty">Error: ' + esc(e.message) + '</div>'; }
+}
+
+function renderLot(r){
+  var lot = r.lot;
+  var flow = (lot.flow_type||'').toLowerCase()==='denim' ? 'denim' : (lot.flow_type ? 'hosiery' : 'unknown');
+  var counts = r.event_counts || {};
+  var steps = Object.keys(STAGE_LABELS).map(function(st){
+    var n = counts[st]||0;
+    return '<div class="step ' + (n>0?'has':'') + '"><span class="s">' + STAGE_LABELS[st] + '</span><span class="v">' + n + '</span></div>';
+  }).join('');
+  var g = r.flow_change || { ok:true };
+  var picker = ['denim','hosiery'].map(function(f){
+    return '<div class="opt ' + (flow===f?'active':'') + '" data-flow="' + f + '">' + f.charAt(0).toUpperCase()+f.slice(1) + '</div>';
+  }).join('');
+  var guardNote = g.ok
+    ? '<div class="note warn" style="background:#f1f5f9;color:#475569">Changing flow is allowed — this lot has not moved past stitching.</div>'
+    : '<div class="note warn">' + esc(g.reason) + '</div>';
+  return '<div class="card">'
+    + '<div style="display:flex;justify-content:space-between;align-items:flex-start;gap:10px;">'
+    +   '<div><div class="lot-no">' + esc((lot.manual_lot_number||lot.lot_no||'').toUpperCase()) + '</div>'
+    +     '<div class="meta">' + esc(lot.sku||'') + ' · ' + (lot.total_pieces||0) + ' pcs · cut by ' + esc(lot.cutter_name||'—') + '</div></div>'
+    +   '<span class="flow ' + (flow==='unknown'?'':flow) + '">' + flow + '</span>'
+    + '</div>'
+    + '<div class="journey">' + steps + '</div>'
+    + '<div class="sec-h">Denim / Hosiery</div>'
+    + '<div class="flow-pick" id="flowPick">' + picker + '</div>'
+    + guardNote
+    + '<div style="margin-top:12px;display:flex;gap:8px;align-items:center;">'
+    +   '<button class="btn primary" id="applyFlow"' + (g.ok?'':' disabled') + '>Change flow</button>'
+    +   '<span id="flowMsg" style="font-size:.9rem;"></span>'
+    + '</div>'
+    + '</div>';
+}
+
+var pendingFlow = null;
+document.addEventListener('click', function(e){
+  var opt = e.target.closest('.flow-pick .opt');
+  if(opt){
+    if(document.getElementById('applyFlow') && document.getElementById('applyFlow').disabled) return;
+    document.querySelectorAll('.flow-pick .opt').forEach(function(o){o.classList.remove('active');});
+    opt.classList.add('active'); pendingFlow = opt.getAttribute('data-flow');
+  }
+  if(e.target.id==='applyFlow'){ applyFlow(); }
+});
+
+async function applyFlow(){
+  if(!lotState) return;
+  var target = pendingFlow || ((lotState.lot.flow_type||'').toLowerCase()==='denim'?'denim':(lotState.lot.flow_type?'hosiery':null));
+  var cur = (lotState.lot.flow_type||'').toLowerCase();
+  var msg = document.getElementById('flowMsg');
+  if(!target){ msg.textContent = 'Pick denim or hosiery.'; return; }
+  if(target===cur){ msg.textContent = 'Already ' + target + '.'; return; }
+  var btn = document.getElementById('applyFlow'); btn.disabled = true; msg.textContent = 'Saving…';
+  try{
+    var r = await (await fetch('/operator/lot-admin/flow-change',{method:'POST',headers:{'content-type':'application/json'},
+      body: JSON.stringify({ cutting_lot_id: lotState.lot.id, flow_type: target })})).json();
+    if(r.ok){ msg.innerHTML = '<span style="color:#16a34a;font-weight:600;">✓ Changed ' + esc(r.from||'—') + ' → ' + esc(r.to) + '</span>'; search(); }
+    else { msg.innerHTML = '<span style="color:#b91c1c;">' + esc(r.error||'failed') + '</span>'; btn.disabled = false; }
+  }catch(e){ msg.innerHTML = '<span style="color:#b91c1c;">' + esc(e.message) + '</span>'; btn.disabled = false; }
+}
+
+document.getElementById('searchBtn').addEventListener('click', search);
+document.getElementById('q').addEventListener('keydown', function(e){ if(e.key==='Enter') search(); });
+</script>
+</body>
+</html>

--- a/views/operatorDashboard.ejs
+++ b/views/operatorDashboard.ejs
@@ -733,6 +733,10 @@
           <i class="bi bi-stopwatch"></i>
           <span class="action-card-title">Lot TAT</span>
         </a>
+        <a href="/operator/lot-admin" class="action-card">
+          <i class="bi bi-sliders"></i>
+          <span class="action-card-title">Lot Admin</span>
+        </a>
         <a href="/operator/rewash-download" class="action-card">
           <i class="bi bi-arrow-repeat"></i>
           <span class="action-card-title">Rewash Excel</span>


### PR DESCRIPTION
Operator can change a lot's denim/hosiery flow_type, but only while it hasn't moved past stitching (else it'd orphan stage data + mis-pay a worker — blocked with a clear message). New pm_lot_audit_log (shared by #3/#4), unit-tested guard, and a mobile-first /operator/lot-admin page. Migration applied to prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)