### PR TITLE
feat(floor): stage event screens onto the Stitch shell

### DIFF
--- a/views/finishingEvents.ejs
+++ b/views/finishingEvents.ejs
@@ -1,5 +1,12 @@
-<%- include('partials/header', { pageTitle: 'Finishing' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/finishingdashboard' }) %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<title>Finishing</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+</head>
+<body>
 
 <style>
   /* ───────────────────────────────────────────────────────────────
@@ -58,9 +65,40 @@
   .sx-page {
     max-width: 960px;
     margin: 0 auto;
-    padding: calc(var(--navbar-height, 60px) + 1.5rem) 1rem 5rem;
+    padding: calc(64px + 1.25rem) 1rem 6rem;
     min-height: 100vh;
   }
+
+  /* ── Stitch shell chrome (matches the Kotty Floor hub) ───────────── */
+  .flx-top {
+    position: fixed; top: 0; left: 0; right: 0; height: 64px; z-index: 50;
+    background: #f7f8fa; border-bottom: 1px solid #e5e7eb;
+    display: flex; align-items: center; justify-content: space-between; padding: 0 16px;
+  }
+  .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+  .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+  .flx-top .brand h1 {
+    font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0;
+  }
+  .flx-top .u {
+    width: 40px; height: 40px; border-radius: 999px; background: #eff6ff; color: #2563eb;
+    display: grid; place-items: center; font-family: 'Space Grotesk', sans-serif; font-weight: 700;
+    text-decoration: none; border: 1px solid rgba(37,99,235,0.1);
+  }
+  .flx-nav {
+    position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 50;
+    background: #ffffff; border-top: 1px solid #e5e7eb;
+    display: flex; justify-content: space-around; align-items: center;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .flx-nav a {
+    display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none;
+    color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flx-nav a.active { color: #2563eb; }
+  .flx-nav a .material-symbols-outlined { font-size: 24px; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
 
   /* ─── Page header ──────────────────────────────────────── */
   .sx-head {
@@ -960,6 +998,14 @@
     font-family: 'Space Grotesk','Inter',sans-serif; letter-spacing: -0.01em;
   }
 </style>
+
+<header class="flx-top">
+  <div class="brand">
+    <span class="material-symbols-outlined">done_all</span>
+    <h1>Finishing</h1>
+  </div>
+  <a class="u" href="/operator/hub" title="Home"><%= (user && user.username) ? user.username.charAt(0).toUpperCase() : 'U' %></a>
+</header>
 
 <main class="sx sx-page">
 
@@ -2091,4 +2137,10 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape' && el('modalO
 loadHistory();
 </script>
 
-<%- include('partials/footer') %>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
+</body>
+</html>

--- a/views/jeansAssemblyEvents.ejs
+++ b/views/jeansAssemblyEvents.ejs
@@ -1,5 +1,12 @@
-<%- include('partials/header', { pageTitle: 'Jeans Assembly' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/jeansassemblydashboard' }) %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<title>Jeans Assembly</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+</head>
+<body>
 
 <style>
   /* ───────────────────────────────────────────────────────────────
@@ -58,9 +65,40 @@
   .sx-page {
     max-width: 960px;
     margin: 0 auto;
-    padding: calc(var(--navbar-height, 60px) + 1.5rem) 1rem 5rem;
+    padding: calc(64px + 1.25rem) 1rem 6rem;
     min-height: 100vh;
   }
+
+  /* ── Stitch shell chrome (matches the Kotty Floor hub) ───────────── */
+  .flx-top {
+    position: fixed; top: 0; left: 0; right: 0; height: 64px; z-index: 50;
+    background: #f7f8fa; border-bottom: 1px solid #e5e7eb;
+    display: flex; align-items: center; justify-content: space-between; padding: 0 16px;
+  }
+  .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+  .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+  .flx-top .brand h1 {
+    font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0;
+  }
+  .flx-top .u {
+    width: 40px; height: 40px; border-radius: 999px; background: #eff6ff; color: #2563eb;
+    display: grid; place-items: center; font-family: 'Space Grotesk', sans-serif; font-weight: 700;
+    text-decoration: none; border: 1px solid rgba(37,99,235,0.1);
+  }
+  .flx-nav {
+    position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 50;
+    background: #ffffff; border-top: 1px solid #e5e7eb;
+    display: flex; justify-content: space-around; align-items: center;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .flx-nav a {
+    display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none;
+    color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flx-nav a.active { color: #2563eb; }
+  .flx-nav a .material-symbols-outlined { font-size: 24px; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
 
   /* ─── Page header ──────────────────────────────────────── */
   .sx-head {
@@ -960,6 +998,14 @@
     font-family: 'Space Grotesk','Inter',sans-serif; letter-spacing: -0.01em;
   }
 </style>
+
+<header class="flx-top">
+  <div class="brand">
+    <span class="material-symbols-outlined">layers</span>
+    <h1>Jeans Assembly</h1>
+  </div>
+  <a class="u" href="/operator/hub" title="Home"><%= (user && user.username) ? user.username.charAt(0).toUpperCase() : 'U' %></a>
+</header>
 
 <main class="sx sx-page">
 
@@ -2083,4 +2129,10 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape' && el('modalO
 loadHistory();
 </script>
 
-<%- include('partials/footer') %>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
+</body>
+</html>

--- a/views/stitchingEvents.ejs
+++ b/views/stitchingEvents.ejs
@@ -1,5 +1,12 @@
-<%- include('partials/header', { pageTitle: 'Stitching' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/stitchingdashboard' }) %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<title>Stitching</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+</head>
+<body>
 
 <style>
   /* ───────────────────────────────────────────────────────────────
@@ -58,9 +65,40 @@
   .sx-page {
     max-width: 960px;
     margin: 0 auto;
-    padding: calc(var(--navbar-height, 60px) + 1.5rem) 1rem 5rem;
+    padding: calc(64px + 1.25rem) 1rem 6rem;
     min-height: 100vh;
   }
+
+  /* ── Stitch shell chrome (matches the Kotty Floor hub) ───────────── */
+  .flx-top {
+    position: fixed; top: 0; left: 0; right: 0; height: 64px; z-index: 50;
+    background: #f7f8fa; border-bottom: 1px solid #e5e7eb;
+    display: flex; align-items: center; justify-content: space-between; padding: 0 16px;
+  }
+  .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+  .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+  .flx-top .brand h1 {
+    font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0;
+  }
+  .flx-top .u {
+    width: 40px; height: 40px; border-radius: 999px; background: #eff6ff; color: #2563eb;
+    display: grid; place-items: center; font-family: 'Space Grotesk', sans-serif; font-weight: 700;
+    text-decoration: none; border: 1px solid rgba(37,99,235,0.1);
+  }
+  .flx-nav {
+    position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 50;
+    background: #ffffff; border-top: 1px solid #e5e7eb;
+    display: flex; justify-content: space-around; align-items: center;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .flx-nav a {
+    display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none;
+    color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flx-nav a.active { color: #2563eb; }
+  .flx-nav a .material-symbols-outlined { font-size: 24px; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
 
   /* ─── Page header ──────────────────────────────────────── */
   .sx-head {
@@ -960,6 +998,14 @@
     font-family: 'Space Grotesk','Inter',sans-serif; letter-spacing: -0.01em;
   }
 </style>
+
+<header class="flx-top">
+  <div class="brand">
+    <span class="material-symbols-outlined">precision_manufacturing</span>
+    <h1>Stitching</h1>
+  </div>
+  <a class="u" href="/operator/hub" title="Home"><%= (user && user.username) ? user.username.charAt(0).toUpperCase() : 'U' %></a>
+</header>
 
 <main class="sx sx-page">
 
@@ -2092,4 +2138,10 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape' && el('modalO
 loadHistory();
 </script>
 
-<%- include('partials/footer') %>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
+</body>
+</html>

--- a/views/washingEvents.ejs
+++ b/views/washingEvents.ejs
@@ -1,5 +1,12 @@
-<%- include('partials/header', { pageTitle: 'Washing' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/washingdashboard' }) %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<title>Washing</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+</head>
+<body>
 
 <style>
   /* ───────────────────────────────────────────────────────────────
@@ -58,9 +65,40 @@
   .sx-page {
     max-width: 960px;
     margin: 0 auto;
-    padding: calc(var(--navbar-height, 60px) + 1.5rem) 1rem 5rem;
+    padding: calc(64px + 1.25rem) 1rem 6rem;
     min-height: 100vh;
   }
+
+  /* ── Stitch shell chrome (matches the Kotty Floor hub) ───────────── */
+  .flx-top {
+    position: fixed; top: 0; left: 0; right: 0; height: 64px; z-index: 50;
+    background: #f7f8fa; border-bottom: 1px solid #e5e7eb;
+    display: flex; align-items: center; justify-content: space-between; padding: 0 16px;
+  }
+  .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+  .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+  .flx-top .brand h1 {
+    font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0;
+  }
+  .flx-top .u {
+    width: 40px; height: 40px; border-radius: 999px; background: #eff6ff; color: #2563eb;
+    display: grid; place-items: center; font-family: 'Space Grotesk', sans-serif; font-weight: 700;
+    text-decoration: none; border: 1px solid rgba(37,99,235,0.1);
+  }
+  .flx-nav {
+    position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 50;
+    background: #ffffff; border-top: 1px solid #e5e7eb;
+    display: flex; justify-content: space-around; align-items: center;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .flx-nav a {
+    display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none;
+    color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flx-nav a.active { color: #2563eb; }
+  .flx-nav a .material-symbols-outlined { font-size: 24px; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
 
   /* ─── Page header ──────────────────────────────────────── */
   .sx-head {
@@ -960,6 +998,14 @@
     font-family: 'Space Grotesk','Inter',sans-serif; letter-spacing: -0.01em;
   }
 </style>
+
+<header class="flx-top">
+  <div class="brand">
+    <span class="material-symbols-outlined">local_laundry_service</span>
+    <h1>Washing</h1>
+  </div>
+  <a class="u" href="/operator/hub" title="Home"><%= (user && user.username) ? user.username.charAt(0).toUpperCase() : 'U' %></a>
+</header>
 
 <main class="sx sx-page">
 
@@ -2083,4 +2129,10 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape' && el('modalO
 loadHistory();
 </script>
 
-<%- include('partials/footer') %>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
+</body>
+</html>

--- a/views/washingInEvents.ejs
+++ b/views/washingInEvents.ejs
@@ -1,5 +1,12 @@
-<%- include('partials/header', { pageTitle: 'Washing In' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/washingin' }) %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<title>Washing In</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+</head>
+<body>
 
 <style>
   /* ───────────────────────────────────────────────────────────────
@@ -58,9 +65,40 @@
   .sx-page {
     max-width: 960px;
     margin: 0 auto;
-    padding: calc(var(--navbar-height, 60px) + 1.5rem) 1rem 5rem;
+    padding: calc(64px + 1.25rem) 1rem 6rem;
     min-height: 100vh;
   }
+
+  /* ── Stitch shell chrome (matches the Kotty Floor hub) ───────────── */
+  .flx-top {
+    position: fixed; top: 0; left: 0; right: 0; height: 64px; z-index: 50;
+    background: #f7f8fa; border-bottom: 1px solid #e5e7eb;
+    display: flex; align-items: center; justify-content: space-between; padding: 0 16px;
+  }
+  .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+  .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+  .flx-top .brand h1 {
+    font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0;
+  }
+  .flx-top .u {
+    width: 40px; height: 40px; border-radius: 999px; background: #eff6ff; color: #2563eb;
+    display: grid; place-items: center; font-family: 'Space Grotesk', sans-serif; font-weight: 700;
+    text-decoration: none; border: 1px solid rgba(37,99,235,0.1);
+  }
+  .flx-nav {
+    position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 50;
+    background: #ffffff; border-top: 1px solid #e5e7eb;
+    display: flex; justify-content: space-around; align-items: center;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .flx-nav a {
+    display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none;
+    color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flx-nav a.active { color: #2563eb; }
+  .flx-nav a .material-symbols-outlined { font-size: 24px; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
 
   /* ─── Page header ──────────────────────────────────────── */
   .sx-head {
@@ -960,6 +998,14 @@
     font-family: 'Space Grotesk','Inter',sans-serif; letter-spacing: -0.01em;
   }
 </style>
+
+<header class="flx-top">
+  <div class="brand">
+    <span class="material-symbols-outlined">water_drop</span>
+    <h1>Washing In</h1>
+  </div>
+  <a class="u" href="/operator/hub" title="Home"><%= (user && user.username) ? user.username.charAt(0).toUpperCase() : 'U' %></a>
+</header>
 
 <main class="sx sx-page">
 
@@ -2083,4 +2129,10 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape' && el('modalO
 loadHistory();
 </script>
 
-<%- include('partials/footer') %>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
+</body>
+</html>


### PR DESCRIPTION
This is the answer to "why didn't stitching change" — the 5 stage operator screens now wear the **Kotty Floor Stitch chrome** and read as one system with `/operator/hub`.

## What changed
Stitching · Jeans-Assembly · Washing · Washing-In · Finishing are now **standalone pages** with the Stitch **TopAppBar** (stage name + icon) and **BottomNav** (Home / Search / Journey), replacing the old shared header/navbar/footer (the colliding-CSS, fake-notifications chrome). Their `.sx` body already matches the Stitch tokens (indigo `#2563eb`, Space Grotesk numbers) from the earlier alignment, so the whole screen now looks like the hub.

## Why this is safe (payment-critical screens)
These screens are **fully self-contained** — zero bootstrap/jQuery, their own scoped `.sx` styles + vanilla JS — so removing the shared chrome breaks nothing. **Verified across all 5:** the take-in / complete / reject / dispatch engine and every endpoint (`/event/approve`, `/event/complete`, `/event/history`, `/event/payments`, `/event/dispatch`) are **byte-identical** — the diff never touches payment logic (each file is 56 insertions / 4 deletions, all in `<head>`, the page padding, one TopAppBar, and the BottomNav).

## Please smoke-test before merge
Even though the logic is untouched, these are now standalone pages — so on a phone please open **`/stitchingdashboard`**, search a lot, and confirm: search → take-in (with a reject/rewash) → mark complete works, the tabs (My Work / Payments / Indent) load, and the stat strip / stage rail render. If that's good, the other four are identical.

## Note on scope
This is a faithful **re-chrome** that keeps the proven engine — not a from-scratch markup rewrite of the per-size panel. It gets the Stitch look on all 5 stage screens now, with zero payment risk. If you later want the inner take-in panel rebuilt to Stitch's exact markup, that's a follow-up I'd do with a live payment test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)