### PR TITLE
feat(operator): edit a lot's cut quantities size-wise (guarded + audited)

### DIFF
--- a/routes/lotAdminRoutes.js
+++ b/routes/lotAdminRoutes.js
@@ -11,6 +11,7 @@ const router = express.Router();
 const { pool } = require('../config/db');
 const { isAuthenticated, isOperator } = require('../middlewares/auth');
 const { EVENT_TABLE } = require('../utils/lotStageUsers');
+const stageEvents = require('../utils/stageEvents');
 const { canChangeFlow } = require('../utils/lotFlowChange');
 const { reversibleStage, payStageFor } = require('../utils/stageReversal');
 const { writeLotAudit } = require('../utils/lotAudit');
@@ -50,6 +51,26 @@ async function resolveLot(q) {
   return rows;
 }
 
+// Per-size cut quantities + the floor each can't be reduced below (what stitching already
+// approved from that size — reducing below it would corrupt the downstream pool).
+async function cutSizesWithFloor(db, lotId) {
+  const [cutSizes] = await db.query(
+    'SELECT id, size_label, total_pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ? ORDER BY id',
+    [lotId]
+  );
+  let stitch = {};
+  try { stitch = await stageEvents.getStageSizeAggregates(db, 'stitching', lotId); } catch (_) { stitch = {}; }
+  return cutSizes.map((s) => {
+    const key = stageEvents.normalizeSizeLabel(s.size_label);
+    return {
+      id: s.id,
+      size_label: s.size_label,
+      total_pieces: Number(s.total_pieces) || 0,
+      floor: (stitch[key] && stitch[key].approved) || 0,
+    };
+  });
+}
+
 async function eventCounts(db, lotId) {
   const counts = {};
   for (const [stage, table] of Object.entries(EVENT_TABLE)) {
@@ -82,6 +103,7 @@ router.get('/lot', isAuthenticated, isOperator, async (req, res) => {
       event_counts: counts,
       flow_change: canChangeFlow(counts),
       reversal: await reversalInfo(pool, lot),
+      sizes: await cutSizesWithFloor(pool, lot.id),
       matches: rows.length,
     });
   } catch (err) {
@@ -181,6 +203,55 @@ router.post('/reverse-stage', isAuthenticated, isOperator, async (req, res) => {
     });
     await conn.commit();
     res.json({ ok: true, reversed_stage: stage, deleted_events: events.length, voided_payments: voided });
+  } catch (err) {
+    await conn.rollback().catch(() => {});
+    res.status(500).json({ ok: false, error: err.message });
+  } finally {
+    conn.release();
+  }
+});
+
+// POST /operator/lot-admin/qty-edit  { cutting_lot_id, sizes: [{ size_label, total_pieces }] }
+// Edit the lot's per-size CUT quantities. Guarded so a size can't drop below what stitching
+// already approved (which would corrupt the downstream pool). Recomputes the lot total and
+// writes a before/after audit row.
+router.post('/qty-edit', isAuthenticated, isOperator, async (req, res) => {
+  const conn = await pool.getConnection();
+  try {
+    const lotId = parseInt(req.body.cutting_lot_id, 10);
+    const edits = Array.isArray(req.body.sizes) ? req.body.sizes : [];
+    if (!lotId || !edits.length) return res.status(400).json({ ok: false, error: 'A lot and sizes are required.' });
+    const [[lot]] = await conn.query('SELECT id, lot_no FROM cutting_lots WHERE id = ?', [lotId]);
+    if (!lot) return res.status(404).json({ ok: false, error: 'Lot not found.' });
+
+    const rows = await cutSizesWithFloor(conn, lotId);
+    const byLabel = new Map(rows.map((r) => [String(r.size_label).toUpperCase(), r]));
+    const applied = [];
+    for (const e of edits) {
+      const row = byLabel.get(String(e.size_label || '').toUpperCase());
+      if (!row) return res.status(400).json({ ok: false, error: `Unknown size ${e.size_label}.` });
+      const to = Math.round(Number(e.total_pieces));
+      if (!Number.isFinite(to) || to < 0) return res.status(400).json({ ok: false, error: `Invalid quantity for ${row.size_label}.` });
+      if (to < row.floor) return res.status(409).json({ ok: false, error: `${row.size_label}: can't go below ${row.floor} — stitching already took that many pieces.` });
+      applied.push({ id: row.id, size_label: row.size_label, from: row.total_pieces, to });
+    }
+    const changed = applied.filter((a) => a.from !== a.to);
+    if (!changed.length) return res.json({ ok: true, changes: 0, message: 'No changes.' });
+
+    await conn.beginTransaction();
+    for (const a of changed) {
+      await conn.query('UPDATE cutting_lot_sizes SET total_pieces = ? WHERE id = ? AND cutting_lot_id = ?', [a.to, a.id, lotId]);
+    }
+    const [[sum]] = await conn.query('SELECT COALESCE(SUM(total_pieces),0) AS t FROM cutting_lot_sizes WHERE cutting_lot_id = ?', [lotId]);
+    await conn.query('UPDATE cutting_lots SET total_pieces = ? WHERE id = ?', [sum.t, lotId]);
+    await writeLotAudit(conn, {
+      cutting_lot_id: lotId, lot_no: lot.lot_no, action: 'qty_edit',
+      detail: { scope: 'cutting_lot_sizes', changes: changed, new_total: Number(sum.t) },
+      performed_by: req.session?.user?.id || null,
+      performed_by_name: req.session?.user?.username || null,
+    });
+    await conn.commit();
+    res.json({ ok: true, changes: changed.length, new_total: Number(sum.t) });
   } catch (err) {
     await conn.rollback().catch(() => {});
     res.status(500).json({ ok: false, error: err.message });

--- a/views/lotAdmin.ejs
+++ b/views/lotAdmin.ejs
@@ -95,6 +95,20 @@ function renderLot(r){
       + '<span id="revMsg" style="font-size:.9rem;"></span></div>'
     : '<div class="note warn">' + esc(rev.reason || 'Nothing to reverse.') + '</div>';
   var revCard = '<div class="card"><div class="sec-h">Reverse a mistaken take-in</div>' + revBody + '</div>';
+
+  var sizes = r.sizes || [];
+  var sizeRows = sizes.map(function(s){
+    return '<div style="display:flex;gap:10px;align-items:center;margin-bottom:7px;">'
+      + '<span style="width:56px;font-weight:700;">' + esc(s.size_label) + '</span>'
+      + '<input type="number" min="' + (s.floor||0) + '" value="' + (s.total_pieces||0) + '" data-size="' + esc(s.size_label) + '" class="qtyInput" style="width:110px;padding:9px;border:1px solid var(--line);border-radius:8px;font-size:1rem;">'
+      + (s.floor>0 ? '<span style="font-size:.72rem;color:var(--ink2);">min ' + s.floor + ' (already stitched)</span>' : '<span style="font-size:.72rem;color:var(--ink2);">not yet stitched</span>')
+      + '</div>';
+  }).join('');
+  var qtyCard = sizes.length ? ('<div class="card"><div class="sec-h">Edit cut quantity (size-wise)</div>'
+    + sizeRows
+    + '<div style="margin-top:10px;display:flex;gap:8px;align-items:center;"><button class="btn primary" id="saveQty">Save quantities</button><span id="qtyMsg" style="font-size:.9rem;"></span></div>'
+    + '</div>') : '';
+
   return '<div class="card">'
     + '<div style="display:flex;justify-content:space-between;align-items:flex-start;gap:10px;">'
     +   '<div><div class="lot-no">' + esc((lot.manual_lot_number||lot.lot_no||'').toUpperCase()) + '</div>'
@@ -109,7 +123,7 @@ function renderLot(r){
     +   '<button class="btn primary" id="applyFlow"' + (g.ok?'':' disabled') + '>Change flow</button>'
     +   '<span id="flowMsg" style="font-size:.9rem;"></span>'
     + '</div>'
-    + '</div>' + revCard;
+    + '</div>' + qtyCard + revCard;
 }
 
 var pendingFlow = null;
@@ -122,7 +136,22 @@ document.addEventListener('click', function(e){
   }
   if(e.target.id==='applyFlow'){ applyFlow(); }
   if(e.target.id==='reverseBtn'){ reverseStage(); }
+  if(e.target.id==='saveQty'){ saveQty(); }
 });
+
+async function saveQty(){
+  if(!lotState) return;
+  var inputs = Array.from(document.querySelectorAll('.qtyInput'));
+  var sizes = inputs.map(function(i){ return { size_label: i.getAttribute('data-size'), total_pieces: i.value }; });
+  var btn=document.getElementById('saveQty'); if(btn) btn.disabled=true;
+  var msg=document.getElementById('qtyMsg'); if(msg) msg.textContent='Saving…';
+  try{
+    var r=await (await fetch('/operator/lot-admin/qty-edit',{method:'POST',headers:{'content-type':'application/json'},
+      body:JSON.stringify({cutting_lot_id:lotState.lot.id, sizes:sizes})})).json();
+    if(r.ok){ if(msg) msg.innerHTML='<span style="color:#16a34a;font-weight:600;">✓ Saved '+(r.changes||0)+' change(s) — new total '+(r.new_total!=null?r.new_total:'')+'</span>'; search(); }
+    else { if(msg) msg.innerHTML='<span style="color:#b91c1c;">'+esc(r.error||'failed')+'</span>'; if(btn) btn.disabled=false; }
+  }catch(e){ if(msg) msg.innerHTML='<span style="color:#b91c1c;">'+esc(e.message)+'</span>'; if(btn) btn.disabled=false; }
+}
 
 async function reverseStage(){
   if(!lotState || !lotState.reversal || !lotState.reversal.reversible) return;


### PR DESCRIPTION
On Lot Admin, edit a lot's per-size cut quantity — guarded so a size can't drop below what stitching already approved (fixes the old editor's integrity gap), recomputes the total, and audits before/after. Edits CUT quantities; downstream-stage event editing flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)