### PR TITLE
feat(ee-po): finishing dispatch → EasyEcom PO pipeline (warehouse GRNs manually)

### DIFF
--- a/app.js
+++ b/app.js
@@ -232,6 +232,7 @@ app.use('/cutting-manager', cuttingManagerRoutes);
 app.use('/manual-lot', manualLotRoutes);
 app.use('/department', departmentRoutes);
 app.use('/stitchingdashboard', stitchingRoutes);
+app.use('/finishingdashboard/ee-po', require('./routes/eeDispatchRoutes'));
 app.use('/finishingdashboard', finishingRoutes);
 app.use('/washingdashboard', washingRoutes);
 app.use('/', searchRoutes);

--- a/routes/eeDispatchRoutes.js
+++ b/routes/eeDispatchRoutes.js
@@ -1,0 +1,82 @@
+// Finishing → EasyEcom PO review screen (the approval gate).
+// Audience: the FINISHING role (user decision 2026-07-10) — they dispatch, they push.
+// The pipeline never writes inventory: it creates a PO; the warehouse GRNs manually.
+const express = require('express');
+const router = express.Router();
+const { pool } = require('../config/db');
+const { isAuthenticated, isFinishingMaster } = require('../middlewares/auth');
+const { buildBatch, reResolveBatch, pushBatch, confirmGrns, pushEnabled, EE_PO_SINCE } = require('../utils/eeDispatchPo');
+
+// GET / — review screen: batches + how many dispatch rows await sweeping.
+router.get('/', isAuthenticated, isFinishingMaster, async (req, res) => {
+  try {
+    const [batches] = await pool.query(
+      `SELECT * FROM ee_dispatch_po ORDER BY id DESC LIMIT 40`);
+    const ids = batches.map(b => b.id);
+    let linesByBatch = {};
+    if (ids.length) {
+      const [lines] = await pool.query(
+        `SELECT * FROM ee_dispatch_po_lines WHERE batch_id IN (?) ORDER BY id`, [ids]);
+      for (const l of lines) (linesByBatch[l.batch_id] = linesByBatch[l.batch_id] || []).push(l);
+    }
+    const [[pending]] = await pool.query(
+      `SELECT COUNT(*) AS c, COALESCE(SUM(fd.quantity),0) AS qty
+         FROM finishing_dispatches fd
+         LEFT JOIN ee_dispatch_po_lines l ON l.dispatch_id = fd.id
+        WHERE l.id IS NULL AND LOWER(fd.destination)='warehouse'
+          AND fd.created_at >= ?`, [EE_PO_SINCE]);
+    res.render('eeDispatchPo', {
+      user: req.session.user,
+      batches, linesByBatch,
+      pendingRows: pending.c, pendingQty: Number(pending.qty),
+      pushEnabled: pushEnabled(),
+    });
+  } catch (err) {
+    console.error('ee-po review error:', err);
+    res.status(500).send('Could not load the EasyEcom PO screen: ' + err.message);
+  }
+});
+
+// POST /build — sweep unswept Warehouse dispatches into a new batch.
+router.post('/build', isAuthenticated, isFinishingMaster, async (req, res) => {
+  try {
+    const out = await buildBatch(req.session.user);
+    res.json({ success: true, ...out });
+  } catch (err) {
+    console.error('ee-po build error:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /reresolve/:id — retry SKU resolution on a blocked batch.
+router.post('/reresolve/:id', isAuthenticated, isFinishingMaster, async (req, res) => {
+  try {
+    const out = await reResolveBatch(Number(req.params.id));
+    res.json({ success: true, ...out });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /push/:id — create the PO in EasyEcom (flag-gated, draft only).
+router.post('/push/:id', isAuthenticated, isFinishingMaster, async (req, res) => {
+  try {
+    const out = await pushBatch(Number(req.params.id));
+    res.json({ success: true, ...out });
+  } catch (err) {
+    console.error('ee-po push error:', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /refresh — poll EasyEcom for warehouse GRNs against our pushed POs.
+router.post('/refresh', isAuthenticated, isFinishingMaster, async (req, res) => {
+  try {
+    const out = await confirmGrns();
+    res.json({ success: true, ...out });
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+});
+
+module.exports = router;

--- a/sql/2026_07_ee_dispatch_po.sql
+++ b/sql/2026_07_ee_dispatch_po.sql
@@ -1,0 +1,51 @@
+-- Finishing dispatch → EasyEcom PO pipeline (docs/EASYECOM_DISPATCH_GRN_DESIGN.md)
+-- Model: kotty-track creates ONLY the PO (the challan). The warehouse GRNs it manually
+-- in the EasyEcom UI; a confirmation poller matches getGrnDetails.po_id back to batches.
+
+-- Batch ledger: one row per PO we create (idempotency spine).
+CREATE TABLE IF NOT EXISTS ee_dispatch_po (
+  id            INT AUTO_INCREMENT PRIMARY KEY,
+  batch_ref     VARCHAR(40) NOT NULL UNIQUE,   -- 'KT-DISP-<id>' → PO referenceCode/docNumber
+  status        ENUM('draft','blocked','pushed','confirmed','failed','cancelled') NOT NULL DEFAULT 'draft',
+  warehouse_id  INT NOT NULL DEFAULT 173983,   -- Faridabad
+  po_id         BIGINT NULL,                   -- EasyEcom poId after push
+  grn_id        BIGINT NULL,                   -- warehouse's GRN once detected
+  grn_status    VARCHAR(40) NULL,
+  total_qty     INT NOT NULL DEFAULT 0,
+  line_count    INT NOT NULL DEFAULT 0,
+  blocked_count INT NOT NULL DEFAULT 0,
+  error         TEXT NULL,
+  created_by    INT NULL,
+  created_by_name VARCHAR(100) NULL,
+  pushed_at     DATETIME NULL,
+  confirmed_at  DATETIME NULL,
+  created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  KEY idx_status (status),
+  KEY idx_po (po_id)
+);
+
+-- Batch lines: one row per finishing_dispatches row swept into a batch.
+-- dispatch_id UNIQUE = a dispatch row can NEVER be pushed twice (DB-level idempotency).
+CREATE TABLE IF NOT EXISTS ee_dispatch_po_lines (
+  id            INT AUTO_INCREMENT PRIMARY KEY,
+  batch_id      INT NOT NULL,
+  dispatch_id   INT NOT NULL UNIQUE,
+  lot_no        VARCHAR(50) NOT NULL,
+  size_label    VARCHAR(20) NOT NULL,
+  quantity      INT NOT NULL,
+  lot_sku       VARCHAR(100) NULL,             -- cutting_lots.sku (style-level)
+  ee_sku        VARCHAR(120) NULL,             -- resolved EasyEcom size-SKU (NULL = blocked)
+  resolve_source VARCHAR(30) NULL,             -- 'map' | 'concat-verified' | NULL
+  unit_cost     DECIMAL(10,2) NULL,            -- from ee_product_master.cost (may be NULL)
+  mrp           DECIMAL(10,2) NULL,
+  created_at    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  KEY idx_batch (batch_id),
+  CONSTRAINT fk_eedpl_batch FOREIGN KEY (batch_id) REFERENCES ee_dispatch_po(id)
+);
+
+-- Unit price source: EasyEcom's own product master (user decision 2026-07-10).
+-- The weekly master sync starts persisting these two fields.
+ALTER TABLE ee_product_master
+  ADD COLUMN cost DECIMAL(10,2) NULL AFTER description,
+  ADD COLUMN mrp  DECIMAL(10,2) NULL AFTER cost;

--- a/utils/easyecomPullWorker.js
+++ b/utils/easyecomPullWorker.js
@@ -724,11 +724,12 @@ async function pullProductMaster(pool, runStartedAt) {
       if (!sku) continue;
       await pool.query(
         `INSERT INTO ee_product_master
-          (sku, product_id, cp_id, product_name, style, description, active, custom_fields, ee_updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+          (sku, product_id, cp_id, product_name, style, description, cost, mrp, active, custom_fields, ee_updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON DUPLICATE KEY UPDATE
           product_id = VALUES(product_id), cp_id = VALUES(cp_id), product_name = VALUES(product_name),
           style = VALUES(style), description = VALUES(description), active = VALUES(active),
+          cost = VALUES(cost), mrp = VALUES(mrp),
           custom_fields = VALUES(custom_fields), ee_updated_at = VALUES(ee_updated_at),
           synced_at = CURRENT_TIMESTAMP`,
         [
@@ -738,6 +739,8 @@ async function pullProductMaster(pool, runStartedAt) {
           p.product_name || null,
           p.style || p.style_code || null,
           p.description || null,
+          p.cost != null ? Number(p.cost) : null,   // unit price source for the dispatch→PO pipeline
+          p.mrp != null ? Number(p.mrp) : null,
           p.active != null ? Number(p.active) : 1,
           p.custom_fields ? JSON.stringify(p.custom_fields) : null,
           p.updated_at || null,

--- a/utils/eeDispatchPo.js
+++ b/utils/eeDispatchPo.js
@@ -1,0 +1,249 @@
+// Finishing dispatch → EasyEcom Purchase Order pipeline.
+// Model (docs/EASYECOM_DISPATCH_GRN_DESIGN.md, revised 2026-07-10 after live Phase-0):
+//   kotty-track creates ONLY the PO (the challan) in EasyEcom. The Faridabad warehouse
+//   receives the physical goods and makes the GRN manually in the EasyEcom UI against
+//   that PO. confirmGrns() then detects their GRN (getGrnDetails.po_id) and marks the
+//   batch confirmed. NO code path here ever writes inventory directly.
+//
+// Live-test-verified API quirks (do not "fix" these):
+//   - CreatePurchaseOrder wants vendorId = the vendor CODE ('V002');
+//     QueueGrnApi (unused here) wants the numeric vendor_c_id instead.
+//   - expDeliveryDate must be strictly AFTER today.
+//   - EasyEcom refuses to inward more than the PO quantity → the PO itself is a
+//     second layer of double-push protection.
+//   - Auth: account-level X-API-Key on every call; location scoping via the JWT
+//     minted with the Faridabad location_key (EASYECOM_LOCATION_KEY).
+
+const { pool } = require('../config/db');
+
+const EE_BASE = process.env.EASYECOM_API_BASE || 'https://api.easyecom.io';
+const EE_API_KEY = process.env.EASYECOM_API_KEY || '';
+const EE_VENDOR_CODE = process.env.EE_PO_VENDOR_CODE || 'V002'; // "Kotty Production" (vendor_c_id 289541)
+const FARIDABAD_WAREHOUSE_ID = 173983;
+
+// HARD CUTOFF: only dispatches created on/after this date are ever swept. Everything
+// before it was physically received long ago — pushing history would double-count
+// live marketplace stock. Overridable via env for testing, never set it backwards.
+const EE_PO_SINCE = process.env.EE_PO_SINCE || global.env?.EE_PO_SINCE || '2026-07-11';
+
+// Push is dangerous-by-default: creating POs in the live OMS stays off until the
+// flag is set on the service (--update-env-vars EE_GRN_PUSH=1).
+function pushEnabled() {
+  return String(process.env.EE_GRN_PUSH || global.env?.EE_GRN_PUSH || '') === '1';
+}
+
+// ── Auth: Faridabad-context JWT, cached ~20h ─────────────────────────────
+let _tok = null;
+let _tokAt = 0;
+async function faridabadToken() {
+  if (_tok && Date.now() - _tokAt < 20 * 3600 * 1000) return _tok;
+  const r = await fetch(`${EE_BASE}/access/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'x-api-key': EE_API_KEY },
+    body: JSON.stringify({
+      email: process.env.EASYECOM_EMAIL,
+      password: process.env.EASYECOM_PASSWORD,
+      location_key: process.env.EASYECOM_LOCATION_KEY, // ee30270084289 = Faridabad
+    }),
+  });
+  const j = await r.json().catch(() => ({}));
+  const tok = j?.data?.token?.jwt_token || j?.data?.jwt_token;
+  if (!tok) throw new Error('EasyEcom auth failed: ' + JSON.stringify(j).slice(0, 160));
+  _tok = tok; _tokAt = Date.now();
+  return tok;
+}
+
+async function eeCall(method, path, body) {
+  const tok = await faridabadToken();
+  const headers = { Authorization: `Bearer ${tok}`, 'x-api-key': EE_API_KEY };
+  if (body) headers['Content-Type'] = 'application/json';
+  let lastErr;
+  for (let attempt = 0; attempt < 4; attempt++) {
+    const r = await fetch(`${EE_BASE}${path}`, { method, headers, body: body ? JSON.stringify(body) : undefined });
+    if (r.status === 429) { await new Promise(s => setTimeout(s, 4000 * (attempt + 1))); continue; }
+    const j = await r.json().catch(() => ({}));
+    if (r.status === 401) { _tok = null; lastErr = new Error('401'); continue; } // re-mint once
+    return j;
+  }
+  throw lastErr || new Error('EasyEcom call kept failing: ' + path);
+}
+
+// ── SKU resolution ────────────────────────────────────────────────────────
+// Chain: (1) pm_sku_resolution map; (2) CONCAT(lot_sku, size) verified to EXIST in
+// the ee_product_master mirror (EasyEcom's own convention, e.g. KTTBLUETOP768 + M).
+// Anything else stays NULL → the line blocks the batch. Never guessed.
+async function resolveLine(db, lotSku, sizeLabel) {
+  const sku = String(lotSku || '').trim().toUpperCase();
+  const size = String(sizeLabel || '').trim().toUpperCase();
+  if (!sku || !size) return { ee_sku: null, source: null, cost: null, mrp: null };
+
+  const [map] = await db.query(
+    `SELECT size_sku FROM pm_sku_resolution
+      WHERE UPPER(cl_sku)=? AND UPPER(size_label)=? AND size_sku IS NOT NULL LIMIT 1`,
+    [sku, size]
+  );
+  let eeSku = map.length ? String(map[0].size_sku).toUpperCase() : null;
+  let source = eeSku ? 'map' : null;
+
+  if (!eeSku) {
+    const candidate = sku + size; // EE convention observed across the live catalog
+    const [hit] = await db.query(
+      `SELECT sku, cost, mrp FROM ee_product_master WHERE sku=? AND active=1 LIMIT 1`,
+      [candidate]
+    );
+    if (hit.length) return { ee_sku: hit[0].sku, source: 'concat-verified', cost: hit[0].cost, mrp: hit[0].mrp };
+    return { ee_sku: null, source: null, cost: null, mrp: null };
+  }
+
+  const [pm] = await db.query(`SELECT cost, mrp FROM ee_product_master WHERE sku=? LIMIT 1`, [eeSku]);
+  return { ee_sku: eeSku, source, cost: pm.length ? pm[0].cost : null, mrp: pm.length ? pm[0].mrp : null };
+}
+
+// ── Batch building ────────────────────────────────────────────────────────
+// Sweep every Warehouse-destination finishing_dispatches row not yet in any batch
+// into ONE new batch (draft if fully resolved, blocked otherwise).
+async function buildBatch(user) {
+  const conn = await pool.getConnection();
+  try {
+    await conn.beginTransaction();
+    const [rows] = await conn.query(
+      `SELECT fd.id AS dispatch_id, fd.lot_no, fd.size_label, fd.quantity, cl.sku AS lot_sku
+         FROM finishing_dispatches fd
+         LEFT JOIN ee_dispatch_po_lines l ON l.dispatch_id = fd.id
+         LEFT JOIN cutting_lots cl ON cl.lot_no = fd.lot_no
+        WHERE l.id IS NULL AND LOWER(fd.destination) = 'warehouse'
+          AND fd.created_at >= ?
+        ORDER BY fd.id
+        LIMIT 500`,
+      [EE_PO_SINCE]
+    );
+    if (!rows.length) { await conn.rollback(); return { created: false, reason: 'No new Warehouse dispatches to sweep.' }; }
+
+    const [ins] = await conn.query(
+      `INSERT INTO ee_dispatch_po (batch_ref, status, warehouse_id, created_by, created_by_name)
+       VALUES ('PENDING', 'draft', ?, ?, ?)`,
+      [FARIDABAD_WAREHOUSE_ID, user?.id || null, user?.username || null]
+    );
+    const batchId = ins.insertId;
+    const batchRef = `KT-DISP-${batchId}`;
+
+    let blocked = 0, totalQty = 0;
+    for (const r of rows) {
+      const res = await resolveLine(conn, r.lot_sku, r.size_label);
+      if (!res.ee_sku) blocked++;
+      totalQty += Number(r.quantity) || 0;
+      await conn.query(
+        `INSERT INTO ee_dispatch_po_lines
+           (batch_id, dispatch_id, lot_no, size_label, quantity, lot_sku, ee_sku, resolve_source, unit_cost, mrp)
+         VALUES (?,?,?,?,?,?,?,?,?,?)`,
+        [batchId, r.dispatch_id, r.lot_no, r.size_label, r.quantity, r.lot_sku || null,
+         res.ee_sku, res.source, res.cost, res.mrp]
+      );
+    }
+    await conn.query(
+      `UPDATE ee_dispatch_po
+          SET batch_ref=?, status=?, total_qty=?, line_count=?, blocked_count=?
+        WHERE id=?`,
+      [batchRef, blocked > 0 ? 'blocked' : 'draft', totalQty, rows.length, blocked, batchId]
+    );
+    await conn.commit();
+    return { created: true, batchId, batchRef, lines: rows.length, blocked };
+  } catch (err) {
+    await conn.rollback();
+    throw err;
+  } finally {
+    conn.release();
+  }
+}
+
+// Re-resolve a blocked batch's lines (after the resolver map / master sync improves).
+async function reResolveBatch(batchId) {
+  const [lines] = await pool.query(
+    `SELECT id, lot_sku, size_label FROM ee_dispatch_po_lines WHERE batch_id=? AND ee_sku IS NULL`, [batchId]);
+  let fixed = 0;
+  for (const l of lines) {
+    const res = await resolveLine(pool, l.lot_sku, l.size_label);
+    if (res.ee_sku) {
+      await pool.query(
+        `UPDATE ee_dispatch_po_lines SET ee_sku=?, resolve_source=?, unit_cost=?, mrp=? WHERE id=?`,
+        [res.ee_sku, res.source, res.cost, res.mrp, l.id]);
+      fixed++;
+    }
+  }
+  const [[b]] = await pool.query(
+    `SELECT COUNT(*) AS blocked FROM ee_dispatch_po_lines WHERE batch_id=? AND ee_sku IS NULL`, [batchId]);
+  await pool.query(
+    `UPDATE ee_dispatch_po SET blocked_count=?, status=IF(?=0 AND status='blocked','draft',status) WHERE id=?`,
+    [b.blocked, b.blocked, batchId]);
+  return { fixed, stillBlocked: b.blocked };
+}
+
+// ── Push: create the PO in EasyEcom (draft batches only) ─────────────────
+async function pushBatch(batchId) {
+  if (!pushEnabled()) throw new Error('EE_GRN_PUSH is not enabled on this environment.');
+  const [[batch]] = await pool.query(`SELECT * FROM ee_dispatch_po WHERE id=?`, [batchId]);
+  if (!batch) throw new Error('Batch not found');
+  if (batch.status !== 'draft') throw new Error(`Batch is ${batch.status}, only draft batches can be pushed.`);
+
+  const [lines] = await pool.query(
+    `SELECT ee_sku, SUM(quantity) AS qty, MAX(unit_cost) AS cost
+       FROM ee_dispatch_po_lines WHERE batch_id=? GROUP BY ee_sku`, [batchId]);
+  if (lines.some(l => !l.ee_sku)) throw new Error('Batch has unresolved lines.');
+
+  const tomorrow = new Date(Date.now() + 86400000).toISOString().slice(0, 10);
+  const body = {
+    vendorId: EE_VENDOR_CODE,
+    referenceCode: batch.batch_ref,
+    docNumber: batch.batch_ref,
+    address: 'Faridabad',
+    expDeliveryDate: tomorrow,
+    shippingCost: 0, createOrUpdate: 'I', isCancel: 0, updateTaxRate: 1,
+    items: lines.map((l, i) => ({
+      lineItemNumber: String(i + 1),
+      sku: l.ee_sku,
+      quantity: String(l.qty),
+      unitPrice: Number(l.cost) || 0,
+      taxRate: '0', taxValue: 0, taxType: 1,
+    })),
+  };
+  const resp = await eeCall('POST', '/WMS/Cart/CreatePurchaseOrder', body);
+  const poId = resp?.data?.poId || resp?.data?.po_id;
+  if (resp?.code !== 200 || !poId) {
+    const msg = (resp?.message || '') + ' ' + (typeof resp?.data === 'string' ? resp.data : '');
+    await pool.query(`UPDATE ee_dispatch_po SET status='failed', error=? WHERE id=?`, [msg.slice(0, 500), batchId]);
+    throw new Error('PO creation failed: ' + msg.slice(0, 200));
+  }
+  await pool.query(
+    `UPDATE ee_dispatch_po SET status='pushed', po_id=?, error=NULL, pushed_at=NOW() WHERE id=?`,
+    [poId, batchId]);
+  return { poId, batchRef: batch.batch_ref, lines: lines.length };
+}
+
+// ── Confirmation: detect the warehouse's manual GRN against our POs ──────
+async function confirmGrns() {
+  const [pushed] = await pool.query(
+    `SELECT id, po_id FROM ee_dispatch_po WHERE status='pushed' AND po_id IS NOT NULL`);
+  if (!pushed.length) return { checked: 0, confirmed: 0 };
+  const since = new Date(Date.now() - 30 * 86400000).toISOString().slice(0, 10);
+  const resp = await eeCall('GET', `/Grn/V2/getGrnDetails?created_after=${since}`);
+  const grns = Array.isArray(resp?.data) ? resp.data : [];
+  const byPo = new Map();
+  for (const g of grns) if (g.po_id) byPo.set(String(g.po_id), g);
+  let confirmed = 0;
+  for (const b of pushed) {
+    const g = byPo.get(String(b.po_id));
+    if (g) {
+      const done = String(g.grn_status || '').toLowerCase() === 'completed';
+      await pool.query(
+        `UPDATE ee_dispatch_po
+            SET grn_id=?, grn_status=?, status=IF(?, 'confirmed', status),
+                confirmed_at=IF(?, NOW(), confirmed_at)
+          WHERE id=?`,
+        [g.grn_id || null, g.grn_status || null, done, done, b.id]);
+      if (done) confirmed++;
+    }
+  }
+  return { checked: pushed.length, confirmed };
+}
+
+module.exports = { buildBatch, reResolveBatch, pushBatch, confirmGrns, pushEnabled, FARIDABAD_WAREHOUSE_ID, EE_PO_SINCE };

--- a/views/eeDispatchPo.ejs
+++ b/views/eeDispatchPo.ejs
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>EasyEcom PO — Dispatch to Warehouse</title>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+<style>
+  :root{ --ink:#0f172a; --muted:#64748b; --line:#e5e7eb; --bg:#f7f8fa; --card:#fff;
+         --blue:#2563eb; --blue-bg:#eff6ff; --green:#16a34a; --green-bg:#dcfce7;
+         --amber:#b45309; --amber-bg:#fef3c7; --red:#dc2626; --red-bg:#fee2e2; }
+  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--ink);font-family:'Inter',sans-serif;font-size:15px;}
+  .num{font-family:'Space Grotesk','Inter',sans-serif;}
+  .material-symbols-outlined{font-variation-settings:'FILL' 0,'wght' 400;vertical-align:middle;}
+  .top{position:fixed;top:0;left:0;right:0;height:56px;z-index:50;background:var(--bg);border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between;padding:0 16px;}
+  .top .brand{display:flex;align-items:center;gap:10px;} .top .brand .material-symbols-outlined{color:var(--blue);}
+  .top h1{font-family:'Space Grotesk',sans-serif;font-weight:700;font-size:17px;text-transform:uppercase;letter-spacing:.07em;color:var(--blue);margin:0;}
+  .top .acts{display:flex;align-items:center;gap:12px;}
+  .top .home{color:var(--muted);display:flex;text-decoration:none;}
+  .top .who{font-size:13px;font-weight:600;}
+  .top .out{display:inline-flex;align-items:center;gap:6px;color:var(--red);text-decoration:none;font-size:13px;font-weight:600;padding:6px 10px;border:1px solid #fecaca;border-radius:8px;}
+  .wrap{max-width:860px;margin:0 auto;padding:72px 16px 40px;}
+  .card{background:var(--card);border:1px solid var(--line);border-radius:12px;box-shadow:0 1px 2px rgba(15,23,42,.06);padding:16px;margin-bottom:14px;}
+  .pill{display:inline-block;font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.04em;padding:3px 10px;border-radius:999px;}
+  .pill.draft{background:var(--blue-bg);color:var(--blue);} .pill.blocked{background:var(--amber-bg);color:var(--amber);}
+  .pill.pushed{background:var(--blue-bg);color:var(--blue);} .pill.confirmed{background:var(--green-bg);color:var(--green);}
+  .pill.failed,.pill.cancelled{background:var(--red-bg);color:var(--red);}
+  .btn{display:inline-flex;align-items:center;justify-content:center;gap:8px;font-size:14px;font-weight:700;padding:11px 16px;border-radius:10px;border:0;cursor:pointer;font-family:inherit;}
+  .btn-primary{background:var(--blue);color:#fff;} .btn-ghost{background:var(--card);color:var(--ink);border:1px solid var(--line);}
+  .btn:disabled{opacity:.5;cursor:not-allowed;}
+  .note{font-size:13px;padding:10px 12px;border-radius:9px;margin-top:10px;}
+  .note.warn{background:var(--amber-bg);color:var(--amber);} .note.info{background:#f1f5f9;color:var(--muted);}
+  table{width:100%;border-collapse:collapse;font-size:13px;margin-top:10px;}
+  th{font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);text-align:left;padding:6px 8px;border-bottom:1px solid var(--line);}
+  td{padding:7px 8px;border-bottom:1px solid #f1f5f9;}
+  td.q{font-family:'Space Grotesk',sans-serif;font-weight:700;}
+  tr.blocked td{background:#fffbeb;}
+  .head-row{display:flex;align-items:center;justify-content:space-between;gap:10px;flex-wrap:wrap;}
+  .meta{font-size:12px;color:var(--muted);margin-top:2px;}
+  .stat{font-family:'Space Grotesk',sans-serif;font-size:26px;font-weight:700;}
+  .twoline .l{font-size:10px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);font-weight:700;}
+  .tblwrap{overflow-x:auto;}
+</style>
+</head>
+<body>
+<header class="top">
+  <div class="brand"><span class="material-symbols-outlined">local_shipping</span><h1>EasyEcom PO</h1></div>
+  <div class="acts">
+    <a class="home" href="/finishingdashboard" title="Finishing"><span class="material-symbols-outlined">home</span></a>
+    <span class="who"><%= user && user.username %></span>
+    <a class="out" href="/logout"><span class="material-symbols-outlined" style="font-size:18px;">logout</span>Log out</a>
+  </div>
+</header>
+
+<main class="wrap">
+  <!-- Sweep card -->
+  <section class="card">
+    <div class="head-row">
+      <div class="twoline">
+        <div class="l">Warehouse dispatches not yet on a PO</div>
+        <div><span class="stat" id="pendQty"><%= pendingQty.toLocaleString('en-IN') %></span>
+             <span class="meta"><%= pendingRows %> dispatch rows</span></div>
+      </div>
+      <button class="btn btn-primary" id="buildBtn" <%= pendingRows ? '' : 'disabled' %> onclick="buildBatch()">
+        <span class="material-symbols-outlined" style="font-size:18px;">post_add</span> Create PO batch
+      </button>
+    </div>
+    <div class="note info">Flow: dispatches are swept into a batch → you review and <strong>Push</strong> it →
+      EasyEcom gets the Purchase Order (challan) → the <strong>warehouse team makes the GRN in EasyEcom</strong>
+      when the goods physically arrive → this screen marks the batch <strong>confirmed</strong>.
+      Stock only enters the OMS through the warehouse's own GRN.</div>
+    <% if (!pushEnabled) { %>
+      <div class="note warn">Pushing is disabled on this environment (<code>EE_GRN_PUSH</code> is off).
+        Batches can be built and reviewed, but not sent.</div>
+    <% } %>
+  </section>
+
+  <div class="head-row" style="margin:4px 2px 10px;">
+    <span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);">Batches</span>
+    <button class="btn btn-ghost" onclick="refreshConfirmations()" style="padding:8px 12px;font-size:13px;">
+      <span class="material-symbols-outlined" style="font-size:17px;">sync</span> Check for warehouse GRNs
+    </button>
+  </div>
+
+  <% if (!batches.length) { %>
+    <section class="card" style="text-align:center;color:var(--muted);padding:34px;">No batches yet.</section>
+  <% } %>
+
+  <% batches.forEach(function(b){ var lines = linesByBatch[b.id] || []; %>
+    <section class="card">
+      <div class="head-row">
+        <div>
+          <strong class="num" style="font-size:17px;"><%= b.batch_ref %></strong>
+          <span class="pill <%= b.status %>"><%= b.status %></span>
+          <div class="meta">
+            <%= b.line_count %> lines · <span class="num"><%= Number(b.total_qty).toLocaleString('en-IN') %></span> pcs
+            <% if (b.po_id) { %> · PO <strong><%= b.po_id %></strong><% } %>
+            <% if (b.grn_id) { %> · GRN <strong><%= b.grn_id %></strong> (<%= b.grn_status %>)<% } %>
+            · by <%= b.created_by_name || '—' %> · <%= new Date(b.created_at).toLocaleString('en-IN', {timeZone:'Asia/Kolkata'}) %>
+          </div>
+        </div>
+        <div style="display:flex;gap:8px;">
+          <% if (b.status === 'blocked') { %>
+            <button class="btn btn-ghost" onclick="reResolve(<%= b.id %>)">Re-resolve SKUs</button>
+          <% } %>
+          <% if (b.status === 'draft') { %>
+            <button class="btn btn-primary" <%= pushEnabled ? '' : 'disabled' %> onclick="pushBatch(<%= b.id %>, '<%= b.batch_ref %>')">
+              Push to EasyEcom
+            </button>
+          <% } %>
+        </div>
+      </div>
+      <% if (b.error) { %><div class="note warn">Last error: <%= b.error %></div><% } %>
+      <% if (b.blocked_count > 0) { %>
+        <div class="note warn"><strong><%= b.blocked_count %></strong> line(s) could not be matched to an
+          EasyEcom SKU — the batch is blocked until they resolve. Nothing is ever pushed on a guess.</div>
+      <% } %>
+      <div class="tblwrap">
+        <table>
+          <thead><tr><th>Lot</th><th>Size</th><th>Qty</th><th>EasyEcom SKU</th><th>Via</th><th>Cost</th><th>MRP</th></tr></thead>
+          <tbody>
+            <% lines.forEach(function(l){ %>
+              <tr class="<%= l.ee_sku ? '' : 'blocked' %>">
+                <td><%= (l.lot_no || '').toUpperCase() %></td>
+                <td><%= l.size_label %></td>
+                <td class="q"><%= l.quantity %></td>
+                <td><%= l.ee_sku || '— unresolved —' %></td>
+                <td style="color:var(--muted);"><%= l.resolve_source || '' %></td>
+                <td><%= l.unit_cost != null ? l.unit_cost : '—' %></td>
+                <td><%= l.mrp != null ? l.mrp : '—' %></td>
+              </tr>
+            <% }) %>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  <% }) %>
+</main>
+
+<script>
+  async function post(url) {
+    const r = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' } });
+    const j = await r.json().catch(() => ({}));
+    if (!r.ok || j.error) throw new Error(j.error || ('HTTP ' + r.status));
+    return j;
+  }
+  async function buildBatch() {
+    const btn = document.getElementById('buildBtn'); btn.disabled = true;
+    try { const j = await post('/finishingdashboard/ee-po/build');
+      alert(j.created ? ('Batch ' + j.batchRef + ' created: ' + j.lines + ' lines' + (j.blocked ? (', ' + j.blocked + ' blocked') : '')) : j.reason);
+      location.reload();
+    } catch (e) { alert('Could not build batch: ' + e.message); btn.disabled = false; }
+  }
+  async function pushBatch(id, ref) {
+    if (!confirm('Create Purchase Order ' + ref + ' in EasyEcom? The warehouse will then GRN it on receipt.')) return;
+    try { const j = await post('/finishingdashboard/ee-po/push/' + id);
+      alert('PO created in EasyEcom: ' + j.poId); location.reload();
+    } catch (e) { alert('Push failed: ' + e.message); }
+  }
+  async function reResolve(id) {
+    try { const j = await post('/finishingdashboard/ee-po/reresolve/' + id);
+      alert('Resolved ' + j.fixed + ' line(s); still blocked: ' + j.stillBlocked); location.reload();
+    } catch (e) { alert('Re-resolve failed: ' + e.message); }
+  }
+  async function refreshConfirmations() {
+    try { const j = await post('/finishingdashboard/ee-po/refresh');
+      alert('Checked ' + j.checked + ' pushed PO(s); newly confirmed: ' + j.confirmed); location.reload();
+    } catch (e) { alert('Refresh failed: ' + e.message); }
+  }
+</script>
+</body>
+</html>

--- a/views/finishingDashboard.ejs
+++ b/views/finishingDashboard.ejs
@@ -435,6 +435,7 @@
     <div class="quick-links">
       <a href="/my-lots" class="quick-link" style="background:#2563eb;color:#fff;"><i class="bi bi-bag-check"></i> My Lots</a>
       <a href="/finishingdashboard/dispatch-download" class="quick-link" style="background:#10b981;color:#fff;"><i class="bi bi-file-earmark-excel"></i> Dispatch Excel</a>
+      <a href="/finishingdashboard/ee-po" class="quick-link" style="background:#2563eb;color:#fff;"><i class="bi bi-truck"></i> EasyEcom PO</a>
       <a href="/payments/my-payments" class="quick-link"><i class="bi bi-wallet2"></i> My Payments</a>
       <button type="button" class="quick-link" onclick="toggleHistorySection()"><i class="bi bi-clock-history"></i> History</button>
       <button type="button" class="quick-link" onclick="toggleIndentSection()"><i class="bi bi-box-seam"></i> Raise Indent</button>


### PR DESCRIPTION
The GRN pipeline, built exactly on the live-tested model: **we create only the PO (the challan); the warehouse GRNs it manually in EasyEcom when goods physically arrive; we detect their GRN and mark the batch confirmed.** No code path ever writes inventory.

## Flow (screen: `/finishingdashboard/ee-po`, finishing role)
1. **Sweep** — un-pushed Warehouse-destination dispatches → a batch (lines resolved to EasyEcom SKUs).
2. **Review** — blocked lines highlighted (unresolved SKU / missing cost); nothing pushes on a guess.
3. **Push** — creates the PO in EasyEcom (`KT-DISP-<id>` as referenceCode; unit price from EE's own product master, per your decision).
4. **Warehouse GRNs it in the EE UI** (proven live today: GRN 2222386 → stock 0→Available).
5. **Check for warehouse GRNs** — matches `getGrnDetails.po_id`, marks batches confirmed.

## Safety spine
- **Hard historical cutoff** `EE_PO_SINCE=2026-07-11`: the sweep excludes the **880 existing rows / 150,468 pcs** already received long ago — pushing history would have double-counted live marketplace stock. Measured against prod.
- **DB-level idempotency**: `dispatch_id UNIQUE` in the lines table — a dispatch row can never ride two POs. Plus EasyEcom's own PO-quantity cap (proven live).
- **Resolver gate**: mapping table → CONCAT(style+size) *verified to exist* in the 98k-SKU master mirror → else blocked visibly.
- **Push disabled by default** — enable with `--update-env-vars EE_GRN_PUSH=1` after merge.
- All live-tested API quirks encoded (vendor code vs numeric id, date-after-today, top-level queueId, Faridabad JWT context).

## Also in this PR
- Weekly product-master sync now persists **cost + mrp** (the PO's unit-price source, zero extra API calls).
- Migration **already applied to prod** (additive: 2 new tables + 2 columns).

## To go live after merge
`EE_GRN_PUSH=1` via `--update-env-vars` (never --set), then: dispatch a lot to Warehouse → sweep → push → warehouse GRNs → Check confirms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)