### PR TITLE
feat(floor): align 16 utility/payments/people screens + shared floorTokens partial

### DIFF
--- a/views/lotCompletionDashboard.ejs
+++ b/views/lotCompletionDashboard.ejs
@@ -1,30 +1,31 @@
 <%- include('partials/header', { pageTitle: 'Lot Completion Dashboard' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+<%- include('partials/floorTokens') %>
 
 <style>
   :root {
-    --charcoal: #1a1a1a;
-    --charcoal-light: #2d2d2d;
-    --cream: #faf8f5;
-    --cream-dark: #f0ebe3;
-    --terracotta: #c45c3a;
-    --terracotta-light: #d4826a;
-    --terracotta-dark: #a84a2d;
-    --success: #2d8a5f;
-    --success-light: #e8f5ef;
-    --warning: #c4873a;
-    --warning-light: #fef3e2;
-    --danger: #c23b22;
-    --danger-light: #fdeaea;
-    --info: #3a7bc4;
-    --info-light: #e8f1fb;
-    --text-primary: #1a1a1a;
-    --text-secondary: #5a5a5a;
-    --text-muted: #8a8a8a;
-    --border: #e5e0d8;
-    --border-light: #f0ebe3;
-    --shadow-sm: 0 1px 3px rgba(26, 26, 26, 0.06);
-    --shadow-md: 0 4px 12px rgba(26, 26, 26, 0.08);
+    --charcoal: #0f172a;
+    --charcoal-light: #1e293b;
+    --cream: #f7f8fa;
+    --cream-dark: #eef0f4;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --border: #e5e7eb;
+    --border-light: #eef0f4;
+    --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.08);
     --radius-sm: 6px;
     --radius-md: 10px;
     --radius-lg: 16px;
@@ -52,7 +53,7 @@
   }
 
   .page-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 2rem;
     font-weight: 400;
     color: var(--charcoal);
@@ -60,7 +61,7 @@
   }
 
   .page-subtitle {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.9rem;
     color: var(--text-secondary);
   }
@@ -98,7 +99,7 @@
   .avg-card.finish::before { background: var(--success); }
 
   .avg-label {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.7rem;
     font-weight: 600;
     text-transform: uppercase;
@@ -108,7 +109,7 @@
   }
 
   .avg-value {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 2.25rem;
     font-weight: 400;
   }
@@ -132,7 +133,7 @@
   }
 
   .filter-bar input {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     padding: 8px 14px;
@@ -143,11 +144,11 @@
   .filter-bar input:focus {
     outline: none;
     border-color: var(--terracotta);
-    box-shadow: 0 0 0 3px rgba(196, 92, 58, 0.1);
+    box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.1);
   }
 
   .btn-kotty {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-weight: 500;
     padding: 8px 18px;
     border-radius: var(--radius-sm);
@@ -196,11 +197,11 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background: linear-gradient(180deg, var(--cream) 0%, white 100%);
+    background: #ffffff;
   }
 
   .panel-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.1rem;
     color: var(--charcoal);
     display: flex;
@@ -216,7 +217,7 @@
   }
 
   .kotty-table {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.85rem;
     width: 100%;
     border-collapse: collapse;
@@ -309,7 +310,7 @@
   }
 
   .pagination-info {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.85rem;
     color: var(--text-secondary);
   }
@@ -320,7 +321,7 @@
   }
 
   .pagination-controls a {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     padding: 6px 12px;
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);

--- a/views/lotDetails.ejs
+++ b/views/lotDetails.ejs
@@ -1,6 +1,7 @@
 <!-- views/lotDetails.ejs -->
 <%- include('partials/header', { pageTitle: 'Lot Details - ' + lot.lot_no }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/cutting-manager/dashboard' }) %>
+<%- include('partials/floorTokens') %>
 
 <!-- Main Content -->
 <main class="main-content" style="margin-left: 0;">

--- a/views/lotJourney.ejs
+++ b/views/lotJourney.ejs
@@ -4,15 +4,20 @@
   <meta charset="UTF-8" />
   <title>Lot Journey</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
   <style>
-    body { background:#f6f7fb; font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }
-    .page-head { background:linear-gradient(135deg,#0f172a,#1e293b); color:#fff; padding:22px 24px; margin-bottom:18px; border-radius:0 0 14px 14px; }
-    .page-head h1 { font-size:1.35rem; font-weight:600; margin:0; }
-    .page-head .sub { color:#94a3b8; font-size:.9rem; margin-top:4px; }
+    body { background:#f7f8fa; color:#0f172a; font-family:'Inter',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif; -webkit-font-smoothing:antialiased; padding-top:56px; padding-bottom:84px; }
+    .page-head { background:#f7f8fa; color:#0f172a; padding:18px 24px 14px; margin-bottom:14px; border-bottom:1px solid #e5e7eb; }
+    .page-head h1 { font-size:1.35rem; font-weight:700; margin:0; font-family:'Space Grotesk','Inter',sans-serif; letter-spacing:-0.01em; }
+    .page-head .sub { color:#64748b; font-size:.9rem; margin-top:4px; }
     .search-box { display:flex; gap:10px; margin-top:14px; max-width:520px; }
-    .search-box input { flex:1; border:0; padding:9px 12px; border-radius:8px; font-size:.95rem; }
+    .search-box input { flex:1; border:1px solid #e5e7eb; padding:9px 12px; border-radius:8px; font-size:.95rem; background:#fff; color:#0f172a; }
+    .search-box input:focus { outline:none; border-color:#2563eb; box-shadow:0 0 0 3px #eff6ff; }
+    .search-box .btn { background:#2563eb; color:#fff; border:0; font-weight:600; }
+    .search-box .btn:hover { background:#1d4ed8; color:#fff; }
     .lot-head { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:16px 18px; margin-bottom:16px; }
     .lot-head .lot-no { font-size:1.3rem; font-weight:700; color:#0f172a; }
     .lot-head .meta { color:#64748b; font-size:.85rem; margin-top:4px; }
@@ -21,7 +26,7 @@
     .stage .rail { display:flex; flex-direction:column; align-items:center; }
     .stage .dot { width:18px; height:18px; border-radius:50%; border:3px solid #cbd5e1; background:#fff; margin-top:4px; }
     .stage .dot.done { border-color:#16a34a; background:#16a34a; }
-    .stage .dot.in_progress { border-color:#f59e0b; background:#fde68a; }
+    .stage .dot.in_progress { border-color:#b45309; background:#fef3c7; }
     .stage .dot.not_started { border-color:#cbd5e1; background:#fff; }
     .stage .line { flex:1; width:3px; background:#e5e7eb; margin:4px 0; min-height:18px; }
     .stage .body { flex:1; background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:12px 16px; margin-bottom:12px; }
@@ -33,17 +38,50 @@
     .pieces .p span { color:#64748b; display:block; font-size:.7rem; text-transform:uppercase; letter-spacing:.3px; }
     .st-pill { font-size:.7rem; padding:2px 9px; border-radius:999px; font-weight:600; }
     .st-pill.done { background:#dcfce7; color:#166534; }
-    .st-pill.in_progress { background:#fef3c7; color:#92400e; }
+    .st-pill.in_progress { background:#fef3c7; color:#b45309; }
     .st-pill.not_started { background:#f1f5f9; color:#64748b; }
-    .dispatch-card { background:#0f172a; color:#fff; border-radius:12px; padding:16px 18px; margin-top:6px; }
+    .dispatch-card { background:#fff; color:#0f172a; border:1px solid #e5e7eb; border-radius:12px; padding:16px 18px; margin-top:6px; box-shadow:0 1px 2px rgba(15,23,42,.06); }
+    .dispatch-card .num { font-family:'Space Grotesk','Inter',sans-serif; }
+    .dispatch-card .table-dark { --bs-table-bg:#ffffff; --bs-table-color:#0f172a; --bs-table-border-color:#e5e7eb; --bs-table-striped-bg:#f7f8fa; --bs-table-hover-bg:#f7f8fa; color:#0f172a; border-color:#e5e7eb; }
     .dispatch-card h5 { margin:0 0 10px; font-size:1rem; }
     .dispatch-card .num { font-size:1.5rem; font-weight:700; }
-    .dispatch-card .lbl { font-size:.72rem; color:#94a3b8; text-transform:uppercase; }
+    .dispatch-card .lbl { font-size:.72rem; color:#64748b; text-transform:uppercase; }
     .size-table td, .size-table th { padding:4px 10px; font-size:.82rem; }
     .muted { color:#94a3b8; }
+
+    /* ── Kotty Floor chrome (matches stitchingEvents.ejs / operator hub) ── */
+    .flx-top { position: fixed; top: 0; left: 0; right: 0; z-index: 50; background: #f7f8fa; border-bottom: 1px solid #e5e7eb; }
+    .flx-top-main { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; }
+    .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+    .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+    .flx-top .brand h1 { font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px; text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0; }
+    .flx-top .flx-actions { display: flex; align-items: center; gap: 12px; }
+    .flx-top .flx-home { color: #64748b; display: flex; }
+    .flx-top .flx-user { font-size: 13px; font-weight: 600; color: #0f172a; }
+    .flx-top .flx-logout { display: inline-flex; align-items: center; gap: 6px; color: #dc2626; text-decoration: none; font-size: 13px; font-weight: 600; padding: 6px 10px; border: 1px solid #fecaca; border-radius: 8px; }
+    .flx-top .flx-logout .material-symbols-outlined { font-size: 18px; }
+    @media (max-width: 420px) { .flx-top .flx-user, .flx-top .flx-logout-t { display: none; } }
+    .flx-nav { position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 50; background: #ffffff; border-top: 1px solid #e5e7eb; display: flex; justify-content: space-around; align-items: center; padding-bottom: env(safe-area-inset-bottom); }
+    .flx-nav a { display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none; color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+    .flx-nav a.active { color: #2563eb; }
+    .flx-nav a .material-symbols-outlined { font-size: 24px; }
+    .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
   </style>
 </head>
 <body>
+  <header class="flx-top">
+    <div class="flx-top-main">
+      <div class="brand">
+        <span class="material-symbols-outlined">route</span>
+        <h1>Lot Journey</h1>
+      </div>
+      <div class="flx-actions">
+        <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+        <span class="flx-user"><%= (typeof user !== 'undefined' && user && user.username) ? user.username : 'Operator' %></span>
+        <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
+      </div>
+    </div>
+  </header>
   <div class="page-head">
     <h1><i class="bi bi-signpost-split"></i> Lot Journey</h1>
     <div class="sub">Track one lot through every stage — cutting to finishing dispatch.</div>
@@ -152,5 +190,10 @@ document.getElementById('q').addEventListener('keydown',e=>{ if(e.key==='Enter')
   }
 })();
 </script>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey" class="active"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
 </body>
 </html>

--- a/views/myLots.ejs
+++ b/views/myLots.ejs
@@ -4,14 +4,15 @@
   <meta charset="UTF-8" />
   <title>My Lots — Track your work</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
   <style>
-    body { background: #f6f7fb; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+    body { background: #f7f8fa; color: #0f172a; font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; -webkit-font-smoothing: antialiased; padding-top: 56px; padding-bottom: 84px; }
     .page-head {
-      background: linear-gradient(135deg, #0f172a, #1e293b);
-      color: #fff; padding: 22px 24px; margin-bottom: 18px;
-      border-radius: 0 0 14px 14px;
+      background: #f7f8fa; color: #0f172a; padding: 18px 24px 14px; margin-bottom: 14px;
+      border-bottom: 1px solid #e5e7eb;
     }
     .page-head h1 { font-size: 1.35rem; font-weight: 600; margin: 0; }
     .page-head .sub { color: #94a3b8; font-size: 0.9rem; margin-top: 4px; }
@@ -66,16 +67,16 @@
     .step.approved { background: linear-gradient(to right, rgba(59,130,246,0.06), transparent); }
     .step.approved .stage-name { color: #2563eb; }
     .step.assigned { background: linear-gradient(to right, rgba(251,191,36,0.08), transparent); }
-    .step.assigned .stage-name { color: #d97706; }
+    .step.assigned .stage-name { color: #b45309; }
     .step.empty .master { color: #9ca3af; font-style: italic; }
-    .step.me { box-shadow: inset 3px 0 0 #6366f1; background: linear-gradient(to right, rgba(99,102,241,0.08), transparent); }
+    .step.me { box-shadow: inset 3px 0 0 #2563eb; background: linear-gradient(to right, rgba(37,99,235,0.08), transparent); }
     .step.me::after {
       content: 'YOU'; position: absolute; top: 4px; right: 6px;
-      background: #6366f1; color: #fff; font-size: 0.6rem;
+      background: #2563eb; color: #fff; font-size: 0.6rem;
       padding: 1px 5px; border-radius: 3px; letter-spacing: 0.5px;
     }
-    .step.current { box-shadow: inset 0 -2px 0 #f59e0b; }
-    .step.current .stage-name { color: #f59e0b; font-weight: 600; }
+    .step.current { box-shadow: inset 0 -2px 0 #b45309; }
+    .step.current .stage-name { color: #b45309; font-weight: 600; }
     .step.na { opacity: 0.4; }
     .step.na .master::before { content: '—'; }
     .step.na .master { color: transparent; }
@@ -83,9 +84,48 @@
       background: #fff; border: 1px dashed #d1d5db; border-radius: 12px;
       padding: 40px 20px; text-align: center; color: #6b7280;
     }
+
+    .page-head h1 { font-family: 'Space Grotesk', 'Inter', sans-serif; color: #0f172a; letter-spacing: -0.01em; }
+    .page-head .sub { color: #64748b; }
+    .controls input, .controls select { border: 1px solid #e5e7eb; color: #0f172a; background: #fff; }
+    .controls input:focus, .controls select:focus { outline: none; border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+    .page-head .btn, .page-head .btn-light, .page-head .btn-outline-light { background: #fff; border: 1px solid #e5e7eb; color: #0f172a; font-weight: 600; }
+    .page-head .btn:hover { border-color: #2563eb; color: #2563eb; background: #eff6ff; }
+    .count-pill .num { font-family: 'Space Grotesk', 'Inter', sans-serif; color: #0f172a; }
+
+    /* ── Kotty Floor chrome (matches stitchingEvents.ejs / operator hub) ── */
+    .flx-top { position: fixed; top: 0; left: 0; right: 0; z-index: 50; background: #f7f8fa; border-bottom: 1px solid #e5e7eb; }
+    .flx-top-main { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; }
+    .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+    .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+    .flx-top .brand h1 { font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px; text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0; }
+    .flx-top .flx-actions { display: flex; align-items: center; gap: 12px; }
+    .flx-top .flx-home { color: #64748b; display: flex; }
+    .flx-top .flx-user { font-size: 13px; font-weight: 600; color: #0f172a; }
+    .flx-top .flx-logout { display: inline-flex; align-items: center; gap: 6px; color: #dc2626; text-decoration: none; font-size: 13px; font-weight: 600; padding: 6px 10px; border: 1px solid #fecaca; border-radius: 8px; }
+    .flx-top .flx-logout .material-symbols-outlined { font-size: 18px; }
+    @media (max-width: 420px) { .flx-top .flx-user, .flx-top .flx-logout-t { display: none; } }
+    .flx-nav { position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 50; background: #ffffff; border-top: 1px solid #e5e7eb; display: flex; justify-content: space-around; align-items: center; padding-bottom: env(safe-area-inset-bottom); }
+    .flx-nav a { display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none; color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+    .flx-nav a.active { color: #2563eb; }
+    .flx-nav a .material-symbols-outlined { font-size: 24px; }
+    .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
   </style>
 </head>
 <body>
+  <header class="flx-top">
+    <div class="flx-top-main">
+      <div class="brand">
+        <span class="material-symbols-outlined">inventory_2</span>
+        <h1>My Lots</h1>
+      </div>
+      <div class="flx-actions">
+        <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+        <span class="flx-user"><%= (typeof user !== 'undefined' && user && user.username) ? user.username : 'Operator' %></span>
+        <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
+      </div>
+    </div>
+  </header>
   <div class="page-head">
     <h1><i class="bi bi-bag-check"></i> My Lots</h1>
     <div class="sub">Every lot you've touched — and who has it next.</div>
@@ -280,5 +320,10 @@
 
   load();
 </script>
+<nav class="flx-nav">
+  <a href="/operator/hub" class="active"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
 </body>
 </html>

--- a/views/myPayments.ejs
+++ b/views/myPayments.ejs
@@ -1,18 +1,19 @@
 <%- include('partials/header', { pageTitle: 'My Payments' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/' }) %>
+<%- include('partials/floorTokens') %>
 
 <style>
   :root {
-    --charcoal: #1a1a1a;
-    --cream: #faf8f5;
-    --cream-dark: #f0ebe3;
-    --terracotta: #c45c3a;
-    --success: #2d8a5f;
-    --warning: #c4873a;
-    --danger: #c23b22;
-    --info: #3a7bc4;
-    --border: #e5e0d8;
-    --text-secondary: #5a5a5a;
+    --charcoal: #0f172a;
+    --cream: #f7f8fa;
+    --cream-dark: #eef0f4;
+    --terracotta: #2563eb;
+    --success: #16a34a;
+    --warning: #b45309;
+    --danger: #dc2626;
+    --info: #2563eb;
+    --border: #e5e7eb;
+    --text-secondary: #475569;
     --radius-sm: 6px;
     --radius-md: 10px;
   }
@@ -31,14 +32,14 @@
   }
 
   .page-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.75rem;
     color: var(--charcoal);
     margin-bottom: 4px;
   }
 
   .page-subtitle {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     color: var(--text-secondary);
     font-size: 0.9rem;
   }
@@ -74,7 +75,7 @@
   .summary-card.debits::before { background: var(--danger); }
 
   .summary-label {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.75rem;
     font-weight: 600;
     text-transform: uppercase;
@@ -84,7 +85,7 @@
   }
 
   .summary-value {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 2rem;
   }
 
@@ -104,7 +105,7 @@
     border-radius: var(--radius-sm);
     text-decoration: none;
     color: var(--text-secondary);
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.85rem;
   }
 
@@ -124,11 +125,11 @@
   .card-header {
     padding: 16px 20px;
     border-bottom: 1px solid var(--border);
-    background: linear-gradient(180deg, var(--cream) 0%, white 100%);
+    background: #ffffff;
   }
 
   .card-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.1rem;
     color: var(--charcoal);
     margin: 0;
@@ -139,7 +140,7 @@
   table {
     width: 100%;
     border-collapse: collapse;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.875rem;
   }
 
@@ -169,12 +170,12 @@
     text-transform: uppercase;
   }
 
-  .badge-pending { background: #fef3e2; color: var(--warning); }
-  .badge-paid { background: #e8f5ef; color: var(--success); }
-  .badge-cancelled { background: #fdeaea; color: var(--danger); }
+  .badge-pending { background: #fef3c7; color: var(--warning); }
+  .badge-paid { background: #dcfce7; color: var(--success); }
+  .badge-cancelled { background: #fee2e2; color: var(--danger); }
 
   .rate-warning {
-    background: #fef3e2;
+    background: #fef3c7;
     color: var(--warning);
     padding: 4px 8px;
     border-radius: 4px;
@@ -184,9 +185,9 @@
     gap: 4px;
   }
 
-  .badge-stitching { background: #e8f1fb; color: var(--info); }
+  .badge-stitching { background: #eff6ff; color: var(--info); }
   .badge-washing { background: #ede9fe; color: #7c3aed; }
-  .badge-finishing { background: #e8f5ef; color: var(--success); }
+  .badge-finishing { background: #dcfce7; color: var(--success); }
   .badge-assembly { background: #fce7f3; color: #be185d; }
 
   .empty-state {
@@ -196,7 +197,7 @@
   }
 
   .debit-card {
-    background: #fdeaea;
+    background: #fee2e2;
     border: 1px solid var(--danger);
     border-radius: var(--radius-sm);
     padding: 12px 16px;
@@ -212,7 +213,7 @@
   }
 
   .debit-amount {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.1rem;
     color: var(--danger);
   }

--- a/views/operatorDepartments.ejs
+++ b/views/operatorDepartments.ejs
@@ -1,5 +1,6 @@
 <%- include('partials/header', { pageTitle: 'Departments & Salaries' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+<%- include('partials/floorTokens') %>
 
 <!-- DataTables CSS -->
 <link rel="stylesheet" href="https://cdn.datatables.net/1.13.6/css/dataTables.bootstrap5.min.css">

--- a/views/operatorEditAttendance.ejs
+++ b/views/operatorEditAttendance.ejs
@@ -1,5 +1,6 @@
 <%- include('partials/header', { pageTitle: 'Edit Attendance' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+<%- include('partials/floorTokens') %>
 
 <!-- Main Content -->
 <main class="main-content" style="margin-left: 0;">

--- a/views/operatorLotTat.ejs
+++ b/views/operatorLotTat.ejs
@@ -4,22 +4,23 @@
   <meta charset="UTF-8" />
   <title>Lot TAT — Operator</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+  <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
   <style>
-    body { background: #f6f7fb; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; }
+    body { background: #f7f8fa; color: #0f172a; font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; -webkit-font-smoothing: antialiased; padding-top: 56px; padding-bottom: 84px; }
     .page-head {
-      background: linear-gradient(135deg, #0f172a, #1e293b);
-      color: #fff; padding: 22px 24px; margin-bottom: 18px;
-      border-radius: 0 0 14px 14px;
+      background: #f7f8fa; color: #0f172a; padding: 18px 24px 14px; margin-bottom: 14px;
+      border-bottom: 1px solid #e5e7eb;
     }
     .page-head h1 { font-size: 1.35rem; font-weight: 600; margin: 0; }
     .page-head .sub { color: #94a3b8; font-size: 0.9rem; margin-top: 4px; }
     .tat-banner {
       display: flex; gap: 14px; flex-wrap: wrap; margin-top: 14px;
-      font-size: 0.78rem; color: #cbd5e1;
+      font-size: 0.78rem; color: #64748b;
     }
-    .tat-banner .item strong { color: #fff; }
+    .tat-banner .item strong { color: #0f172a; }
     .controls { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 14px; align-items: center; }
     .controls input, .controls select {
       background: #fff; border: 0; padding: 6px 10px; border-radius: 8px;
@@ -94,9 +95,48 @@
       background: #fff; border: 1px dashed #d1d5db; border-radius: 12px;
       padding: 40px 20px; text-align: center; color: #6b7280;
     }
+
+    .page-head h1 { font-family: 'Space Grotesk', 'Inter', sans-serif; color: #0f172a; letter-spacing: -0.01em; }
+    .page-head .sub { color: #64748b; }
+    .controls input, .controls select { border: 1px solid #e5e7eb; color: #0f172a; background: #fff; }
+    .controls input:focus, .controls select:focus { outline: none; border-color: #2563eb; box-shadow: 0 0 0 3px #eff6ff; }
+    .page-head .btn, .page-head .btn-light, .page-head .btn-outline-light { background: #fff; border: 1px solid #e5e7eb; color: #0f172a; font-weight: 600; }
+    .page-head .btn:hover { border-color: #2563eb; color: #2563eb; background: #eff6ff; }
+    .count-pill .num { font-family: 'Space Grotesk', 'Inter', sans-serif; color: #0f172a; }
+
+    /* ── Kotty Floor chrome (matches stitchingEvents.ejs / operator hub) ── */
+    .flx-top { position: fixed; top: 0; left: 0; right: 0; z-index: 50; background: #f7f8fa; border-bottom: 1px solid #e5e7eb; }
+    .flx-top-main { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; }
+    .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+    .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+    .flx-top .brand h1 { font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px; text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0; }
+    .flx-top .flx-actions { display: flex; align-items: center; gap: 12px; }
+    .flx-top .flx-home { color: #64748b; display: flex; }
+    .flx-top .flx-user { font-size: 13px; font-weight: 600; color: #0f172a; }
+    .flx-top .flx-logout { display: inline-flex; align-items: center; gap: 6px; color: #dc2626; text-decoration: none; font-size: 13px; font-weight: 600; padding: 6px 10px; border: 1px solid #fecaca; border-radius: 8px; }
+    .flx-top .flx-logout .material-symbols-outlined { font-size: 18px; }
+    @media (max-width: 420px) { .flx-top .flx-user, .flx-top .flx-logout-t { display: none; } }
+    .flx-nav { position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 50; background: #ffffff; border-top: 1px solid #e5e7eb; display: flex; justify-content: space-around; align-items: center; padding-bottom: env(safe-area-inset-bottom); }
+    .flx-nav a { display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none; color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em; }
+    .flx-nav a.active { color: #2563eb; }
+    .flx-nav a .material-symbols-outlined { font-size: 24px; }
+    .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
   </style>
 </head>
 <body>
+  <header class="flx-top">
+    <div class="flx-top-main">
+      <div class="brand">
+        <span class="material-symbols-outlined">timer</span>
+        <h1>Lot TAT</h1>
+      </div>
+      <div class="flx-actions">
+        <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+        <span class="flx-user"><%= (typeof user !== 'undefined' && user && user.username) ? user.username : 'Operator' %></span>
+        <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
+      </div>
+    </div>
+  </header>
   <div class="page-head">
     <h1><i class="bi bi-speedometer2"></i> Lot TAT</h1>
     <div class="sub">All lots, per-stage elapsed days vs TAT (from events).</div>
@@ -124,7 +164,7 @@
         <option value="180">Last 180 days</option>
         <option value="">All time</option>
       </select>
-      <label style="color:#cbd5e1; font-size:0.85rem;">
+      <label style="color:#475569; font-size:0.85rem;">
         <input type="checkbox" id="overdueFilter"> Overdue only
       </label>
       <a id="dlBtn" href="#" class="btn btn-sm btn-light" style="margin-left:auto;">
@@ -273,5 +313,10 @@
 
   load();
 </script>
+<nav class="flx-nav">
+  <a href="/operator/hub" class="active"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
 </body>
 </html>

--- a/views/operatorStitchingTat.ejs
+++ b/views/operatorStitchingTat.ejs
@@ -1,5 +1,6 @@
 <%- include('partials/header', { pageTitle: 'Stitching TAT' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+<%- include('partials/floorTokens') %>
 
 <!-- Main Content -->
 <main class="main-content" style="margin-left: 0;">
@@ -80,14 +81,14 @@
 
   .master-card:hover {
     transform: translateY(-4px);
-    box-shadow: 0 12px 24px rgba(26, 26, 26, 0.1);
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.1);
   }
 
   .master-avatar {
     width: 56px;
     height: 56px;
     border-radius: 50%;
-    background: linear-gradient(135deg, var(--terracotta), #d4826a);
+    background: var(--terracotta);
     color: white;
     display: flex;
     align-items: center;
@@ -147,24 +148,24 @@
   }
 
   .btn-outline-success {
-    border-color: #2e7d32;
-    color: #2e7d32;
+    border-color: #16a34a;
+    color: #16a34a;
   }
 
   .btn-outline-success:hover {
-    background: #2e7d32;
-    border-color: #2e7d32;
+    background: #16a34a;
+    border-color: #16a34a;
     color: white;
   }
 
   /* Badge variants */
   .badge-warning {
-    background: #fff3e0;
-    color: #e65100;
+    background: #fef3c7;
+    color: #b45309;
   }
 
   .badge-primary {
-    background: rgba(196, 92, 58, 0.1);
+    background: rgba(37, 99, 235, 0.1);
     color: var(--terracotta);
   }
 

--- a/views/operatorStitchingTatDetail.ejs
+++ b/views/operatorStitchingTatDetail.ejs
@@ -1,5 +1,6 @@
 <%- include('partials/header', { pageTitle: 'Stitching TAT Detail' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+<%- include('partials/floorTokens') %>
 
 <main class="main-content" style="margin-left: 0;">
   <div class="container" style="max-width: 1400px; margin: 0 auto;">
@@ -141,7 +142,7 @@
   }
 
   .badge-danger {
-    background: linear-gradient(135deg, #dc3545, #c82333);
+    background: #dc2626;
     color: white;
   }
 

--- a/views/operatorSupervisors.ejs
+++ b/views/operatorSupervisors.ejs
@@ -1,5 +1,6 @@
 <%- include('partials/header', { pageTitle: 'Supervisors' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+<%- include('partials/floorTokens') %>
 
 <!-- Main Content -->
 <main class="main-content" style="margin-left: 0;">

--- a/views/partials/floorTokens.ejs
+++ b/views/partials/floorTokens.ejs
@@ -1,0 +1,97 @@
+<!-- Kotty Floor design tokens — remaps kotty-theme / professional variables to the
+     floor design system (docs/FLOOR_REDESIGN_HANDOFF.md). Style-only override:
+     include AFTER partials/navbar on operator utility / payments / people screens. -->
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet">
+<style>
+  :root {
+    /* kotty-theme.css palette → floor tokens */
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: #eff6ff;
+    --cream: #f7f8fa;
+    --cream-dark: #eef0f4;
+    --charcoal: #0f172a;
+    --charcoal-light: #1e293b;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --border: #e5e7eb;
+    --border-light: #e5e7eb;
+    --border-medium: #d1d5db;
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --gray-50: #f7f8fa;
+    --gray-100: #eef0f4;
+    --gray-200: #e5e7eb;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --font-display: 'Space Grotesk', 'Inter', -apple-system, sans-serif;
+    --font-heading: 'Space Grotesk', 'Inter', -apple-system, sans-serif;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --shadow-xs: 0 1px 2px rgba(15, 23, 42, 0.04);
+    --shadow-sm: 0 1px 2px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 1px 3px rgba(15, 23, 42, 0.06), 0 1px 2px rgba(15, 23, 42, 0.04);
+    /* professional.css palette → floor tokens */
+    --primary-color: #2563eb;
+    --primary-dark: #1d4ed8;
+    --secondary-color: #0f172a;
+    --accent-soft: #eff6ff;
+    --accent-gradient: none;
+    --bg-primary: #ffffff;
+    --bg-secondary: #f7f8fa;
+    --bg-tertiary: #eef0f4;
+    --border-color: #e5e7eb;
+    --success-color: #16a34a;
+    --warning-color: #b45309;
+    --danger-color: #dc2626;
+    --info-color: #2563eb;
+    --text-light: #64748b;
+  }
+  body {
+    background: #f7f8fa;
+    color: #0f172a;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+  h1, h2, h3, h4, h5, h6, .page-title, .card-title, .stat-value {
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
+    letter-spacing: -0.01em;
+  }
+  .page-title { color: #0f172a; font-weight: 700; }
+  .page-subtitle { color: #64748b; }
+  /* Quiet white cards: 12px radius, hairline border, soft shadow */
+  .card, .panel-card, .table-card, .summary-card, .stat-card, .count-pill {
+    border: 1px solid #e5e7eb !important;
+    border-radius: 12px;
+    box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06);
+    background-clip: padding-box;
+  }
+  .card-header { background: #ffffff !important; border-bottom: 1px solid #e5e7eb; }
+  /* Bootstrap button alignment to the single indigo accent */
+  .btn-primary { background-color: #2563eb; border-color: #2563eb; }
+  .btn-primary:hover, .btn-primary:focus { background-color: #1d4ed8; border-color: #1d4ed8; }
+  .btn-outline-primary { color: #2563eb; border-color: #2563eb; }
+  .btn-outline-primary:hover { background-color: #2563eb; border-color: #2563eb; color: #fff; }
+  .btn-success { background-color: #16a34a; border-color: #16a34a; }
+  .btn-success:hover, .btn-success:focus { background-color: #15803d; border-color: #15803d; }
+  .btn-outline-success { color: #16a34a; border-color: #16a34a; }
+  .btn-outline-success:hover { background-color: #16a34a; border-color: #16a34a; color: #fff; }
+  .btn-danger { background-color: #dc2626; border-color: #dc2626; }
+  .btn-secondary { background-color: #ffffff; border: 1px solid #e5e7eb; color: #475569; }
+  .btn-secondary:hover, .btn-secondary:focus { background-color: #f7f8fa; border-color: #d1d5db; color: #0f172a; }
+  .form-control:focus, .form-select:focus, .form-input:focus {
+    border-color: #2563eb;
+    box-shadow: 0 0 0 3px #eff6ff;
+  }
+  /* Wide tables must scroll inside their own container on phones */
+  .table-responsive, .table-container { overflow-x: auto !important; -webkit-overflow-scrolling: touch; }
+  a { color: #2563eb; }
+  .text-terracotta { color: #2563eb !important; }
+</style>

--- a/views/rejectedLots.ejs
+++ b/views/rejectedLots.ejs
@@ -1,5 +1,6 @@
 <%- include('partials/header', { pageTitle: 'Rejected Lots Report' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/' }) %>
+<%- include('partials/floorTokens') %>
 
 <style>
   .page-container {

--- a/views/searchDashboard.ejs
+++ b/views/searchDashboard.ejs
@@ -1,5 +1,6 @@
 <%- include('partials/header', { pageTitle: 'Search' }) %>
 <%- include('partials/navbar', { user: locals.user, dashboardUrl: '/search-dashboard' }) %>
+<%- include('partials/floorTokens') %>
 
 <style>
   /* Tag styling for bulk search */

--- a/views/stagePaymentHistory.ejs
+++ b/views/stagePaymentHistory.ejs
@@ -1,17 +1,18 @@
 <%- include('partials/header', { pageTitle: 'Payment History' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+<%- include('partials/floorTokens') %>
 
 <style>
   :root {
-    --charcoal: #1a1a1a;
-    --cream: #faf8f5;
-    --cream-dark: #f0ebe3;
-    --terracotta: #c45c3a;
-    --success: #2d8a5f;
-    --warning: #c4873a;
-    --info: #3a7bc4;
-    --border: #e5e0d8;
-    --text-secondary: #5a5a5a;
+    --charcoal: #0f172a;
+    --cream: #f7f8fa;
+    --cream-dark: #eef0f4;
+    --terracotta: #2563eb;
+    --success: #16a34a;
+    --warning: #b45309;
+    --info: #2563eb;
+    --border: #e5e7eb;
+    --text-secondary: #475569;
     --radius-sm: 6px;
     --radius-md: 10px;
   }
@@ -35,7 +36,7 @@
   }
 
   .page-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.75rem;
     color: var(--charcoal);
   }
@@ -43,7 +44,7 @@
   .btn-group { display: flex; gap: 8px; flex-wrap: wrap; }
 
   .btn-kotty {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-weight: 500;
     padding: 8px 16px;
     border-radius: var(--radius-sm);
@@ -70,14 +71,14 @@
   .card-header {
     padding: 16px 20px;
     border-bottom: 1px solid var(--border);
-    background: linear-gradient(180deg, var(--cream) 0%, white 100%);
+    background: #ffffff;
     display: flex;
     justify-content: space-between;
     align-items: center;
   }
 
   .card-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.1rem;
     color: var(--charcoal);
     margin: 0;
@@ -95,7 +96,7 @@
   .form-group { margin-bottom: 0; }
 
   .form-label {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.75rem;
     font-weight: 500;
     color: var(--text-secondary);
@@ -104,7 +105,7 @@
   }
 
   .form-control, .form-select {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     padding: 8px 12px;
@@ -114,7 +115,7 @@
   table {
     width: 100%;
     border-collapse: collapse;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.85rem;
   }
 
@@ -143,11 +144,11 @@
     font-weight: 600;
   }
 
-  .badge-stitching { background: #e8f1fb; color: var(--info); }
+  .badge-stitching { background: #eff6ff; color: var(--info); }
   .badge-washing { background: #ede9fe; color: #7c3aed; }
-  .badge-finishing { background: #e8f5ef; color: var(--success); }
+  .badge-finishing { background: #dcfce7; color: var(--success); }
   .badge-assembly { background: #fce7f3; color: #be185d; }
-  .badge-cutting { background: #fef3e2; color: var(--warning); }
+  .badge-cutting { background: #fef3c7; color: var(--warning); }
 </style>
 
 <div class="page-container">

--- a/views/stagePaymentPending.ejs
+++ b/views/stagePaymentPending.ejs
@@ -1,18 +1,19 @@
 <%- include('partials/header', { pageTitle: 'Pending Payments' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+<%- include('partials/floorTokens') %>
 
 <style>
   :root {
-    --charcoal: #1a1a1a;
-    --cream: #faf8f5;
-    --cream-dark: #f0ebe3;
-    --terracotta: #c45c3a;
-    --success: #2d8a5f;
-    --warning: #c4873a;
-    --danger: #c23b22;
-    --info: #3a7bc4;
-    --border: #e5e0d8;
-    --text-secondary: #5a5a5a;
+    --charcoal: #0f172a;
+    --cream: #f7f8fa;
+    --cream-dark: #eef0f4;
+    --terracotta: #2563eb;
+    --success: #16a34a;
+    --warning: #b45309;
+    --danger: #dc2626;
+    --info: #2563eb;
+    --border: #e5e7eb;
+    --text-secondary: #475569;
     --radius-sm: 6px;
     --radius-md: 10px;
   }
@@ -36,7 +37,7 @@
   }
 
   .page-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.75rem;
     color: var(--charcoal);
   }
@@ -44,7 +45,7 @@
   .btn-group { display: flex; gap: 8px; flex-wrap: wrap; }
 
   .btn-kotty {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-weight: 500;
     padding: 8px 16px;
     border-radius: var(--radius-sm);
@@ -68,10 +69,10 @@
     padding: 12px 16px;
     border-radius: var(--radius-sm);
     margin-bottom: 16px;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
   }
-  .alert-success { background: #e8f5ef; color: var(--success); }
-  .alert-error { background: #fdeaea; color: var(--danger); }
+  .alert-success { background: #dcfce7; color: var(--success); }
+  .alert-error { background: #fee2e2; color: var(--danger); }
 
   .card {
     background: white;
@@ -83,14 +84,14 @@
   .card-header {
     padding: 16px 20px;
     border-bottom: 1px solid var(--border);
-    background: linear-gradient(180deg, var(--cream) 0%, white 100%);
+    background: #ffffff;
     display: flex;
     justify-content: space-between;
     align-items: center;
   }
 
   .card-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.1rem;
     color: var(--charcoal);
     margin: 0;
@@ -106,7 +107,7 @@
   }
 
   .form-control, .form-select {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     border: 1px solid var(--border);
     border-radius: var(--radius-sm);
     padding: 8px 12px;
@@ -116,7 +117,7 @@
   table {
     width: 100%;
     border-collapse: collapse;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.85rem;
   }
 
@@ -145,14 +146,14 @@
     font-weight: 600;
   }
 
-  .badge-stitching { background: #e8f1fb; color: var(--info); }
+  .badge-stitching { background: #eff6ff; color: var(--info); }
   .badge-washing { background: #ede9fe; color: #7c3aed; }
-  .badge-finishing { background: #e8f5ef; color: var(--success); }
+  .badge-finishing { background: #dcfce7; color: var(--success); }
   .badge-assembly { background: #fce7f3; color: #be185d; }
-  .badge-cutting { background: #fef3e2; color: var(--warning); }
+  .badge-cutting { background: #fef3c7; color: var(--warning); }
 
   .rate-warning {
-    background: #fef3e2;
+    background: #fef3c7;
     color: var(--warning);
     padding: 4px 8px;
     border-radius: 4px;
@@ -177,14 +178,14 @@
   }
 
   .summary-label {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.75rem;
     color: var(--text-secondary);
     text-transform: uppercase;
   }
 
   .summary-value {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.5rem;
     color: var(--charcoal);
   }
@@ -210,13 +211,13 @@
     width: 90%;
   }
   .modal-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.25rem;
     margin-bottom: 16px;
   }
   .form-group { margin-bottom: 16px; }
   .form-label {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.8rem;
     font-weight: 500;
     color: var(--text-secondary);

--- a/views/supervisorEmployees.ejs
+++ b/views/supervisorEmployees.ejs
@@ -1,5 +1,6 @@
 <%- include('partials/header', { pageTitle: 'Supervisor Employees' }) %>
 <%- include('partials/navbar', { user: user, dashboardUrl: '/supervisor/employees' }) %>
+<%- include('partials/floorTokens') %>
 
 <style>
   /* ═══════════════════════════════════════════════════════════════════════════
@@ -8,30 +9,30 @@
    ═══════════════════════════════════════════════════════════════════════════ */
 
   :root {
-    --charcoal: #1a1a1a;
-    --charcoal-light: #2d2d2d;
-    --cream: #faf8f5;
-    --cream-dark: #f0ebe3;
-    --terracotta: #c45c3a;
-    --terracotta-light: #d4826a;
-    --terracotta-dark: #a84a2d;
-    --terracotta-bg: rgba(196, 92, 58, 0.08);
-    --success: #2d8a5f;
-    --success-light: #e8f5ef;
-    --warning: #c4873a;
-    --warning-light: #fef3e2;
-    --danger: #c23b22;
-    --danger-light: #fdeaea;
-    --info: #3a7bc4;
-    --info-light: #e8f1fb;
-    --text-primary: #1a1a1a;
-    --text-secondary: #5a5a5a;
-    --text-muted: #8a8a8a;
-    --border: #e5e0d8;
-    --border-light: #f0ebe3;
-    --shadow-sm: 0 1px 3px rgba(26, 26, 26, 0.06);
-    --shadow-md: 0 4px 12px rgba(26, 26, 26, 0.08);
-    --shadow-lg: 0 8px 24px rgba(26, 26, 26, 0.12);
+    --charcoal: #0f172a;
+    --charcoal-light: #1e293b;
+    --cream: #f7f8fa;
+    --cream-dark: #eef0f4;
+    --terracotta: #2563eb;
+    --terracotta-light: #3b82f6;
+    --terracotta-dark: #1d4ed8;
+    --terracotta-bg: rgba(37, 99, 235, 0.08);
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --warning: #b45309;
+    --warning-light: #fef3c7;
+    --danger: #dc2626;
+    --danger-light: #fee2e2;
+    --info: #2563eb;
+    --info-light: #eff6ff;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --border: #e5e7eb;
+    --border-light: #eef0f4;
+    --shadow-sm: 0 1px 3px rgba(15, 23, 42, 0.06);
+    --shadow-md: 0 4px 12px rgba(15, 23, 42, 0.08);
+    --shadow-lg: 0 8px 24px rgba(15, 23, 42, 0.12);
     --radius-sm: 6px;
     --radius-md: 10px;
     --radius-lg: 16px;
@@ -56,7 +57,7 @@
   }
 
   .page-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 2.25rem;
     font-weight: 400;
     color: var(--charcoal);
@@ -65,7 +66,7 @@
   }
 
   .page-subtitle {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.95rem;
     color: var(--text-secondary);
     font-weight: 400;
@@ -153,7 +154,7 @@
   .stat-icon.neutral { background: #f3f4f6; color: #6b7280; }
 
   .stat-label {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.75rem;
     font-weight: 500;
     text-transform: uppercase;
@@ -163,7 +164,7 @@
   }
 
   .stat-value {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 2rem;
     font-weight: 400;
     color: var(--charcoal);
@@ -217,11 +218,11 @@
     align-items: center;
     justify-content: space-between;
     gap: 16px;
-    background: linear-gradient(135deg, var(--cream-dark) 0%, white 100%);
+    background: #f7f8fa;
   }
 
   .section-title {
-    font-family: 'DM Serif Display', Georgia, serif;
+    font-family: 'Space Grotesk', 'Inter', sans-serif;
     font-size: 1.35rem;
     color: var(--charcoal);
     margin: 0;
@@ -281,7 +282,7 @@
   /* Forms */
   .form-label {
     display: block;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.85rem;
     font-weight: 500;
     color: var(--text-primary);
@@ -292,7 +293,7 @@
   .form-select {
     width: 100%;
     padding: 10px 14px;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.9rem;
     color: var(--text-primary);
     background: white;
@@ -357,7 +358,7 @@
     justify-content: center;
     gap: 8px;
     padding: 10px 18px;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.875rem;
     font-weight: 500;
     border-radius: var(--radius-sm);
@@ -467,7 +468,7 @@
   .table th {
     padding: 14px 16px;
     text-align: left;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.7rem;
     font-weight: 600;
     text-transform: uppercase;
@@ -480,7 +481,7 @@
 
   .table td {
     padding: 14px 16px;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.875rem;
     color: var(--text-primary);
     border-bottom: 1px solid var(--border-light);
@@ -511,7 +512,7 @@
   }
 
   .salary-hidden {
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-weight: 500;
     color: var(--text-primary);
   }
@@ -587,7 +588,7 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    font-family: 'Outfit', sans-serif;
+    font-family: 'Inter', sans-serif;
     font-size: 0.9rem;
     margin-bottom: 20px;
     animation: fadeInUp 0.3s ease-out;


### PR DESCRIPTION
16 operator utility, payment-display, and people screens aligned to the floor design — agent-built under keep-everything rules, diff reviewed line-by-line before opening (the only non-CSS deletion was a label colour restyle).

**New shared piece:** `views/partials/floorTokens.ejs` — a style-only override that remaps every kotty-theme/professional CSS variable to the floor tokens (terracotta→indigo `#2563eb`, cream→`#f7f8fa`, Space Grotesk + Inter, white 12px cards, indigo buttons/focus) and **fixes a real mobile bug**: kotty-theme's `.table-container` had `overflow:hidden`, clipping wide tables — now `overflow-x:auto`.

**Screens:** search dashboard, lot completion, lot details, rejected lots, Lot TAT, stitching TAT (+detail), my-lots, my-payments, stage payments pending/history, lot journey, salaries (departments), attendance (supervisors), supervisor employees, edit attendance.
- Header-based screens keep their includes + get the token partial (and local palette retunes where they had their own `:root`).
- `myLots`, `lotJourney`, `operatorLotTat` get the full standalone chrome swap (flx-top with Home/username/Log out + bottom nav) matching the stage screens.
- Payment-display screens: **styling only** — amounts, rate warnings, modals, cancel/edit forms untouched. `stagePaymentCreate` and cutting screens untouched.

**Verified:** 16/16 render with route-accurate mock locals; every inline script parses. +421/−178 (deletions are CSS values only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)