### PR TITLE
feat(operator): reverse a lot to its previous stage (guarded + payment-safe + audited)

### DIFF
--- a/routes/lotAdminRoutes.js
+++ b/routes/lotAdminRoutes.js
@@ -12,7 +12,27 @@ const { pool } = require('../config/db');
 const { isAuthenticated, isOperator } = require('../middlewares/auth');
 const { EVENT_TABLE } = require('../utils/lotStageUsers');
 const { canChangeFlow } = require('../utils/lotFlowChange');
+const { reversibleStage, payStageFor } = require('../utils/stageReversal');
 const { writeLotAudit } = require('../utils/lotAudit');
+
+// Whether the lot's furthest stage can be reversed, and why not. Blocks on: nothing to
+// reverse, finishing already dispatched, or a hand-off payment already PAID.
+async function reversalInfo(db, lot) {
+  const flow = (lot.flow_type || '').toLowerCase() === 'denim' ? 'denim' : 'hosiery';
+  const counts = await eventCounts(db, lot.id);
+  const rev = reversibleStage(flow, counts);
+  if (!rev) return { reversible: false, reason: 'This lot is only cut — nothing to reverse.' };
+  if (rev.stage === 'finishing') {
+    const [[d]] = await db.query('SELECT COUNT(*) AS c FROM finishing_dispatches WHERE lot_no = ?', [lot.lot_no]);
+    if (Number(d.c) > 0) return { reversible: false, stage: rev.stage, label: rev.label, reason: 'Finishing has already been dispatched — the goods have shipped, so it can\'t be reversed.' };
+  }
+  const payStage = payStageFor(rev.stage, flow);
+  if (payStage) {
+    const [[p]] = await db.query(`SELECT COUNT(*) AS c FROM stage_payments WHERE lot_no = ? AND stage = ? AND status = 'paid'`, [lot.lot_no, payStage]);
+    if (Number(p.c) > 0) return { reversible: false, stage: rev.stage, label: rev.label, reason: `A ${payStage} worker was already PAID for this hand-off — get that payment un-paid before reversing.` };
+  }
+  return { reversible: true, stage: rev.stage, label: rev.label, pay_stage: payStage };
+}
 
 async function resolveLot(q) {
   const exact = q.trim();
@@ -61,6 +81,7 @@ router.get('/lot', isAuthenticated, isOperator, async (req, res) => {
       },
       event_counts: counts,
       flow_change: canChangeFlow(counts),
+      reversal: await reversalInfo(pool, lot),
       matches: rows.length,
     });
   } catch (err) {
@@ -97,6 +118,69 @@ router.post('/flow-change', isAuthenticated, isOperator, async (req, res) => {
     });
     await conn.commit();
     res.json({ ok: true, from: lot.flow_type || null, to: target });
+  } catch (err) {
+    await conn.rollback().catch(() => {});
+    res.status(500).json({ ok: false, error: err.message });
+  } finally {
+    conn.release();
+  }
+});
+
+// POST /operator/lot-admin/reverse-stage  { cutting_lot_id }
+// Reverses the lot's furthest-along stage: deletes that stage's events (children first, due to
+// the parent_event_id FK), voids the pending hand-off payment, and snapshots everything to the
+// audit log. The upstream "available" pool re-opens automatically (it's derived). Blocks if the
+// stage is dispatched or its hand-off payment was already paid.
+router.post('/reverse-stage', isAuthenticated, isOperator, async (req, res) => {
+  const conn = await pool.getConnection();
+  try {
+    const lotId = parseInt(req.body.cutting_lot_id, 10);
+    if (!lotId) return res.status(400).json({ ok: false, error: 'A lot is required.' });
+    const [[lot]] = await conn.query('SELECT id, lot_no, flow_type FROM cutting_lots WHERE id = ?', [lotId]);
+    if (!lot) return res.status(404).json({ ok: false, error: 'Lot not found.' });
+
+    const info = await reversalInfo(conn, lot);
+    if (!info.reversible) return res.status(409).json({ ok: false, error: info.reason });
+    const stage = info.stage;
+    const table = EVENT_TABLE[stage];
+    const payStage = info.pay_stage;
+
+    // Snapshot BEFORE deleting, for the audit trail.
+    const [events] = await conn.query(
+      `SELECT id, event_type, pieces, operator_id, parent_event_id, created_at FROM \`${table}\` WHERE cutting_lot_id = ? ORDER BY id`,
+      [lotId]
+    );
+    let pendingPayments = [];
+    if (payStage) {
+      const [pp] = await conn.query(
+        `SELECT id, username, stage, qty, total_amount FROM stage_payments WHERE lot_no = ? AND stage = ? AND status = 'pending'`,
+        [lot.lot_no, payStage]
+      );
+      pendingPayments = pp;
+    }
+
+    await conn.beginTransaction();
+    // Children (complete/inline-reject, parent_event_id NOT NULL) first — the FK forbids
+    // deleting a parent approve while a child references it. *_event_sizes cascade on delete.
+    await conn.query(`DELETE FROM \`${table}\` WHERE cutting_lot_id = ? AND parent_event_id IS NOT NULL`, [lotId]);
+    await conn.query(`DELETE FROM \`${table}\` WHERE cutting_lot_id = ? AND parent_event_id IS NULL`, [lotId]);
+    let voided = 0;
+    if (payStage) {
+      const [r] = await conn.query(
+        `UPDATE stage_payments SET status = 'cancelled', updated_at = NOW() WHERE lot_no = ? AND stage = ? AND status = 'pending'`,
+        [lot.lot_no, payStage]
+      );
+      voided = r.affectedRows || 0;
+    }
+    await writeLotAudit(conn, {
+      cutting_lot_id: lotId, lot_no: lot.lot_no, action: 'stage_reversal',
+      detail: { reversed_stage: stage, flow: lot.flow_type || null, pay_stage: payStage,
+        deleted_events: events, voided_payments: pendingPayments },
+      performed_by: req.session?.user?.id || null,
+      performed_by_name: req.session?.user?.username || null,
+    });
+    await conn.commit();
+    res.json({ ok: true, reversed_stage: stage, deleted_events: events.length, voided_payments: voided });
   } catch (err) {
     await conn.rollback().catch(() => {});
     res.status(500).json({ ok: false, error: err.message });

--- a/test/stageReversal.test.js
+++ b/test/stageReversal.test.js
@@ -1,0 +1,21 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { reversibleStage, payStageFor } = require('../utils/stageReversal');
+
+test('reversibleStage = furthest-along stage that has events', () => {
+  assert.strictEqual(reversibleStage('denim', { stitching: 2, jeans_assembly: 1 }).stage, 'jeans_assembly');
+  assert.strictEqual(reversibleStage('denim', { stitching: 2 }).stage, 'stitching');
+  assert.strictEqual(reversibleStage('denim', { stitching: 2, washing: 1 }).stage, 'washing');
+  assert.strictEqual(reversibleStage('denim', {}), null);
+  // hosiery skips the denim-only stages
+  assert.strictEqual(reversibleStage('hosiery', { stitching: 1, finishing: 2 }).stage, 'finishing');
+});
+
+test('payStageFor maps a stage to the upstream payee it must void, flow-aware', () => {
+  assert.strictEqual(payStageFor('stitching', 'denim'), 'cutting');
+  assert.strictEqual(payStageFor('jeans_assembly', 'denim'), 'stitching');
+  assert.strictEqual(payStageFor('washing', 'denim'), 'assembly');
+  assert.strictEqual(payStageFor('washing_in', 'denim'), 'washing');
+  assert.strictEqual(payStageFor('finishing', 'denim'), 'washing_in');
+  assert.strictEqual(payStageFor('finishing', 'hosiery'), 'stitching');
+});

--- a/utils/stageReversal.js
+++ b/utils/stageReversal.js
@@ -1,0 +1,37 @@
+// Pure helpers for reversing a lot to its previous stage (undoing a stage that mistakenly
+// took a lot in). No DB, so it's unit-tested.
+
+const { orderedStages } = require('./lotJourney');
+
+const STAGE_LABEL = {
+  stitching: 'Stitching', jeans_assembly: 'Jeans Assembly',
+  washing: 'Washing', washing_in: 'Washing-In', finishing: 'Finishing',
+};
+
+// The ONLY reversible stage is the furthest-along stage that has events: you can't reverse a
+// stage while a later stage has already pulled pieces from it (that guarantees no downstream
+// event references what we're about to delete). Returns { stage, label } or null.
+function reversibleStage(flowType, eventCounts) {
+  const counts = eventCounts || {};
+  const stages = orderedStages(flowType).filter((s) => s !== 'cutting');
+  let last = null;
+  for (const s of stages) if ((Number(counts[s]) || 0) > 0) last = s;
+  return last ? { stage: last, label: STAGE_LABEL[last] || last } : null;
+}
+
+// When stage X approves (takes the lot in), it pays the UPSTREAM worker via stage_payments
+// with stage = the payee's stage. Reversing X must void that pending payment. Finishing's
+// payee depends on flow (denim pulls from washing_in, hosiery from stitching). Returns the
+// stage_payments.stage value to void, or null if the stage pays nobody.
+function payStageFor(stage, flowType) {
+  const denim = flowType === 'denim';
+  return ({
+    stitching: 'cutting',
+    jeans_assembly: 'stitching',
+    washing: 'assembly',
+    washing_in: 'washing',
+    finishing: denim ? 'washing_in' : 'stitching',
+  })[stage] || null;
+}
+
+module.exports = { reversibleStage, payStageFor, STAGE_LABEL };

--- a/views/lotAdmin.ejs
+++ b/views/lotAdmin.ejs
@@ -87,6 +87,14 @@ function renderLot(r){
   var guardNote = g.ok
     ? '<div class="note warn" style="background:#f1f5f9;color:#475569">Changing flow is allowed — this lot has not moved past stitching.</div>'
     : '<div class="note warn">' + esc(g.reason) + '</div>';
+  var rev = r.reversal || {};
+  var revBody = rev.reversible
+    ? '<div class="note warn">This lot is at <b>' + esc(rev.label) + '</b>. Reversing undoes that stage for this lot and voids the pending hand-off payment — the lot returns to the previous stage. Logged.</div>'
+      + '<div style="margin-top:12px;display:flex;gap:8px;align-items:center;">'
+      + '<button class="btn" style="background:#b91c1c;color:#fff;" id="reverseBtn">Reverse ' + esc(rev.label) + '</button>'
+      + '<span id="revMsg" style="font-size:.9rem;"></span></div>'
+    : '<div class="note warn">' + esc(rev.reason || 'Nothing to reverse.') + '</div>';
+  var revCard = '<div class="card"><div class="sec-h">Reverse a mistaken take-in</div>' + revBody + '</div>';
   return '<div class="card">'
     + '<div style="display:flex;justify-content:space-between;align-items:flex-start;gap:10px;">'
     +   '<div><div class="lot-no">' + esc((lot.manual_lot_number||lot.lot_no||'').toUpperCase()) + '</div>'
@@ -101,7 +109,7 @@ function renderLot(r){
     +   '<button class="btn primary" id="applyFlow"' + (g.ok?'':' disabled') + '>Change flow</button>'
     +   '<span id="flowMsg" style="font-size:.9rem;"></span>'
     + '</div>'
-    + '</div>';
+    + '</div>' + revCard;
 }
 
 var pendingFlow = null;
@@ -113,7 +121,21 @@ document.addEventListener('click', function(e){
     opt.classList.add('active'); pendingFlow = opt.getAttribute('data-flow');
   }
   if(e.target.id==='applyFlow'){ applyFlow(); }
+  if(e.target.id==='reverseBtn'){ reverseStage(); }
 });
+
+async function reverseStage(){
+  if(!lotState || !lotState.reversal || !lotState.reversal.reversible) return;
+  if(!confirm('Reverse ' + lotState.reversal.label + '? This undoes that stage for the lot and voids its pending hand-off payment.')) return;
+  var btn=document.getElementById('reverseBtn'); if(btn) btn.disabled=true;
+  var msg=document.getElementById('revMsg'); if(msg) msg.textContent='Reversing…';
+  try{
+    var r=await (await fetch('/operator/lot-admin/reverse-stage',{method:'POST',headers:{'content-type':'application/json'},
+      body:JSON.stringify({cutting_lot_id:lotState.lot.id})})).json();
+    if(r.ok){ if(msg) msg.innerHTML='<span style="color:#16a34a;font-weight:600;">✓ Reversed '+esc(r.reversed_stage)+' — '+r.deleted_events+' events removed, '+r.voided_payments+' payment(s) voided</span>'; search(); }
+    else { if(msg) msg.innerHTML='<span style="color:#b91c1c;">'+esc(r.error||'failed')+'</span>'; if(btn) btn.disabled=false; }
+  }catch(e){ if(msg) msg.innerHTML='<span style="color:#b91c1c;">'+esc(e.message)+'</span>'; if(btn) btn.disabled=false; }
+}
 
 async function applyFlow(){
   if(!lotState) return;


### PR DESCRIPTION
Operator can push a lot back when a stage mistakenly took it in. Reverses ONLY the furthest stage (no downstream refs), deletes its events children-first, VOIDS the pending hand-off payment (BLOCKS if already paid), blocks if finishing was dispatched, all in one transaction with a full audit snapshot. Pure helpers unit-tested.

**Not auto-merged — please review + test on a throwaway lot before merging (it voids payments).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)