### PR TITLE
feat(floor): the final four screens onto the floor tokens

### DIFF
--- a/views/editWashingAssignments.ejs
+++ b/views/editWashingAssignments.ejs
@@ -1,5 +1,6 @@
 <%- include('partials/header', { pageTitle: 'Edit Washing Assignments' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+<%- include('partials/navbar', { user: user, dashboardUrl: '/operator/hub' }) %>
+<%- include('partials/floorTokens') %>
 
 <style>
   /* Page Layout */

--- a/views/editcuttinglots.ejs
+++ b/views/editcuttinglots.ejs
@@ -1,6 +1,7 @@
 <!-- views/editcuttinglots.ejs -->
 <%- include('partials/header', { pageTitle: 'Edit Cutting Lots' }) %>
-<%- include('partials/navbar', { dashboardUrl: '/operator/dashboard', user: user }) %>
+<%- include('partials/navbar', { dashboardUrl: '/operator/hub', user: user }) %>
+<%- include('partials/floorTokens') %>
 
 <!-- Main Content -->
 <main class="main-content" style="margin-left: 0;">

--- a/views/lotAdmin.ejs
+++ b/views/lotAdmin.ejs
@@ -5,11 +5,12 @@
   <title>Lot Admin</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <style>
-    :root{ --ink:#0f172a; --ink2:#64748b; --line:#e5e7eb; --bg:#f6f7fb; --card:#fff;
+    @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&display=swap');
+    :root{ --ink:#0f172a; --ink2:#64748b; --line:#e5e7eb; --bg:#f7f8fa; --card:#fff;
            --blue:#2563eb; --blue-bg:#eff6ff; --green:#16a34a; --green-bg:#dcfce7;
-           --amber:#b45309; --amber-bg:#fef3c7; --red:#b91c1c; }
+           --amber:#b45309; --amber-bg:#fef3c7; --red:#dc2626; }
     *{box-sizing:border-box}
-    body{margin:0;background:var(--bg);color:var(--ink);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;}
+    body{margin:0;background:var(--bg);color:var(--ink);font-family:'Inter',-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;}
     .head{background:#0f172a;color:#fff;padding:18px 16px;}
     .head h1{margin:0;font-size:1.2rem;font-weight:650;}
     .head p{margin:4px 0 0;color:#94a3b8;font-size:.85rem;}

--- a/views/stagePaymentCreate.ejs
+++ b/views/stagePaymentCreate.ejs
@@ -1,21 +1,22 @@
 <%- include('partials/header', { pageTitle: 'Create Payments' }) %>
-<%- include('partials/navbar', { user: user, dashboardUrl: '/operator/dashboard' }) %>
+<%- include('partials/navbar', { user: user, dashboardUrl: '/operator/hub' }) %>
+<%- include('partials/floorTokens') %>
 
 <style>
   :root {
-    --charcoal: #1a1a1a;
-    --cream: #faf8f5;
-    --cream-dark: #f0ebe3;
-    --terracotta: #c45c3a;
-    --terracotta-dark: #a84a2d;
-    --success: #2d8a5f;
-    --warning: #c4873a;
-    --danger: #c23b22;
-    --info: #3a7bc4;
-    --border: #e5e0d8;
-    --text-secondary: #5a5a5a;
+    --charcoal: #0f172a;
+    --cream: #f7f8fa;
+    --cream-dark: #f1f5f9;
+    --terracotta: #2563eb;
+    --terracotta-dark: #1d4ed8;
+    --success: #16a34a;
+    --warning: #b45309;
+    --danger: #dc2626;
+    --info: #2563eb;
+    --border: #e5e7eb;
+    --text-secondary: #64748b;
     --radius-sm: 6px;
-    --radius-md: 10px;
+    --radius-md: 12px;
   }
 
   body { background: var(--cream); }


### PR DESCRIPTION
Closes the last gap in the floor redesign — after this, **every floor/operator screen except cutting (your exclusion) is on the new design**.

| Screen | Change |
|---|---|
| **Lot Admin** | 2 hex tweaks (ground, red) + Inter/Space Grotesk — it was built just before the final system, so it was already 95% on-token |
| **Stage Payment Create** | the payment **write** screen, deliberately kept out of the agent batch and done by hand: its terracotta/cream palette retuned to the floor tokens purely via CSS-variable values — rate/payment logic, forms, and JS untouched |
| **Edit Lots** + **Edit Wash** | `floorTokens` partial (same one-line pattern as #530's screens) |
| All three header-based ones | navbar brand link → `/operator/hub` (one less hop after #532) |

Verified: all 4 render with route-accurate locals; every inline script parses; `stagePaymentCreate`'s diff is CSS-values + 2 include lines only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)