### PR TITLE
feat(floor): align all 8 assign/hand-off screens to the Kotty Floor design

### DIFF
--- a/views/StitchingAssignFinishing.ejs
+++ b/views/StitchingAssignFinishing.ejs
@@ -415,4 +415,82 @@
   })();
 </script>
 
+<!-- ── Kotty Floor alignment (docs/FLOOR_REDESIGN_HANDOFF.md) — token overrides only.
+     Retunes the kotty-theme palette to the floor design system: ground #f7f8fa, ink #0f172a,
+     muted #64748b, hairline #e5e7eb, single blue accent #2563eb; Space Grotesk numbers/headings
+     + Inter body. Styling/chrome only — zero logic changes. ── -->
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+  :root {
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --border-light: #e5e7eb;
+    --border-medium: #d7dbe2;
+    --border-dark: #94a3b8;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: #eff6ff;
+    --cream: #f7f8fa;
+    --cream-dark: #f1f5f9;
+    --cream-darker: #e5e7eb;
+    --gray-50: #f8fafc;
+    --gray-100: #f1f5f9;
+    --gray-200: #e2e8f0;
+    --gray-300: #cbd5e1;
+    --gray-400: #94a3b8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.04);
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 12px;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body {
+    background: var(--bg-page);
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Numbers & headings are the hero — Space Grotesk */
+  .page-title {
+    font-family: 'Space Grotesk', var(--font-body);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  /* Bootstrap chrome onto the floor tokens (white cards, hairline, quiet) */
+  .btn-primary { background: #2563eb; border-color: #2563eb; }
+  .btn-primary:hover, .btn-primary:focus { background: #1d4ed8; border-color: #1d4ed8; }
+  .btn-secondary { background: #ffffff; border: 1px solid #e5e7eb; color: #0f172a; }
+  .btn-secondary:hover, .btn-secondary:focus { background: #f8fafc; border-color: #d7dbe2; color: #0f172a; }
+  .card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .card .card-header, .card .card-footer { background: #ffffff; border-color: #e5e7eb; }
+  .form-control:focus, .form-select:focus { border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+  .alert-success { background: #f0fdf4; color: #16a34a; border-color: #bbf7d0; }
+  .alert-danger { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+  .alert-warning { background: #fffbeb; color: #b45309; border-color: #fde68a; }
+  .alert-info { background: #eff6ff; color: #2563eb; border-color: #bfdbfe; }
+
+  /* page: hero numbers, soft ID pill */
+  .pieces-count { font-family: 'Space Grotesk', var(--font-body); font-weight: 600; }
+  .badge-neutral { background: #f1f5f9; color: #475569; border-radius: 999px; }
+</style>
+
 <%- include('partials/footer') %>

--- a/views/StitchingAssignJeansAssembly.ejs
+++ b/views/StitchingAssignJeansAssembly.ejs
@@ -725,4 +725,83 @@
   })();
 </script>
 
+<!-- ── Kotty Floor alignment (docs/FLOOR_REDESIGN_HANDOFF.md) — token overrides only.
+     Retunes the kotty-theme palette to the floor design system: ground #f7f8fa, ink #0f172a,
+     muted #64748b, hairline #e5e7eb, single blue accent #2563eb; Space Grotesk numbers/headings
+     + Inter body. Styling/chrome only — zero logic changes. ── -->
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+  :root {
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --border-light: #e5e7eb;
+    --border-medium: #d7dbe2;
+    --border-dark: #94a3b8;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: #eff6ff;
+    --cream: #f7f8fa;
+    --cream-dark: #f1f5f9;
+    --cream-darker: #e5e7eb;
+    --gray-50: #f8fafc;
+    --gray-100: #f1f5f9;
+    --gray-200: #e2e8f0;
+    --gray-300: #cbd5e1;
+    --gray-400: #94a3b8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.04);
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 12px;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body {
+    background: var(--bg-page);
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Numbers & headings are the hero — Space Grotesk */
+  .page-title {
+    font-family: 'Space Grotesk', var(--font-body);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  /* Bootstrap chrome onto the floor tokens (white cards, hairline, quiet) */
+  .btn-primary { background: #2563eb; border-color: #2563eb; }
+  .btn-primary:hover, .btn-primary:focus { background: #1d4ed8; border-color: #1d4ed8; }
+  .btn-secondary { background: #ffffff; border: 1px solid #e5e7eb; color: #0f172a; }
+  .btn-secondary:hover, .btn-secondary:focus { background: #f8fafc; border-color: #d7dbe2; color: #0f172a; }
+  .card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .card .card-header, .card .card-footer { background: #ffffff; border-color: #e5e7eb; }
+  .form-control:focus, .form-select:focus { border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+  .alert-success { background: #f0fdf4; color: #16a34a; border-color: #bbf7d0; }
+  .alert-danger { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+  .alert-warning { background: #fffbeb; color: #b45309; border-color: #fde68a; }
+  .alert-info { background: #eff6ff; color: #2563eb; border-color: #bfdbfe; }
+
+  /* page: soft pills, hero numbers, wide tables scroll inside the card */
+  .pieces-badge { font-family: 'Space Grotesk', var(--font-body); font-weight: 600; }
+  .lot-badge { background: #f1f5f9; color: #475569; }
+  .assignment-body { overflow-x: auto; }
+</style>
+
 <%- include('partials/footer') %>

--- a/views/WashingAssignFinishing.ejs
+++ b/views/WashingAssignFinishing.ejs
@@ -623,4 +623,84 @@
   })();
 </script>
 
+<!-- ── Kotty Floor alignment (docs/FLOOR_REDESIGN_HANDOFF.md) — token overrides only.
+     Retunes the kotty-theme palette to the floor design system: ground #f7f8fa, ink #0f172a,
+     muted #64748b, hairline #e5e7eb, single blue accent #2563eb; Space Grotesk numbers/headings
+     + Inter body. Styling/chrome only — zero logic changes. ── -->
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+  :root {
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --border-light: #e5e7eb;
+    --border-medium: #d7dbe2;
+    --border-dark: #94a3b8;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: #eff6ff;
+    --cream: #f7f8fa;
+    --cream-dark: #f1f5f9;
+    --cream-darker: #e5e7eb;
+    --gray-50: #f8fafc;
+    --gray-100: #f1f5f9;
+    --gray-200: #e2e8f0;
+    --gray-300: #cbd5e1;
+    --gray-400: #94a3b8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.04);
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 12px;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body {
+    background: var(--bg-page);
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Numbers & headings are the hero — Space Grotesk */
+  .page-title {
+    font-family: 'Space Grotesk', var(--font-body);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  /* Bootstrap chrome onto the floor tokens (white cards, hairline, quiet) */
+  .btn-primary { background: #2563eb; border-color: #2563eb; }
+  .btn-primary:hover, .btn-primary:focus { background: #1d4ed8; border-color: #1d4ed8; }
+  .btn-secondary { background: #ffffff; border: 1px solid #e5e7eb; color: #0f172a; }
+  .btn-secondary:hover, .btn-secondary:focus { background: #f8fafc; border-color: #d7dbe2; color: #0f172a; }
+  .card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .card .card-header, .card .card-footer { background: #ffffff; border-color: #e5e7eb; }
+  .form-control:focus, .form-select:focus { border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+  .alert-success { background: #f0fdf4; color: #16a34a; border-color: #bbf7d0; }
+  .alert-danger { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+  .alert-warning { background: #fffbeb; color: #b45309; border-color: #fde68a; }
+  .alert-info { background: #eff6ff; color: #2563eb; border-color: #bfdbfe; }
+
+  /* page: hero numbers, soft ID pill, table scrolls in card */
+  .assignment-table .pieces-count { font-family: 'Space Grotesk', var(--font-body); }
+  .assignment-card-header .badge-id { background: #f1f5f9; color: #475569; }
+  .assignment-card { border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .assignment-card-body { overflow-x: auto; }
+</style>
+
 <%- include('partials/footer') %>

--- a/views/assignStitching.ejs
+++ b/views/assignStitching.ejs
@@ -650,4 +650,86 @@
   }
 </script>
 
+<!-- ── Kotty Floor alignment (docs/FLOOR_REDESIGN_HANDOFF.md) — token overrides only.
+     Retunes the kotty-theme palette to the floor design system: ground #f7f8fa, ink #0f172a,
+     muted #64748b, hairline #e5e7eb, single blue accent #2563eb; Space Grotesk numbers/headings
+     + Inter body. Styling/chrome only — zero logic changes. ── -->
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+  :root {
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --border-light: #e5e7eb;
+    --border-medium: #d7dbe2;
+    --border-dark: #94a3b8;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: #eff6ff;
+    --cream: #f7f8fa;
+    --cream-dark: #f1f5f9;
+    --cream-darker: #e5e7eb;
+    --gray-50: #f8fafc;
+    --gray-100: #f1f5f9;
+    --gray-200: #e2e8f0;
+    --gray-300: #cbd5e1;
+    --gray-400: #94a3b8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.04);
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 12px;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body {
+    background: var(--bg-page);
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Numbers & headings are the hero — Space Grotesk */
+  .page-title {
+    font-family: 'Space Grotesk', var(--font-body);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  /* Bootstrap chrome onto the floor tokens (white cards, hairline, quiet) */
+  .btn-primary { background: #2563eb; border-color: #2563eb; }
+  .btn-primary:hover, .btn-primary:focus { background: #1d4ed8; border-color: #1d4ed8; }
+  .btn-secondary { background: #ffffff; border: 1px solid #e5e7eb; color: #0f172a; }
+  .btn-secondary:hover, .btn-secondary:focus { background: #f8fafc; border-color: #d7dbe2; color: #0f172a; }
+  .card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .card .card-header, .card .card-footer { background: #ffffff; border-color: #e5e7eb; }
+  .form-control:focus, .form-select:focus { border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+  .alert-success { background: #f0fdf4; color: #16a34a; border-color: #bbf7d0; }
+  .alert-danger { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+  .alert-warning { background: #fffbeb; color: #b45309; border-color: #fde68a; }
+  .alert-info { background: #eff6ff; color: #2563eb; border-color: #bfdbfe; }
+
+  /* page: quiet pills, hero numbers, accent search button */
+  .search-btn { background: #2563eb; border-color: #2563eb; }
+  .search-btn:hover { background: #1d4ed8; }
+  .lot-badge { background: #f1f5f9; }
+  .lot-badge strong { font-family: 'Space Grotesk', var(--font-body); }
+  .badge.bg-secondary { background: #f1f5f9 !important; color: #475569; border-radius: 999px; font-family: 'Space Grotesk', var(--font-body); }
+  .accordion-container { border-radius: 12px; }
+</style>
+
 <%- include('partials/footer') %>

--- a/views/assignToWashingDashboard.ejs
+++ b/views/assignToWashingDashboard.ejs
@@ -309,4 +309,85 @@
   });
 </script>
 
+<!-- ── Kotty Floor alignment (docs/FLOOR_REDESIGN_HANDOFF.md) — token overrides only.
+     Retunes the kotty-theme palette to the floor design system: ground #f7f8fa, ink #0f172a,
+     muted #64748b, hairline #e5e7eb, single blue accent #2563eb; Space Grotesk numbers/headings
+     + Inter body. Styling/chrome only — zero logic changes. ── -->
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+  :root {
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --border-light: #e5e7eb;
+    --border-medium: #d7dbe2;
+    --border-dark: #94a3b8;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: #eff6ff;
+    --cream: #f7f8fa;
+    --cream-dark: #f1f5f9;
+    --cream-darker: #e5e7eb;
+    --gray-50: #f8fafc;
+    --gray-100: #f1f5f9;
+    --gray-200: #e2e8f0;
+    --gray-300: #cbd5e1;
+    --gray-400: #94a3b8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.04);
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 12px;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body {
+    background: var(--bg-page);
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Numbers & headings are the hero — Space Grotesk */
+  .page-title {
+    font-family: 'Space Grotesk', var(--font-body);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  /* Bootstrap chrome onto the floor tokens (white cards, hairline, quiet) */
+  .btn-primary { background: #2563eb; border-color: #2563eb; }
+  .btn-primary:hover, .btn-primary:focus { background: #1d4ed8; border-color: #1d4ed8; }
+  .btn-secondary { background: #ffffff; border: 1px solid #e5e7eb; color: #0f172a; }
+  .btn-secondary:hover, .btn-secondary:focus { background: #f8fafc; border-color: #d7dbe2; color: #0f172a; }
+  .card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .card .card-header, .card .card-footer { background: #ffffff; border-color: #e5e7eb; }
+  .form-control:focus, .form-select:focus { border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+  .alert-success { background: #f0fdf4; color: #16a34a; border-color: #bbf7d0; }
+  .alert-danger { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+  .alert-warning { background: #fffbeb; color: #b45309; border-color: #fde68a; }
+  .alert-info { background: #eff6ff; color: #2563eb; border-color: #bfdbfe; }
+
+  /* page: entry header goes quiet (was a dark tile), soft pills, hero numbers */
+  .entry-card-header { background: #f8fafc; color: #0f172a; border-bottom: 1px solid #e5e7eb; }
+  .entry-card-header i { color: #2563eb; }
+  .badge-primary { background: #eff6ff; color: #2563eb; border-radius: 999px; font-family: 'Space Grotesk', var(--font-body); }
+  .badge-neutral { background: #f1f5f9; color: #475569; border-radius: 999px; }
+  .size-badge strong { font-family: 'Space Grotesk', var(--font-body); }
+</style>
+
 <%- include('partials/footer') %>

--- a/views/washingAssignFinishing.ejs
+++ b/views/washingAssignFinishing.ejs
@@ -623,4 +623,84 @@
   })();
 </script>
 
+<!-- ── Kotty Floor alignment (docs/FLOOR_REDESIGN_HANDOFF.md) — token overrides only.
+     Retunes the kotty-theme palette to the floor design system: ground #f7f8fa, ink #0f172a,
+     muted #64748b, hairline #e5e7eb, single blue accent #2563eb; Space Grotesk numbers/headings
+     + Inter body. Styling/chrome only — zero logic changes. ── -->
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+  :root {
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --border-light: #e5e7eb;
+    --border-medium: #d7dbe2;
+    --border-dark: #94a3b8;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: #eff6ff;
+    --cream: #f7f8fa;
+    --cream-dark: #f1f5f9;
+    --cream-darker: #e5e7eb;
+    --gray-50: #f8fafc;
+    --gray-100: #f1f5f9;
+    --gray-200: #e2e8f0;
+    --gray-300: #cbd5e1;
+    --gray-400: #94a3b8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.04);
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 12px;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body {
+    background: var(--bg-page);
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Numbers & headings are the hero — Space Grotesk */
+  .page-title {
+    font-family: 'Space Grotesk', var(--font-body);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  /* Bootstrap chrome onto the floor tokens (white cards, hairline, quiet) */
+  .btn-primary { background: #2563eb; border-color: #2563eb; }
+  .btn-primary:hover, .btn-primary:focus { background: #1d4ed8; border-color: #1d4ed8; }
+  .btn-secondary { background: #ffffff; border: 1px solid #e5e7eb; color: #0f172a; }
+  .btn-secondary:hover, .btn-secondary:focus { background: #f8fafc; border-color: #d7dbe2; color: #0f172a; }
+  .card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .card .card-header, .card .card-footer { background: #ffffff; border-color: #e5e7eb; }
+  .form-control:focus, .form-select:focus { border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+  .alert-success { background: #f0fdf4; color: #16a34a; border-color: #bbf7d0; }
+  .alert-danger { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+  .alert-warning { background: #fffbeb; color: #b45309; border-color: #fde68a; }
+  .alert-info { background: #eff6ff; color: #2563eb; border-color: #bfdbfe; }
+
+  /* page: hero numbers, soft ID pill, table scrolls in card */
+  .assignment-table .pieces-count { font-family: 'Space Grotesk', var(--font-body); }
+  .assignment-card-header .badge-id { background: #f1f5f9; color: #475569; }
+  .assignment-card { border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .assignment-card-body { overflow-x: auto; }
+</style>
+
 <%- include('partials/footer') %>

--- a/views/washingAssignWashingIn.ejs
+++ b/views/washingAssignWashingIn.ejs
@@ -448,4 +448,84 @@
   })();
 </script>
 
+<!-- ── Kotty Floor alignment (docs/FLOOR_REDESIGN_HANDOFF.md) — token overrides only.
+     Retunes the kotty-theme palette to the floor design system: ground #f7f8fa, ink #0f172a,
+     muted #64748b, hairline #e5e7eb, single blue accent #2563eb; Space Grotesk numbers/headings
+     + Inter body. Styling/chrome only — zero logic changes. ── -->
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+  :root {
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --border-light: #e5e7eb;
+    --border-medium: #d7dbe2;
+    --border-dark: #94a3b8;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: #eff6ff;
+    --cream: #f7f8fa;
+    --cream-dark: #f1f5f9;
+    --cream-darker: #e5e7eb;
+    --gray-50: #f8fafc;
+    --gray-100: #f1f5f9;
+    --gray-200: #e2e8f0;
+    --gray-300: #cbd5e1;
+    --gray-400: #94a3b8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.04);
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 12px;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body {
+    background: var(--bg-page);
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Numbers & headings are the hero — Space Grotesk */
+  .page-title {
+    font-family: 'Space Grotesk', var(--font-body);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  /* Bootstrap chrome onto the floor tokens (white cards, hairline, quiet) */
+  .btn-primary { background: #2563eb; border-color: #2563eb; }
+  .btn-primary:hover, .btn-primary:focus { background: #1d4ed8; border-color: #1d4ed8; }
+  .btn-secondary { background: #ffffff; border: 1px solid #e5e7eb; color: #0f172a; }
+  .btn-secondary:hover, .btn-secondary:focus { background: #f8fafc; border-color: #d7dbe2; color: #0f172a; }
+  .card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .card .card-header, .card .card-footer { background: #ffffff; border-color: #e5e7eb; }
+  .form-control:focus, .form-select:focus { border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+  .alert-success { background: #f0fdf4; color: #16a34a; border-color: #bbf7d0; }
+  .alert-danger { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+  .alert-warning { background: #fffbeb; color: #b45309; border-color: #fde68a; }
+  .alert-info { background: #eff6ff; color: #2563eb; border-color: #bfdbfe; }
+
+  /* page: quiet ID pill (was a dark tile), hero numbers, table scrolls in card */
+  .assignment-card-header .wash-data-badge { background: #f1f5f9; color: #475569; }
+  .assignment-table .pieces-count { font-family: 'Space Grotesk', var(--font-body); }
+  .assignment-card { border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .assignment-card-body { overflow-x: auto; }
+</style>
+
 <%- include('partials/footer') %>

--- a/views/washingInAssignFinishing.ejs
+++ b/views/washingInAssignFinishing.ejs
@@ -502,4 +502,84 @@
   })();
 </script>
 
+<!-- ── Kotty Floor alignment (docs/FLOOR_REDESIGN_HANDOFF.md) — token overrides only.
+     Retunes the kotty-theme palette to the floor design system: ground #f7f8fa, ink #0f172a,
+     muted #64748b, hairline #e5e7eb, single blue accent #2563eb; Space Grotesk numbers/headings
+     + Inter body. Styling/chrome only — zero logic changes. ── -->
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+  :root {
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --border-light: #e5e7eb;
+    --border-medium: #d7dbe2;
+    --border-dark: #94a3b8;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: #eff6ff;
+    --cream: #f7f8fa;
+    --cream-dark: #f1f5f9;
+    --cream-darker: #e5e7eb;
+    --gray-50: #f8fafc;
+    --gray-100: #f1f5f9;
+    --gray-200: #e2e8f0;
+    --gray-300: #cbd5e1;
+    --gray-400: #94a3b8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.04);
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 12px;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body {
+    background: var(--bg-page);
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Numbers & headings are the hero — Space Grotesk */
+  .page-title {
+    font-family: 'Space Grotesk', var(--font-body);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  /* Bootstrap chrome onto the floor tokens (white cards, hairline, quiet) */
+  .btn-primary { background: #2563eb; border-color: #2563eb; }
+  .btn-primary:hover, .btn-primary:focus { background: #1d4ed8; border-color: #1d4ed8; }
+  .btn-secondary { background: #ffffff; border: 1px solid #e5e7eb; color: #0f172a; }
+  .btn-secondary:hover, .btn-secondary:focus { background: #f8fafc; border-color: #d7dbe2; color: #0f172a; }
+  .card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .card .card-header, .card .card-footer { background: #ffffff; border-color: #e5e7eb; }
+  .form-control:focus, .form-select:focus { border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+  .alert-success { background: #f0fdf4; color: #16a34a; border-color: #bbf7d0; }
+  .alert-danger { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+  .alert-warning { background: #fffbeb; color: #b45309; border-color: #fde68a; }
+  .alert-info { background: #eff6ff; color: #2563eb; border-color: #bfdbfe; }
+
+  /* page: size pill goes quiet (was a dark tile), hero numbers, table scrolls in card */
+  .size-badge { background: #f1f5f9; color: #0f172a; font-family: 'Space Grotesk', var(--font-body); }
+  .pieces-count { font-family: 'Space Grotesk', var(--font-body); font-weight: 600; }
+  .assignment-card { border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .assignment-card-body { overflow-x: auto; }
+</style>
+
 <%- include('partials/footer') %>

--- a/views/washingInAssignRewash.ejs
+++ b/views/washingInAssignRewash.ejs
@@ -549,4 +549,85 @@
   });
 </script>
 
+<!-- ── Kotty Floor alignment (docs/FLOOR_REDESIGN_HANDOFF.md) — token overrides only.
+     Retunes the kotty-theme palette to the floor design system: ground #f7f8fa, ink #0f172a,
+     muted #64748b, hairline #e5e7eb, single blue accent #2563eb; Space Grotesk numbers/headings
+     + Inter body. Styling/chrome only — zero logic changes. ── -->
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+
+  :root {
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --border-light: #e5e7eb;
+    --border-medium: #d7dbe2;
+    --border-dark: #94a3b8;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: #eff6ff;
+    --cream: #f7f8fa;
+    --cream-dark: #f1f5f9;
+    --cream-darker: #e5e7eb;
+    --gray-50: #f8fafc;
+    --gray-100: #f1f5f9;
+    --gray-200: #e2e8f0;
+    --gray-300: #cbd5e1;
+    --gray-400: #94a3b8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.08), 0 2px 6px rgba(15, 23, 42, 0.04);
+    --radius-md: 8px;
+    --radius-lg: 12px;
+    --radius-xl: 12px;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  }
+
+  body {
+    background: var(--bg-page);
+    font-family: var(--font-body);
+    color: var(--text-primary);
+    -webkit-font-smoothing: antialiased;
+  }
+
+  /* Numbers & headings are the hero — Space Grotesk */
+  .page-title {
+    font-family: 'Space Grotesk', var(--font-body);
+    font-weight: 700;
+    letter-spacing: -0.01em;
+  }
+
+  /* Bootstrap chrome onto the floor tokens (white cards, hairline, quiet) */
+  .btn-primary { background: #2563eb; border-color: #2563eb; }
+  .btn-primary:hover, .btn-primary:focus { background: #1d4ed8; border-color: #1d4ed8; }
+  .btn-secondary { background: #ffffff; border: 1px solid #e5e7eb; color: #0f172a; }
+  .btn-secondary:hover, .btn-secondary:focus { background: #f8fafc; border-color: #d7dbe2; color: #0f172a; }
+  .card { background: #ffffff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06); }
+  .card .card-header, .card .card-footer { background: #ffffff; border-color: #e5e7eb; }
+  .form-control:focus, .form-select:focus { border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+  .alert-success { background: #f0fdf4; color: #16a34a; border-color: #bbf7d0; }
+  .alert-danger { background: #fef2f2; color: #dc2626; border-color: #fecaca; }
+  .alert-warning { background: #fffbeb; color: #b45309; border-color: #fde68a; }
+  .alert-info { background: #eff6ff; color: #2563eb; border-color: #bfdbfe; }
+
+  /* page: card header goes quiet (was a dark tile), hero numbers, table scrolls */
+  .form-card-header { background: #ffffff; color: #0f172a; border-bottom: 1px solid #e5e7eb; }
+  .form-card-header .header-icon { background: #eff6ff; color: #2563eb; }
+  .form-card-header h2 { font-family: 'Space Grotesk', var(--font-body); font-weight: 600; }
+  .qty-input, .total-value { font-family: 'Space Grotesk', var(--font-body); }
+  .table-container { overflow-x: auto; }
+</style>
+
 <%- include('partials/footer') %>


### PR DESCRIPTION
All 8 assign / hand-off screens aligned to the floor design system — built by a dedicated agent under hard keep-everything rules, diff reviewed before opening.

**Screens:** assign stitching · stitching→jeans-assembly · stitching→finishing · washing→washing-in · washing→finishing · washing-in→finishing · washing-in rewash · assign-to-washing.

**Approach:** these pages depend on Bootstrap from the shared header, so the includes stay; each gets one appended "Kotty Floor alignment" style block that retunes the shared theme variables to the floor tokens (ground `#f7f8fa`, single accent `#2563eb`, status green/amber/red, Space Grotesk numbers + Inter, white 12px cards, soft shadows) and maps Bootstrap buttons/cards/alerts/focus rings onto them. Quiet pass: the dark charcoal header tiles and loud badges become white cards / soft pills; wide tables get `overflow-x:auto` (fixes the #1 mobile breakage).

**Safety:**
- **Insertion-only: 721 insertions, 0 deletions** — zero edits to markup, forms, fetch calls, or JS. Every control preserved by construction.
- All 8 render with route-accurate mock locals; all 25 inline scripts parse.
- No cutting screens, no payment logic.

Eyeball any one assign screen on a phone — the rest follow the same one-block pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)