### PR TITLE
feat(floor): real Stitch shell + operator hub rebuilt on it

### DIFF
--- a/docs/stitch/01-hub.html
+++ b/docs/stitch/01-hub.html
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+
+<html class="light" lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport"/>
+<title>Kotty Floor | Operator Hub</title>
+<!-- Tailwind CSS -->
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<!-- Google Fonts: Space Grotesk & Inter -->
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Space+Grotesk:wght@500;700;900&amp;display=swap" rel="stylesheet"/>
+<!-- Material Symbols -->
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              'surface': '#f7f8fa',
+              'surface-container-lowest': '#ffffff',
+              'on-surface': '#0f172a',
+              'on-surface-variant': '#64748b',
+              'outline-variant': '#e5e7eb',
+              'primary': '#2563eb',
+              'on-primary': '#ffffff',
+              'primary-container': '#eff6ff',
+              'secondary': '#16a34a',
+              'secondary-container': '#dcfce7',
+              'tertiary': '#b45309',
+              'tertiary-container': '#fef3c7',
+              'error': '#dc2626',
+              'error-container': '#fee2e2',
+            },
+            borderRadius: {
+              "DEFAULT": "0.5rem",
+              "lg": "1rem",
+              "xl": "1.5rem",
+              "full": "9999px"
+            },
+            fontFamily: {
+              "headline": ["Space Grotesk", "sans-serif"],
+              "display": ["Space Grotesk", "sans-serif"],
+              "body": ["Inter", "sans-serif"],
+              "label": ["Inter", "sans-serif"]
+            }
+          },
+        },
+      }
+    </script>
+<style>
+      body {
+        font-family: 'Inter', sans-serif;
+        background-color: #f7f8fa;
+        -webkit-tap-highlight-color: transparent;
+      }
+      .material-symbols-outlined {
+        font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+      }
+      .font-headline { font-family: 'Space Grotesk', sans-serif; }
+      .font-label { font-family: 'Inter', sans-serif; }
+      
+      /* Subtle lift animation for cards */
+      .action-card:active {
+        transform: scale(0.96);
+        transition: transform 0.1s ease-out;
+      }
+      
+      /* Smooth scroll for mobile */
+      .no-scrollbar::-webkit-scrollbar {
+        display: none;
+      }
+      .no-scrollbar {
+        -ms-overflow-style: none;
+        scrollbar-width: none;
+      }
+    </style>
+<style>
+    body {
+      min-height: max(884px, 100dvh);
+    }
+  </style>
+  </head>
+<body class="bg-surface text-on-surface antialiased pb-24">
+<!-- TopAppBar -->
+<header class="fixed top-0 w-full z-50 bg-surface border-b border-outline-variant flex items-center justify-between px-4 py-3 h-16">
+<div class="flex items-center gap-2">
+<span class="material-symbols-outlined text-primary" data-icon="factory">factory</span>
+<h1 class="font-headline font-black text-xl tracking-tighter text-on-surface">KOTTY FLOOR</h1>
+</div>
+<div class="flex items-center gap-3">
+<div class="text-right">
+<p class="text-[10px] uppercase tracking-widest text-on-surface-variant font-medium">Shift Operator</p>
+<p class="text-sm font-semibold">Hi, Admin</p>
+</div>
+<div class="w-10 h-10 rounded-full bg-primary-container flex items-center justify-center border border-primary/10">
+<span class="material-symbols-outlined text-primary" data-icon="account_circle">account_circle</span>
+</div>
+</div>
+</header>
+<!-- Main Content Canvas -->
+<main class="pt-20 px-4 max-w-lg mx-auto">
+<!-- Search Sticky (Visual Anchor) -->
+<div class="mb-6">
+<div class="relative">
+<div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+<span class="material-symbols-outlined text-on-surface-variant text-xl" data-icon="search">search</span>
+</div>
+<input class="block w-full pl-10 pr-3 py-3.5 bg-surface-container-lowest border border-outline-variant rounded-xl text-sm focus:ring-primary focus:border-primary placeholder:text-on-surface-variant/50 font-label" placeholder="Lot no, manual lot, or SKU" type="text"/>
+</div>
+</div>
+<!-- Compact Stats Strip -->
+<section class="grid grid-cols-3 gap-2 mb-8 bg-surface-container-lowest p-3 rounded-xl border border-outline-variant shadow-sm">
+<div class="text-center border-r border-outline-variant/60">
+<p class="text-[10px] uppercase tracking-wider text-on-surface-variant font-bold mb-1">In Prod</p>
+<p class="font-headline text-lg font-bold leading-none">4,820</p>
+<p class="text-[9px] text-on-surface-variant">PCS</p>
+</div>
+<div class="text-center border-r border-outline-variant/60">
+<p class="text-[10px] uppercase tracking-wider text-on-surface-variant font-bold mb-1">Today</p>
+<p class="font-headline text-lg font-bold leading-none text-primary">37</p>
+<p class="text-[9px] text-on-surface-variant">LOTS</p>
+</div>
+<div class="text-center">
+<p class="text-[10px] uppercase tracking-wider text-on-surface-variant font-bold mb-1">Overdue</p>
+<p class="font-headline text-lg font-bold leading-none text-error">5</p>
+<p class="text-[9px] text-on-surface-variant">CRITICAL</p>
+</div>
+</section>
+<!-- Action Grid (2-Column) -->
+<div class="grid grid-cols-2 gap-3">
+<!-- My Lots -->
+<button class="action-card text-left bg-surface-container-lowest p-4 rounded-xl border border-outline-variant flex flex-col justify-between h-36 transition-all hover:border-primary/30">
+<div class="w-10 h-10 rounded-lg bg-primary-container flex items-center justify-center">
+<span class="material-symbols-outlined text-primary" data-icon="list_alt">list_alt</span>
+</div>
+<div>
+<h3 class="font-bold text-on-surface text-[15px] leading-tight">My Lots</h3>
+<p class="text-[11px] text-on-surface-variant mt-1 leading-snug">View your active assignments</p>
+</div>
+</button>
+<!-- Lot TAT -->
+<button class="action-card text-left bg-surface-container-lowest p-4 rounded-xl border border-outline-variant flex flex-col justify-between h-36 transition-all hover:border-primary/30">
+<div class="w-10 h-10 rounded-lg bg-tertiary-container flex items-center justify-center">
+<span class="material-symbols-outlined text-tertiary" data-icon="timer">timer</span>
+</div>
+<div>
+<h3 class="font-bold text-on-surface text-[15px] leading-tight">Lot TAT</h3>
+<p class="text-[11px] text-on-surface-variant mt-1 leading-snug">Turnaround time tracking</p>
+</div>
+</button>
+<!-- Lot Journey -->
+<button class="action-card text-left bg-surface-container-lowest p-4 rounded-xl border border-outline-variant flex flex-col justify-between h-36 transition-all hover:border-primary/30">
+<div class="w-10 h-10 rounded-lg bg-secondary-container flex items-center justify-center">
+<span class="material-symbols-outlined text-secondary" data-icon="route">route</span>
+</div>
+<div>
+<h3 class="font-bold text-on-surface text-[15px] leading-tight">Lot Journey</h3>
+<p class="text-[11px] text-on-surface-variant mt-1 leading-snug">Track lot progress</p>
+</div>
+</button>
+<!-- Lot Admin -->
+<button class="action-card text-left bg-surface-container-lowest p-4 rounded-xl border border-outline-variant flex flex-col justify-between h-36 transition-all hover:border-primary/30">
+<div class="w-10 h-10 rounded-lg bg-gray-100 flex items-center justify-center">
+<span class="material-symbols-outlined text-on-surface-variant" data-icon="settings_suggest">settings_suggest</span>
+</div>
+<div>
+<h3 class="font-bold text-on-surface text-[15px] leading-tight">Lot Admin</h3>
+<p class="text-[11px] text-on-surface-variant mt-1 leading-snug">Administrative tasks</p>
+</div>
+</button>
+<!-- Edit Cutting Lots -->
+<button class="action-card text-left bg-surface-container-lowest p-4 rounded-xl border border-outline-variant flex flex-col justify-between h-36 transition-all hover:border-primary/30">
+<div class="w-10 h-10 rounded-lg bg-primary-container flex items-center justify-center">
+<span class="material-symbols-outlined text-primary" data-icon="content_cut">content_cut</span>
+</div>
+<div>
+<h3 class="font-bold text-on-surface text-[15px] leading-tight">Edit Cutting</h3>
+<p class="text-[11px] text-on-surface-variant mt-1 leading-snug">Modify records</p>
+</div>
+</button>
+<!-- Rewash Excel -->
+<button class="action-card text-left bg-surface-container-lowest p-4 rounded-xl border border-outline-variant flex flex-col justify-between h-36 transition-all hover:border-primary/30">
+<div class="w-10 h-10 rounded-lg bg-secondary-container flex items-center justify-center">
+<span class="material-symbols-outlined text-secondary" data-icon="table_view">table_view</span>
+</div>
+<div>
+<h3 class="font-bold text-on-surface text-[15px] leading-tight">Rewash</h3>
+<p class="text-[11px] text-on-surface-variant mt-1 leading-snug">QC reports</p>
+</div>
+</button>
+<!-- Payments -->
+<button class="action-card text-left bg-surface-container-lowest p-4 rounded-xl border border-outline-variant flex flex-col justify-between h-36 transition-all hover:border-primary/30">
+<div class="w-10 h-10 rounded-lg bg-tertiary-container flex items-center justify-center">
+<span class="material-symbols-outlined text-tertiary" data-icon="payments">payments</span>
+</div>
+<div>
+<h3 class="font-bold text-on-surface text-[15px] leading-tight">Payments</h3>
+<p class="text-[11px] text-on-surface-variant mt-1 leading-snug">Earnings &amp; history</p>
+</div>
+</button>
+<!-- Material Indent -->
+<button class="action-card text-left bg-surface-container-lowest p-4 rounded-xl border border-outline-variant flex flex-col justify-between h-36 transition-all hover:border-primary/30">
+<div class="w-10 h-10 rounded-lg bg-gray-100 flex items-center justify-center">
+<span class="material-symbols-outlined text-on-surface-variant" data-icon="inventory_2">inventory_2</span>
+</div>
+<div>
+<h3 class="font-bold text-on-surface text-[15px] leading-tight">Materials</h3>
+<p class="text-[11px] text-on-surface-variant mt-1 leading-snug">Request supply</p>
+</div>
+</button>
+</div>
+<!-- Featured Visual Element (Bento-lite) -->
+<div class="mt-8 relative overflow-hidden rounded-2xl h-40 border border-outline-variant">
+<div class="absolute inset-0 z-0 overflow-hidden">
+<div class="w-full h-full bg-cover bg-center opacity-60" data-alt="A clean, high-resolution architectural interior of a modern textile garment factory floor. Soft natural morning light filters through large industrial windows, highlighting organized workstations and precision sewing machines. The color palette is composed of muted grays, whites, and subtle indigo accents. The atmosphere is calm, professional, and efficiently industrial." style="background-image: url('https://lh3.googleusercontent.com/aida-public/AB6AXuD7XT_mAfoEil22fACzCR4JUxKFsDKI2fCge2cUNvAxDQFTXXuK_M2CLXnwWi6lkFkoXmRzWJeL0BVHhkESzW1_opBmjtVk-wd8j12i4KesmmpmJyrY0NniNCyBY5zEak2WzZCB8bMDSo5ig5-JyfqLrlPegHR1tihABD7rLFJjv2LAHviYfd6uEHUFrOEwQYKuPXHzrpcO5bq_l0uW-wFutXmddtQkUu_H0jWjZqoU_sDcda3Ma5rJU_1vUZzXo9yJq-7RIfCfMA')"></div>
+<div class="absolute inset-0 bg-gradient-to-t from-surface via-transparent to-transparent"></div>
+</div>
+<div class="relative z-10 p-6 flex flex-col justify-end h-full">
+<span class="text-[10px] uppercase font-bold tracking-[0.2em] text-primary mb-1">Production Goal</span>
+<h4 class="font-headline text-2xl font-black">94% EFFICIENCY</h4>
+<div class="w-full bg-outline-variant h-1 rounded-full mt-2 overflow-hidden">
+<div class="bg-primary h-full w-[94%]"></div>
+</div>
+</div>
+</div>
+</main>
+<!-- BottomNavBar -->
+<nav class="fixed bottom-0 left-0 w-full z-50 h-16 bg-surface border-t border-outline-variant flex justify-around items-center px-4 pb-safe">
+<button class="flex flex-col items-center justify-center text-primary bg-primary-container rounded-xl px-4 py-1.5 transition-opacity active:opacity-80">
+<span class="material-symbols-outlined text-2xl" data-icon="home" style="font-variation-settings: 'FILL' 1;">home</span>
+<span class="font-label text-[10px] uppercase tracking-wider font-bold mt-0.5">Home</span>
+</button>
+<button class="flex flex-col items-center justify-center text-on-surface-variant hover:text-primary transition-opacity active:opacity-80">
+<span class="material-symbols-outlined text-2xl" data-icon="search">search</span>
+<span class="font-label text-[10px] uppercase tracking-wider font-medium mt-0.5">Search</span>
+</button>
+<button class="flex flex-col items-center justify-center text-on-surface-variant hover:text-primary transition-opacity active:opacity-80">
+<span class="material-symbols-outlined text-2xl" data-icon="history">history</span>
+<span class="font-label text-[10px] uppercase tracking-wider font-medium mt-0.5">History</span>
+</button>
+</nav>
+<!-- Micro-interaction Script -->
+<script>
+        document.querySelectorAll('.action-card').forEach(card => {
+            card.addEventListener('click', () => {
+                // Subtle feedback handled by CSS active state
+                console.log('Action triggered:', card.querySelector('h3').innerText);
+            });
+        });
+    </script>
+</body></html>

--- a/docs/stitch/02-stitching-full.html
+++ b/docs/stitch/02-stitching-full.html
@@ -1,0 +1,347 @@
+<!DOCTYPE html>
+
+<html class="light" lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport"/>
+<title>Kotty Floor — Stitching Operator</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Space+Grotesk:wght@500;700&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<script id="tailwind-config">
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        'surface': '#f7f8fa',
+                        'surface-container-lowest': '#ffffff',
+                        'on-surface': '#0f172a',
+                        'on-surface-variant': '#64748b',
+                        'outline-variant': '#e5e7eb',
+                        'primary': '#2563eb',
+                        'on-primary': '#ffffff',
+                        'primary-container': '#eff6ff',
+                        'secondary': '#16a34a',
+                        'secondary-container': '#dcfce7',
+                        'tertiary': '#b45309',
+                        'tertiary-container': '#fef3c7',
+                        'error': '#dc2626',
+                        'error-container': '#fee2e2'
+                    },
+                    borderRadius: {
+                        "DEFAULT": "0.5rem",
+                        "lg": "1rem",
+                        "xl": "1.5rem",
+                        "full": "9999px"
+                    },
+                    fontFamily: {
+                        "headline": ["Space Grotesk", "sans-serif"],
+                        "display": ["Space Grotesk", "sans-serif"],
+                        "body": ["Inter", "sans-serif"],
+                        "label": ["Inter", "sans-serif"]
+                    }
+                }
+            }
+        }
+    </script>
+<style>
+        body {
+            font-family: 'Inter', sans-serif;
+            -webkit-tap-highlight-color: transparent;
+            background-color: #f7f8fa;
+        }
+        .font-headline { font-family: 'Space Grotesk', sans-serif; }
+        .material-symbols-outlined {
+            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+            vertical-align: middle;
+        }
+        .stage-rail-connector {
+            position: absolute;
+            top: 14px;
+            left: 50%;
+            width: 100%;
+            height: 2px;
+            z-index: 0;
+        }
+        /* Custom scroll behavior for small focus areas if needed, though prompt bans horizontal scroll */
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+    </style>
+<style>
+    body {
+      min-height: max(884px, 100dvh);
+    }
+  </style>
+</head>
+<body class="text-on-surface antialiased pb-24">
+<!-- TopAppBar -->
+<header class="fixed top-0 w-full z-50 bg-surface border-b border-outline-variant">
+<div class="flex items-center justify-between px-4 h-16 w-full">
+<div class="flex items-center gap-3">
+<span class="material-symbols-outlined text-primary" data-icon="precision_manufacturing">precision_manufacturing</span>
+<h1 class="font-headline font-bold text-primary text-lg uppercase tracking-wider">STITCHING</h1>
+</div>
+<button class="w-10 h-10 flex items-center justify-center rounded-full hover:bg-primary-container active:scale-95 transition-transform">
+<span class="material-symbols-outlined text-on-surface-variant" data-icon="search">search</span>
+</button>
+</div>
+<!-- Sticky Search Bar -->
+<div class="px-4 pb-4 bg-surface">
+<div class="relative group">
+<div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+<span class="material-symbols-outlined text-on-surface-variant text-sm" data-icon="search">search</span>
+</div>
+<input class="block w-full pl-10 pr-3 py-3 bg-surface-container-lowest border border-outline-variant rounded-lg text-sm focus:ring-2 focus:ring-primary focus:border-primary outline-none transition-all placeholder:text-on-surface-variant/60 font-body" placeholder="Lot number or SKU" type="text"/>
+</div>
+</div>
+</header>
+<!-- Main Content Area -->
+<main class="mt-36 px-4 space-y-4">
+<!-- Welcome / State Message (Subtle) -->
+<p class="text-[11px] font-label uppercase tracking-widest text-on-surface-variant px-1">Active Assignment</p>
+<!-- Lot Card -->
+<section class="bg-surface-container-lowest rounded-[12px] border border-outline-variant shadow-[0_1px_2px_rgba(15,23,42,0.06)] overflow-hidden">
+<!-- Card Header -->
+<div class="p-4 flex items-center justify-between">
+<h2 class="font-headline text-2xl font-bold tracking-tight">AK1423</h2>
+<span class="px-2.5 py-1 rounded-full bg-primary-container text-primary text-[10px] font-bold uppercase tracking-wider">DENIM</span>
+</div>
+<!-- Card Subheader -->
+<div class="px-4 pb-4">
+<p class="text-sm text-on-surface-variant font-body">
+                    KTTMENSJEANS381 <span class="mx-1 opacity-40">·</span> cut by <span class="font-medium text-on-surface">Ramesh</span>
+</p>
+</div>
+<!-- The Stage Rail -->
+<div class="px-4 py-6 bg-surface/30 border-t border-outline-variant/50 border-b border-outline-variant/50">
+<div class="grid grid-cols-3 gap-y-8 relative">
+<!-- Stage: Cut (Completed) -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-surface-container-lowest border-2 border-secondary text-secondary flex items-center justify-center mb-2">
+<span class="material-symbols-outlined text-[16px]" data-icon="check" data-weight="bold">check</span>
+</div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-on-surface-variant">Cut</span>
+<span class="text-[9px] font-medium text-on-surface uppercase mt-0.5">RAMESH</span>
+<div class="stage-rail-connector bg-primary top-[13px] -z-10"></div>
+</div>
+<!-- Stage: Stitch (Current) -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-8 h-8 rounded-full bg-primary text-on-primary flex items-center justify-center mb-1.5 ring-4 ring-primary-container shadow-sm">
+<span class="material-symbols-outlined text-[18px]" data-icon="precision_manufacturing">precision_manufacturing</span>
+</div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-primary font-bold">Stitch</span>
+<span class="text-[9px] font-medium text-primary uppercase mt-0.5">SURESH</span>
+<div class="stage-rail-connector bg-outline-variant top-[13px] -z-10"></div>
+</div>
+<!-- Stage: Assembly -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-on-surface-variant/50">Assembly</span>
+<div class="stage-rail-connector bg-outline-variant top-[13px] hidden -z-10"></div>
+</div>
+<!-- Second Row (Wrap) -->
+<!-- Stage: Wash -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-on-surface-variant/50">Wash</span>
+<div class="stage-rail-connector bg-outline-variant top-[13px] -z-10"></div>
+</div>
+<!-- Stage: Wash-in -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-on-surface-variant/50">Wash-in</span>
+<div class="stage-rail-connector bg-outline-variant top-[13px] -z-10"></div>
+</div>
+<!-- Stage: Finish -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-on-surface-variant/50">Finish</span>
+</div>
+</div>
+</div>
+<!-- Stat Row -->
+<div class="px-4 py-5 grid grid-cols-4 gap-2 border-b border-outline-variant/50">
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Approved</span>
+<span class="font-headline text-xl leading-none text-on-surface font-bold">1500</span>
+</div>
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Completed</span>
+<span class="font-headline text-xl leading-none text-secondary font-bold">1200</span>
+</div>
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Rejected</span>
+<span class="font-headline text-xl leading-none text-error font-bold">40</span>
+</div>
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Inline</span>
+<span class="font-headline text-xl leading-none text-tertiary font-bold">260</span>
+</div>
+</div>
+<!-- The Critical Work Panel -->
+<div class="p-4 border-b border-outline-variant/50 bg-surface-container-lowest">
+<h3 class="font-label text-sm font-semibold mb-4 text-on-surface">Take into stitching</h3>
+<div class="space-y-6">
+<!-- Size 30 -->
+<div class="pb-4 border-b border-outline-variant/30">
+<div class="flex items-center justify-between mb-2">
+<div class="flex items-center gap-2">
+<span class="font-headline font-bold text-lg">30</span>
+<span class="text-xs text-on-surface-variant bg-surface px-2 py-0.5 rounded-full border border-outline-variant">Avail 420</span>
+</div>
+<div class="flex items-center border border-outline-variant rounded-lg overflow-hidden h-12 shadow-sm">
+<button class="w-12 h-full flex items-center justify-center bg-surface hover:bg-surface-container-lowest border-r border-outline-variant text-xl active:bg-outline-variant">-</button>
+<input class="w-16 h-full text-center font-headline font-bold border-none p-0 focus:ring-0" type="text" value="420"/>
+<button class="w-12 h-full flex items-center justify-center bg-surface hover:bg-surface-container-lowest border-l border-outline-variant text-xl active:bg-outline-variant">+</button>
+</div>
+</div>
+<div class="flex items-center justify-between">
+<button class="text-xs text-error font-medium flex items-center gap-1 hover:bg-error-container/50 px-2 py-1 rounded transition-colors">
+<span class="material-symbols-outlined text-[14px]">warning</span> Reject / rewash
+                </button>
+<span class="text-xs font-headline font-semibold text-on-surface-variant">Total: 420</span>
+</div>
+</div>
+<!-- Size 32 (With Reject Open) -->
+<div class="pb-4 border-b border-outline-variant/30">
+<div class="flex items-center justify-between mb-2">
+<div class="flex items-center gap-2">
+<span class="font-headline font-bold text-lg">32</span>
+<span class="text-xs text-on-surface-variant bg-surface px-2 py-0.5 rounded-full border border-outline-variant">Avail 500</span>
+</div>
+<div class="flex items-center border border-outline-variant rounded-lg overflow-hidden h-12 shadow-sm">
+<button class="w-12 h-full flex items-center justify-center bg-surface hover:bg-surface-container-lowest border-r border-outline-variant text-xl active:bg-outline-variant">-</button>
+<input class="w-16 h-full text-center font-headline font-bold border-none p-0 focus:ring-0" type="text" value="480"/>
+<button class="w-12 h-full flex items-center justify-center bg-surface hover:bg-surface-container-lowest border-l border-outline-variant text-xl active:bg-outline-variant">+</button>
+</div>
+</div>
+<!-- Reject Open State -->
+<div class="bg-error-container/30 rounded-lg p-3 mt-3 border border-error/20">
+<div class="flex items-center justify-between mb-3">
+<span class="text-sm font-medium text-error flex items-center gap-1">
+<span class="material-symbols-outlined text-[16px]">warning</span> Rejections
+                    </span>
+<div class="flex items-center border border-error/30 rounded-lg overflow-hidden h-10 bg-surface-container-lowest shadow-sm">
+<button class="w-10 h-full flex items-center justify-center bg-error-container/50 hover:bg-error-container border-r border-error/30 text-error text-lg active:bg-error/20">-</button>
+<input class="w-12 h-full text-center font-headline font-bold text-error border-none p-0 focus:ring-0 bg-transparent" type="text" value="20"/>
+<button class="w-10 h-full flex items-center justify-center bg-error-container/50 hover:bg-error-container border-l border-error/30 text-error text-lg active:bg-error/20">+</button>
+</div>
+</div>
+<input class="w-full text-sm p-2 bg-surface-container-lowest border border-error/30 rounded focus:ring-1 focus:ring-error focus:border-error outline-none placeholder:text-error/50" placeholder="Reason for rejection (optional)" type="text"/>
+</div>
+<div class="flex items-center justify-between mt-2">
+<button class="text-xs text-error font-medium flex items-center gap-1 bg-error-container px-2 py-1 rounded transition-colors">
+<span class="material-symbols-outlined text-[14px]">close</span> Close reject
+                </button>
+<span class="text-xs font-headline font-semibold text-on-surface-variant">Total: 480</span>
+</div>
+</div>
+<!-- Size 34 -->
+<div class="pb-4 border-b border-outline-variant/30">
+<div class="flex items-center justify-between mb-2">
+<div class="flex items-center gap-2">
+<span class="font-headline font-bold text-lg">34</span>
+<span class="text-xs text-on-surface-variant bg-surface px-2 py-0.5 rounded-full border border-outline-variant">Avail 380</span>
+</div>
+<div class="flex items-center border border-outline-variant rounded-lg overflow-hidden h-12 shadow-sm">
+<button class="w-12 h-full flex items-center justify-center bg-surface hover:bg-surface-container-lowest border-r border-outline-variant text-xl active:bg-outline-variant">-</button>
+<input class="w-16 h-full text-center font-headline font-bold border-none p-0 focus:ring-0" type="text" value="380"/>
+<button class="w-12 h-full flex items-center justify-center bg-surface hover:bg-surface-container-lowest border-l border-outline-variant text-xl active:bg-outline-variant">+</button>
+</div>
+</div>
+<div class="flex items-center justify-between">
+<button class="text-xs text-error font-medium flex items-center gap-1 hover:bg-error-container/50 px-2 py-1 rounded transition-colors">
+<span class="material-symbols-outlined text-[14px]">warning</span> Reject / rewash
+                </button>
+<span class="text-xs font-headline font-semibold text-on-surface-variant">Total: 380</span>
+</div>
+</div>
+<!-- Size 36 -->
+<div class="pb-2">
+<div class="flex items-center justify-between mb-2">
+<div class="flex items-center gap-2">
+<span class="font-headline font-bold text-lg">36</span>
+<span class="text-xs text-on-surface-variant bg-surface px-2 py-0.5 rounded-full border border-outline-variant">Avail 220</span>
+</div>
+<div class="flex items-center border border-outline-variant rounded-lg overflow-hidden h-12 shadow-sm">
+<button class="w-12 h-full flex items-center justify-center bg-surface hover:bg-surface-container-lowest border-r border-outline-variant text-xl active:bg-outline-variant">-</button>
+<input class="w-16 h-full text-center font-headline font-bold border-none p-0 focus:ring-0" type="text" value="220"/>
+<button class="w-12 h-full flex items-center justify-center bg-surface hover:bg-surface-container-lowest border-l border-outline-variant text-xl active:bg-outline-variant">+</button>
+</div>
+</div>
+<div class="flex items-center justify-between">
+<button class="text-xs text-error font-medium flex items-center gap-1 hover:bg-error-container/50 px-2 py-1 rounded transition-colors">
+<span class="material-symbols-outlined text-[14px]">warning</span> Reject / rewash
+                </button>
+<span class="text-xs font-headline font-semibold text-on-surface-variant">Total: 220</span>
+</div>
+</div>
+</div>
+<!-- Grand Total & Remark -->
+<div class="mt-6 pt-4 border-t border-outline-variant/50">
+<div class="flex justify-between items-center mb-4">
+<span class="font-label font-medium text-on-surface">Grand Total</span>
+<span class="font-headline text-xl font-bold text-primary">Taking 1500 pcs</span>
+</div>
+<input class="w-full text-sm p-3 bg-surface border border-outline-variant rounded-lg focus:ring-2 focus:ring-primary focus:border-primary outline-none placeholder:text-on-surface-variant/60 font-body mb-6" placeholder="Add remarks (optional)" type="text"/>
+<!-- Actions -->
+<div class="space-y-3">
+<button class="w-full bg-primary text-on-primary font-bold py-3.5 rounded-lg shadow-sm hover:bg-primary/90 active:scale-[0.98] transition-all">Take into stitching</button>
+<button class="w-full bg-surface border border-outline-variant text-on-surface font-semibold py-3.5 rounded-lg hover:bg-surface-container-lowest active:scale-[0.98] transition-all">Mark complete</button>
+</div>
+</div>
+</div>
+</section>
+<!-- Segmented Tabs -->
+<div class="flex bg-surface-container-lowest p-1 rounded-lg border border-outline-variant shadow-sm mt-6">
+<button class="flex-1 py-2 text-sm font-semibold rounded-md bg-surface border border-outline-variant/50 text-on-surface shadow-[0_1px_2px_rgba(0,0,0,0.05)]">My Work</button>
+<button class="flex-1 py-2 text-sm font-medium rounded-md text-on-surface-variant hover:text-on-surface">My Payments</button>
+<button class="flex-1 py-2 text-sm font-medium rounded-md text-on-surface-variant hover:text-on-surface">Material Indent</button>
+</div>
+<!-- History List -->
+<section class="mt-4 pb-8">
+<div class="flex items-center justify-between px-1 mb-4">
+<h3 class="font-headline font-bold text-lg">History</h3>
+<button class="flex items-center gap-1 text-sm font-medium text-on-surface-variant hover:text-on-surface border border-outline-variant rounded-full px-3 py-1 bg-surface-container-lowest">
+            Today <span class="material-symbols-outlined text-[16px]">expand_more</span>
+</button>
+</div>
+<div class="space-y-2">
+<!-- History Item 1 -->
+<div class="bg-surface-container-lowest p-3 rounded-lg border border-outline-variant flex items-center justify-between shadow-sm">
+<div class="flex items-center gap-3">
+<div class="w-2 h-2 rounded-full bg-primary"></div>
+<div>
+<p class="font-headline font-bold text-sm">AK1423 <span class="font-body font-normal text-on-surface-variant text-xs ml-1">Stitching</span></p>
+<p class="text-xs text-on-surface-variant">Taken in · 10:45 AM</p>
+</div>
+</div>
+<span class="font-headline font-bold">1500 pcs</span>
+</div>
+<!-- History Item 2 -->
+<div class="bg-surface-container-lowest p-3 rounded-lg border border-outline-variant flex items-center justify-between shadow-sm">
+<div class="flex items-center gap-3">
+<div class="w-2 h-2 rounded-full bg-secondary"></div>
+<div>
+<p class="font-headline font-bold text-sm">AK1410 <span class="font-body font-normal text-on-surface-variant text-xs ml-1">Stitching</span></p>
+<p class="text-xs text-on-surface-variant">Completed · Yesterday</p>
+</div>
+</div>
+<span class="font-headline font-bold">800 pcs</span>
+</div>
+<!-- History Item 3 -->
+<div class="bg-surface-container-lowest p-3 rounded-lg border border-outline-variant flex items-center justify-between shadow-sm">
+<div class="flex items-center gap-3">
+<div class="w-2 h-2 rounded-full bg-error"></div>
+<div>
+<p class="font-headline font-bold text-sm">AK1399 <span class="font-body font-normal text-on-surface-variant text-xs ml-1">Stitching</span></p>
+<p class="text-xs text-on-surface-variant">Rejected · Yesterday</p>
+</div>
+</div>
+<span class="font-headline font-bold">12 pcs</span>
+</div>
+</div>
+</section>
+</main>
+</body></html>

--- a/docs/stitch/03-lot-admin.html
+++ b/docs/stitch/03-lot-admin.html
@@ -1,0 +1,274 @@
+<!DOCTYPE html>
+
+<html class="light" lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport"/>
+<title>Kotty Floor — Lot Admin</title>
+<!-- Fonts -->
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Space+Grotesk:wght@500;700&amp;display=swap" rel="stylesheet"/>
+<!-- Icons -->
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<script id="tailwind-config">
+      tailwind.config = {
+        darkMode: "class",
+        theme: {
+          extend: {
+            colors: {
+              surface: '#f7f8fa',
+              'surface-container-lowest': '#ffffff',
+              'on-surface': '#0f172a',
+              'on-surface-variant': '#64748b',
+              'outline-variant': '#e5e7eb',
+              primary: '#2563eb',
+              'on-primary': '#ffffff',
+              'primary-container': '#eff6ff',
+              secondary: '#16a34a',
+              'secondary-container': '#dcfce7',
+              tertiary: '#b45309',
+              'tertiary-container': '#fef3c7',
+              error: '#dc2626',
+              'error-container': '#fee2e2'
+            },
+            borderRadius: {
+              "DEFAULT": "0.5rem",
+              "lg": "1rem",
+              "xl": "1.5rem",
+              "full": "9999px"
+            },
+            fontFamily: {
+              headline: ["Space Grotesk"],
+              display: ["Space Grotesk"],
+              body: ["Inter"],
+              label: ["Inter"]
+            }
+          },
+        },
+      }
+    </script>
+<style>
+      body { font-family: 'Inter', sans-serif; -webkit-tap-highlight-color: transparent; }
+      .font-headline { font-family: 'Space Grotesk', sans-serif; }
+      .material-symbols-outlined {
+        font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+        display: inline-block;
+        line-height: 1;
+        text-transform: none;
+        letter-spacing: normal;
+        word-wrap: normal;
+        white-space: nowrap;
+        direction: ltr;
+      }
+      .no-scrollbar::-webkit-scrollbar { display: none; }
+      .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+      .stage-rail-active { box-shadow: 0 0 0 4px #eff6ff; }
+    </style>
+<style>
+    body {
+      min-height: max(884px, 100dvh);
+    }
+  </style>
+  </head>
+<body class="bg-surface text-on-surface pb-24">
+<!-- TopAppBar -->
+<header class="fixed top-0 w-full z-50 border-b border-outline-variant bg-surface px-4 pt-3 pb-4">
+<div class="flex items-center justify-between mb-3">
+<div class="flex items-center gap-2">
+<span class="material-symbols-outlined text-primary" data-icon="factory">factory</span>
+<span class="font-headline font-black text-xl tracking-tighter text-on-surface">KOTTY FLOOR</span>
+</div>
+<span class="text-[11px] uppercase tracking-wider font-bold text-on-surface-variant bg-outline-variant/30 px-2 py-0.5 rounded">Lot Admin</span>
+</div>
+<div class="relative group">
+<span class="absolute left-3 top-1/2 -translate-y-1/2 material-symbols-outlined text-on-surface-variant text-xl">search</span>
+<input class="w-full bg-surface-container-lowest border border-outline-variant rounded-lg pl-10 pr-4 py-3 text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all outline-none" placeholder="Lot no, manual lot, or SKU" type="text" value="KTTWOMENSPANT990"/>
+</div>
+</header>
+<main class="mt-32 px-4 space-y-4 max-w-lg mx-auto">
+<!-- Lot Header Card -->
+<section class="bg-surface-container-lowest rounded-xl p-5 border border-outline-variant shadow-[0_1px_2px_rgba(15,23,42,0.06)]">
+<div class="flex justify-between items-start mb-1">
+<h1 class="font-headline text-2xl font-bold tracking-tight">KTTWOMENSPANT990</h1>
+<span class="bg-primary-container text-primary text-[10px] font-bold px-2 py-0.5 rounded uppercase tracking-wider">Denim</span>
+</div>
+<p class="text-on-surface-variant text-sm mb-6 flex items-center gap-1.5">
+                Valentino <span class="opacity-30">•</span> 2,529 pcs <span class="opacity-30">•</span> <span class="text-[11px] uppercase tracking-wide">cut by akshay</span>
+</p>
+<!-- Stage Rail -->
+<div class="grid grid-cols-5 gap-2 relative">
+<!-- Connectors -->
+<div class="absolute top-4 left-[10%] right-[10%] h-[2px] bg-outline-variant -z-0"></div>
+<!-- Node: Stitch -->
+<div class="flex flex-col items-center gap-1.5 relative z-10">
+<div class="w-8 h-8 rounded-full bg-secondary-container text-secondary flex items-center justify-center">
+<span class="material-symbols-outlined text-lg" style="font-variation-settings: 'FILL' 1;">check_circle</span>
+</div>
+<div class="text-center">
+<p class="text-[10px] font-bold uppercase tracking-tighter text-on-surface">Stitch</p>
+<p class="text-[9px] text-on-surface-variant leading-none">Done (2)</p>
+</div>
+</div>
+<!-- Node: Assembly -->
+<div class="flex flex-col items-center gap-1.5 relative z-10">
+<div class="w-8 h-8 rounded-full bg-secondary-container text-secondary flex items-center justify-center">
+<span class="material-symbols-outlined text-lg" style="font-variation-settings: 'FILL' 1;">check_circle</span>
+</div>
+<div class="text-center">
+<p class="text-[10px] font-bold uppercase tracking-tighter text-on-surface">Assembly</p>
+<p class="text-[9px] text-on-surface-variant leading-none">Done (2)</p>
+</div>
+</div>
+<!-- Node: Wash (Current) -->
+<div class="flex flex-col items-center gap-1.5 relative z-10">
+<div class="w-8 h-8 rounded-full bg-primary text-on-primary flex items-center justify-center stage-rail-active">
+<span class="material-symbols-outlined text-lg">water_drop</span>
+</div>
+<div class="text-center">
+<p class="text-[10px] font-bold uppercase tracking-tighter text-primary">Wash</p>
+<p class="text-[9px] text-primary font-medium leading-none">WIP (2)</p>
+</div>
+</div>
+<!-- Node: Wash-in -->
+<div class="flex flex-col items-center gap-1.5 relative z-10 opacity-40">
+<div class="w-8 h-8 rounded-full bg-surface border border-outline-variant flex items-center justify-center">
+<div class="w-1.5 h-1.5 rounded-full bg-on-surface-variant"></div>
+</div>
+<div class="text-center">
+<p class="text-[10px] font-bold uppercase tracking-tighter">Wash-in</p>
+<p class="text-[9px] leading-none">Next</p>
+</div>
+</div>
+<!-- Node: Finish -->
+<div class="flex flex-col items-center gap-1.5 relative z-10 opacity-40">
+<div class="w-8 h-8 rounded-full bg-surface border border-outline-variant flex items-center justify-center">
+<div class="w-1.5 h-1.5 rounded-full bg-on-surface-variant"></div>
+</div>
+<div class="text-center">
+<p class="text-[10px] font-bold uppercase tracking-tighter">Finish</p>
+<p class="text-[9px] leading-none">Queue</p>
+</div>
+</div>
+</div>
+</section>
+<!-- Flow Control Card -->
+<section class="bg-surface-container-lowest rounded-xl p-5 border border-outline-variant shadow-[0_1px_2px_rgba(15,23,42,0.06)]">
+<h3 class="text-xs font-bold uppercase tracking-widest text-on-surface-variant mb-4">Flow Control</h3>
+<div class="grid grid-cols-2 p-1 bg-surface border border-outline-variant rounded-lg mb-4">
+<button class="bg-surface-container-lowest shadow-sm rounded-md py-2 text-sm font-semibold text-primary">Denim</button>
+<button class="py-2 text-sm font-medium text-on-surface-variant">Hosiery</button>
+</div>
+<div class="bg-tertiary-container/30 border border-tertiary/10 rounded-lg p-3 flex gap-3 mb-4">
+<span class="material-symbols-outlined text-tertiary text-xl mt-0.5">warning</span>
+<p class="text-sm text-tertiary leading-snug">
+                    This lot has moved into assembly + washing — changing flow now would orphan that work. Reverse it back to stitching first.
+                </p>
+</div>
+<button class="w-full bg-outline-variant text-on-surface-variant font-semibold py-3.5 rounded-lg opacity-50 cursor-not-allowed" disabled="">
+                Change flow
+            </button>
+</section>
+<!-- Size Edit Card -->
+<section class="bg-surface-container-lowest rounded-xl border border-outline-variant shadow-[0_1px_2px_rgba(15,23,42,0.06)] overflow-hidden">
+<div class="p-5 border-b border-outline-variant">
+<h3 class="text-xs font-bold uppercase tracking-widest text-on-surface-variant">Edit cut quantity (size-wise)</h3>
+</div>
+<div class="divide-y divide-outline-variant">
+<!-- Size Row 1 -->
+<div class="p-4 flex items-center justify-between">
+<div>
+<span class="font-headline text-lg font-bold">30</span>
+<p class="text-[11px] text-on-surface-variant font-medium">MIN 141 (ALREADY STITCHED)</p>
+</div>
+<div class="flex items-center gap-3">
+<button class="w-10 h-10 rounded-full border border-outline-variant flex items-center justify-center active:scale-90 transition-transform">
+<span class="material-symbols-outlined">remove</span>
+</button>
+<input class="w-16 text-center font-headline text-xl font-bold bg-transparent border-none focus:ring-0 p-0" type="number" value="141"/>
+<button class="w-10 h-10 rounded-full border border-outline-variant flex items-center justify-center active:scale-90 transition-transform">
+<span class="material-symbols-outlined">add</span>
+</button>
+</div>
+</div>
+<!-- Size Row 2 -->
+<div class="p-4 flex items-center justify-between">
+<div>
+<span class="font-headline text-lg font-bold">32</span>
+<p class="text-[11px] text-on-surface-variant font-medium">MIN 205 (ALREADY STITCHED)</p>
+</div>
+<div class="flex items-center gap-3">
+<button class="w-10 h-10 rounded-full border border-outline-variant flex items-center justify-center active:scale-90 transition-transform">
+<span class="material-symbols-outlined">remove</span>
+</button>
+<input class="w-16 text-center font-headline text-xl font-bold bg-transparent border-none focus:ring-0 p-0" type="number" value="205"/>
+<button class="w-10 h-10 rounded-full border border-outline-variant flex items-center justify-center active:scale-90 transition-transform">
+<span class="material-symbols-outlined">add</span>
+</button>
+</div>
+</div>
+<!-- Size Row 3 -->
+<div class="p-4 flex items-center justify-between">
+<div>
+<span class="font-headline text-lg font-bold">34</span>
+<p class="text-[11px] text-on-surface-variant font-medium">MIN 198 (ALREADY STITCHED)</p>
+</div>
+<div class="flex items-center gap-3">
+<button class="w-10 h-10 rounded-full border border-outline-variant flex items-center justify-center active:scale-90 transition-transform">
+<span class="material-symbols-outlined">remove</span>
+</button>
+<input class="w-16 text-center font-headline text-xl font-bold bg-transparent border-none focus:ring-0 p-0" type="number" value="198"/>
+<button class="w-10 h-10 rounded-full border border-outline-variant flex items-center justify-center active:scale-90 transition-transform">
+<span class="material-symbols-outlined">add</span>
+</button>
+</div>
+</div>
+</div>
+<div class="p-5 bg-surface/50">
+<button class="w-full bg-primary text-on-primary font-semibold py-4 rounded-lg active:scale-[0.98] transition-transform flex items-center justify-center gap-2">
+                    Save quantities
+                </button>
+</div>
+</section>
+<!-- Reverse Intervention Card -->
+<section class="bg-surface-container-lowest rounded-xl p-5 border border-outline-variant shadow-[0_1px_2px_rgba(15,23,42,0.06)]">
+<h3 class="text-xs font-bold uppercase tracking-widest text-error mb-4">Reverse Intervention</h3>
+<div class="mb-5">
+<h4 class="font-semibold text-on-surface mb-1">Reverse a mistaken take-in</h4>
+<p class="text-sm text-on-surface-variant leading-relaxed">
+                    This lot is at <span class="font-bold text-on-surface">Washing</span>. Reversing undoes that stage and voids the pending hand-off payment — the lot returns to the previous stage. Logged.
+                </p>
+</div>
+<button class="w-full border-2 border-error text-error font-bold py-3.5 rounded-lg active:bg-error active:text-white transition-all uppercase tracking-widest text-xs">
+                Reverse Washing
+            </button>
+</section>
+</main>
+<!-- BottomNavBar -->
+<nav class="fixed bottom-0 left-0 w-full z-50 flex justify-around items-center px-4 pb-safe bg-surface border-t border-outline-variant h-16">
+<a class="flex flex-col items-center justify-center text-on-surface-variant hover:text-primary transition-colors" href="#">
+<span class="material-symbols-outlined">home</span>
+<span class="text-[11px] uppercase tracking-wider font-medium mt-1">Home</span>
+</a>
+<a class="flex flex-col items-center justify-center text-on-surface-variant hover:text-primary transition-colors" href="#">
+<span class="material-symbols-outlined">search</span>
+<span class="text-[11px] uppercase tracking-wider font-medium mt-1">Search</span>
+</a>
+<a class="flex flex-col items-center justify-center text-primary bg-primary-container rounded-xl p-2 px-4" href="#">
+<span class="material-symbols-outlined" style="font-variation-settings: 'FILL' 1;">history</span>
+<span class="text-[11px] uppercase tracking-wider font-bold mt-1">History</span>
+</a>
+</nav>
+<!-- Visual Polish: Soft shadow for sticky top on scroll -->
+<script>
+        window.addEventListener('scroll', () => {
+            const header = document.querySelector('header');
+            if (window.scrollY > 10) {
+                header.classList.add('shadow-lg', 'shadow-on-surface/5');
+            } else {
+                header.classList.remove('shadow-lg', 'shadow-on-surface/5');
+            }
+        });
+    </script>
+</body></html>

--- a/docs/stitch/04-cutting-create.html
+++ b/docs/stitch/04-cutting-create.html
@@ -1,0 +1,318 @@
+<!DOCTYPE html>
+
+<html class="light" lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport"/>
+<title>Create Cutting Lot - Kotty Floor</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;family=Space+Grotesk:wght@400;500;600;700&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<script id="tailwind-config">
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        surface: '#f7f8fa',
+                        'surface-container-lowest': '#ffffff',
+                        'on-surface': '#0f172a',
+                        'on-surface-variant': '#64748b',
+                        'outline-variant': '#e5e7eb',
+                        primary: '#2563eb',
+                        'on-primary': '#ffffff',
+                        'primary-container': '#eff6ff',
+                        secondary: '#16a34a',
+                        'secondary-container': '#dcfce7',
+                        tertiary: '#b45309',
+                        'tertiary-container': '#fef3c7',
+                        error: '#dc2626',
+                        'error-container': '#fee2e2'
+                    },
+                    borderRadius: {
+                        DEFAULT: "0.5rem",
+                        lg: "1rem",
+                        xl: "1.5rem",
+                        full: "9999px"
+                    },
+                    fontFamily: {
+                        headline: ["Space Grotesk", "sans-serif"],
+                        display: ["Space Grotesk", "sans-serif"],
+                        body: ["Inter", "sans-serif"],
+                        label: ["Inter", "sans-serif"]
+                    }
+                }
+            }
+        }
+    </script>
+<style>
+        body {
+            -webkit-tap-highlight-color: transparent;
+        }
+        /* Custom scrollbar for webkit to keep it clean if ever needed */
+        ::-webkit-scrollbar {
+            width: 0px;
+            background: transparent;
+        }
+    </style>
+<style>
+    body {
+      min-height: max(884px, 100dvh);
+    }
+  </style>
+  </head>
+<body class="bg-surface text-on-surface font-body antialiased pb-24">
+<!-- Sticky Header -->
+<header class="sticky top-0 z-40 bg-surface/90 backdrop-blur-md border-b border-outline-variant px-4 h-14 flex items-center justify-between shadow-sm">
+<div class="flex items-center gap-3">
+<button aria-label="Go back" class="w-10 h-10 flex items-center justify-center -ml-2 rounded-full hover:bg-surface-container-lowest active:scale-95 transition-all">
+<span class="material-symbols-outlined text-on-surface">arrow_back</span>
+</button>
+<h1 class="font-headline font-bold text-lg tracking-tight">NEW CUTTING LOT</h1>
+</div>
+<!-- Segmented Toggle -->
+<div class="flex bg-outline-variant/30 p-0.5 rounded-lg border border-outline-variant/50">
+<button class="px-3 py-1.5 text-xs font-semibold rounded-md bg-surface-container-lowest shadow-sm text-on-surface" id="btn-denim">
+                Denim
+            </button>
+<button class="px-3 py-1.5 text-xs font-medium rounded-md text-on-surface-variant hover:text-on-surface transition-colors" id="btn-hosiery">
+                Hosiery
+            </button>
+</div>
+</header>
+<!-- Main Content Canvas -->
+<main class="p-4 flex flex-col gap-4">
+<!-- 1. Lot Card -->
+<section class="bg-surface-container-lowest rounded-xl border border-outline-variant p-4 shadow-[0_1px_2px_rgba(15,23,42,.06)] flex flex-col gap-4">
+<div class="flex justify-between items-center">
+<div class="flex flex-col gap-1">
+<label class="font-label text-[11px] uppercase tracking-wider text-on-surface-variant font-semibold">Lot Number</label>
+<div class="flex items-center gap-2">
+<span class="font-headline text-2xl font-bold tracking-tight">te42</span>
+<span class="bg-primary-container text-primary font-bold text-[10px] uppercase px-2 py-0.5 rounded-md self-center mt-1">AUTO</span>
+</div>
+</div>
+</div>
+<div class="flex flex-col gap-1">
+<label class="font-label text-[11px] uppercase tracking-wider text-on-surface-variant font-semibold" for="manual_lot">Manual Lot Number *</label>
+<input class="w-full h-12 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-base font-medium px-3 placeholder-on-surface-variant/50 bg-surface/30" id="manual_lot" placeholder="Enter manual lot #" type="text"/>
+</div>
+<div class="flex flex-col gap-1">
+<label class="font-label text-[11px] uppercase tracking-wider text-on-surface-variant font-semibold" for="cutting_date">Cutting Date</label>
+<div class="relative">
+<span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none">calendar_month</span>
+<input class="w-full h-12 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-base font-medium pl-10 pr-3 bg-surface/30" id="cutting_date" type="date"/>
+</div>
+</div>
+</section>
+<!-- 2. SKU Builder Card -->
+<section class="bg-surface-container-lowest rounded-xl border border-outline-variant p-4 shadow-[0_1px_2px_rgba(15,23,42,.06)] flex flex-col gap-4">
+<h2 class="font-headline font-semibold text-sm">SKU Builder</h2>
+<div class="grid grid-cols-2 gap-3">
+<div class="flex flex-col gap-1">
+<label class="font-label text-[10px] uppercase tracking-wider text-on-surface-variant font-semibold">Brand</label>
+<select class="h-11 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-sm font-medium px-2 bg-surface/30">
+<option>KTT</option>
+</select>
+</div>
+<div class="flex flex-col gap-1">
+<label class="font-label text-[10px] uppercase tracking-wider text-on-surface-variant font-semibold">Gender</label>
+<select class="h-11 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-sm font-medium px-2 bg-surface/30">
+<option>WOMENS</option>
+<option>MENS</option>
+</select>
+</div>
+<div class="flex flex-col gap-1">
+<label class="font-label text-[10px] uppercase tracking-wider text-on-surface-variant font-semibold">Category</label>
+<select class="h-11 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-sm font-medium px-2 bg-surface/30">
+<option>JEANS</option>
+<option>JACKETS</option>
+</select>
+</div>
+<div class="flex flex-col gap-1">
+<label class="font-label text-[10px] uppercase tracking-wider text-on-surface-variant font-semibold">Code</label>
+<input class="h-11 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-sm font-medium px-2 bg-surface/30" type="text" value="990"/>
+</div>
+</div>
+<div class="mt-1 bg-primary-container/50 border border-primary/20 rounded-lg p-3 flex items-center justify-between">
+<div class="flex items-center gap-2">
+<span class="material-symbols-outlined text-primary text-sm">barcode</span>
+<span class="font-headline font-bold text-primary tracking-tight">KTTWOMENSJEANS990</span>
+</div>
+<button class="text-primary p-1 rounded-md hover:bg-primary/10 transition-colors">
+<span class="material-symbols-outlined text-[18px]">content_copy</span>
+</button>
+</div>
+</section>
+<!-- 3. Fabric Card -->
+<section class="bg-surface-container-lowest rounded-xl border border-outline-variant p-4 shadow-[0_1px_2px_rgba(15,23,42,.06)] flex flex-col gap-4">
+<h2 class="font-headline font-semibold text-sm">Fabric Details</h2>
+<div class="flex flex-col gap-1">
+<label class="font-label text-[11px] uppercase tracking-wider text-on-surface-variant font-semibold">Fabric Type</label>
+<div class="relative">
+<span class="material-symbols-outlined absolute left-3 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none">search</span>
+<input class="w-full h-12 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-base font-medium pl-10 pr-3 bg-surface/30" type="text" value="Valentino"/>
+</div>
+</div>
+<div class="flex flex-col gap-1 transition-all duration-300 overflow-hidden opacity-100 max-h-24" id="table-length-container">
+<label class="font-label text-[11px] uppercase tracking-wider text-on-surface-variant font-semibold">Table Length (m)</label>
+<input class="w-full h-12 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-base font-medium px-3 bg-surface/30 font-headline" step="0.1" type="number" value="12.5"/>
+</div>
+<div class="flex flex-col gap-1">
+<label class="font-label text-[11px] uppercase tracking-wider text-on-surface-variant font-semibold">Remark</label>
+<textarea class="w-full rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-sm font-medium px-3 py-2 bg-surface/30 resize-none" placeholder="Optional notes..." rows="2"></textarea>
+</div>
+</section>
+<!-- 4. Sizes & Patterns Card -->
+<section class="bg-surface-container-lowest rounded-xl border border-outline-variant p-4 shadow-[0_1px_2px_rgba(15,23,42,.06)] flex flex-col gap-4">
+<div class="flex justify-between items-center">
+<h2 class="font-headline font-semibold text-sm">Sizes &amp; Patterns</h2>
+<button class="text-primary font-medium text-xs flex items-center gap-1 hover:bg-primary-container px-2 py-1 rounded-md transition-colors">
+<span class="material-symbols-outlined text-[16px]">add</span> Add Size
+                </button>
+</div>
+<div class="flex flex-col gap-1">
+<label class="font-label text-[10px] uppercase tracking-wider text-on-surface-variant font-semibold">Bulk Entry</label>
+<input class="w-full h-10 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-sm font-medium px-3 bg-surface/30 placeholder-on-surface-variant/40" placeholder="e.g., 30-6, 32-7, 34-5..." type="text"/>
+</div>
+<div class="flex flex-col gap-2 mt-2">
+<!-- Row 1 -->
+<div class="flex items-center gap-3">
+<select class="w-24 h-12 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary font-headline font-bold text-base px-2 bg-surface/30">
+<option selected="">30</option>
+</select>
+<div class="flex-1 flex items-center justify-between border border-outline-variant rounded-lg h-12 px-2 bg-surface/30">
+<button class="w-8 h-8 rounded-md bg-surface text-on-surface-variant hover:text-on-surface active:scale-95 flex items-center justify-center shadow-sm border border-outline-variant/50"><span class="material-symbols-outlined text-sm">remove</span></button>
+<span class="font-headline font-bold text-lg">6</span>
+<button class="w-8 h-8 rounded-md bg-surface text-on-surface-variant hover:text-on-surface active:scale-95 flex items-center justify-center shadow-sm border border-outline-variant/50"><span class="material-symbols-outlined text-sm">add</span></button>
+</div>
+<button class="text-on-surface-variant hover:text-error transition-colors p-2"><span class="material-symbols-outlined">close</span></button>
+</div>
+<!-- Row 2 -->
+<div class="flex items-center gap-3">
+<select class="w-24 h-12 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary font-headline font-bold text-base px-2 bg-surface/30">
+<option selected="">32</option>
+</select>
+<div class="flex-1 flex items-center justify-between border border-outline-variant rounded-lg h-12 px-2 bg-surface/30">
+<button class="w-8 h-8 rounded-md bg-surface text-on-surface-variant hover:text-on-surface active:scale-95 flex items-center justify-center shadow-sm border border-outline-variant/50"><span class="material-symbols-outlined text-sm">remove</span></button>
+<span class="font-headline font-bold text-lg">7</span>
+<button class="w-8 h-8 rounded-md bg-surface text-on-surface-variant hover:text-on-surface active:scale-95 flex items-center justify-center shadow-sm border border-outline-variant/50"><span class="material-symbols-outlined text-sm">add</span></button>
+</div>
+<button class="text-on-surface-variant hover:text-error transition-colors p-2"><span class="material-symbols-outlined">close</span></button>
+</div>
+<!-- Row 3 -->
+<div class="flex items-center gap-3">
+<select class="w-24 h-12 rounded-lg border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary font-headline font-bold text-base px-2 bg-surface/30">
+<option selected="">34</option>
+</select>
+<div class="flex-1 flex items-center justify-between border border-outline-variant rounded-lg h-12 px-2 bg-surface/30">
+<button class="w-8 h-8 rounded-md bg-surface text-on-surface-variant hover:text-on-surface active:scale-95 flex items-center justify-center shadow-sm border border-outline-variant/50"><span class="material-symbols-outlined text-sm">remove</span></button>
+<span class="font-headline font-bold text-lg">5</span>
+<button class="w-8 h-8 rounded-md bg-surface text-on-surface-variant hover:text-on-surface active:scale-95 flex items-center justify-center shadow-sm border border-outline-variant/50"><span class="material-symbols-outlined text-sm">add</span></button>
+</div>
+<button class="text-on-surface-variant hover:text-error transition-colors p-2"><span class="material-symbols-outlined">close</span></button>
+</div>
+</div>
+</section>
+<!-- 5. Rolls Used Card -->
+<section class="bg-surface-container-lowest rounded-xl border border-outline-variant p-4 shadow-[0_1px_2px_rgba(15,23,42,.06)] flex flex-col gap-4 mb-4">
+<div class="flex justify-between items-center">
+<h2 class="font-headline font-semibold text-sm">Rolls Used</h2>
+<button class="text-primary font-medium text-xs flex items-center gap-1 hover:bg-primary-container px-2 py-1 rounded-md transition-colors">
+<span class="material-symbols-outlined text-[16px]">add</span> Add Roll
+                </button>
+</div>
+<!-- Single Roll Item -->
+<div class="border border-outline-variant rounded-lg p-3 bg-surface/30 flex flex-col gap-3">
+<div class="flex items-center gap-2">
+<div class="relative flex-1">
+<span class="material-symbols-outlined absolute left-2 top-1/2 -translate-y-1/2 text-on-surface-variant pointer-events-none text-sm">search</span>
+<input class="w-full h-10 rounded-md border-outline-variant focus:border-primary focus:ring-1 focus:ring-primary text-sm font-headline font-bold pl-8 pr-2 bg-surface-container-lowest" type="text" value="R-8821A"/>
+</div>
+<button class="text-on-surface-variant hover:text-error p-2"><span class="material-symbols-outlined text-sm">delete</span></button>
+</div>
+<div class="grid grid-cols-2 gap-2 text-sm">
+<div class="flex flex-col border border-outline-variant/50 rounded p-1.5 bg-surface-container-lowest">
+<span class="font-label text-[9px] uppercase tracking-wider text-on-surface-variant font-semibold">Layers</span>
+<input class="w-full bg-transparent border-none p-0 focus:ring-0 font-headline font-semibold text-sm h-5" type="number" value="120"/>
+</div>
+<div class="flex flex-col border border-outline-variant/50 rounded p-1.5 bg-surface-container-lowest">
+<span class="font-label text-[9px] uppercase tracking-wider text-on-surface-variant font-semibold">Used Wt (kg)</span>
+<input class="w-full bg-transparent border-none p-0 focus:ring-0 text-primary font-headline font-semibold text-sm h-5" step="0.1" type="number" value="45.2"/>
+</div>
+</div>
+<div class="flex justify-between text-[10px] text-on-surface-variant px-1 uppercase tracking-wider font-semibold">
+<span>Full: 60.0 kg</span>
+<span>Rem: 14.8 kg</span>
+</div>
+</div>
+</section>
+</main>
+<!-- Sticky Bottom Bar -->
+<div class="fixed bottom-0 w-full bg-surface-container-lowest border-t border-outline-variant p-4 pb-safe flex flex-col gap-3 z-50 shadow-[0_-4px_6px_-1px_rgba(0,0,0,0.05)]">
+<div class="flex justify-between items-end px-1">
+<span class="font-label text-xs font-semibold text-on-surface-variant uppercase tracking-wider">Est. Total Pieces</span>
+<span class="font-headline text-3xl font-bold tracking-tight leading-none">1,500</span>
+</div>
+<button class="w-full h-14 bg-primary text-on-primary font-bold text-base rounded-xl active:scale-95 transition-transform flex items-center justify-center gap-2 shadow-sm">
+<span class="material-symbols-outlined">add_task</span>
+            Create Lot
+        </button>
+</div>
+<!-- Initialization Script -->
+<script>
+        // Set date to today
+        document.getElementById('cutting_date').valueAsDate = new Date();
+
+        // Toggle Logic for Denim/Hosiery
+        const btnDenim = document.getElementById('btn-denim');
+        const btnHosiery = document.getElementById('btn-hosiery');
+        const tableLengthContainer = document.getElementById('table-length-container');
+
+        function setToggleState(isDenim) {
+            if (isDenim) {
+                // Denim Active
+                btnDenim.classList.replace('text-on-surface-variant', 'text-on-surface');
+                btnDenim.classList.replace('hover:text-on-surface', 'bg-surface-container-lowest');
+                btnDenim.classList.add('bg-surface-container-lowest', 'shadow-sm');
+                btnDenim.classList.remove('font-medium');
+                btnDenim.classList.add('font-semibold');
+
+                btnHosiery.classList.replace('text-on-surface', 'text-on-surface-variant');
+                btnHosiery.classList.remove('bg-surface-container-lowest', 'shadow-sm', 'font-semibold');
+                btnHosiery.classList.add('hover:text-on-surface', 'font-medium');
+
+                // Show Table Length
+                tableLengthContainer.classList.remove('max-h-0', 'opacity-0', 'mb-0');
+                tableLengthContainer.classList.add('max-h-24', 'opacity-100');
+            } else {
+                // Hosiery Active
+                btnHosiery.classList.replace('text-on-surface-variant', 'text-on-surface');
+                btnHosiery.classList.replace('hover:text-on-surface', 'bg-surface-container-lowest');
+                btnHosiery.classList.add('bg-surface-container-lowest', 'shadow-sm');
+                btnHosiery.classList.remove('font-medium');
+                btnHosiery.classList.add('font-semibold');
+
+                btnDenim.classList.replace('text-on-surface', 'text-on-surface-variant');
+                btnDenim.classList.remove('bg-surface-container-lowest', 'shadow-sm', 'font-semibold');
+                btnDenim.classList.add('hover:text-on-surface', 'font-medium');
+
+                // Hide Table Length
+                tableLengthContainer.classList.add('max-h-0', 'opacity-0');
+                tableLengthContainer.classList.remove('max-h-24', 'opacity-100');
+            }
+        }
+
+        btnDenim.addEventListener('click', () => setToggleState(true));
+        btnHosiery.addEventListener('click', () => setToggleState(false));
+
+        // Adding safe area support for iOS
+        document.documentElement.style.setProperty('--sat', 'env(safe-area-inset-top)');
+        document.documentElement.style.setProperty('--sab', 'env(safe-area-inset-bottom)');
+        const style = document.createElement('style');
+        style.innerHTML = `
+            .pb-safe { padding-bottom: max(1rem, env(safe-area-inset-bottom)); }
+        `;
+        document.head.appendChild(style);
+    </script>
+</body></html>

--- a/docs/stitch/05-stitching-read.html
+++ b/docs/stitch/05-stitching-read.html
@@ -1,0 +1,260 @@
+<!DOCTYPE html>
+
+<html class="light" lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport"/>
+<title>Kotty Floor — Stitching Operator</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Space+Grotesk:wght@500;700&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<script id="tailwind-config">
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        'surface': '#f7f8fa',
+                        'surface-container-lowest': '#ffffff',
+                        'on-surface': '#0f172a',
+                        'on-surface-variant': '#64748b',
+                        'outline-variant': '#e5e7eb',
+                        'primary': '#2563eb',
+                        'on-primary': '#ffffff',
+                        'primary-container': '#eff6ff',
+                        'secondary': '#16a34a',
+                        'secondary-container': '#dcfce7',
+                        'tertiary': '#b45309',
+                        'tertiary-container': '#fef3c7',
+                        'error': '#dc2626',
+                        'error-container': '#fee2e2'
+                    },
+                    borderRadius: {
+                        "DEFAULT": "0.5rem",
+                        "lg": "1rem",
+                        "xl": "1.5rem",
+                        "full": "9999px"
+                    },
+                    fontFamily: {
+                        "headline": ["Space Grotesk", "sans-serif"],
+                        "display": ["Space Grotesk", "sans-serif"],
+                        "body": ["Inter", "sans-serif"],
+                        "label": ["Inter", "sans-serif"]
+                    }
+                }
+            }
+        }
+    </script>
+<style>
+        body {
+            font-family: 'Inter', sans-serif;
+            -webkit-tap-highlight-color: transparent;
+            background-color: #f7f8fa;
+        }
+        .font-headline { font-family: 'Space Grotesk', sans-serif; }
+        .material-symbols-outlined {
+            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+            vertical-align: middle;
+        }
+        .stage-rail-connector {
+            position: absolute;
+            top: 14px;
+            left: 50%;
+            width: 100%;
+            height: 2px;
+            z-index: 0;
+        }
+        /* Custom scroll behavior for small focus areas if needed, though prompt bans horizontal scroll */
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+    </style>
+<style>
+    body {
+      min-height: max(884px, 100dvh);
+    }
+  </style>
+  </head>
+<body class="text-on-surface antialiased pb-24">
+<!-- TopAppBar -->
+<header class="fixed top-0 w-full z-50 bg-surface border-b border-outline-variant">
+<div class="flex items-center justify-between px-4 h-16 w-full">
+<div class="flex items-center gap-3">
+<span class="material-symbols-outlined text-primary" data-icon="precision_manufacturing">precision_manufacturing</span>
+<h1 class="font-headline font-bold text-primary text-lg uppercase tracking-wider">STITCHING</h1>
+</div>
+<button class="w-10 h-10 flex items-center justify-center rounded-full hover:bg-primary-container active:scale-95 transition-transform">
+<span class="material-symbols-outlined text-on-surface-variant" data-icon="search">search</span>
+</button>
+</div>
+<!-- Sticky Search Bar -->
+<div class="px-4 pb-4 bg-surface">
+<div class="relative group">
+<div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+<span class="material-symbols-outlined text-on-surface-variant text-sm" data-icon="search">search</span>
+</div>
+<input class="block w-full pl-10 pr-3 py-3 bg-surface-container-lowest border border-outline-variant rounded-lg text-sm focus:ring-2 focus:ring-primary focus:border-primary outline-none transition-all placeholder:text-on-surface-variant/60 font-body" placeholder="Lot no, manual lot, or SKU" type="text"/>
+</div>
+</div>
+</header>
+<!-- Main Content Area -->
+<main class="mt-36 px-4 space-y-4">
+<!-- Welcome / State Message (Subtle) -->
+<p class="text-[11px] font-label uppercase tracking-widest text-on-surface-variant px-1">Active Assignment</p>
+<!-- Lot Card -->
+<section class="bg-surface-container-lowest rounded-[12px] border border-outline-variant shadow-[0_1px_2px_rgba(15,23,42,0.06)] overflow-hidden">
+<!-- Card Header -->
+<div class="p-4 flex items-center justify-between">
+<h2 class="font-headline text-2xl font-bold tracking-tight">AK1423</h2>
+<span class="px-2.5 py-1 rounded-full bg-primary-container text-primary text-[10px] font-bold uppercase tracking-wider">DENIM</span>
+</div>
+<!-- Card Subheader -->
+<div class="px-4 pb-4">
+<p class="text-sm text-on-surface-variant font-body">
+                    KTTMENSJEANS381 <span class="mx-1 opacity-40">·</span> 1,500 pcs <span class="mx-1 opacity-40">·</span> cut by <span class="font-medium text-on-surface">Ramesh</span>
+</p>
+</div>
+<!-- The Stage Rail -->
+<div class="px-4 py-6 bg-surface/30">
+<div class="grid grid-cols-3 gap-y-8 relative">
+<!-- Stage: Cut (Completed) -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-secondary text-on-primary flex items-center justify-center mb-2">
+<span class="material-symbols-outlined text-[18px]" data-icon="check" data-weight="fill" style="font-variation-settings: 'FILL' 1;">check</span>
+</div>
+<span class="text-[10px] font-label uppercase tracking-tighter text-on-surface-variant">Cut</span>
+<span class="text-[9px] font-medium text-on-surface uppercase">RAMESH</span>
+<div class="stage-rail-connector bg-secondary"></div>
+</div>
+<!-- Stage: Stitch (Current) -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-8 h-8 rounded-full bg-primary text-on-primary flex items-center justify-center mb-1.5 ring-4 ring-primary-container">
+<span class="material-symbols-outlined text-[20px]" data-icon="precision_manufacturing">precision_manufacturing</span>
+</div>
+<span class="text-[10px] font-label uppercase tracking-tighter text-primary font-bold">Stitch</span>
+<span class="text-[9px] font-medium text-primary uppercase">SURESH</span>
+<div class="stage-rail-connector bg-outline-variant"></div>
+</div>
+<!-- Stage: Assembly -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[10px] font-label uppercase tracking-tighter text-on-surface-variant/50">Assembly</span>
+<div class="stage-rail-connector bg-outline-variant hidden"></div>
+</div>
+<!-- Second Row (Wrap) -->
+<!-- Stage: Wash -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[10px] font-label uppercase tracking-tighter text-on-surface-variant/50">Wash</span>
+<div class="stage-rail-connector bg-outline-variant"></div>
+</div>
+<!-- Stage: Wash-in -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[10px] font-label uppercase tracking-tighter text-on-surface-variant/50">Wash-in</span>
+<div class="stage-rail-connector bg-outline-variant"></div>
+</div>
+<!-- Stage: Finish -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[10px] font-label uppercase tracking-tighter text-on-surface-variant/50">Finish</span>
+</div>
+</div>
+</div>
+<!-- Size Piece Chips -->
+<div class="p-4 border-t border-outline-variant/50">
+<div class="flex flex-wrap gap-2">
+<div class="flex flex-col items-center bg-surface px-3 py-2 rounded-lg border border-outline-variant min-w-[56px]">
+<span class="font-headline text-lg leading-none">420</span>
+<span class="text-[9px] uppercase tracking-widest text-on-surface-variant mt-1">30</span>
+</div>
+<div class="flex flex-col items-center bg-surface px-3 py-2 rounded-lg border border-outline-variant min-w-[56px]">
+<span class="font-headline text-lg leading-none">510</span>
+<span class="text-[9px] uppercase tracking-widest text-on-surface-variant mt-1">32</span>
+</div>
+<div class="flex flex-col items-center bg-surface px-3 py-2 rounded-lg border border-outline-variant min-w-[56px]">
+<span class="font-headline text-lg leading-none">340</span>
+<span class="text-[9px] uppercase tracking-widest text-on-surface-variant mt-1">34</span>
+</div>
+<div class="flex flex-col items-center bg-surface px-3 py-2 rounded-lg border border-outline-variant min-w-[56px]">
+<span class="font-headline text-lg leading-none">230</span>
+<span class="text-[9px] uppercase tracking-widest text-on-surface-variant mt-1">36</span>
+</div>
+</div>
+</div>
+<!-- Stat Row -->
+<div class="px-4 py-5 grid grid-cols-4 gap-2 border-t border-outline-variant/50">
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Approved</span>
+<span class="font-headline text-xl leading-none text-on-surface">1500</span>
+</div>
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Completed</span>
+<span class="font-headline text-xl leading-none text-secondary">1200</span>
+</div>
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Rejected</span>
+<span class="font-headline text-xl leading-none text-error">40</span>
+</div>
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Inline</span>
+<span class="font-headline text-xl leading-none text-tertiary">260</span>
+</div>
+</div>
+<!-- Footer Action -->
+<div class="p-4 pt-0">
+<button class="w-full py-4 bg-primary text-on-primary rounded-lg font-bold uppercase tracking-widest text-sm flex items-center justify-center gap-2 active:scale-[0.98] transition-transform">
+<span class="material-symbols-outlined text-lg" data-icon="check_circle">check_circle</span>
+                    Approve pieces
+                </button>
+</div>
+</section>
+<!-- Empty State Invitation (As per Guidelines) -->
+<div class="py-12 flex flex-col items-center justify-center text-center">
+<span class="material-symbols-outlined text-on-surface-variant/20 text-4xl mb-2" data-icon="barcode_scanner">barcode_scanner</span>
+<p class="text-on-surface-variant/60 font-body text-sm">Search a lot to begin</p>
+</div>
+</main>
+<!-- BottomNavBar -->
+<nav class="fixed bottom-0 w-full z-50 bg-surface border-t border-outline-variant">
+<div class="flex justify-around items-center h-20 px-2 pb-safe w-full">
+<!-- Lots Tab -->
+<a class="flex flex-col items-center justify-center text-on-surface-variant hover:bg-surface-container-lowest px-4 py-1 rounded-xl transition-colors" href="#">
+<span class="material-symbols-outlined" data-icon="factory">factory</span>
+<span class="font-label text-[11px] uppercase tracking-[0.04em] mt-1">Lots</span>
+</a>
+<!-- Tasks Tab (Active) -->
+<a class="flex flex-col items-center justify-center text-primary bg-primary-container rounded-xl px-4 py-1 active:opacity-80 transition-opacity" href="#">
+<span class="material-symbols-outlined" data-icon="assignment_turned_in" data-weight="fill" style="font-variation-settings: 'FILL' 1;">assignment_turned_in</span>
+<span class="font-label text-[11px] uppercase tracking-[0.04em] mt-1">Tasks</span>
+</a>
+<!-- History Tab -->
+<a class="flex flex-col items-center justify-center text-on-surface-variant hover:bg-surface-container-lowest px-4 py-1 rounded-xl transition-colors" href="#">
+<span class="material-symbols-outlined" data-icon="history">history</span>
+<span class="font-label text-[11px] uppercase tracking-[0.04em] mt-1">History</span>
+</a>
+</div>
+</nav>
+<!-- Interaction Script -->
+<script>
+        document.addEventListener('DOMContentLoaded', () => {
+            // Ripple effect or micro-interactions for the primary button
+            const primaryBtn = document.querySelector('button.bg-primary');
+            primaryBtn.addEventListener('click', function() {
+                this.classList.add('ring-4', 'ring-primary-container');
+                setTimeout(() => {
+                    this.classList.remove('ring-4', 'ring-primary-container');
+                }, 200);
+            });
+
+            // Simulate search focus
+            const searchInput = document.querySelector('input[type="text"]');
+            searchInput.addEventListener('focus', () => {
+                document.querySelector('header').classList.add('shadow-md');
+            });
+            searchInput.addEventListener('blur', () => {
+                document.querySelector('header').classList.remove('shadow-md');
+            });
+        });
+    </script>
+</body></html>

--- a/docs/stitch/06-stitching-refined.html
+++ b/docs/stitch/06-stitching-refined.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+
+<html class="light" lang="en"><head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport"/>
+<title>Kotty Floor — Stitching Operator</title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&amp;family=Space+Grotesk:wght@500;700&amp;display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&amp;display=swap" rel="stylesheet"/>
+<script id="tailwind-config">
+        tailwind.config = {
+            darkMode: "class",
+            theme: {
+                extend: {
+                    colors: {
+                        'surface': '#f7f8fa',
+                        'surface-container-lowest': '#ffffff',
+                        'on-surface': '#0f172a',
+                        'on-surface-variant': '#64748b',
+                        'outline-variant': '#e5e7eb',
+                        'primary': '#2563eb',
+                        'on-primary': '#ffffff',
+                        'primary-container': '#eff6ff',
+                        'secondary': '#16a34a',
+                        'secondary-container': '#dcfce7',
+                        'tertiary': '#b45309',
+                        'tertiary-container': '#fef3c7',
+                        'error': '#dc2626',
+                        'error-container': '#fee2e2'
+                    },
+                    borderRadius: {
+                        "DEFAULT": "0.5rem",
+                        "lg": "1rem",
+                        "xl": "1.5rem",
+                        "full": "9999px"
+                    },
+                    fontFamily: {
+                        "headline": ["Space Grotesk", "sans-serif"],
+                        "display": ["Space Grotesk", "sans-serif"],
+                        "body": ["Inter", "sans-serif"],
+                        "label": ["Inter", "sans-serif"]
+                    }
+                }
+            }
+        }
+    </script>
+<style>
+        body {
+            font-family: 'Inter', sans-serif;
+            -webkit-tap-highlight-color: transparent;
+            background-color: #f7f8fa;
+        }
+        .font-headline { font-family: 'Space Grotesk', sans-serif; }
+        .material-symbols-outlined {
+            font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24;
+            vertical-align: middle;
+        }
+        .stage-rail-connector {
+            position: absolute;
+            top: 14px;
+            left: 50%;
+            width: 100%;
+            height: 2px;
+            z-index: 0;
+        }
+        /* Custom scroll behavior for small focus areas if needed, though prompt bans horizontal scroll */
+        .no-scrollbar::-webkit-scrollbar { display: none; }
+    </style>
+<style>
+    body {
+      min-height: max(884px, 100dvh);
+    }
+  </style>
+</head>
+<body class="text-on-surface antialiased pb-24">
+<!-- TopAppBar -->
+<header class="fixed top-0 w-full z-50 bg-surface border-b border-outline-variant">
+<div class="flex items-center justify-between px-4 h-16 w-full">
+<div class="flex items-center gap-3">
+<span class="material-symbols-outlined text-primary" data-icon="precision_manufacturing">precision_manufacturing</span>
+<h1 class="font-headline font-bold text-primary text-lg uppercase tracking-wider">STITCHING</h1>
+</div>
+<button class="w-10 h-10 flex items-center justify-center rounded-full hover:bg-primary-container active:scale-95 transition-transform">
+<span class="material-symbols-outlined text-on-surface-variant" data-icon="search">search</span>
+</button>
+</div>
+<!-- Sticky Search Bar -->
+<div class="px-4 pb-4 bg-surface">
+<div class="relative group">
+<div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+<span class="material-symbols-outlined text-on-surface-variant text-sm" data-icon="search">search</span>
+</div>
+<input class="block w-full pl-10 pr-3 py-3 bg-surface-container-lowest border border-outline-variant rounded-lg text-sm focus:ring-2 focus:ring-primary focus:border-primary outline-none transition-all placeholder:text-on-surface-variant/60 font-body" placeholder="Lot no, manual lot, or SKU" type="text"/>
+</div>
+</div>
+</header>
+<!-- Main Content Area -->
+<main class="mt-36 px-4 space-y-4">
+<!-- Welcome / State Message (Subtle) -->
+<p class="text-[11px] font-label uppercase tracking-widest text-on-surface-variant px-1">Active Assignment</p>
+<!-- Lot Card -->
+<section class="bg-surface-container-lowest rounded-[12px] border border-outline-variant shadow-[0_1px_2px_rgba(15,23,42,0.06)] overflow-hidden">
+<!-- Card Header -->
+<div class="p-4 flex items-center justify-between">
+<h2 class="font-headline text-2xl font-bold tracking-tight">AK1423</h2>
+<span class="px-2.5 py-1 rounded-full bg-primary-container text-primary text-[10px] font-bold uppercase tracking-wider">DENIM</span>
+</div>
+<!-- Card Subheader -->
+<div class="px-4 pb-4">
+<p class="text-sm text-on-surface-variant font-body">
+                    KTTMENSJEANS381 <span class="mx-1 opacity-40">·</span> 1,500 pcs <span class="mx-1 opacity-40">·</span> cut by <span class="font-medium text-on-surface">Ramesh</span>
+</p>
+</div>
+<!-- The Stage Rail -->
+<div class="px-4 py-6 bg-surface/30 border-t border-outline-variant/50 border-b border-outline-variant/50">
+<div class="grid grid-cols-3 gap-y-8 relative">
+<!-- Stage: Cut (Completed) -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-surface-container-lowest border-2 border-secondary text-secondary flex items-center justify-center mb-2">
+<span class="material-symbols-outlined text-[16px]" data-icon="check" data-weight="bold">check</span>
+</div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-on-surface-variant">Cut</span>
+<span class="text-[9px] font-medium text-on-surface uppercase mt-0.5">RAMESH</span>
+<div class="stage-rail-connector bg-primary top-[13px] -z-10"></div>
+</div>
+<!-- Stage: Stitch (Current) -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-8 h-8 rounded-full bg-primary text-on-primary flex items-center justify-center mb-1.5 ring-4 ring-primary-container shadow-sm">
+<span class="material-symbols-outlined text-[18px]" data-icon="precision_manufacturing">precision_manufacturing</span>
+</div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-primary font-bold">Stitch</span>
+<span class="text-[9px] font-medium text-primary uppercase mt-0.5">SURESH</span>
+<div class="stage-rail-connector bg-outline-variant top-[13px] -z-10"></div>
+</div>
+<!-- Stage: Assembly -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-on-surface-variant/50">Assembly</span>
+<div class="stage-rail-connector bg-outline-variant top-[13px] hidden -z-10"></div>
+</div>
+<!-- Second Row (Wrap) -->
+<!-- Stage: Wash -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-on-surface-variant/50">Wash</span>
+<div class="stage-rail-connector bg-outline-variant top-[13px] -z-10"></div>
+</div>
+<!-- Stage: Wash-in -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-on-surface-variant/50">Wash-in</span>
+<div class="stage-rail-connector bg-outline-variant top-[13px] -z-10"></div>
+</div>
+<!-- Stage: Finish -->
+<div class="flex flex-col items-center relative z-10">
+<div class="w-7 h-7 rounded-full bg-outline-variant flex items-center justify-center mb-2"></div>
+<span class="text-[11px] font-label uppercase tracking-[0.06em] text-on-surface-variant/50">Finish</span>
+</div>
+</div>
+</div>
+<!-- Size Piece Chips -->
+<div class="p-4 pb-2 border-b border-outline-variant/50">
+<div class="flex flex-wrap gap-3">
+<div class="flex flex-col items-center bg-surface px-4 py-2.5 rounded-lg border border-outline-variant min-w-[64px]">
+<span class="font-headline text-xl leading-none font-bold text-on-surface">420</span>
+<span class="text-[10px] uppercase tracking-widest text-on-surface-variant mt-1.5 font-label">30</span>
+</div>
+<div class="flex flex-col items-center bg-surface px-4 py-2.5 rounded-lg border border-outline-variant min-w-[64px]">
+<span class="font-headline text-xl leading-none font-bold text-on-surface">510</span>
+<span class="text-[10px] uppercase tracking-widest text-on-surface-variant mt-1.5 font-label">32</span>
+</div>
+<div class="flex flex-col items-center bg-surface px-4 py-2.5 rounded-lg border border-outline-variant min-w-[64px]">
+<span class="font-headline text-xl leading-none font-bold text-on-surface">340</span>
+<span class="text-[10px] uppercase tracking-widest text-on-surface-variant mt-1.5 font-label">34</span>
+</div>
+<div class="flex flex-col items-center bg-surface px-4 py-2.5 rounded-lg border border-outline-variant min-w-[64px]">
+<span class="font-headline text-xl leading-none font-bold text-on-surface">230</span>
+<span class="text-[10px] uppercase tracking-widest text-on-surface-variant mt-1.5 font-label">36</span>
+</div>
+</div>
+</div>
+<!-- Stat Row -->
+<div class="px-4 py-5 grid grid-cols-4 gap-2 border-b border-outline-variant/50">
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Approved</span>
+<span class="font-headline text-xl leading-none text-on-surface font-bold">1500</span>
+</div>
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Completed</span>
+<span class="font-headline text-xl leading-none text-secondary font-bold">1200</span>
+</div>
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Rejected</span>
+<span class="font-headline text-xl leading-none text-error font-bold">40</span>
+</div>
+<div class="flex flex-col">
+<span class="text-[9px] font-label uppercase tracking-wider text-on-surface-variant mb-1">Inline</span>
+<span class="font-headline text-xl leading-none text-tertiary font-bold">260</span>
+</div>
+</div>
+<!-- Footer Action -->
+<div class="p-4">
+<button class="w-full py-3.5 bg-primary text-on-primary rounded-lg font-bold uppercase tracking-widest text-sm flex items-center justify-center gap-2 active:scale-[0.98] transition-transform">
+<span class="material-symbols-outlined text-lg" data-icon="check_circle">check_circle</span>
+                    Approve pieces
+                </button>
+</div>
+</section>
+<!-- Empty State Invitation (As per Guidelines) -->
+<div class="py-12 flex flex-col items-center justify-center text-center">
+<span class="material-symbols-outlined text-on-surface-variant/20 text-4xl mb-2" data-icon="barcode_scanner">barcode_scanner</span>
+<p class="text-on-surface-variant/60 font-body text-sm">Search a lot to begin</p>
+</div>
+</main>
+<!-- BottomNavBar -->
+<nav class="fixed bottom-0 w-full z-50 bg-surface border-t border-outline-variant">
+<div class="flex justify-around items-center h-20 px-2 pb-safe w-full">
+<!-- Lots Tab -->
+<a class="flex flex-col items-center justify-center text-on-surface-variant hover:bg-surface-container-lowest px-4 py-1 rounded-xl transition-colors" href="#">
+<span class="material-symbols-outlined" data-icon="factory">factory</span>
+<span class="font-label text-[11px] uppercase tracking-[0.04em] mt-1">Lots</span>
+</a>
+<!-- Tasks Tab (Active) -->
+<a class="flex flex-col items-center justify-center text-primary bg-primary-container rounded-xl px-4 py-1 active:opacity-80 transition-opacity" href="#">
+<span class="material-symbols-outlined" data-icon="assignment_turned_in" data-weight="fill" style="font-variation-settings: 'FILL' 1;">assignment_turned_in</span>
+<span class="font-label text-[11px] uppercase tracking-[0.04em] mt-1">Tasks</span>
+</a>
+<!-- History Tab -->
+<a class="flex flex-col items-center justify-center text-on-surface-variant hover:bg-surface-container-lowest px-4 py-1 rounded-xl transition-colors" href="#">
+<span class="material-symbols-outlined" data-icon="history">history</span>
+<span class="font-label text-[11px] uppercase tracking-[0.04em] mt-1">History</span>
+</a>
+</div>
+</nav>
+<!-- Interaction Script -->
+<script>
+        document.addEventListener('DOMContentLoaded', () => {
+            // Ripple effect or micro-interactions for the primary button
+            const primaryBtn = document.querySelector('button.bg-primary');
+            if(primaryBtn) {
+                primaryBtn.addEventListener('click', function() {
+                    this.classList.add('ring-4', 'ring-primary-container');
+                    setTimeout(() => {
+                        this.classList.remove('ring-4', 'ring-primary-container');
+                    }, 200);
+                });
+            }
+
+            // Simulate search focus
+            const searchInput = document.querySelector('input[type="text"]');
+            if(searchInput) {
+                searchInput.addEventListener('focus', () => {
+                    document.querySelector('header').classList.add('shadow-md');
+                });
+                searchInput.addEventListener('blur', () => {
+                    document.querySelector('header').classList.remove('shadow-md');
+                });
+            }
+        });
+    </script>
+</body></html>

--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -316,10 +316,37 @@ router.get(
 /**************************************************
  * 3) /operator/dashboard – must define lotCount etc.
  **************************************************/
-// Redesigned mobile-first operator hub ("Kotty Floor"). Standalone page on the new
-// floor.css token system — opt-in alongside the classic /dashboard while it's reviewed.
-router.get("/hub", isAuthenticated, isOperator, (req, res) => {
-  res.render("floorHub", { user: req.session.user });
+// Redesigned mobile-first operator hub ("Kotty Floor") on the actual Stitch design.
+// Full rebuild of the operator dashboard — same data/panels, opt-in alongside /dashboard.
+router.get("/hub", isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const { search, startDate, endDate,
+      sortField = "lot_no", sortOrder = "asc", category = "all" } = req.query;
+
+    const [[totals]] = await pool.query(`
+      SELECT
+        (SELECT COUNT(*) FROM cutting_lots)                      AS lotCount,
+        (SELECT COALESCE(SUM(total_pieces),0) FROM cutting_lots) AS totalPieces,
+        (SELECT COALESCE(SUM(pieces),0) FROM finishing_events
+           WHERE event_type='complete')                         AS totalFinished,
+        (SELECT COUNT(*) FROM users)                             AS userCount
+    `);
+
+    const advancedAnalytics = await computeAdvancedAnalytics(startDate, endDate);
+
+    return res.render("floorHub", {
+      user: req.session.user,
+      lotCount: totals.lotCount,
+      totalPiecesCut: parseFloat(totals.totalPieces) || 0,
+      totalFinished: totals.totalFinished,
+      userCount: totals.userCount,
+      advancedAnalytics,
+      query: { search, startDate, endDate, sortField, sortOrder, category },
+    });
+  } catch (err) {
+    console.error("Error loading operator hub:", err);
+    return res.status(500).send("Server error");
+  }
 });
 
 router.get("/dashboard", isAuthenticated, isOperator, async (req, res) => {

--- a/views/floorHub.ejs
+++ b/views/floorHub.ejs
@@ -1,119 +1,358 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <title>Kotty Floor</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link rel="stylesheet" href="/public/css/floor.css" />
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" />
-</head>
-<body class="fl">
-  <div class="fl-top">
-    <div class="fl-top-inner wide">
-      <div style="display:flex;justify-content:space-between;align-items:center;">
+<%
+  var _username = (user && user.username) ? user.username : 'Operator';
+  var isMohit = (_username || '').toLowerCase() === 'mohitoperator';
+  var aa = (typeof advancedAnalytics !== 'undefined' && advancedAnalytics) ? advancedAnalytics : { top10SKUs: [], bottom10SKUs: [], totalCut: 0 };
+  var q  = (typeof query !== 'undefined' && query) ? query : {};
+  function num(n){ return Number(n || 0).toLocaleString('en-IN'); }
+%>
+<%- include('partials/floorHead', {
+  pageTitle: 'Kotty Floor | Operator Hub',
+  topTitle: 'KOTTY FLOOR', topIcon: 'factory',
+  topEyebrow: 'Shift Operator', topSub: 'Hi, ' + _username,
+  user: user
+}) %>
+<link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" rel="stylesheet"/>
+<link href="https://unpkg.com/tabulator-tables@5.5.0/dist/css/tabulator.min.css" rel="stylesheet"/>
+<style>
+  /* legacy support scoped for the restored data panels (keeps them working on Tailwind) */
+  .d-none { display: none !important; }
+  .badge-kotty { display:inline-block; font-family:'Space Grotesk',sans-serif; font-weight:700; font-size:12px; padding:2px 9px; border-radius:999px; }
+  .badge-kotty.badge-success { background:#dcfce7; color:#16a34a; }
+  .badge-kotty.badge-warning { background:#fef3c7; color:#b45309; }
+  .badge-kotty.badge-danger  { background:#fee2e2; color:#dc2626; }
+  .badge-kotty.badge-info    { background:#eff6ff; color:#2563eb; }
+  .tabulator { border:1px solid #e5e7eb; border-radius:12px; background:#fff; font-family:'Inter',sans-serif; font-size:13px; }
+  .tabulator .tabulator-header { background:#f7f8fa; border-bottom:1px solid #e5e7eb; }
+  .tabulator .tabulator-header .tabulator-col { background:#f7f8fa; }
+  .fhub-modal { position:fixed; inset:0; z-index:60; display:none; align-items:flex-start; justify-content:center; padding:80px 16px 16px; background:rgba(15,23,42,.5); }
+  .fhub-modal.open { display:flex; }
+</style>
+
+<main class="pt-20 px-4 max-w-lg md:max-w-3xl lg:max-w-6xl mx-auto">
+
+  <!-- Feature search (live-filters the tools below) -->
+  <div class="mb-5">
+    <div class="relative max-w-xl">
+      <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
+        <span class="material-symbols-outlined text-on-surface-variant text-xl">search</span>
+      </div>
+      <input id="featureSearch" autocomplete="off" oninput="filterFeatures(this.value)"
+             class="block w-full pl-10 pr-3 py-3.5 bg-surface-container-lowest border border-outline-variant rounded-xl text-sm focus:ring-primary focus:border-primary placeholder:text-on-surface-variant/50 font-label"
+             placeholder="Search for a tool — “wash”, “rates”, “reverse”…" type="text"/>
+    </div>
+  </div>
+
+  <!-- KPI stats strip -->
+  <section class="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-8 bg-surface-container-lowest p-3 rounded-xl border border-outline-variant shadow-sm">
+    <div class="text-center sm:border-r border-outline-variant/60">
+      <p class="text-[10px] uppercase tracking-wider text-on-surface-variant font-bold mb-1">Total Kits</p>
+      <p class="font-headline text-xl font-bold leading-none"><%= num(lotCount) %></p>
+    </div>
+    <div class="text-center sm:border-r border-outline-variant/60">
+      <p class="text-[10px] uppercase tracking-wider text-on-surface-variant font-bold mb-1">Cut Pieces</p>
+      <p class="font-headline text-xl font-bold leading-none text-primary"><%= num(totalPiecesCut) %></p>
+    </div>
+    <div class="text-center sm:border-r border-outline-variant/60">
+      <p class="text-[10px] uppercase tracking-wider text-on-surface-variant font-bold mb-1">Finished</p>
+      <p class="font-headline text-xl font-bold leading-none text-secondary"><%= num(totalFinished) %></p>
+    </div>
+    <div class="text-center">
+      <p class="text-[10px] uppercase tracking-wider text-on-surface-variant font-bold mb-1">Users</p>
+      <p class="font-headline text-xl font-bold leading-none"><%= num(userCount) %></p>
+    </div>
+  </section>
+
+  <%
+    // [href, material-icon, title, subtitle, keywords, mohitOnly]
+    var groups = [
+      ['Production', 'primary', [
+        ['/operator/dashboard','dashboard','Dashboard','Classic overview','home overview classic',false],
+        ['/operator/day-activity','event_available','Day Activity','What moved today','today log movement',false],
+        ['/operator/lot-tat','timer','Lot TAT','Turnaround time','speed delay aging',false],
+        ['/operator/lot-admin','settings_suggest','Lot Admin','Flow · reverse · qty','denim hosiery correct reverse quantity',false],
+        ['/operator/rewash-download','table_view','Rewash Excel','Rewash report','rewash redo download',false],
+        ['/operator/editcuttinglots','content_cut','Edit Lots','Fix cutting records','cutting correct amend',false],
+        ['/operator/dashboard/download-all-lots','download','Export All','All lots','download everything',false],
+        ['/search-dashboard','search','Search','Find any lot / SKU','lookup find barcode',false],
+        ['/dashboard/rejected-lots','cancel','Rejected Lots','Rejects across stages','reject damaged',false],
+      ]],
+      ['Inventory & Stock', 'tertiary', [
+        ['/easyecom/stock-market','production_quantity_limits','Out-of-stock','EasyEcom stock','oos inventory easyecom',false],
+        ['/inventory-ops/logs','lan','Inventory Hooks','Webhook logs','webhook integration',false],
+      ]],
+      ['Washing', 'secondary', [
+        ['/assign-to-washing','water_drop','Assign Washing','Send lots to wash','laundry dispatch',false],
+        ['/operator/editwashingassignments','edit_note','Edit Wash','Adjust assignments','washing reassign',false],
+        ['/operator/correct-approval','published_with_changes','Fix Approval','Re-attribute a stage','approve wrong reassign',false],
+        ['/operator/dashboard/washing-summary/download','calendar_month','Wash Monthly','Monthly summary','washing month',false],
+      ]],
+      ['Customer Support & Media', 'gray', [
+        ['/mail-manager','mail','Mail Manager','Auto-reply','email reply',true],
+        ['/video-finder','smart_display','Video Finder','Packing video','video packing',false],
+        ['/vms','radio_button_checked','VMS Recorder','Record','video record',false],
+        ['/vms-operator','upload_file','AWB Uploads','Upload AWBs','awb courier',false],
+        ['/return-grn/dashboard','assignment_return','Returns','Return GRN','return grn inward',false],
+        ['/return-challan','receipt_long','Return Challans','Challans','challan document',false],
+        ['/admin/user-roles','admin_panel_settings','Manage User Roles','Roles & permissions','admin permissions',true],
+      ]],
+      ['Reports', 'primary', [
+        ['/operator/dashboard/pic-report','fact_check','PIC Report','In-production report','pieces wip',false],
+        ['/operator/dashboard/pic-size-report','table_chart','Size PIC Report','By size','size breakdown',false],
+        ['/operator/dashboard/employees/download','badge','Employee Excel','Staff export','workers export',false],
+        ['/operator/dashboard/lot-departments/download','account_tree','Lot Dept Counts','Per department','department counts',false],
+        ['/operator/dashboard/consumption/download','calculate','Consumption','Fabric consumption','fabric usage cad',false],
+        ['/operator/lot-completion','percent','Lot Completion','Close finished lots','finish close complete',false],
+      ]],
+      ['HR & Finance', 'tertiary', [
+        ['/operator/departments','account_balance_wallet','Salaries','Department salaries','pay wages',false],
+        ['/operator/supervisors','schedule','Attendance','Supervisor attendance','present absent',false],
+        ['/stitchingdashboard/payments/rates','currency_rupee','Stitch Rates','Stitching rates','pay rate price',false],
+        ['/operator/payments/rates','sell','Stage Rates','All stage rates','pay rate all',false],
+        ['/operator/payments/pending','payments','Payments','Pending payouts','pay earnings',false],
+        ['/operator/payments/debits','remove_circle','Debits','Deductions','debit deduction',false],
+      ]],
+      ['Management', 'gray', [
+        ['/operator/stitching-tat','hourglass_top','Stitching TAT','Stitching turnaround','tat time stitch',false],
+        ['/po-creator/operator/dashboard','inventory_2','PO Management','Purchase orders','po purchase',false],
+        ['/returns/dashboard','keyboard_return','Returns','Returns dashboard','return',false],
+        ['/operator/sku-categories','sell','SKU Categories','Manage categories','sku category',false],
+        ['#session-usage','query_stats','Account Usage','Session usage','usage sessions time',true],
+      ]],
+    ];
+    var chip = { primary:['bg-primary-container','text-primary'], tertiary:['bg-tertiary-container','text-tertiary'], secondary:['bg-secondary-container','text-secondary'], gray:['bg-gray-100','text-on-surface-variant'] };
+  %>
+
+  <% groups.forEach(function(g){ var c = chip[g[1]] || chip.primary; %>
+    <section class="fhub-group mb-6">
+      <h2 class="text-[11px] font-bold uppercase tracking-[0.08em] text-on-surface-variant mb-2.5"><%= g[0] %></h2>
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+        <% g[2].forEach(function(t){ if (t[5] && !isMohit) return; var kw = (t[2]+' '+t[3]+' '+t[4]).toLowerCase(); %>
+          <a href="<%= t[0] %>" data-kw="<%= kw %>"
+             class="fhub-tile action-card text-left bg-surface-container-lowest p-4 rounded-xl border border-outline-variant flex flex-col justify-between min-h-[94px] transition-all hover:border-primary/30">
+            <div class="w-10 h-10 rounded-lg <%= c[0] %> flex items-center justify-center">
+              <span class="material-symbols-outlined <%= c[1] %>"><%= t[1] %></span>
+            </div>
+            <div class="mt-3">
+              <h3 class="font-bold text-on-surface text-[14px] leading-tight"><%= t[2] %></h3>
+              <p class="text-[11px] text-on-surface-variant mt-0.5 leading-snug"><%= t[3] %></p>
+            </div>
+          </a>
+        <% }) %>
+      </div>
+    </section>
+  <% }) %>
+
+  <div id="featureEmpty" class="hidden text-center text-on-surface-variant py-8 text-sm">
+    No tool matches “<span id="fq"></span>”. Try a shorter word.
+  </div>
+
+  <% if (isMohit) { %>
+  <!-- Account Usage (Mohit only) -->
+  <section id="session-usage" class="mt-8 bg-surface-container-lowest rounded-xl border border-outline-variant p-4 shadow-sm">
+    <div class="flex items-end justify-between gap-3 flex-wrap mb-3">
+      <div>
+        <p class="text-[10px] uppercase tracking-widest text-on-surface-variant font-bold">Overview</p>
+        <h2 class="font-headline text-lg font-bold">Account Usage</h2>
+      </div>
+      <div class="flex items-center gap-2">
+        <select id="sessionRange" class="text-sm border border-outline-variant rounded-lg py-2 px-3 bg-surface">
+          <option value="7">Last 7 days</option>
+          <option value="30">Last 30 days</option>
+          <option value="90">Last 90 days</option>
+        </select>
+        <button id="refreshSessionUsage" type="button" class="text-sm font-semibold bg-primary text-on-primary rounded-lg py-2 px-3 active:scale-[0.98]">Refresh</button>
+      </div>
+    </div>
+    <div class="overflow-x-auto">
+      <table id="sessionUsageTable" class="w-full text-sm text-left">
+        <thead class="text-[10px] uppercase tracking-wider text-on-surface-variant border-b border-outline-variant">
+          <tr><th class="py-2 pr-3">Date</th><th class="py-2 pr-3">User</th><th class="py-2 pr-3">Sessions</th><th class="py-2 pr-3">Time Used</th><th class="py-2">Last Active</th></tr>
+        </thead>
+        <tbody class="divide-y divide-outline-variant/60"></tbody>
+      </table>
+      <div id="sessionUsageEmpty" class="d-none text-on-surface-variant text-sm py-3 text-center">No account usage logged for the selected range.</div>
+    </div>
+    <p class="text-on-surface-variant text-xs mt-3">Time used counts activity from login until logout or the most recent page view.</p>
+  </section>
+  <% } %>
+
+  <!-- SKU Insights -->
+  <section class="mt-8 bg-surface-container-lowest rounded-xl border border-outline-variant p-4 shadow-sm">
+    <div class="flex items-end justify-between gap-3 flex-wrap mb-4">
+      <div>
+        <p class="text-[10px] uppercase tracking-widest text-on-surface-variant font-bold">Analytics</p>
+        <h2 class="font-headline text-lg font-bold">SKU Insights</h2>
+      </div>
+      <form method="GET" action="/operator/hub" class="flex gap-2 flex-wrap items-center">
+        <input type="date" name="startDate" value="<%= q.startDate || '' %>" class="text-sm border border-outline-variant rounded-lg py-2 px-3 bg-surface"/>
+        <input type="date" name="endDate" value="<%= q.endDate || '' %>" class="text-sm border border-outline-variant rounded-lg py-2 px-3 bg-surface"/>
+        <button type="submit" class="text-sm font-semibold bg-primary text-on-primary rounded-lg py-2 px-3 active:scale-[0.98]">Apply</button>
+      </form>
+    </div>
+    <div class="grid md:grid-cols-2 gap-6">
+      <% [['Top 10 SKUs','arrow_upward','secondary',aa.top10SKUs||[],'badge-success'],['Bottom 10 SKUs','arrow_downward','tertiary',aa.bottom10SKUs||[],'badge-warning']].forEach(function(col){ %>
         <div>
-          <div class="fl-eyebrow">Kotty Floor</div>
-          <div class="fl-title">Hi, <%= (user && user.username) ? user.username : 'Operator' %></div>
+          <h3 class="flex items-center gap-1.5 text-sm font-bold mb-2"><span class="material-symbols-outlined text-<%= col[2] %> text-base"><%= col[1] %></span><%= col[0] %></h3>
+          <div class="overflow-x-auto">
+            <table class="w-full text-sm text-left">
+              <thead class="text-[10px] uppercase tracking-wider text-on-surface-variant border-b border-outline-variant">
+                <tr><th class="py-2 pr-3">SKU</th><th class="py-2 pr-3">Pieces</th><th class="py-2">% Share</th></tr>
+              </thead>
+              <tbody class="divide-y divide-outline-variant/60">
+                <% col[3].forEach(function(item){ var pct = (aa.totalCut>0)?((item.total/aa.totalCut)*100).toFixed(2):'0.00'; %>
+                  <tr><td class="py-2 pr-3 font-semibold"><%= item.sku %></td><td class="py-2 pr-3 font-headline"><%= Number(item.total).toLocaleString() %></td><td class="py-2"><span class="badge-kotty <%= col[4] %>"><%= pct %>%</span></td></tr>
+                <% }) %>
+                <% if (!col[3].length) { %><tr><td colspan="3" class="py-4 text-center text-on-surface-variant text-xs">No data for this range.</td></tr><% } %>
+              </tbody>
+            </table>
+          </div>
         </div>
-        <a href="/logout" class="fl-pill info" style="text-decoration:none;color:var(--fl-muted);background:#f1f5f9;">Log out</a>
-      </div>
-      <input class="fl-search" id="featureSearch" autocomplete="off"
-             placeholder="Search for a tool — “wash”, “rates”, “reverse”…"
-             oninput="filterFeatures(this.value)" />
+      <% }) %>
     </div>
-  </div>
+  </section>
 
-  <div class="fl-wrap wide">
-    <%
-      // [href, icon, title, desc, extra search keywords]
-      const groups = [
-        ['Lots', [
-          ['/operator/lot-admin','sliders','Lot Admin','Flow · reverse · qty','denim hosiery correct fix change quantity mistake'],
-          ['/operator/lot-journey','signpost-split','Lot Journey','Track a lot end-to-end','trace timeline stage where'],
-          ['/operator/lot-tat','stopwatch','Lot TAT','Turnaround time','speed delay slow aging'],
-          ['/operator/editcuttinglots','scissors','Edit Lots','Fix cutting records','cutting correct amend'],
-          ['/operator/lot-completion','check2-circle','Lot Completion','Close finished lots','finish close done complete'],
-          ['/operator/day-activity','calendar3','Day Activity','What moved today','today log movement'],
-          ['/search-dashboard','search','Search Lots','Find any lot / SKU','lookup find sku barcode'],
-          ['/operator/dashboard','grid','Classic Dashboard','The old view','home overview legacy'],
-        ]],
-        ['Washing', [
-          ['/assign-to-washing','box-arrow-in-right','Assign Washing','Send lots to wash','laundry dispatch send'],
-          ['/operator/editwashingassignments','pencil-square','Edit Wash','Adjust assignments','washing change reassign'],
-          ['/operator/correct-approval','person-check','Fix Approval','Re-attribute a stage','approve wrong operator reassign'],
-          ['/operator/rewash-download','arrow-repeat','Rewash Excel','Rewash report','rewash redo report download'],
-          ['/operator/dashboard/washing-summary/download','file-earmark-spreadsheet','Wash Monthly','Monthly summary','washing month report'],
-        ]],
-        ['Reports & exports', [
-          ['/operator/dashboard/pic-report','clipboard-data','PIC Report','In-production report','pieces in production wip'],
-          ['/operator/dashboard/pic-size-report','clipboard2-data','Size PIC Report','By size','size breakdown wip'],
-          ['/operator/dashboard/consumption/download','hexagon','Consumption','Fabric consumption','fabric usage cad'],
-          ['/operator/dashboard/lot-departments/download','diagram-3','Lot Dept Counts','Per department','department counts'],
-          ['/operator/dashboard/employees/download','people','Employee Excel','Employee export','staff workers export'],
-          ['/operator/dashboard/download-all-lots','download','Export All','All lots','download everything'],
-        ]],
-        ['Pay & people', [
-          ['/operator/departments','cash-stack','Salaries','Department salaries','pay wages salary money'],
-          ['/operator/supervisors','person-badge','Attendance','Supervisor attendance','present absent supervisor'],
-          ['/stitchingdashboard/payments/rates','currency-rupee','Stitch Rates','Stitching rates','pay rate stitching price'],
-          ['/operator/payments/rates','tags','Stage Rates','All stage rates','pay rate price all stages'],
-        ]],
-        ['Other', [
-          ['/easyecom/stock-market','graph-down','Out-of-stock','EasyEcom stock','oos stock inventory easyecom'],
-          ['/inventory-ops/logs','hdd-network','Inventory Hooks','Webhook logs','webhook integration logs'],
-          ['/mail-manager','envelope','Mail Manager','Auto-reply','email mail reply'],
-          ['/video-finder','camera-video','Video Finder','Packing video','video packing find'],
-          ['/vms','record-circle','VMS Recorder','Record','video record'],
-          ['/vms-operator','upload','AWB Uploads','Upload AWBs','awb courier upload'],
-          ['/return-grn/dashboard','arrow-return-left','Returns','Return GRN','return grn inward'],
-          ['/return-challan','receipt','Return Challans','Challans','challan return document'],
-          ['/admin/user-roles','shield-lock','User Roles','Manage roles','admin permissions users manage'],
-        ]],
-      ];
-      function kw(t){ return (t[2] + ' ' + t[3] + ' ' + (t[4]||'')).toLowerCase(); }
-    %>
-    <% groups.forEach(function(g){ %>
-      <div class="fl-group">
-        <div class="fl-sec" style="margin-top:14px;"><%= g[0] %></div>
-        <div class="fl-tiles">
-          <% g[1].forEach(function(t){ %>
-            <a class="fl-tile" href="<%= t[0] %>" data-kw="<%= kw(t) %>">
-              <span class="ic"><i class="bi bi-<%= t[1] %>"></i></span>
-              <span class="t"><%= t[2] %></span>
-              <span class="d"><%= t[3] %></span>
-            </a>
-          <% }) %>
-        </div>
+  <!-- Pendency -->
+  <section class="mt-8 bg-surface-container-lowest rounded-xl border border-outline-variant p-4 shadow-sm">
+    <div class="flex items-end justify-between gap-3 flex-wrap mb-4">
+      <div>
+        <p class="text-[10px] uppercase tracking-widest text-on-surface-variant font-bold">Work in progress</p>
+        <h2 class="font-headline text-lg font-bold">Pendency</h2>
       </div>
-    <% }) %>
-
-    <div id="featureEmpty" class="fl-empty" style="display:none;">
-      No tool matches “<span id="fq"></span>”. Try a shorter word.
+      <select id="deptFilter" class="text-sm border border-outline-variant rounded-lg py-2 px-3 bg-surface">
+        <option value="all">All Departments</option>
+        <option value="stitching">Stitching</option>
+        <option value="assembly">Assembly</option>
+        <option value="washing">Washing</option>
+        <option value="washing_in">Washing In</option>
+        <option value="finishing">Finishing</option>
+      </select>
     </div>
-  </div>
+    <div id="pendencyTable"></div>
+  </section>
 
-  <div class="fl-nav">
-    <a class="active" href="/operator/hub"><span class="ic"><i class="bi bi-house"></i></span>Home</a>
-    <a href="/search-dashboard"><span class="ic"><i class="bi bi-search"></i></span>Lots</a>
-    <a href="/operator/lot-journey"><span class="ic"><i class="bi bi-signpost-split"></i></span>Journey</a>
-  </div>
+  <!-- Material Indent (self-contained partial) -->
+  <section class="mt-8">
+    <h2 class="text-[11px] font-bold uppercase tracking-[0.08em] text-on-surface-variant mb-2.5">Material Indent</h2>
+    <div class="bg-surface-container-lowest rounded-xl border border-outline-variant overflow-hidden">
+      <%- include('partials/indentWrapper', { user: user, stage: 'Operator' }) %>
+    </div>
+  </section>
+</main>
 
-  <script>
-    function filterFeatures(q) {
-      q = (q || '').trim().toLowerCase();
-      var any = false;
-      document.querySelectorAll('.fl-group').forEach(function (group) {
-        var visible = 0;
-        group.querySelectorAll('.fl-tile').forEach(function (tile) {
-          var show = !q || (tile.dataset.kw || '').indexOf(q) >= 0;
-          tile.style.display = show ? '' : 'none';
-          if (show) { visible++; any = true; }
-        });
-        group.style.display = visible ? '' : 'none';
+<!-- Lot Details modal (Tailwind overlay, no Bootstrap) -->
+<div id="lotModal" class="fhub-modal">
+  <div class="bg-surface-container-lowest w-full max-w-lg rounded-xl border border-outline-variant shadow-xl">
+    <div class="flex items-center justify-between px-5 py-4 border-b border-outline-variant">
+      <h3 class="font-headline text-lg font-bold">Lot Details</h3>
+      <button type="button" onclick="closeLotModal()" class="material-symbols-outlined text-on-surface-variant">close</button>
+    </div>
+    <div id="lotModalBody" class="p-5 text-sm"></div>
+  </div>
+</div>
+
+<script src="https://unpkg.com/tabulator-tables@5.5.0/dist/js/tabulator.min.js"></script>
+<script>
+  // ---- Feature search filter over the action tiles ----
+  function filterFeatures(qv) {
+    qv = (qv || '').trim().toLowerCase();
+    var any = false;
+    document.querySelectorAll('.fhub-group').forEach(function (group) {
+      var visible = 0;
+      group.querySelectorAll('.fhub-tile').forEach(function (tile) {
+        var show = !qv || (tile.dataset.kw || '').indexOf(qv) >= 0;
+        tile.style.display = show ? '' : 'none';
+        if (show) { visible++; any = true; }
       });
-      document.getElementById('featureEmpty').style.display = any ? 'none' : '';
-      document.getElementById('fq').textContent = q;
+      group.style.display = visible ? '' : 'none';
+    });
+    document.getElementById('featureEmpty').classList.toggle('hidden', any);
+    document.getElementById('fq').textContent = qv;
+  }
+
+  // ---- Account usage (Mohit) ----
+  (function(){
+    var sessionRange = document.getElementById('sessionRange');
+    var tbody = document.querySelector('#sessionUsageTable tbody');
+    var empty = document.getElementById('sessionUsageEmpty');
+    var refreshBtn = document.getElementById('refreshSessionUsage');
+    if (!sessionRange || !tbody) return;
+    function fmtDur(s){ if(s==null) return '—'; s=Math.max(0,Math.round(s)); var h=Math.floor(s/3600),m=Math.floor((s%3600)/60); if(h===0&&m===0) return Math.max(1,Math.ceil(s/60))+'m'; if(h===0) return m+'m'; return h+'h '+String(m).padStart(2,'0')+'m'; }
+    function fmtDate(v){ return v? new Date(v).toLocaleDateString('en-IN',{timeZone:'Asia/Kolkata'}) : '—'; }
+    function fmtDT(v){ return v? new Date(v).toLocaleString('en-IN',{timeZone:'Asia/Kolkata',hour12:true}) : '—'; }
+    function td(text){ var c=document.createElement('td'); c.className='py-2 pr-3'; c.textContent=text; return c; }
+    async function load(){
+      empty.classList.add('d-none'); tbody.innerHTML='<tr><td colspan="5" class="py-4 text-center text-on-surface-variant">Loading usage…</td></tr>';
+      try {
+        var r = await fetch('/operator/dashboard/api/session-usage?days=' + sessionRange.value);
+        var payload = await r.json();
+        var rows = Array.isArray(payload && payload.data) ? payload.data : [];
+        tbody.innerHTML='';
+        if (!rows.length) { empty.classList.remove('d-none'); return; }
+        rows.forEach(function(row){
+          var tr=document.createElement('tr');
+          tr.appendChild(td(fmtDate(row.loginDate)));
+          var u=document.createElement('td'); u.className='py-2 pr-3 font-semibold'; u.textContent=row.username; tr.appendChild(u);
+          tr.appendChild(td(row.sessionCount));
+          tr.appendChild(td(fmtDur(row.totalSeconds)));
+          tr.appendChild(td(fmtDT(row.lastActivityAt)));
+          tbody.appendChild(tr);
+        });
+      } catch(e){ tbody.innerHTML='<tr><td colspan="5" class="py-4 text-center text-error">Unable to load account usage right now.</td></tr>'; }
     }
-  </script>
-</body>
-</html>
+    load();
+    sessionRange.addEventListener('change', load);
+    if (refreshBtn) refreshBtn.addEventListener('click', load);
+  })();
+
+  // ---- Pendency Tabulator ----
+  (function(){
+    var el = document.getElementById('pendencyTable');
+    if (!el || typeof Tabulator === 'undefined') return;
+    var table = new Tabulator("#pendencyTable", {
+      layout: "fitColumns", pagination: "local", paginationSize: 50,
+      ajaxURL: "/operator/dashboard/api/pendency?dept=all",
+      placeholder: "No pendency data available",
+      columns: [
+        { title: "Lot No", field: "lot_no", width: 150, formatter: function(cell){
+            var lotNo = cell.getValue(); var a=document.createElement('a');
+            a.href='#'; a.style.cssText='color:#2563eb;font-weight:600;text-decoration:none;'; a.textContent=lotNo;
+            a.onclick=function(e){ e.preventDefault(); showLotDetails(lotNo); }; return a; } },
+        { title: "Manual Lot No", field: "manual_lot_number", width: 150, formatter: function(c){ return c.getValue() || '—'; } },
+        { title: "Username", field: "username", width: 150 },
+        { title: "Assigned", field: "assigned", width: 120 },
+        { title: "Completed", field: "completed", width: 120 },
+        { title: "Pending", field: "pending", width: 120, formatter: function(cell){
+            var val=cell.getValue(); var s=document.createElement('span'); s.className='badge-kotty';
+            s.classList.add(val>100?'badge-danger':(val>50?'badge-warning':'badge-success')); s.textContent=val; return s; } }
+      ]
+    });
+    var deptFilter = document.getElementById('deptFilter');
+    if (deptFilter) deptFilter.addEventListener('change', function(e){ table.setData('/operator/dashboard/api/pendency?dept=' + e.target.value); });
+  })();
+
+  // ---- Lot details modal (Tailwind overlay) ----
+  var lotModal = document.getElementById('lotModal');
+  function closeLotModal(){ lotModal.classList.remove('open'); }
+  window.closeLotModal = closeLotModal;
+  lotModal.addEventListener('click', function(e){ if (e.target === lotModal) closeLotModal(); });
+  function showLotDetails(lotNo){
+    var body = document.getElementById('lotModalBody');
+    body.innerHTML = '<div class="py-6 text-center text-on-surface-variant">Loading…</div>';
+    lotModal.classList.add('open');
+    fetch('/operator/dashboard/api/lot?lotNo=' + encodeURIComponent(lotNo))
+      .then(function(r){ return r.json(); })
+      .then(function(data){
+        if (data.error){ body.innerHTML = '<div class="text-error">'+data.error+'</div>'; return; }
+        function row(k,v){ return '<div class="flex justify-between gap-4 py-1.5 border-b border-outline-variant/60"><span class="text-on-surface-variant">'+k+'</span><span class="font-semibold text-right">'+(v||'N/A')+'</span></div>'; }
+        body.innerHTML =
+          row('Lot No', data.lot_no) + row('SKU', data.sku) +
+          row('Total Pieces', data.total_pieces) + row('Type', data.lot_type) +
+          row('Status', '<span class="badge-kotty badge-info">'+(data.status||'N/A')+'</span>') +
+          row('Created', data.created_at ? new Date(data.created_at).toLocaleDateString() : 'N/A') +
+          row('Department', data.current_department);
+      })
+      .catch(function(){ body.innerHTML = '<div class="text-error">Error loading lot details</div>'; });
+  }
+  window.showLotDetails = showLotDetails;
+</script>
+<%- include('partials/floorNav', { navActive: 'home' }) %>

--- a/views/partials/floorHead.ejs
+++ b/views/partials/floorHead.ejs
@@ -1,0 +1,97 @@
+<%
+  /* Shared Stitch shell — opens the document + renders the TopAppBar.
+     Design system lifted verbatim from docs/stitch/*.html (Kotty Floor — Operator).
+     Params (all optional):
+       pageTitle  — <title> text
+       topTitle   — app-bar wordmark/title (default "KOTTY FLOOR")
+       topIcon    — leading Material Symbol (default "factory")
+       back       — url; if set, shows a back arrow instead of topIcon
+       topTag     — small chip after the title (e.g. "Lot Admin")
+       topEyebrow / topSub — right-side stacked labels (e.g. "Shift Operator" / "Hi, Admin")
+       user       — session user (for the avatar initial)
+     Pages render their own <main>… then include partials/floorNav to close. */
+  var _title   = (typeof pageTitle !== 'undefined' && pageTitle) ? pageTitle : 'Kotty Floor';
+  var _topT    = (typeof topTitle  !== 'undefined' && topTitle)  ? topTitle  : 'KOTTY FLOOR';
+  var _topIcon = (typeof topIcon   !== 'undefined' && topIcon)   ? topIcon   : 'factory';
+  var _back    = (typeof back      !== 'undefined') ? back : '';
+  var _tag     = (typeof topTag    !== 'undefined') ? topTag : '';
+  var _eyebrow = (typeof topEyebrow!== 'undefined') ? topEyebrow : '';
+  var _sub     = (typeof topSub    !== 'undefined') ? topSub : '';
+  var _initial = (typeof user !== 'undefined' && user && user.username) ? user.username.charAt(0).toUpperCase() : 'U';
+%><!DOCTYPE html>
+<html class="light" lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" name="viewport"/>
+<title><%= _title %></title>
+<script src="https://cdn.tailwindcss.com?plugins=forms,container-queries"></script>
+<link href="https://fonts.googleapis.com" rel="preconnect"/>
+<link crossorigin="" href="https://fonts.gstatic.com" rel="preconnect"/>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;700;900&display=swap" rel="stylesheet"/>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<script id="tailwind-config">
+  tailwind.config = {
+    darkMode: "class",
+    theme: {
+      extend: {
+        colors: {
+          'surface': '#f7f8fa',
+          'surface-container-lowest': '#ffffff',
+          'on-surface': '#0f172a',
+          'on-surface-variant': '#64748b',
+          'outline-variant': '#e5e7eb',
+          'primary': '#2563eb',
+          'on-primary': '#ffffff',
+          'primary-container': '#eff6ff',
+          'secondary': '#16a34a',
+          'secondary-container': '#dcfce7',
+          'tertiary': '#b45309',
+          'tertiary-container': '#fef3c7',
+          'error': '#dc2626',
+          'error-container': '#fee2e2',
+        },
+        borderRadius: { "DEFAULT": "0.5rem", "lg": "1rem", "xl": "1.5rem", "full": "9999px" },
+        fontFamily: {
+          "headline": ["Space Grotesk", "sans-serif"],
+          "display": ["Space Grotesk", "sans-serif"],
+          "body": ["Inter", "sans-serif"],
+          "label": ["Inter", "sans-serif"]
+        }
+      },
+    },
+  }
+</script>
+<style>
+  body { font-family: 'Inter', sans-serif; background-color: #f7f8fa; -webkit-tap-highlight-color: transparent; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 24; vertical-align: middle; }
+  .font-headline { font-family: 'Space Grotesk', sans-serif; }
+  .font-label { font-family: 'Inter', sans-serif; }
+  .action-card:active { transform: scale(0.96); transition: transform 0.1s ease-out; }
+  .no-scrollbar::-webkit-scrollbar { display: none; }
+  .no-scrollbar { -ms-overflow-style: none; scrollbar-width: none; }
+  .pb-safe { padding-bottom: env(safe-area-inset-bottom); }
+</style>
+</head>
+<body class="bg-surface text-on-surface antialiased pb-24">
+<header class="fixed top-0 w-full z-50 bg-surface border-b border-outline-variant flex items-center justify-between px-4 py-3 h-16">
+  <div class="flex items-center gap-2 min-w-0">
+    <% if (_back) { %>
+      <a href="<%= _back %>" class="material-symbols-outlined text-on-surface-variant -ml-1" data-icon="arrow_back">arrow_back</a>
+    <% } else { %>
+      <span class="material-symbols-outlined text-primary" data-icon="<%= _topIcon %>"><%= _topIcon %></span>
+    <% } %>
+    <h1 class="font-headline font-black text-xl tracking-tighter text-on-surface truncate"><%= _topT %></h1>
+    <% if (_tag) { %>
+      <span class="ml-1 shrink-0 text-[10px] uppercase font-bold tracking-wider bg-primary-container text-primary px-2 py-0.5 rounded-full"><%= _tag %></span>
+    <% } %>
+  </div>
+  <div class="flex items-center gap-3 shrink-0">
+    <% if (_eyebrow || _sub) { %>
+      <div class="text-right hidden sm:block">
+        <% if (_eyebrow) { %><p class="text-[10px] uppercase tracking-widest text-on-surface-variant font-medium"><%= _eyebrow %></p><% } %>
+        <% if (_sub) { %><p class="text-sm font-semibold"><%= _sub %></p><% } %>
+      </div>
+    <% } %>
+    <div class="w-10 h-10 rounded-full bg-primary-container flex items-center justify-center border border-primary/10 font-headline font-bold text-primary"><%= _initial %></div>
+  </div>
+</header>

--- a/views/partials/floorNav.ejs
+++ b/views/partials/floorNav.ejs
@@ -1,0 +1,20 @@
+<%
+  /* Shared Stitch BottomNav + document close. Include at the end of every floor page,
+     AFTER the page's own <main> and <script> blocks.
+     Param: navActive — one of 'home' | 'search' | 'journey' (highlights the tab). */
+  var _active = (typeof navActive !== 'undefined') ? navActive : '';
+  var _items = [
+    ['home',    'Home',    '/operator/hub',          'home'],
+    ['search',  'Search',  '/search-dashboard',      'search'],
+    ['journey', 'Journey', '/operator/lot-journey',  'route'],
+  ];
+%>
+<nav class="fixed bottom-0 left-0 w-full z-50 h-16 bg-surface border-t border-outline-variant flex justify-around items-center px-4 pb-safe">
+  <% _items.forEach(function(it){ var on = (_active === it[0]); %>
+    <a href="<%= it[2] %>" class="flex flex-col items-center justify-center transition-opacity active:opacity-80 <%= on ? 'text-primary bg-primary-container rounded-xl px-4 py-1.5' : 'text-on-surface-variant hover:text-primary' %>">
+      <span class="material-symbols-outlined text-2xl" data-icon="<%= it[3] %>"<% if (on) { %> style="font-variation-settings: 'FILL' 1;"<% } %>><%= it[3] %></span>
+      <span class="font-label text-[10px] uppercase tracking-wider mt-0.5 <%= on ? 'font-bold' : 'font-medium' %>"><%= it[1] %></span>
+    </a>
+  <% }) %>
+</nav>
+</body></html>


### PR DESCRIPTION
Restarts the floor redesign on the **actual Stitch HTML** (not my hand-rendition), per the agreed plan. This is the foundation + the first fully-rebuilt screen.

## Foundation
- **`docs/stitch/*.html`** — the 6 real Stitch exports downloaded from the project, kept as source-of-truth.
- **`partials/floorHead.ejs`** — the exact Stitch `<head>` (Tailwind config + Space Grotesk/Inter + Material Symbols) + the Stitch **TopAppBar**, lifted verbatim and parameterised.
- **`partials/floorNav.ejs`** — the Stitch **BottomNav** + document close.
These are standalone-page chrome — the old `header`/`navbar` (with its colliding CSS + fake notifications) is gone from floor pages.

## Operator hub — rebuilt + Stitch-omission audit
Built on the Stitch Hub screen. **Audited against `operatorDashboard.ejs`; the Stitch mockup omitted everything below, so I added it all back** (nothing dropped this time):

| Stitch mockup had | Restored from the real dashboard |
|---|---|
| 3 fake stats | **4 real KPIs** (Total Kits / Cut Pieces / Finished / Users) |
| 8 sample tiles | **all ~34 tiles**, grouped, incl. the 8 the old hub lost (Rejected Lots, Payments, Debits, Stitching TAT, PO Mgmt, Returns, SKU Categories, Account Usage) |
| — | **Mohit-only gating** (Mail Manager, User Roles, Account Usage) |
| — | **SKU Insights** (Top/Bottom-10 + date filter) |
| — | **Pendency** (Tabulator + dept filter) |
| — | **Account Usage** panel (Mohit) |
| — | **Material Indent** workflow (self-contained partial) |
| — | **Lot-detail modal** — re-implemented as a Tailwind overlay (dropped the Bootstrap dependency) |
| a hero image | live **feature-search** that filters the tiles |

Desktop-responsive (2→3→4-up). Route `/operator/hub` now supplies the same data as `/operator/dashboard`.

## Notes
- Additive: the classic `/operator/dashboard` is untouched; this lives at `/operator/hub`.
- I can't see a browser — **please open `/operator/hub` on phone + desktop** and confirm it looks right and every panel loads.
- Next PRs (same design): the 5 stage event screens (stitching full rebuild, payment-tested), the 6 role dashboards, then Tiers B–D.

🤖 Generated with [Claude Code](https://claude.com/claude-code)