### PR TITLE
feat(floor): the 5 role landing dashboards onto the Kotty Floor chrome

### DIFF
--- a/views/finishingDashboard.ejs
+++ b/views/finishingDashboard.ejs
@@ -1,11 +1,110 @@
-<%- include('partials/header', { pageTitle: 'Finishing Dashboard' }) %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<title>Finishing</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"/>
 <!-- Select2 for indent item search -->
 <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/finishingdashboard' }) %>
+</head>
+<body>
 
 <style>
+  /* ── Kotty Floor shell chrome (copied from stitchingEvents.ejs) ── */
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
+  body { background: #f7f8fa; margin: 0; padding-bottom: 80px; }
+  .flx-top {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 1050;
+    background: #f7f8fa; border-bottom: 1px solid #e5e7eb;
+  }
+  .flx-top-main { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; }
+  .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+  .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+  .flx-top .brand h1 {
+    font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0;
+  }
+  .flx-nav {
+    position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 1050;
+    background: #ffffff; border-top: 1px solid #e5e7eb;
+    display: flex; justify-content: space-around; align-items: center;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .flx-nav a {
+    display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none;
+    color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flx-nav a.active { color: #2563eb; }
+  .flx-nav a .material-symbols-outlined { font-size: 24px; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
+  .flx-top .flx-actions { display: flex; align-items: center; gap: 12px; }
+  .flx-top .flx-home { color: #64748b; display: flex; }
+  .flx-top .flx-user { font-size: 13px; font-weight: 600; color: #0f172a; }
+  .flx-top .flx-logout { display: inline-flex; align-items: center; gap: 6px; color: #dc2626;
+    text-decoration: none; font-size: 13px; font-weight: 600; padding: 6px 10px;
+    border: 1px solid #fecaca; border-radius: 8px; }
+  .flx-top .flx-logout .material-symbols-outlined { font-size: 18px; }
+  @media (max-width: 420px) { .flx-top .flx-user, .flx-top .flx-logout-t { display: none; } }
+</style>
+
+<header class="flx-top">
+  <div class="flx-top-main">
+    <div class="brand">
+      <span class="material-symbols-outlined">checkroom</span>
+      <h1>Finishing</h1>
+    </div>
+    <div class="flx-actions">
+      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
+      <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
+    </div>
+  </div>
+</header>
+
+<style>
+  /* Kotty Floor tokens — replaces the kotty-theme.css variables this page
+     previously inherited from partials/header (now standalone). */
+  :root {
+    --navbar-height: 56px;
+    --bg-page: #f7f8fa;
+    --bg-card: #ffffff;
+    --border-light: #e5e7eb;
+    --text-primary: #0f172a;
+    --text-secondary: #475569;
+    --text-muted: #64748b;
+    --text-xs: 0.75rem;
+    --text-sm: 0.875rem;
+    --text-base: 1rem;
+    --text-lg: 1.125rem;
+    --text-xl: 1.25rem;
+    --text-2xl: 1.5rem;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --radius-sm: 8px;
+    --radius-md: 10px;
+    --radius-lg: 12px;
+    --radius-full: 999px;
+    /* One blue accent (kotty-theme's terracotta remapped to the floor accent) */
+    --terracotta: #2563eb;
+    --terracotta-dark: #1d4ed8;
+    --success: #16a34a;
+    --success-light: #dcfce7;
+    --success-dark: #15803d;
+    --danger: #dc2626;
+    --error: #dc2626;
+    --error-light: #fee2e2;
+    --gray-50: #f7f8fa;
+    --gray-100: #f1f5f9;
+    --gray-200: #e5e7eb;
+    --gray-300: #cbd5e1;
+  }
+  body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    color: var(--text-primary);
+  }
   .page-wrapper {
     padding-top: calc(var(--navbar-height) + 24px);
     padding-bottom: 3rem;
@@ -335,7 +434,7 @@
     <h1 class="page-title">Finishing Dashboard</h1>
 
     <div class="quick-links">
-      <a href="/my-lots" class="quick-link" style="background:#6366f1;color:#fff;"><i class="bi bi-bag-check"></i> My Lots</a>
+      <a href="/my-lots" class="quick-link" style="background:#2563eb;color:#fff;"><i class="bi bi-bag-check"></i> My Lots</a>
       <a href="/finishingdashboard/dispatch-download" class="quick-link" style="background:#10b981;color:#fff;"><i class="bi bi-file-earmark-excel"></i> Dispatch Excel</a>
       <a href="/payments/my-payments" class="quick-link"><i class="bi bi-wallet2"></i> My Payments</a>
       <button type="button" class="quick-link" onclick="toggleHistorySection()"><i class="bi bi-clock-history"></i> History</button>
@@ -1138,4 +1237,10 @@ function escHtml(str) {
 }
 </script>
 
-<%- include('partials/footer') %>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
+</body>
+</html>

--- a/views/jeansAssemblyDashboard.ejs
+++ b/views/jeansAssemblyDashboard.ejs
@@ -1,9 +1,69 @@
-<%- include('partials/header', { pageTitle: 'Jeans Assembly Dashboard' }) %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<title>Jeans Assembly</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"/>
 <!-- Select2 for indent item search -->
 <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/jeansassemblydashboard' }) %>
+</head>
+<body>
+
+<style>
+  /* ── Kotty Floor shell chrome (copied from stitchingEvents.ejs) ── */
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
+  body { background: #f7f8fa; margin: 0; padding-bottom: 80px; }
+  .flx-top {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 1050;
+    background: #f7f8fa; border-bottom: 1px solid #e5e7eb;
+  }
+  .flx-top-main { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; }
+  .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+  .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+  .flx-top .brand h1 {
+    font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0;
+  }
+  .flx-nav {
+    position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 1050;
+    background: #ffffff; border-top: 1px solid #e5e7eb;
+    display: flex; justify-content: space-around; align-items: center;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .flx-nav a {
+    display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none;
+    color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flx-nav a.active { color: #2563eb; }
+  .flx-nav a .material-symbols-outlined { font-size: 24px; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
+  .flx-top .flx-actions { display: flex; align-items: center; gap: 12px; }
+  .flx-top .flx-home { color: #64748b; display: flex; }
+  .flx-top .flx-user { font-size: 13px; font-weight: 600; color: #0f172a; }
+  .flx-top .flx-logout { display: inline-flex; align-items: center; gap: 6px; color: #dc2626;
+    text-decoration: none; font-size: 13px; font-weight: 600; padding: 6px 10px;
+    border: 1px solid #fecaca; border-radius: 8px; }
+  .flx-top .flx-logout .material-symbols-outlined { font-size: 18px; }
+  @media (max-width: 420px) { .flx-top .flx-user, .flx-top .flx-logout-t { display: none; } }
+</style>
+
+<header class="flx-top">
+  <div class="flx-top-main">
+    <div class="brand">
+      <span class="material-symbols-outlined">apparel</span>
+      <h1>Jeans Assembly</h1>
+    </div>
+    <div class="flx-actions">
+      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
+      <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
+    </div>
+  </div>
+</header>
 
 <style>
   * { box-sizing: border-box; }
@@ -14,18 +74,18 @@
     --success-light: #dcfce7;
     --danger: #dc2626;
     --danger-light: #fee2e2;
-    --warning: #f59e0b;
-    --bg: #f8fafc;
+    --warning: #b45309;
+    --bg: #f7f8fa;
     --card: #ffffff;
-    --text: #1e293b;
+    --text: #0f172a;
     --text-light: #64748b;
-    --border: #e2e8f0;
-    --shadow: 0 1px 3px rgba(0,0,0,0.1);
+    --border: #e5e7eb;
+    --shadow: 0 1px 2px rgba(15,23,42,.06);
   }
 
   body {
     background: var(--bg);
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 16px;
     color: var(--text);
   }
@@ -258,7 +318,7 @@
   }
 
   .size-card {
-    background: #f8fafc;
+    background: #f7f8fa;
     border: 2px solid var(--border);
     border-radius: 12px;
     padding: 12px;
@@ -377,7 +437,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 16px 20px;
-    background: #f8fafc;
+    background: #f7f8fa;
     border-bottom: 1px solid var(--border);
   }
 
@@ -487,7 +547,7 @@
   .btn-add-item { padding: 8px 14px; background: var(--primary); color: white; border: none; border-radius: 8px; font-size: 0.875rem; font-weight: 600; cursor: pointer; }
   .btn-add-item:hover { background: #1d4ed8; }
   .indent-items { display: flex; flex-direction: column; gap: 16px; }
-  .indent-item { background: #f8fafc; border: 1px solid var(--border); border-radius: 12px; padding: 16px; }
+  .indent-item { background: #f7f8fa; border: 1px solid var(--border); border-radius: 12px; padding: 16px; }
   .indent-item-header { display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px; }
   .indent-item-num { font-size: 0.8rem; font-weight: 600; color: var(--text-light); }
   .btn-remove-item { padding: 4px 8px; background: transparent; color: var(--danger); border: 1px solid var(--danger); border-radius: 6px; font-size: 0.75rem; cursor: pointer; }
@@ -529,14 +589,14 @@
   /* Modal overlay */
   .modal-overlay { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); z-index: 10000; display: flex; align-items: center; justify-content: center; padding: 16px; }
   .modal-content { background: white; border-radius: 16px; width: 100%; max-width: 500px; max-height: 85vh; overflow: hidden; display: flex; flex-direction: column; }
-  .modal-header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; border-bottom: 1px solid var(--border); background: #f8fafc; }
+  .modal-header { display: flex; justify-content: space-between; align-items: center; padding: 16px 20px; border-bottom: 1px solid var(--border); background: #f7f8fa; }
   .modal-title { font-size: 1.125rem; font-weight: 700; }
   .modal-close { background: none; border: none; font-size: 1.5rem; cursor: pointer; color: var(--text-light); line-height: 1; }
   .modal-body { padding: 20px; overflow-y: auto; flex: 1; }
   .detail-section { margin-bottom: 20px; }
   .detail-section-title { font-size: 0.8rem; font-weight: 600; color: var(--text-light); text-transform: uppercase; margin-bottom: 10px; }
   .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-  .detail-item { background: #f8fafc; padding: 12px; border-radius: 10px; }
+  .detail-item { background: #f7f8fa; padding: 12px; border-radius: 10px; }
   .detail-label { font-size: 0.75rem; color: var(--text-light); margin-bottom: 4px; }
   .detail-value { font-size: 0.9375rem; font-weight: 600; }
   .detail-value.highlight { color: var(--primary); }
@@ -554,7 +614,7 @@
   <div class="page-header">
     <h1 class="page-title">Jeans Assembly</h1>
     <div style="display: inline-flex; gap: 8px;">
-      <a href="/my-lots" class="btn-payments" style="background:#6366f1;">
+      <a href="/my-lots" class="btn-payments" style="background:#2563eb;">
         <i class="bi bi-bag-check"></i> My Lots
       </a>
       <a href="/payments/my-payments" class="btn-payments">
@@ -1167,4 +1227,10 @@ loadHistory(true);
 // INDENT TAB handled by views/partials/indentWrapper.ejs
 </script>
 
-<%- include('partials/footer') %>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
+</body>
+</html>

--- a/views/stitchingDashboard.ejs
+++ b/views/stitchingDashboard.ejs
@@ -1,9 +1,69 @@
-<%- include('partials/header', { pageTitle: 'Stitching Dashboard' }) %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<title>Stitching</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"/>
 <!-- Select2 for indent item search -->
 <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/stitchingdashboard' }) %>
+</head>
+<body>
+
+<style>
+  /* ── Kotty Floor shell chrome (copied from stitchingEvents.ejs) ── */
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
+  body { background: #f7f8fa; margin: 0; padding-bottom: 80px; }
+  .flx-top {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 1050;
+    background: #f7f8fa; border-bottom: 1px solid #e5e7eb;
+  }
+  .flx-top-main { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; }
+  .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+  .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+  .flx-top .brand h1 {
+    font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0;
+  }
+  .flx-nav {
+    position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 1050;
+    background: #ffffff; border-top: 1px solid #e5e7eb;
+    display: flex; justify-content: space-around; align-items: center;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .flx-nav a {
+    display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none;
+    color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flx-nav a.active { color: #2563eb; }
+  .flx-nav a .material-symbols-outlined { font-size: 24px; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
+  .flx-top .flx-actions { display: flex; align-items: center; gap: 12px; }
+  .flx-top .flx-home { color: #64748b; display: flex; }
+  .flx-top .flx-user { font-size: 13px; font-weight: 600; color: #0f172a; }
+  .flx-top .flx-logout { display: inline-flex; align-items: center; gap: 6px; color: #dc2626;
+    text-decoration: none; font-size: 13px; font-weight: 600; padding: 6px 10px;
+    border: 1px solid #fecaca; border-radius: 8px; }
+  .flx-top .flx-logout .material-symbols-outlined { font-size: 18px; }
+  @media (max-width: 420px) { .flx-top .flx-user, .flx-top .flx-logout-t { display: none; } }
+</style>
+
+<header class="flx-top">
+  <div class="flx-top-main">
+    <div class="brand">
+      <span class="material-symbols-outlined">precision_manufacturing</span>
+      <h1>Stitching</h1>
+    </div>
+    <div class="flx-actions">
+      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
+      <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
+    </div>
+  </div>
+</header>
 
 <style>
   /* ═══════════════════════════════════════════════════════════════════════════
@@ -20,19 +80,19 @@
     --success-light: #dcfce7;
     --danger: #dc2626;
     --danger-light: #fee2e2;
-    --warning: #f59e0b;
+    --warning: #b45309;
     --warning-light: #fef3c7;
-    --bg: #f8fafc;
+    --bg: #f7f8fa;
     --card: #ffffff;
-    --text: #1e293b;
+    --text: #0f172a;
     --text-light: #64748b;
-    --border: #e2e8f0;
-    --shadow: 0 1px 3px rgba(0,0,0,0.1);
+    --border: #e5e7eb;
+    --shadow: 0 1px 2px rgba(15,23,42,.06);
   }
 
   body {
     background: var(--bg);
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 16px;
     color: var(--text);
     line-height: 1.5;
@@ -177,7 +237,7 @@
     bottom: calc(100% + 8px);
     left: 50%;
     transform: translateX(-50%);
-    background: #1e293b;
+    background: #0f172a;
     color: white;
     padding: 10px 14px;
     border-radius: 8px;
@@ -201,7 +261,7 @@
     left: 50%;
     transform: translateX(-50%);
     border: 6px solid transparent;
-    border-top-color: #1e293b;
+    border-top-color: #0f172a;
   }
 
   .tooltip-wrapper:hover .tooltip-text,
@@ -499,7 +559,7 @@
   }
 
   .size-card {
-    background: #f8fafc;
+    background: #f7f8fa;
     border: 2px solid var(--border);
     border-radius: 12px;
     padding: 16px;
@@ -1021,7 +1081,7 @@
   }
 
   .indent-item {
-    background: #f8fafc;
+    background: #f7f8fa;
     border: 1px solid var(--border);
     border-radius: 12px;
     padding: 16px;
@@ -1262,7 +1322,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    background: #f8fafc;
+    background: #f7f8fa;
     border-radius: 16px 16px 0 0;
   }
   .modal-title { font-size: 1.125rem; font-weight: 700; color: var(--text); }
@@ -1294,7 +1354,7 @@
     gap: 6px;
   }
   .detail-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
-  .detail-item { background: #f8fafc; padding: 12px; border-radius: 8px; }
+  .detail-item { background: #f7f8fa; padding: 12px; border-radius: 8px; }
   .detail-item.full { grid-column: span 2; }
   .detail-label { font-size: 0.75rem; color: var(--text-light); margin-bottom: 4px; }
   .detail-value { font-size: 0.9375rem; font-weight: 600; color: var(--text); }
@@ -1309,7 +1369,7 @@
     flex-wrap: wrap;
     padding: 12px 16px;
     border-bottom: 1px solid var(--border);
-    background: #f8fafc;
+    background: #f7f8fa;
   }
   .history-date-input {
     padding: 10px 12px;
@@ -1376,7 +1436,7 @@
   <div class="page-header">
     <h1 class="page-title">Stitching</h1>
     <div style="display: inline-flex; gap: 8px;">
-      <a href="/my-lots" class="btn-payments" style="background:#6366f1;">
+      <a href="/my-lots" class="btn-payments" style="background:#2563eb;">
         <i class="bi bi-bag-check"></i> My Lots
       </a>
       <a href="/payments/my-payments" class="btn-payments">
@@ -2250,4 +2310,10 @@
   // INDENT TAB handled by views/partials/indentWrapper.ejs
 </script>
 
-<%- include('partials/footer') %>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
+</body>
+</html>

--- a/views/washingDashboard.ejs
+++ b/views/washingDashboard.ejs
@@ -1,5 +1,65 @@
-<%- include('partials/header', { pageTitle: 'Washing Dashboard' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/washingdashboard' }) %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<title>Washing</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"/>
+</head>
+<body>
+
+<style>
+  /* ── Kotty Floor shell chrome (copied from stitchingEvents.ejs) ── */
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
+  body { background: #f7f8fa; margin: 0; padding-bottom: 80px; }
+  .flx-top {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 1050;
+    background: #f7f8fa; border-bottom: 1px solid #e5e7eb;
+  }
+  .flx-top-main { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; }
+  .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+  .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+  .flx-top .brand h1 {
+    font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0;
+  }
+  .flx-nav {
+    position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 1050;
+    background: #ffffff; border-top: 1px solid #e5e7eb;
+    display: flex; justify-content: space-around; align-items: center;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .flx-nav a {
+    display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none;
+    color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flx-nav a.active { color: #2563eb; }
+  .flx-nav a .material-symbols-outlined { font-size: 24px; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
+  .flx-top .flx-actions { display: flex; align-items: center; gap: 12px; }
+  .flx-top .flx-home { color: #64748b; display: flex; }
+  .flx-top .flx-user { font-size: 13px; font-weight: 600; color: #0f172a; }
+  .flx-top .flx-logout { display: inline-flex; align-items: center; gap: 6px; color: #dc2626;
+    text-decoration: none; font-size: 13px; font-weight: 600; padding: 6px 10px;
+    border: 1px solid #fecaca; border-radius: 8px; }
+  .flx-top .flx-logout .material-symbols-outlined { font-size: 18px; }
+  @media (max-width: 420px) { .flx-top .flx-user, .flx-top .flx-logout-t { display: none; } }
+</style>
+
+<header class="flx-top">
+  <div class="flx-top-main">
+    <div class="brand">
+      <span class="material-symbols-outlined">local_laundry_service</span>
+      <h1>Washing</h1>
+    </div>
+    <div class="flx-actions">
+      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
+      <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
+    </div>
+  </div>
+</header>
 
 <style>
   /* Mobile-First, Clean Design - Matching Stitching Dashboard */
@@ -12,19 +72,19 @@
     --success-light: #dcfce7;
     --danger: #dc2626;
     --danger-light: #fee2e2;
-    --warning: #f59e0b;
+    --warning: #b45309;
     --warning-light: #fef3c7;
-    --bg: #f8fafc;
+    --bg: #f7f8fa;
     --card: #ffffff;
-    --text: #1e293b;
+    --text: #0f172a;
     --text-light: #64748b;
-    --border: #e2e8f0;
-    --shadow: 0 1px 3px rgba(0,0,0,0.1);
+    --border: #e5e7eb;
+    --shadow: 0 1px 2px rgba(15,23,42,.06);
   }
 
   body {
     background: var(--bg);
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     font-size: 16px;
     color: var(--text);
     line-height: 1.5;
@@ -277,7 +337,7 @@
   }
 
   .size-card {
-    background: #f8fafc;
+    background: #f7f8fa;
     border: 2px solid var(--border);
     border-radius: 12px;
     padding: 12px;
@@ -410,7 +470,7 @@
     justify-content: space-between;
     align-items: center;
     padding: 16px 20px;
-    background: #f8fafc;
+    background: #f7f8fa;
     border-bottom: 1px solid var(--border);
   }
 
@@ -542,7 +602,7 @@
   <div class="page-header">
     <h1 class="page-title">Washing</h1>
     <div style="display: inline-flex; gap: 8px;">
-      <a href="/my-lots" class="btn-payments" style="background:#6366f1;">
+      <a href="/my-lots" class="btn-payments" style="background:#2563eb;">
         <i class="bi bi-bag-check"></i> My Lots
       </a>
       <a href="/washingdashboard/rewash-download" class="btn-payments" style="background:#10b981;">
@@ -570,7 +630,7 @@
       <i class="bi bi-plus-circle"></i> Submit
     </button>
     <button class="tab-btn" data-tab="rewash">
-      <i class="bi bi-arrow-repeat"></i> Rewash <span id="rewashBadge" style="display:none; background:#f59e0b; color:white; padding:2px 6px; border-radius:10px; font-size:0.7rem; margin-left:4px;">0</span>
+      <i class="bi bi-arrow-repeat"></i> Rewash <span id="rewashBadge" style="display:none; background:#b45309; color:white; padding:2px 6px; border-radius:10px; font-size:0.7rem; margin-left:4px;">0</span>
     </button>
     <button class="tab-btn" data-tab="history">
       <i class="bi bi-clock-history"></i> History
@@ -1170,4 +1230,10 @@ document.querySelector('[data-tab="rewash"]').addEventListener('click', function
 });
 </script>
 
-<%- include('partials/footer') %>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
+</body>
+</html>

--- a/views/washingInDashboard.ejs
+++ b/views/washingInDashboard.ejs
@@ -1,9 +1,69 @@
-<%- include('partials/header', { pageTitle: 'Washing In Dashboard' }) %>
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"/>
+<title>Washing In</title>
+<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css"/>
 <!-- Select2 for indent item search -->
 <link href="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/css/select2.min.css" rel="stylesheet" />
 <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/select2@4.1.0-rc.0/dist/js/select2.min.js"></script>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/washingin' }) %>
+</head>
+<body>
+
+<style>
+  /* ── Kotty Floor shell chrome (copied from stitchingEvents.ejs) ── */
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap');
+  body { background: #f7f8fa; margin: 0; padding-bottom: 80px; }
+  .flx-top {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 1050;
+    background: #f7f8fa; border-bottom: 1px solid #e5e7eb;
+  }
+  .flx-top-main { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; }
+  .flx-top .brand { display: flex; align-items: center; gap: 10px; }
+  .flx-top .brand .material-symbols-outlined { color: #2563eb; }
+  .flx-top .brand h1 {
+    font-family: 'Space Grotesk', sans-serif; font-weight: 700; font-size: 18px;
+    text-transform: uppercase; letter-spacing: 0.08em; color: #2563eb; margin: 0;
+  }
+  .flx-nav {
+    position: fixed; bottom: 0; left: 0; right: 0; height: 64px; z-index: 1050;
+    background: #ffffff; border-top: 1px solid #e5e7eb;
+    display: flex; justify-content: space-around; align-items: center;
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+  .flx-nav a {
+    display: flex; flex-direction: column; align-items: center; gap: 2px; text-decoration: none;
+    color: #64748b; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.04em;
+  }
+  .flx-nav a.active { color: #2563eb; }
+  .flx-nav a .material-symbols-outlined { font-size: 24px; }
+  .material-symbols-outlined { font-variation-settings: 'FILL' 0, 'wght' 400; vertical-align: middle; }
+  .flx-top .flx-actions { display: flex; align-items: center; gap: 12px; }
+  .flx-top .flx-home { color: #64748b; display: flex; }
+  .flx-top .flx-user { font-size: 13px; font-weight: 600; color: #0f172a; }
+  .flx-top .flx-logout { display: inline-flex; align-items: center; gap: 6px; color: #dc2626;
+    text-decoration: none; font-size: 13px; font-weight: 600; padding: 6px 10px;
+    border: 1px solid #fecaca; border-radius: 8px; }
+  .flx-top .flx-logout .material-symbols-outlined { font-size: 18px; }
+  @media (max-width: 420px) { .flx-top .flx-user, .flx-top .flx-logout-t { display: none; } }
+</style>
+
+<header class="flx-top">
+  <div class="flx-top-main">
+    <div class="brand">
+      <span class="material-symbols-outlined">move_to_inbox</span>
+      <h1>Washing In</h1>
+    </div>
+    <div class="flx-actions">
+      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
+      <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
+    </div>
+  </div>
+</header>
 
 <style>
   /* =========================================================
@@ -13,27 +73,30 @@
      ========================================================= */
   * { box-sizing: border-box; }
   body {
-    background: #F4F5F9;
-    font-family: var(--font-body, 'Outfit', sans-serif);
-    color: #1a1a1a;
+    background: #f7f8fa;
+    font-family: var(--font-body, 'Inter', sans-serif);
+    color: #0f172a;
     font-size: 16px;
   }
 
   :root {
-    --wi-indigo: #5b5bf5;
-    --wi-indigo-dark: #4f46e5;
-    --wi-indigo-bg: #EEF0FE;
-    --wi-amber: #c4873a;
-    --wi-amber-bg: #FEF6E5;
-    --wi-amber-chip: #FFE9B8;
-    --wi-red: #c23b22;
-    --wi-red-bg: #FCEDEA;
-    --wi-red-chip: #FAD3CD;
-    --wi-green: #2d8a5f;
-    --wi-ink: #1a1a1a;
-    --wi-muted: #6b7280;
-    --wi-line: rgba(0,0,0,.08);
-    --wi-bg: #F4F5F9;
+    --font-body: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    --font-display: 'Space Grotesk', 'Inter', sans-serif;
+    --font-mono: 'Space Grotesk', 'Inter', sans-serif;
+    --wi-indigo: #2563eb;
+    --wi-indigo-dark: #1d4ed8;
+    --wi-indigo-bg: #eff6ff;
+    --wi-amber: #b45309;
+    --wi-amber-bg: #fef3c7;
+    --wi-amber-chip: #fde68a;
+    --wi-red: #dc2626;
+    --wi-red-bg: #fee2e2;
+    --wi-red-chip: #fecaca;
+    --wi-green: #16a34a;
+    --wi-ink: #0f172a;
+    --wi-muted: #64748b;
+    --wi-line: #e5e7eb;
+    --wi-bg: #f7f8fa;
     --wi-card: #ffffff;
   }
 
@@ -57,13 +120,13 @@
   /* Stats strip */
   .wi-stats { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; margin: 0 16px 16px; }
   .wi-stat  { background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 14px; padding: 14px 16px; }
-  .wi-stat__n { font-family: var(--font-mono, 'JetBrains Mono', monospace); font-size: 1.6rem; font-weight: 600; color: #111; line-height: 1; }
+  .wi-stat__n { font-family: var(--font-mono, 'JetBrains Mono', monospace); font-size: 1.6rem; font-weight: 600; color: #0f172a; line-height: 1; }
   .wi-stat__l { font-size: .72rem; color: var(--wi-muted); text-transform: uppercase; letter-spacing: .08em; margin-top: 6px; font-weight: 600; }
 
   /* Tabs */
   .wi-tabs { display: flex; background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 14px; padding: 4px; margin: 0 16px 16px; }
   .wi-tab  { flex: 1; padding: 11px 8px; border: none; background: transparent; border-radius: 10px; font-weight: 600; font-size: .85rem; color: var(--wi-muted); cursor: pointer; display: flex; align-items: center; justify-content: center; gap: 6px; }
-  .wi-tab.active { background: #111; color: white; }
+  .wi-tab.active { background: #2563eb; color: white; }
 
   .tab-content { display: none; }
   .tab-content.active { display: block; }
@@ -71,11 +134,11 @@
   /* =================== Search =================== */
   .wi-search { background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 14px; padding: 18px; margin: 0 16px 16px; }
   .wi-search label { display: block; font-size: .72rem; font-weight: 700; color: var(--wi-muted); text-transform: uppercase; letter-spacing: .1em; margin-bottom: 10px; }
-  .wi-search input { width: 100%; padding: 14px 16px; border: 1.5px solid #e4e4ea; border-radius: 12px; font-size: 1.05rem; font-family: var(--font-mono, monospace); text-transform: uppercase; letter-spacing: .04em; }
+  .wi-search input { width: 100%; padding: 14px 16px; border: 1.5px solid #e5e7eb; border-radius: 12px; font-size: 1.05rem; font-family: var(--font-mono, monospace); text-transform: uppercase; letter-spacing: .04em; }
   .wi-search input:focus { outline: none; border-color: var(--wi-indigo); box-shadow: 0 0 0 3px var(--wi-indigo-bg); }
   .wi-search input.input-error { border-color: var(--wi-red); animation: shake .3s; }
   @keyframes shake { 0%, 100% { transform: translateX(0); } 25% { transform: translateX(-4px); } 75% { transform: translateX(4px); } }
-  .wi-search button { width: 100%; padding: 14px; background: #111; color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 10px; display: flex; align-items: center; justify-content: center; gap: 8px; }
+  .wi-search button { width: 100%; padding: 14px; background: #2563eb; color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 10px; display: flex; align-items: center; justify-content: center; gap: 8px; }
 
   /* Multi-match picker */
   .wi-pickHeader { font-size: .72rem; font-weight: 700; color: var(--wi-muted); text-transform: uppercase; letter-spacing: .1em; padding: 0 4px 8px; }
@@ -97,7 +160,7 @@
   }
   .wi-lotHeader__top { display: flex; align-items: baseline; gap: 12px; flex-wrap: wrap; }
   .wi-lotHeader__no { font-family: var(--font-mono, monospace); font-size: 1.4rem; font-weight: 700; text-transform: uppercase; letter-spacing: .04em; }
-  .wi-lotHeader__badge { display: inline-block; padding: 2px 8px; border-radius: 999px; background: #111; color: white; font-size: .65rem; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; }
+  .wi-lotHeader__badge { display: inline-block; padding: 2px 8px; border-radius: 999px; background: #0f172a; color: white; font-size: .65rem; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; }
   .wi-lotHeader__close { margin-left: auto; background: transparent; border: 1px solid var(--wi-line); border-radius: 999px; width: 32px; height: 32px; cursor: pointer; color: var(--wi-muted); display: inline-flex; align-items: center; justify-content: center; }
   .wi-lotHeader__close:hover { background: white; color: var(--wi-ink); }
   .wi-lotHeader__meta { font-size: .82rem; color: var(--wi-muted); margin-top: 4px; }
@@ -244,7 +307,7 @@
 
   .wi-btn {
     width: 40px; height: 40px;
-    border: 1px solid #e4e4ea;
+    border: 1px solid #e5e7eb;
     background: var(--wi-card);
     border-radius: 10px;
     font-size: 1.1rem; font-weight: 600;
@@ -269,7 +332,7 @@
     flex: 1 1 70px;
     min-width: 60px;
     height: 40px;
-    border: 1px solid #e4e4ea;
+    border: 1px solid #e5e7eb;
     border-radius: 10px;
     text-align: center;
     font-family: var(--font-mono, monospace);
@@ -338,7 +401,7 @@
 
   .wi-submitMirror {
     width: 100%; padding: 14px;
-    background: #111; color: white;
+    background: #2563eb; color: white;
     border: none; border-radius: 12px;
     font-size: .98rem; font-weight: 700;
     cursor: pointer;
@@ -364,11 +427,11 @@
 
   /* History */
   .history-search { background: var(--wi-card); border-radius: 14px; padding: 16px; margin: 0 16px 16px; border: 1px solid var(--wi-line); }
-  .history-input  { width: 100%; padding: 12px 14px; border: 1px solid #e4e4ea; border-radius: 10px; }
+  .history-input  { width: 100%; padding: 12px 14px; border: 1px solid #e5e7eb; border-radius: 10px; }
   .history-filters { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
-  .history-filters input[type="date"] { flex: 1; min-width: 120px; padding: 10px 12px; border: 1px solid #e4e4ea; border-radius: 10px; font-size: .875rem; }
+  .history-filters input[type="date"] { flex: 1; min-width: 120px; padding: 10px 12px; border: 1px solid #e5e7eb; border-radius: 10px; font-size: .875rem; }
   .btn-filter, .btn-download { padding: 10px 14px; border: none; border-radius: 10px; font-size: .85rem; font-weight: 600; cursor: pointer; display: flex; align-items: center; gap: 6px; }
-  .btn-filter   { background: #111; color: white; }
+  .btn-filter   { background: #2563eb; color: white; }
   .btn-download { background: var(--wi-green); color: white; }
   .history-list { background: var(--wi-card); border-radius: 14px; margin: 0 16px 16px; border: 1px solid var(--wi-line); overflow: hidden; }
   .history-item { display: flex; justify-content: space-between; align-items: center; padding: 14px 18px; border-bottom: 1px solid rgba(0,0,0,.05); }
@@ -413,7 +476,7 @@
   .indent-row { display: grid; grid-template-columns: 1fr 80px; gap: 10px; margin-bottom: 10px; }
   .indent-row.single { grid-template-columns: 1fr; }
   .indent-label { font-size: .78rem; font-weight: 600; margin-bottom: 6px; display: block; }
-  .indent-select, .indent-input { width: 100%; padding: 11px; font-size: .92rem; border: 1.5px solid #e4e4ea; border-radius: 10px; }
+  .indent-select, .indent-input { width: 100%; padding: 11px; font-size: .92rem; border: 1.5px solid #e5e7eb; border-radius: 10px; }
   .btn-submit-indent { width: 100%; padding: 14px; background: var(--wi-green); color: white; border: none; border-radius: 12px; font-size: 1rem; font-weight: 600; cursor: pointer; margin-top: 16px; }
   .indent-requests-card { background: var(--wi-card); border: 1px solid var(--wi-line); border-radius: 14px; margin: 0 16px 16px; overflow: hidden; }
   .indent-requests-header { padding: 12px 18px; background: #f5f5f9; border-bottom: 1px solid var(--wi-line); font-weight: 700; }
@@ -428,11 +491,11 @@
   .indent-request-status.proceeding { background: #cffafe; color: #155e75; }
   .indent-request-status.arrived { background: #e8f5ee; color: var(--wi-green); }
   .indent-empty { padding: 28px 18px; text-align: center; color: var(--wi-muted); }
-  .select2-container--default .select2-selection--single { height: auto; padding: 8px 12px; border: 1.5px solid #e4e4ea; border-radius: 10px; }
+  .select2-container--default .select2-selection--single { height: auto; padding: 8px 12px; border: 1.5px solid #e5e7eb; border-radius: 10px; }
 
   /* Spinner */
   .spinner { width: 18px; height: 18px; border: 2px solid rgba(255,255,255,.3); border-top-color: white; border-radius: 50%; animation: spin .8s linear infinite; }
-  .spinner.dark { border: 2px solid rgba(0,0,0,.2); border-top-color: #111; }
+  .spinner.dark { border: 2px solid rgba(0,0,0,.2); border-top-color: #0f172a; }
   @keyframes spin { to { transform: rotate(360deg); } }
 </style>
 
@@ -443,7 +506,7 @@
   <div class="wi-pageHeader">
     <h1>Washing&nbsp;In</h1>
     <div style="display: inline-flex; gap: 8px;">
-      <a href="/my-lots" class="wi-payLink" style="background:#6366f1;color:#fff;"><i class="bi bi-bag-check"></i> My Lots</a>
+      <a href="/my-lots" class="wi-payLink" style="background:#2563eb;color:#fff;"><i class="bi bi-bag-check"></i> My Lots</a>
       <a href="/washingin/rewash-download" class="wi-payLink" style="background:#10b981;color:#fff;"><i class="bi bi-file-earmark-excel"></i> Rewash Excel</a>
       <a href="/payments/my-payments" class="wi-payLink"><i class="bi bi-wallet2"></i> Payments</a>
     </div>
@@ -1122,4 +1185,10 @@ loadToday();
 loadHistory(true);
 </script>
 
-<%- include('partials/footer') %>
+<nav class="flx-nav">
+  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
+  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
+  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
+</nav>
+</body>
+</html>


### PR DESCRIPTION
The 5 role landing dashboards — the screens masters land on — rebuilt onto the floor chrome. Agent-built, diff spot-checked (no leftover includes, element counts identical). **Cutting untouched.**

**Screens:** `/stitchingdashboard` · jeans-assembly · washing · washing-in · finishing.

**Approach — full chrome swap** (all 5 verified Bootstrap-independent): the old `header`/`navbar`/`footer` includes are replaced by the standalone Stitch chrome from the stage screens — `.flx-top` (stage icon + name, Home → `/operator/hub`, username, red-outline **Log out**) and the `.flx-nav` bottom nav. Bootstrap-icons font re-added explicitly (they use `bi-` icons); finishing got a local compat block for the 30 kotty-theme variables it referenced.

**Palette:** each dashboard's own tokens retuned to the system — single accent `#2563eb` (indigo/black/`#5b5bf5` variants all normalized), status green `#16a34a` / amber `#b45309` / red `#dc2626`, ground `#f7f8fa`, ink `#0f172a`, Inter + Space Grotesk.

**Safety:**
- Scripted before/after element inventory (`form/button/input/select/table/textarea/section`): **identical in all 5** — nothing dropped; Material Indent kept in the 4 that had it.
- All 5 render with route-derived locals; all 9 inline scripts parse.
- No route or JS data-logic changes.

Eyeball `/stitchingdashboard` on a phone — same family as the lot screens now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)