### PR TITLE
fix(operator): reversal targets the right stage for null-flow lots

### DIFF
--- a/routes/lotAdminRoutes.js
+++ b/routes/lotAdminRoutes.js
@@ -13,14 +13,16 @@ const { isAuthenticated, isOperator } = require('../middlewares/auth');
 const { EVENT_TABLE } = require('../utils/lotStageUsers');
 const stageEvents = require('../utils/stageEvents');
 const { canChangeFlow } = require('../utils/lotFlowChange');
-const { reversibleStage, payStageFor } = require('../utils/stageReversal');
+const { reversibleStage, payStageFor, effectiveFlow } = require('../utils/stageReversal');
 const { writeLotAudit } = require('../utils/lotAudit');
 
 // Whether the lot's furthest stage can be reversed, and why not. Blocks on: nothing to
 // reverse, finishing already dispatched, or a hand-off payment already PAID.
 async function reversalInfo(db, lot) {
-  const flow = (lot.flow_type || '').toLowerCase() === 'denim' ? 'denim' : 'hosiery';
   const counts = await eventCounts(db, lot.id);
+  // Use the EFFECTIVE flow: a null-flow lot with denim-only stage events is denim, so the
+  // furthest stage (and the payment to void) is identified correctly.
+  const flow = effectiveFlow(lot.flow_type, counts);
   const rev = reversibleStage(flow, counts);
   if (!rev) return { reversible: false, reason: 'This lot is only cut — nothing to reverse.' };
   if (rev.stage === 'finishing') {

--- a/test/stageReversal.test.js
+++ b/test/stageReversal.test.js
@@ -1,6 +1,16 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
-const { reversibleStage, payStageFor } = require('../utils/stageReversal');
+const { reversibleStage, payStageFor, effectiveFlow } = require('../utils/stageReversal');
+
+test('effectiveFlow infers denim from denim-only stage events even when flow_type is null', () => {
+  // The bug: a null-flow lot at washing was treated as hosiery → wrong reversible stage.
+  assert.strictEqual(effectiveFlow(null, { stitching: 2, jeans_assembly: 2, washing: 2 }), 'denim');
+  assert.strictEqual(effectiveFlow(null, { stitching: 2 }), 'hosiery');
+  assert.strictEqual(effectiveFlow('denim', {}), 'denim');
+  assert.strictEqual(effectiveFlow('hosiery', { stitching: 1, finishing: 1 }), 'hosiery');
+  // and the furthest stage is now correct for that null-flow denim lot:
+  assert.strictEqual(reversibleStage(effectiveFlow(null, { stitching: 2, jeans_assembly: 2, washing: 2 }), { stitching: 2, jeans_assembly: 2, washing: 2 }).stage, 'washing');
+});
 
 test('reversibleStage = furthest-along stage that has events', () => {
   assert.strictEqual(reversibleStage('denim', { stitching: 2, jeans_assembly: 1 }).stage, 'jeans_assembly');

--- a/utils/stageReversal.js
+++ b/utils/stageReversal.js
@@ -8,6 +8,17 @@ const STAGE_LABEL = {
   washing: 'Washing', washing_in: 'Washing-In', finishing: 'Finishing',
 };
 
+// The lot's effective flow. A lot whose flow_type is null/unknown but which has events in a
+// denim-only stage (jeans_assembly / washing / washing_in) IS denim — otherwise the hosiery
+// fallback would skip those stages and mis-identify the furthest stage (e.g. a lot at washing
+// wrongly reported as reversible at stitching). Declared 'denim' also wins.
+const DENIM_ONLY_STAGES = ['jeans_assembly', 'washing', 'washing_in'];
+function effectiveFlow(flowType, eventCounts) {
+  const counts = eventCounts || {};
+  if (DENIM_ONLY_STAGES.some((s) => (Number(counts[s]) || 0) > 0)) return 'denim';
+  return String(flowType || '').toLowerCase() === 'denim' ? 'denim' : 'hosiery';
+}
+
 // The ONLY reversible stage is the furthest-along stage that has events: you can't reverse a
 // stage while a later stage has already pulled pieces from it (that guarantees no downstream
 // event references what we're about to delete). Returns { stage, label } or null.
@@ -34,4 +45,4 @@ function payStageFor(stage, flowType) {
   })[stage] || null;
 }
 
-module.exports = { reversibleStage, payStageFor, STAGE_LABEL };
+module.exports = { reversibleStage, payStageFor, effectiveFlow, STAGE_LABEL };


### PR DESCRIPTION
A null-flow lot with denim-only stage events was treated as hosiery, so the reversal targeted the wrong (too-early) stage. New effectiveFlow() infers denim from the events; fixes 'Reverse Stitching' showing on a lot that's actually at washing. Unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)