### PR TITLE
feat(consumption): add raw Manual Cutting Date column

### DIFF
--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -805,6 +805,7 @@ router.get("/dashboard/consumption/download", isAuthenticated, isOperator, async
         l.fabric_type,
         l.lot_no,
         l.manual_lot_number,
+        DATE_FORMAT(l.manual_cutting_date, '%d-%m-%Y') AS manual_cutting_date,
         DATE_FORMAT(COALESCE(l.manual_cutting_date, l.created_at), '%d-%m-%Y') AS cutting_date,
         CASE
           WHEN LOWER(l.flow_type) = 'denim'   THEN 'Denim'
@@ -836,6 +837,7 @@ router.get("/dashboard/consumption/download", isAuthenticated, isOperator, async
       { header: "Fabric Type", key: "fabric_type", width: 18 },
       { header: "Lot No", key: "lot_no", width: 15 },
       { header: "Manual Lot No", key: "manual_lot_number", width: 16 },
+      { header: "Manual Cutting Date", key: "manual_cutting_date", width: 18 },
       { header: "Cutting Date", key: "cutting_date", width: 14 },
       { header: "Type", key: "flow_type", width: 12 },
       { header: "SKU", key: "sku", width: 25 },


### PR DESCRIPTION
Adds **Manual Cutting Date** (the date exactly as entered by the cutter — blank when not entered) right after Manual Lot No in the roll-wise Consumption Report. The existing **Cutting Date** column (which falls back to the lot's created date for old lots) stays as-is, so nothing you rely on changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)