### PR TITLE
fix(sku-categories): page silently redirected — query used a non-existent column

### DIFF
--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -2735,10 +2735,11 @@ router.get("/lot-completion/download", isAuthenticated, isOperator, async (req, 
 // GET /operator/sku-categories - Render management page
 router.get('/sku-categories', isAuthenticated, isOperator, async (req, res) => {
   try {
+    // NOTE: sku_categories has no created_by column in prod — the old join on
+    // sc.created_by made this whole page 500 → silent redirect to the hub.
     const [categories] = await pool.query(`
-      SELECT sc.*, u.username AS created_by_name
+      SELECT sc.*, NULL AS created_by_name
       FROM sku_categories sc
-      LEFT JOIN users u ON sc.created_by = u.id
       ORDER BY sc.name
     `);
     res.render('operator-sku-categories', {


### PR DESCRIPTION
**Answer to "who can access / is it working":** access was never the issue — sarvind has the operator role and the gate is `isOperator`. The page was **broken for every operator**: its query joins `users` on `sku_categories.created_by`, a column that doesn't exist in prod. The SQL error hit the catch block → flash + **silent redirect back to the hub** — so clicking the tile looked like "nothing happened".

**Fix:** query now matches the real schema (`created_by_name` passed as `NULL`; the view already tolerates it). The add/delete/list APIs were already schema-correct and untouched.

**Verified:** the exact new query runs against prod (18 categories); the view renders with the null field; route parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)