### PR TITLE
feat(floor): align 5 stage screens to the hub + declutter navbar

### DIFF
--- a/views/finishingEvents.ejs
+++ b/views/finishingEvents.ejs
@@ -8,29 +8,29 @@
      Inter throughout, indigo accent, strict color coding.
      ─────────────────────────────────────────────────────────────── */
 
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
 
   /* Scope all rules under .sx so we don't fight global kotty-theme styles */
   .sx {
-    --c-bg:        #f5f7fb;
+    --c-bg:        #f7f8fa;
     --c-card:      #ffffff;
-    --c-border:    #e5e8ee;
+    --c-border:    #e5e7eb;
     --c-border-2:  #eef0f4;
 
     --c-text:      #0f172a;   /* slate-900 */
     --c-text-2:    #475569;   /* slate-600 */
     --c-text-3:    #94a3b8;   /* slate-400 */
 
-    --c-primary:        #4f46e5;   /* indigo-600 */
-    --c-primary-hover:  #4338ca;   /* indigo-700 */
-    --c-primary-soft:   #eef2ff;   /* indigo-50 */
-    --c-primary-strip:  #6366f1;   /* indigo-500 */
+    --c-primary:        #2563eb;   /* indigo-600 */
+    --c-primary-hover:  #1d4ed8;   /* indigo-700 */
+    --c-primary-soft:   #eff6ff;   /* indigo-50 */
+    --c-primary-strip:  #3b82f6;   /* indigo-500 */
 
     --c-success:        #16a34a;   /* emerald-600 */
     --c-success-hover:  #15803d;
     --c-success-soft:   #dcfce7;
 
-    --c-warning:        #d97706;   /* amber-600 */
+    --c-warning:        #b45309;   /* amber-600 */
     --c-warning-soft:   #fef3c7;
 
     --c-danger:         #dc2626;   /* red-600 */
@@ -53,7 +53,7 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  body { background: #f5f7fb; }
+  body { background: #f7f8fa; }
 
   .sx-page {
     max-width: 960px;
@@ -954,6 +954,10 @@
       from { transform: translateY(100%); }
       to { transform: translateY(0); }
     }
+  }
+  /* Numbers are the hero (floor design system) */
+  .sx-lot-no, .sx-stat .v, .sx-chip-label, .sx-chip-num, .sx-mini-total .v, .sx-input-avail .n {
+    font-family: 'Space Grotesk','Inter',sans-serif; letter-spacing: -0.01em;
   }
 </style>
 

--- a/views/jeansAssemblyEvents.ejs
+++ b/views/jeansAssemblyEvents.ejs
@@ -8,29 +8,29 @@
      Inter throughout, indigo accent, strict color coding.
      ─────────────────────────────────────────────────────────────── */
 
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
 
   /* Scope all rules under .sx so we don't fight global kotty-theme styles */
   .sx {
-    --c-bg:        #f5f7fb;
+    --c-bg:        #f7f8fa;
     --c-card:      #ffffff;
-    --c-border:    #e5e8ee;
+    --c-border:    #e5e7eb;
     --c-border-2:  #eef0f4;
 
     --c-text:      #0f172a;   /* slate-900 */
     --c-text-2:    #475569;   /* slate-600 */
     --c-text-3:    #94a3b8;   /* slate-400 */
 
-    --c-primary:        #4f46e5;   /* indigo-600 */
-    --c-primary-hover:  #4338ca;   /* indigo-700 */
-    --c-primary-soft:   #eef2ff;   /* indigo-50 */
-    --c-primary-strip:  #6366f1;   /* indigo-500 */
+    --c-primary:        #2563eb;   /* indigo-600 */
+    --c-primary-hover:  #1d4ed8;   /* indigo-700 */
+    --c-primary-soft:   #eff6ff;   /* indigo-50 */
+    --c-primary-strip:  #3b82f6;   /* indigo-500 */
 
     --c-success:        #16a34a;   /* emerald-600 */
     --c-success-hover:  #15803d;
     --c-success-soft:   #dcfce7;
 
-    --c-warning:        #d97706;   /* amber-600 */
+    --c-warning:        #b45309;   /* amber-600 */
     --c-warning-soft:   #fef3c7;
 
     --c-danger:         #dc2626;   /* red-600 */
@@ -53,7 +53,7 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  body { background: #f5f7fb; }
+  body { background: #f7f8fa; }
 
   .sx-page {
     max-width: 960px;
@@ -954,6 +954,10 @@
       from { transform: translateY(100%); }
       to { transform: translateY(0); }
     }
+  }
+  /* Numbers are the hero (floor design system) */
+  .sx-lot-no, .sx-stat .v, .sx-chip-label, .sx-chip-num, .sx-mini-total .v, .sx-input-avail .n {
+    font-family: 'Space Grotesk','Inter',sans-serif; letter-spacing: -0.01em;
   }
 </style>
 

--- a/views/partials/navbar.ejs
+++ b/views/partials/navbar.ejs
@@ -17,22 +17,6 @@
 
     <!-- Right Section: User Menu -->
     <div class="navbar-menu">
-      <!-- Notifications (if any) -->
-      <% if (typeof user !== 'undefined' && user.role === 'operator') { %>
-        <button class="navbar-btn position-relative" data-bs-toggle="dropdown">
-          <i class="bi bi-bell"></i>
-          <span class="position-absolute top-0 start-100 translate-middle badge rounded-pill bg-danger" style="font-size: 0.6rem; padding: 0.2rem 0.4rem;">
-            3
-          </span>
-        </button>
-        <ul class="dropdown-menu dropdown-menu-end">
-          <li><a class="dropdown-item" href="#"><i class="bi bi-info-circle me-2"></i>New assignment</a></li>
-          <li><a class="dropdown-item" href="#"><i class="bi bi-check-circle me-2"></i>Task completed</a></li>
-          <li><hr class="dropdown-divider"></li>
-          <li><a class="dropdown-item text-center" href="#">View all</a></li>
-        </ul>
-      <% } %>
-
       <!-- User Profile -->
       <% if (typeof user !== 'undefined') { %>
         <div class="navbar-user dropdown">
@@ -47,8 +31,6 @@
           </a>
           <ul class="dropdown-menu dropdown-menu-end">
             <li><a class="dropdown-item" href="/my-lots"><i class="bi bi-bag-check me-2"></i>My Lots</a></li>
-            <li><a class="dropdown-item" href="/profile"><i class="bi bi-person me-2"></i>Profile</a></li>
-            <li><a class="dropdown-item" href="/settings"><i class="bi bi-gear me-2"></i>Settings</a></li>
             <li><hr class="dropdown-divider"></li>
             <li><a class="dropdown-item text-danger" href="/logout"><i class="bi bi-box-arrow-right me-2"></i>Logout</a></li>
           </ul>

--- a/views/stitchingEvents.ejs
+++ b/views/stitchingEvents.ejs
@@ -8,29 +8,29 @@
      Inter throughout, indigo accent, strict color coding.
      ─────────────────────────────────────────────────────────────── */
 
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
 
   /* Scope all rules under .sx so we don't fight global kotty-theme styles */
   .sx {
-    --c-bg:        #f5f7fb;
+    --c-bg:        #f7f8fa;
     --c-card:      #ffffff;
-    --c-border:    #e5e8ee;
+    --c-border:    #e5e7eb;
     --c-border-2:  #eef0f4;
 
     --c-text:      #0f172a;   /* slate-900 */
     --c-text-2:    #475569;   /* slate-600 */
     --c-text-3:    #94a3b8;   /* slate-400 */
 
-    --c-primary:        #4f46e5;   /* indigo-600 */
-    --c-primary-hover:  #4338ca;   /* indigo-700 */
-    --c-primary-soft:   #eef2ff;   /* indigo-50 */
-    --c-primary-strip:  #6366f1;   /* indigo-500 */
+    --c-primary:        #2563eb;   /* indigo-600 */
+    --c-primary-hover:  #1d4ed8;   /* indigo-700 */
+    --c-primary-soft:   #eff6ff;   /* indigo-50 */
+    --c-primary-strip:  #3b82f6;   /* indigo-500 */
 
     --c-success:        #16a34a;   /* emerald-600 */
     --c-success-hover:  #15803d;
     --c-success-soft:   #dcfce7;
 
-    --c-warning:        #d97706;   /* amber-600 */
+    --c-warning:        #b45309;   /* amber-600 */
     --c-warning-soft:   #fef3c7;
 
     --c-danger:         #dc2626;   /* red-600 */
@@ -53,7 +53,7 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  body { background: #f5f7fb; }
+  body { background: #f7f8fa; }
 
   .sx-page {
     max-width: 960px;
@@ -954,6 +954,10 @@
       from { transform: translateY(100%); }
       to { transform: translateY(0); }
     }
+  }
+  /* Numbers are the hero (floor design system) */
+  .sx-lot-no, .sx-stat .v, .sx-chip-label, .sx-chip-num, .sx-mini-total .v, .sx-input-avail .n {
+    font-family: 'Space Grotesk','Inter',sans-serif; letter-spacing: -0.01em;
   }
 </style>
 

--- a/views/washingEvents.ejs
+++ b/views/washingEvents.ejs
@@ -8,29 +8,29 @@
      Inter throughout, indigo accent, strict color coding.
      ─────────────────────────────────────────────────────────────── */
 
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
 
   /* Scope all rules under .sx so we don't fight global kotty-theme styles */
   .sx {
-    --c-bg:        #f5f7fb;
+    --c-bg:        #f7f8fa;
     --c-card:      #ffffff;
-    --c-border:    #e5e8ee;
+    --c-border:    #e5e7eb;
     --c-border-2:  #eef0f4;
 
     --c-text:      #0f172a;   /* slate-900 */
     --c-text-2:    #475569;   /* slate-600 */
     --c-text-3:    #94a3b8;   /* slate-400 */
 
-    --c-primary:        #4f46e5;   /* indigo-600 */
-    --c-primary-hover:  #4338ca;   /* indigo-700 */
-    --c-primary-soft:   #eef2ff;   /* indigo-50 */
-    --c-primary-strip:  #6366f1;   /* indigo-500 */
+    --c-primary:        #2563eb;   /* indigo-600 */
+    --c-primary-hover:  #1d4ed8;   /* indigo-700 */
+    --c-primary-soft:   #eff6ff;   /* indigo-50 */
+    --c-primary-strip:  #3b82f6;   /* indigo-500 */
 
     --c-success:        #16a34a;   /* emerald-600 */
     --c-success-hover:  #15803d;
     --c-success-soft:   #dcfce7;
 
-    --c-warning:        #d97706;   /* amber-600 */
+    --c-warning:        #b45309;   /* amber-600 */
     --c-warning-soft:   #fef3c7;
 
     --c-danger:         #dc2626;   /* red-600 */
@@ -53,7 +53,7 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  body { background: #f5f7fb; }
+  body { background: #f7f8fa; }
 
   .sx-page {
     max-width: 960px;
@@ -954,6 +954,10 @@
       from { transform: translateY(100%); }
       to { transform: translateY(0); }
     }
+  }
+  /* Numbers are the hero (floor design system) */
+  .sx-lot-no, .sx-stat .v, .sx-chip-label, .sx-chip-num, .sx-mini-total .v, .sx-input-avail .n {
+    font-family: 'Space Grotesk','Inter',sans-serif; letter-spacing: -0.01em;
   }
 </style>
 

--- a/views/washingInEvents.ejs
+++ b/views/washingInEvents.ejs
@@ -8,29 +8,29 @@
      Inter throughout, indigo accent, strict color coding.
      ─────────────────────────────────────────────────────────────── */
 
-  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap');
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
 
   /* Scope all rules under .sx so we don't fight global kotty-theme styles */
   .sx {
-    --c-bg:        #f5f7fb;
+    --c-bg:        #f7f8fa;
     --c-card:      #ffffff;
-    --c-border:    #e5e8ee;
+    --c-border:    #e5e7eb;
     --c-border-2:  #eef0f4;
 
     --c-text:      #0f172a;   /* slate-900 */
     --c-text-2:    #475569;   /* slate-600 */
     --c-text-3:    #94a3b8;   /* slate-400 */
 
-    --c-primary:        #4f46e5;   /* indigo-600 */
-    --c-primary-hover:  #4338ca;   /* indigo-700 */
-    --c-primary-soft:   #eef2ff;   /* indigo-50 */
-    --c-primary-strip:  #6366f1;   /* indigo-500 */
+    --c-primary:        #2563eb;   /* indigo-600 */
+    --c-primary-hover:  #1d4ed8;   /* indigo-700 */
+    --c-primary-soft:   #eff6ff;   /* indigo-50 */
+    --c-primary-strip:  #3b82f6;   /* indigo-500 */
 
     --c-success:        #16a34a;   /* emerald-600 */
     --c-success-hover:  #15803d;
     --c-success-soft:   #dcfce7;
 
-    --c-warning:        #d97706;   /* amber-600 */
+    --c-warning:        #b45309;   /* amber-600 */
     --c-warning-soft:   #fef3c7;
 
     --c-danger:         #dc2626;   /* red-600 */
@@ -53,7 +53,7 @@
     -webkit-font-smoothing: antialiased;
   }
 
-  body { background: #f5f7fb; }
+  body { background: #f7f8fa; }
 
   .sx-page {
     max-width: 960px;
@@ -954,6 +954,10 @@
       from { transform: translateY(100%); }
       to { transform: translateY(0); }
     }
+  }
+  /* Numbers are the hero (floor design system) */
+  .sx-lot-no, .sx-stat .v, .sx-chip-label, .sx-chip-num, .sx-mini-total .v, .sx-input-avail .n {
+    font-family: 'Space Grotesk','Inter',sans-serif; letter-spacing: -0.01em;
   }
 </style>
 


### PR DESCRIPTION
This is why merging #515 didn't visibly change the stitching screen — #515 only added the shared stylesheet + the new hub. This PR actually brings the stage operator screens into the same look, and strips the shared-navbar clutter you flagged.

## Stage screens now match the hub (stitching · jeans-assembly · washing · washing-in · finishing)
These screens already shared **one** token-driven design (`.sx { --c-* }`) with the same building blocks as the hub — stat strip, size chips, the "who handled it" journey chain, My Work / Payments / Indent tabs, and the per-size take/reject **steppers**. So the safe, faithful move was to tune their tokens to the exact `floor.css` palette rather than rewrite the payment-critical logic:

- Accent indigo `#4f46e5 → #2563eb` (+ hover/soft/strip), amber `→ #b45309`, ground `→ #f7f8fa`, border `→ #e5e7eb`.
- **Numbers are the hero:** lot number, the Approved/Completed/Rejected/Inline figures, size-chip counts, mini-totals and available counts now render in **Space Grotesk** — the hub's signature face.
- Applied identically to all 5 (their token blocks were byte-for-byte identical).

**Zero markup or JS changed** — the ~1000 lines of take-in/complete/reject/dispatch logic and every per-size control are untouched. Diff is purely CSS values + one appended font rule per file.

## Declutter — everywhere at once
`partials/navbar.ejs` is shared by **132 views**, so cleaning it here removes the noise across the whole app:
- Removed the **fake Notifications bell** (hardcoded "3" badge, items all linking to `#`).
- Removed the dead **Profile** (`/profile`) and **Settings** (`/settings`) links — neither route exists. Kept My Lots + Logout.

## Review
Open a lot on `/stitchingdashboard` (and the other four stage dashboards) on a phone — same calm palette and Space-Grotesk numbers as `/operator/hub`, all controls exactly where they were. I can't verify visuals in a browser, so please eyeball before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)