### PR TITLE
fix: search-dashboard 500 + lot-journey ?q= auto-search

### DIFF
--- a/routes/searchRoutes.js
+++ b/routes/searchRoutes.js
@@ -219,6 +219,7 @@ router.route('/search-dashboard')
 
       // Render with empty results
       res.render('searchDashboard', {
+        user: req.session.user,
         allTables,
         selectedTable,
         columnList,
@@ -246,6 +247,7 @@ router.route('/search-dashboard')
       // Validate table
       if (!selectedTable || !allTables.includes(selectedTable)) {
         return res.render('searchDashboard', {
+          user: req.session.user,
           allTables,
           selectedTable: '',
           columnList: [],
@@ -268,6 +270,7 @@ router.route('/search-dashboard')
           DEFAULT_LIMIT
         );
         return res.render('searchDashboard', {
+          user: req.session.user,
           allTables,
           selectedTable,
           columnList,

--- a/views/lotJourney.ejs
+++ b/views/lotJourney.ejs
@@ -70,6 +70,8 @@ async function go(){
   const picker = document.getElementById('picker');
   out.innerHTML=''; picker.innerHTML='';
   if(!q){ return; }
+  // Keep the URL in sync so the search survives refresh / can be shared.
+  try{ history.replaceState(null,'','/operator/lot-journey?q='+encodeURIComponent(q)); }catch(_e){}
   status.style.display='block'; status.textContent='Searching…';
   try{
     const r = await fetch('/operator/lot-journey/data?q='+encodeURIComponent(q));
@@ -78,14 +80,21 @@ async function go(){
     if(!data.journey){ status.textContent='No lot found for "'+q+'".'; return; }
     status.style.display='none';
     if(data.matches.length>1){
+      lastMatches = data.matches;
       picker.innerHTML = '<div class="muted small mb-1">'+data.matches.length+' lots matched — showing the first. Pick another:</div>'+
-        data.matches.map(m=>'<button class="btn btn-sm btn-outline-secondary me-1 mb-1" onclick="pick(\''+esc(m.lot_no)+'\')">'+
+        data.matches.map((m,idx)=>'<button class="btn btn-sm btn-outline-secondary me-1 mb-1" onclick="pick('+idx+')">'+
           esc(m.lot_no)+(m.manual_lot_number?(' / '+esc(m.manual_lot_number)):'')+' · '+esc(m.sku)+'</button>').join('');
     }
     out.innerHTML = render(data.journey);
   }catch(e){ status.textContent='Error: '+e.message; }
 }
-function pick(lotNo){ document.getElementById('q').value=lotNo; go(); }
+let lastMatches = [];
+function pick(idx){
+  const m = lastMatches[idx];
+  if(!m) return;
+  document.getElementById('q').value = m.lot_no;
+  go();
+}
 
 function render(j){
   const L=j.lot;
@@ -133,6 +142,15 @@ function render(j){
 }
 
 document.getElementById('q').addEventListener('keydown',e=>{ if(e.key==='Enter') go(); });
+
+// Arriving with ?q=... (e.g. from another screen's nav): prefill the box and run the search.
+(function(){
+  const initialQ = new URLSearchParams(location.search).get('q');
+  if(initialQ && initialQ.trim()){
+    document.getElementById('q').value = initialQ.trim();
+    go();
+  }
+})();
 </script>
 </body>
 </html>

--- a/views/searchDashboard.ejs
+++ b/views/searchDashboard.ejs
@@ -1,5 +1,5 @@
 <%- include('partials/header', { pageTitle: 'Search' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/search-dashboard' }) %>
+<%- include('partials/navbar', { user: locals.user, dashboardUrl: '/search-dashboard' }) %>
 
 <style>
   /* Tag styling for bulk search */


### PR DESCRIPTION
The two backend bugs you flagged — both diagnosed to root cause and fixed surgically (+24/−3 across 3 files). These matter extra now because the stage screens' bottom nav links to both pages.

## 1. `/search-dashboard` → 500
**Root cause:** the redesigned `searchDashboard.ejs` passes `user` to the navbar partial, but `routes/searchRoutes.js` never supplied a `user` local → `ReferenceError: user is not defined` at render → 500. Reproduced exactly before the fix.
**Fix:** route now passes `req.session.user` on all three renders; the view also reads `locals.user` defensively so a missing local can never 500 again.

## 2. Lot Journey search
**Root cause:** the backend was fine — the page just ignored the incoming `?q=` param, so arriving from any other screen landed on an empty box. Bonus bug: lot numbers containing an apostrophe broke the multi-match picker (inline `onclick` interpolation).
**Fix:** on load, `?q=` prefills the input and auto-runs the search; the query mirrors into the URL (`history.replaceState`) so refresh/share works; picker now selects by index — no string interpolation.

## Verification
- Renders verified with and without `user` (the pre-fix repro fails at line 2, post-fix passes).
- Both route files parse; `test/lotJourney.test.js` passes.
- No payment logic or other screens touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)