### PR TITLE
fix(floor): audience-correct navigation + hub logout + KPI overflow

### DIFF
--- a/views/finishingDashboard.ejs
+++ b/views/finishingDashboard.ejs
@@ -58,7 +58,6 @@
       <h1>Finishing</h1>
     </div>
     <div class="flx-actions">
-      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -1237,10 +1236,5 @@ function escHtml(str) {
 }
 </script>
 
-<nav class="flx-nav">
-  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>

--- a/views/finishingEvents.ejs
+++ b/views/finishingEvents.ejs
@@ -1203,7 +1203,7 @@
       <h1>Finishing</h1>
     </div>
     <div class="flx-actions">
-      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <a class="flx-home" href="/finishingdashboard" title="Home"><span class="material-symbols-outlined">home</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -2319,10 +2319,5 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape' && el('modalO
 loadHistory();
 </script>
 
-<nav class="flx-nav">
-  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>

--- a/views/floorHub.ejs
+++ b/views/floorHub.ejs
@@ -41,10 +41,10 @@
         ['Cut Pieces', num(totalPiecesCut), 'text-primary', 'content_cut'],
         ['Finished', num(totalFinished), 'text-secondary', 'check_circle'],
         ['Users', num(userCount), '', 'group']].forEach(function(k){ %>
-      <div class="bg-surface-container-lowest p-5 rounded-xl border border-outline-variant shadow-sm flex items-center justify-between">
-        <div>
+      <div class="bg-surface-container-lowest p-5 rounded-xl border border-outline-variant shadow-sm flex items-center justify-between gap-2 min-w-0">
+        <div class="min-w-0">
           <p class="text-[10px] uppercase tracking-wider text-on-surface-variant font-bold mb-1"><%= k[0] %></p>
-          <p class="font-headline text-3xl font-bold leading-none <%= k[2] %>"><%= k[1] %></p>
+          <p class="font-headline text-[clamp(1.25rem,5.5vw,1.875rem)] font-bold leading-none tracking-tight <%= k[2] %>"><%= k[1] %></p>
         </div>
         <span class="material-symbols-outlined text-on-surface-variant/40 text-3xl"><%= k[3] %></span>
       </div>

--- a/views/jeansAssemblyDashboard.ejs
+++ b/views/jeansAssemblyDashboard.ejs
@@ -58,7 +58,6 @@
       <h1>Jeans Assembly</h1>
     </div>
     <div class="flx-actions">
-      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -1227,10 +1226,5 @@ loadHistory(true);
 // INDENT TAB handled by views/partials/indentWrapper.ejs
 </script>
 
-<nav class="flx-nav">
-  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>

--- a/views/jeansAssemblyEvents.ejs
+++ b/views/jeansAssemblyEvents.ejs
@@ -1203,7 +1203,7 @@
       <h1>Jeans Assembly</h1>
     </div>
     <div class="flx-actions">
-      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <a class="flx-home" href="/jeansassemblydashboard" title="Home"><span class="material-symbols-outlined">home</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -2311,10 +2311,5 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape' && el('modalO
 loadHistory();
 </script>
 
-<nav class="flx-nav">
-  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>

--- a/views/myLots.ejs
+++ b/views/myLots.ejs
@@ -120,7 +120,7 @@
         <h1>My Lots</h1>
       </div>
       <div class="flx-actions">
-        <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+        <a class="flx-home" href="/" title="Home"><span class="material-symbols-outlined">home</span></a>
         <span class="flx-user"><%= (typeof user !== 'undefined' && user && user.username) ? user.username : 'Operator' %></span>
         <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
       </div>
@@ -320,10 +320,5 @@
 
   load();
 </script>
-<nav class="flx-nav">
-  <a href="/operator/hub" class="active"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>

--- a/views/partials/floorHead.ejs
+++ b/views/partials/floorHead.ejs
@@ -93,5 +93,8 @@
       </div>
     <% } %>
     <div class="w-10 h-10 rounded-full bg-primary-container flex items-center justify-center border border-primary/10 font-headline font-bold text-primary"><%= _initial %></div>
+    <a href="/logout" class="flex items-center gap-1.5 text-error text-[13px] font-semibold border border-error/30 rounded-lg px-2.5 py-1.5 hover:bg-error-container/40">
+      <span class="material-symbols-outlined text-[18px]">logout</span><span class="hidden sm:inline">Log out</span>
+    </a>
   </div>
 </header>

--- a/views/stitchingDashboard.ejs
+++ b/views/stitchingDashboard.ejs
@@ -58,7 +58,6 @@
       <h1>Stitching</h1>
     </div>
     <div class="flx-actions">
-      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -2310,10 +2309,5 @@
   // INDENT TAB handled by views/partials/indentWrapper.ejs
 </script>
 
-<nav class="flx-nav">
-  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>

--- a/views/stitchingEvents.ejs
+++ b/views/stitchingEvents.ejs
@@ -1203,7 +1203,7 @@
       <h1>Stitching</h1>
     </div>
     <div class="flx-actions">
-      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <a class="flx-home" href="/stitchingdashboard" title="Home"><span class="material-symbols-outlined">home</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -2322,10 +2322,5 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape' && el('modalO
 loadHistory();
 </script>
 
-<nav class="flx-nav">
-  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>

--- a/views/washingDashboard.ejs
+++ b/views/washingDashboard.ejs
@@ -54,7 +54,6 @@
       <h1>Washing</h1>
     </div>
     <div class="flx-actions">
-      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -1230,10 +1229,5 @@ document.querySelector('[data-tab="rewash"]').addEventListener('click', function
 });
 </script>
 
-<nav class="flx-nav">
-  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>

--- a/views/washingEvents.ejs
+++ b/views/washingEvents.ejs
@@ -1203,7 +1203,7 @@
       <h1>Washing</h1>
     </div>
     <div class="flx-actions">
-      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <a class="flx-home" href="/washingdashboard" title="Home"><span class="material-symbols-outlined">home</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -2311,10 +2311,5 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape' && el('modalO
 loadHistory();
 </script>
 
-<nav class="flx-nav">
-  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>

--- a/views/washingInDashboard.ejs
+++ b/views/washingInDashboard.ejs
@@ -58,7 +58,6 @@
       <h1>Washing In</h1>
     </div>
     <div class="flx-actions">
-      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -1185,10 +1184,5 @@ loadToday();
 loadHistory(true);
 </script>
 
-<nav class="flx-nav">
-  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>

--- a/views/washingInEvents.ejs
+++ b/views/washingInEvents.ejs
@@ -1203,7 +1203,7 @@
       <h1>Washing In</h1>
     </div>
     <div class="flx-actions">
-      <a class="flx-home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <a class="flx-home" href="/washingin" title="Home"><span class="material-symbols-outlined">home</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -2311,10 +2311,5 @@ document.addEventListener('keydown', e => { if (e.key === 'Escape' && el('modalO
 loadHistory();
 </script>
 
-<nav class="flx-nav">
-  <a href="/operator/hub"><span class="material-symbols-outlined">home</span>Home</a>
-  <a href="/search-dashboard"><span class="material-symbols-outlined">search</span>Search</a>
-  <a href="/operator/lot-journey"><span class="material-symbols-outlined">route</span>Journey</a>
-</nav>
 </body>
 </html>


### PR DESCRIPTION
Your three reports — and this time the fix is swept across **every** chrome variant, with the roles actually checked.

## 1. Log out on the hub
It was missing: the hub uses the shared `floorHead` partial, which never got the logout that the stage screens' own chrome got. Now in `floorHead` (red-outline button; icon-only on small phones) — every screen using that partial has it.

## 2. Numbers bursting out of cards on phone
Hub KPI values (7-digit Indian-formatted) at fixed `text-3xl` overflowed the 2-col cards. Now `clamp(1.25rem, 5.5vw, 1.875rem)` + `min-w-0` — scales with the phone, never overflows, full size on desktop.

## 3. Search/Journey in the stage screens' bottom nav — your question answered honestly
I checked the role gates: **all three destinations (`/operator/hub`, `/search-dashboard`, `/operator/lot-journey`) are operator-only, but the stage screens are used by masters** — who literally cannot open any of them. The nav wasn't just purposeless; it was broken for its audience. I had copied the mockup's nav pattern without asking who uses the screen.

| Screen family | Fix |
|---|---|
| 5 stage event screens (masters) | bottom nav **removed**; top-bar Home → the master's **own** dashboard |
| 5 role landing dashboards (masters) | bottom nav + Home link removed — they *are* home |
| myLots (mixed) | nav removed; Home → `/` (bounces to each role's own dashboard) |
| lotJourney / Lot TAT (operator-only) | nav kept — valid for operators |
| Hub (operator-only) | nav kept — valid |

Verified: 12 views render, scripts parse, payment code untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)