### PR TITLE
feat(fe): MySQL session store (no more random logouts) + frontend CI hardening

### DIFF
--- a/app.js
+++ b/app.js
@@ -92,6 +92,29 @@ app.use('/returns/api', cors({
 }));
 
 // Session Configuration
+// FE-5: sessions live in MySQL (shared across Cloud Run instances / restarts) instead of
+// the default in-process MemoryStore, which caused intermittent logouts whenever a request
+// hit a different instance or an instance recycled.
+const { pool } = require('./config/db');
+const MySQLStore = require('express-mysql-session')(session);
+
+// Must match cookie.maxAge below so the store row and the cookie expire together.
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24;
+
+const sessionStore = new MySQLStore({
+    createDatabaseTable: true, // auto-create the `sessions` table on first boot
+    schema: { tableName: 'sessions' },
+    clearExpired: true,
+    checkExpirationInterval: 15 * 60 * 1000, // sweep expired rows every 15 minutes
+    expiration: SESSION_TTL_MS
+}, pool); // reuse the existing mysql2/promise pool (same Cloud SQL socket/env config)
+
+// The store connects lazily via the shared pool; if table creation fails at boot the app
+// must still start (reads/writes will retry per-request), so log instead of crashing.
+sessionStore.onReady()
+    .then(() => console.log('Session store ready (MySQL `sessions` table)'))
+    .catch((err) => console.error('Session store init error (app continues, sessions handled lazily):', err.message));
+
 const sessionSecret = global.env.SESSION_SECRET;
 if (!sessionSecret && process.env.NODE_ENV === 'production') {
     console.error('CRITICAL: SESSION_SECRET must be set in production!');
@@ -103,6 +126,7 @@ const isProduction = !!(process.env.K_SERVICE || process.env.NODE_ENV === 'produ
 
 app.use(session({
     secret: sessionSecret || 'dev-only-secret-not-for-production',
+    store: sessionStore,
     resave: false,
     saveUninitialized: false,
     rolling: true, // refresh expiry on each request so active users are not logged out unexpectedly
@@ -281,7 +305,7 @@ app.use('/api/po-admin', poAdminApiRoutes);
 app.use('/returns', returnRoutes);
 app.use('/return-grn', returnGrnRoutes);
 
-const { pool } = require('./config/db');
+// (config/db pool is already required near the session setup at the top of this file)
 
 // Start scheduled jobs (Ajio recon, mail auto-reply, EasyEcom pull worker, etc.)
 const { startCronJobs } = require('./utils/scheduler');

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,12 +9,14 @@ steps:
       - '-c'
       - 'npm ci && NODE_ENV=test npm test'
 
-  # Gate on the frontend test suite (Vitest). Fails the build on any red test.
+  # Gate on the frontend test suite (Vitest) AND a full production build of both islands
+  # (Tasks + QC). The Dockerfile's frontend-builder stage rebuilds these inside the image;
+  # this step fails the deploy fast (before any image is built/pushed) if the build breaks.
   - name: 'node:20'
     entrypoint: bash
     args:
       - '-c'
-      - 'cd frontend && npm ci && npm run test'
+      - 'cd frontend && npm ci && npm run test && npm run build && npm run build:qc'
 
   # Build the container image
   - name: 'gcr.io/cloud-builders/docker'

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "ejs": "^3.1.10",
         "exceljs": "^4.4.0",
         "express": "^4.21.2",
+        "express-mysql-session": "^3.0.3",
         "express-rate-limit": "^8.3.1",
         "express-session": "^1.18.1",
         "express-validator": "^7.2.1",
@@ -3364,6 +3365,79 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-mysql-session": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/express-mysql-session/-/express-mysql-session-3.0.3.tgz",
+      "integrity": "sha512-sEYrzFrOs3er+Ie/uk1dt93qz4AQ9SU1mpJJ0HPs0MJ4t4hE9AcDRNq0sZQUwy2F/SbXusBt1E5+FY6KzSqXNg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4.3.4",
+        "mysql2": "3.10.2"
+      }
+    },
+    "node_modules/express-mysql-session/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/express-mysql-session/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/express-mysql-session/node_modules/lru-cache": {
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-8.0.5.tgz",
+      "integrity": "sha512-MhWWlVnuab1RG5/zMRRcVGXZLCXrZTgfwMikgzCegsPnG62yDQo5JnqKkrK4jO5iKqDAZGItAqN5CtKBCBWRUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16.14"
+      }
+    },
+    "node_modules/express-mysql-session/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
+    "node_modules/express-mysql-session/node_modules/mysql2": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-3.10.2.tgz",
+      "integrity": "sha512-KCXPEvAkO0RcHPr362O5N8tFY2fXvbjfkPvRY/wGumh4EOemo9Hm5FjQZqv/pCmrnuxGu5OxnSENG0gTXqKMgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "denque": "^2.1.0",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^5.2.1",
+        "lru-cache": "^8.0.0",
+        "named-placeholders": "^1.1.3",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
       }
     },
     "node_modules/express-rate-limit": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ejs": "^3.1.10",
     "exceljs": "^4.4.0",
     "express": "^4.21.2",
+    "express-mysql-session": "^3.0.3",
     "express-rate-limit": "^8.3.1",
     "express-session": "^1.18.1",
     "express-validator": "^7.2.1",


### PR DESCRIPTION
Plan 04's top two items (FE-5, FE-6), agent-built and reviewed.

## FE-5 — Sessions move off MemoryStore → MySQL
Today sessions live in-process: every restart/deploy logs everyone out, and with multiple Cloud Run instances users get **randomly logged out** when routed to another instance. Now `express-mysql-session@3` wired to the **existing** DB pool (same env config, Cloud SQL socket in prod), auto-creating a `sessions` table; TTL matches the current 24h cookie; every cookie flag and the secret are byte-identical. Store failures can't block boot (verified against a dead DB).

**Rollout note:** one-time re-login for everyone when this deploys; after that, sessions survive restarts and are shared across instances.

## FE-6 — Frontend island CI
Finding: the Dockerfile already builds the React islands (plan doc was stale). Hardened anyway: the cloudbuild frontend step now runs test **+ build + build:qc**, so a broken island build fails the deploy *before* any image is built. Zero deploy-flag changes (env handling untouched).

**Verified:** `node --check app.js`, YAML valid, `npm test` → **167 pass / 0 fail**, dead-DB boot resilience test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)