### PR TITLE
fix(fe): XSS audit fixes across views + shared API client (FE-3, FE-2)

### DIFF
--- a/public/js/api.js
+++ b/public/js/api.js
@@ -1,0 +1,63 @@
+/**
+ * KottyApi — shared thin API client (FE-2, docs/plans/04-frontend-best-practices.md).
+ *
+ * Usage: <script src="/public/js/api.js"></script> then
+ *   KottyApi.apiGet('/some/endpoint').then(function (data) { ... });
+ *
+ * Behaviour:
+ *   - always sends session cookies (credentials: 'same-origin')
+ *   - sets JSON headers on POST bodies
+ *   - redirects to /login on 401
+ *   - throws Error with the server-provided message on !res.ok
+ *   - parses and returns JSON (or null for empty/non-JSON responses)
+ */
+(function (global) {
+  'use strict';
+
+  function handleResponse(res) {
+    if (res.status === 401) {
+      global.location.href = '/login';
+      return new Promise(function () {}); // never resolves; page is navigating away
+    }
+    var contentType = res.headers.get('content-type') || '';
+    var isJson = contentType.indexOf('application/json') !== -1;
+    var bodyPromise = isJson ? res.json().catch(function () { return null; }) : res.text();
+    return bodyPromise.then(function (body) {
+      if (!res.ok) {
+        var message =
+          (body && typeof body === 'object' && (body.error || body.message)) ||
+          (typeof body === 'string' && body.slice(0, 200)) ||
+          (res.status + ' ' + res.statusText);
+        var err = new Error(message);
+        err.status = res.status;
+        err.body = body;
+        throw err;
+      }
+      return isJson ? body : (body ? body : null);
+    });
+  }
+
+  function request(url, options) {
+    var opts = options || {};
+    opts.credentials = opts.credentials || 'same-origin';
+    return fetch(url, opts).then(handleResponse);
+  }
+
+  function apiGet(url) {
+    return request(url, { method: 'GET', headers: { Accept: 'application/json' } });
+  }
+
+  function apiPost(url, body) {
+    return request(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify(body === undefined ? {} : body)
+    });
+  }
+
+  function apiDelete(url) {
+    return request(url, { method: 'DELETE', headers: { Accept: 'application/json' } });
+  }
+
+  global.KottyApi = { apiGet: apiGet, apiPost: apiPost, apiDelete: apiDelete, request: request };
+})(window);

--- a/views/accountsChallanGeneration.ejs
+++ b/views/accountsChallanGeneration.ejs
@@ -89,7 +89,7 @@
     </div>
 
     <form action="/accounts-challan/create" method="POST">
-      <input type="hidden" name="selectedRows" value='<%- JSON.stringify(selectedRows) %>'>
+      <input type="hidden" name="selectedRows" value="<%= JSON.stringify(selectedRows) %>">
 
       <div class="row g-4">
         <!-- Challan Details Form -->

--- a/views/challanGeneration.ejs
+++ b/views/challanGeneration.ejs
@@ -24,7 +24,7 @@
     <div class="kotty-card" style="background: var(--bg-card); border-radius: var(--radius-xl); box-shadow: var(--shadow-md); border: 1px solid var(--border-light); overflow: hidden;">
       <form action="/challandashboard/create" method="POST" id="challanForm">
         <!-- Hidden Data -->
-        <input type="hidden" name="selectedRows" value="<%- JSON.stringify(selectedRows).replace(/\"/g,'&quot;') %>">
+        <input type="hidden" name="selectedRows" value="<%= JSON.stringify(selectedRows) %>">
 
         <!-- Form Section: Basic Details -->
         <div style="padding: 24px; border-bottom: 1px solid var(--border-light);">

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -602,7 +602,7 @@
             <line x1="12" y1="8" x2="12" y2="12"/>
             <line x1="12" y1="16" x2="12.01" y2="16"/>
           </svg>
-          <span><%- error %></span>
+          <span><%= error %></span>
           <button class="alert-close" onclick="this.parentElement.remove()" aria-label="Dismiss">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="18" y1="6" x2="6" y2="18"/>

--- a/views/lotJourney.ejs
+++ b/views/lotJourney.ejs
@@ -97,6 +97,7 @@
     <div id="out"></div>
   </div>
 
+<script src="/public/js/api.js"></script>
 <script>
 const fmtDate = d => d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short',year:'numeric',timeZone:'Asia/Kolkata'}) : '—';
 const esc = s => String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
@@ -112,8 +113,7 @@ async function go(){
   try{ history.replaceState(null,'','/operator/lot-journey?q='+encodeURIComponent(q)); }catch(_e){}
   status.style.display='block'; status.textContent='Searching…';
   try{
-    const r = await fetch('/operator/lot-journey/data?q='+encodeURIComponent(q));
-    const data = await r.json();
+    const data = await KottyApi.apiGet('/operator/lot-journey/data?q='+encodeURIComponent(q));
     if(!data.ok){ status.textContent='Error: '+(data.error||'failed'); return; }
     if(!data.journey){ status.textContent='No lot found for "'+q+'".'; return; }
     status.style.display='none';

--- a/views/operator-sku-categories.ejs
+++ b/views/operator-sku-categories.ejs
@@ -88,6 +88,7 @@
   </div>
 </div>
 
+<script src="/public/js/api.js"></script>
 <script>
 function showToast(msg, type) {
   var toast = document.getElementById('toast');
@@ -104,20 +105,15 @@ document.getElementById('addForm').addEventListener('submit', async function(e) 
   if (!name) return;
 
   try {
-    var res = await fetch('/operator/api/sku-categories', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ name: name })
-    });
-    var data = await res.json();
-    if (data.success) {
+    var data = await KottyApi.apiPost('/operator/api/sku-categories', { name: name });
+    if (data && data.success) {
       showToast('Category "' + name.toUpperCase() + '" added!', 'success');
       input.value = '';
       setTimeout(function() { location.reload(); }, 1000);
     } else {
-      showToast(data.error || 'Failed to add', 'error');
+      showToast((data && data.error) || 'Failed to add', 'error');
     }
-  } catch (e) { showToast('Error: ' + e.message, 'error'); }
+  } catch (e) { showToast(e.message || 'Failed to add', 'error'); }
 });
 
 document.querySelectorAll('.btn-delete').forEach(function(btn) {
@@ -127,17 +123,16 @@ document.querySelectorAll('.btn-delete').forEach(function(btn) {
     if (!confirm('Delete category "' + name + '"?')) return;
 
     try {
-      var res = await fetch('/operator/api/sku-categories/' + id, { method: 'DELETE' });
-      var data = await res.json();
-      if (data.success) {
+      var data = await KottyApi.apiDelete('/operator/api/sku-categories/' + id);
+      if (data && data.success) {
         showToast('Category deleted', 'success');
         document.querySelector('tr[data-id="' + id + '"]').remove();
         var count = document.querySelectorAll('#categoriesTable tbody tr').length;
         document.getElementById('categoryCount').textContent = count;
       } else {
-        showToast(data.error || 'Failed to delete', 'error');
+        showToast((data && data.error) || 'Failed to delete', 'error');
       }
-    } catch (e) { showToast('Error: ' + e.message, 'error'); }
+    } catch (e) { showToast(e.message || 'Failed to delete', 'error'); }
   });
 });
 </script>

--- a/views/operatorLotTat.ejs
+++ b/views/operatorLotTat.ejs
@@ -181,6 +181,7 @@
     <div id="list"></div>
   </div>
 
+<script src="/public/js/api.js"></script>
 <script>
   const $ = (id) => document.getElementById(id);
 
@@ -290,12 +291,13 @@
     $('list').innerHTML = '<div class="empty-state">Loading…</div>';
     const qs = buildQS();
     $('dlBtn').href = '/operator/lot-tat/download' + (qs ? '?' + qs : '');
-    const r = await fetch('/operator/lot-tat/data' + (qs ? '?' + qs : ''));
-    if (!r.ok) {
-      $('list').innerHTML = '<div class="empty-state">Failed to load. ' + r.status + '</div>';
+    let data;
+    try {
+      data = await KottyApi.apiGet('/operator/lot-tat/data' + (qs ? '?' + qs : ''));
+    } catch (e) {
+      $('list').innerHTML = '<div class="empty-state">Failed to load. ' + (e.status || e.message) + '</div>';
       return;
     }
-    const data = await r.json();
     const lots = data.lots || [];
     renderCounts(lots);
     $('list').innerHTML = lots.length

--- a/views/operatorPICReport.ejs
+++ b/views/operatorPICReport.ejs
@@ -102,6 +102,9 @@
       </div>
       <div class="card-body p-0">
         <%
+          function escHtml(x) {
+            return String(x).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+          }
           function statusBadge(s) {
             if (!s || s === 'N/A' || s === '—') return '<span class="text-muted">—</span>';
             const m = String(s).toLowerCase();
@@ -111,12 +114,12 @@
             if (m === 'pending approval') return '<span class="badge badge-warning">Pending Approval</span>';
             if (m === 'denied')    return '<span class="badge badge-danger">Denied</span>';
             if (m === 'not started') return '<span class="badge badge-neutral">Not Started</span>';
-            return '<span class="badge badge-neutral">' + s + '</span>';
+            return '<span class="badge badge-neutral">' + escHtml(s) + '</span>';
           }
           function qtyOrDash(v) {
             if (v === '' || v === null || v === undefined) return '<span class="text-muted">—</span>';
             if (v === '—') return '<span class="text-muted">—</span>';
-            return v;
+            return escHtml(v);
           }
         %>
         <div class="table-container" style="border: none; border-radius: 0;">

--- a/views/operatorSizeReport.ejs
+++ b/views/operatorSizeReport.ejs
@@ -100,6 +100,9 @@
         <span class="badge badge-neutral"><%= rows.length %> records with size breakdown</span>
       </div>
       <%
+        function escHtml(x) {
+          return String(x).replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+        }
         function statusBadge(s) {
           if (!s || s === 'N/A' || s === '—') return '<span class="text-muted">—</span>';
           const m = String(s).toLowerCase();
@@ -109,11 +112,11 @@
           if (m === 'pending approval') return '<span class="badge badge-warning">Pending Approval</span>';
           if (m === 'denied')    return '<span class="badge badge-danger">Denied</span>';
           if (m === 'not started') return '<span class="badge badge-neutral">Not Started</span>';
-          return '<span class="badge badge-neutral">' + s + '</span>';
+          return '<span class="badge badge-neutral">' + escHtml(s) + '</span>';
         }
         function qtyOrDash(v) {
           if (v === '' || v === null || v === undefined || v === '—') return '<span class="text-muted">—</span>';
-          return v;
+          return escHtml(v);
         }
       %>
       <div class="table-responsive">

--- a/views/searchDashboard.ejs
+++ b/views/searchDashboard.ejs
@@ -369,7 +369,7 @@
 <script>
   // Restore existing tags if searchTerm was previously used
   let tags = [];
-  const existing = (<%- JSON.stringify(searchTerm || '') %>).trim();
+  const existing = (<%- JSON.stringify(searchTerm || '').replace(/</g, '\\u003c') %>).trim();
   if (existing) {
     // For a true multi-tag scenario, you might split on spaces:
     tags = existing.split(/\s+/).filter(Boolean);

--- a/views/washingInAssignRewash.ejs
+++ b/views/washingInAssignRewash.ejs
@@ -365,13 +365,13 @@
     <% if (error && error.length) { %>
       <div class="alert alert-danger">
         <i class="bi bi-exclamation-circle me-2"></i>
-        <%- error.join('<br>') %>
+        <% error.forEach(function(msg, i){ %><% if (i > 0) { %><br><% } %><%= msg %><% }); %>
       </div>
     <% } %>
     <% if (success && success.length) { %>
       <div class="alert alert-success">
         <i class="bi bi-check-circle me-2"></i>
-        <%- success.join('<br>') %>
+        <% success.forEach(function(msg, i){ %><% if (i > 0) { %><br><% } %><%= msg %><% }); %>
       </div>
     <% } %>
 

--- a/views/washingPaymentSummary.ejs
+++ b/views/washingPaymentSummary.ejs
@@ -356,8 +356,15 @@
 </div>
 
 <script>
-  // Server-rendered rate options for dynamic row creation
-  const rateOptions = `<option value="">Select description</option><% rates.forEach(function(r){ %><option value="<%- r.description.replace(/'/g, "\\'") %>" data-rate="<%= r.rate %>"><%- r.description.replace(/'/g, "\\'") %> (Rs. <%= r.rate %>)</option><% }); %>`;
+  // Server-provided rate data; options built client-side with HTML escaping
+  const RATE_LIST = <%- JSON.stringify(rates.map(function(r){ return { description: r.description, rate: r.rate }; })).replace(/</g, '\\u003c') %>;
+  function escHtml(s){
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+  }
+  const rateOptions = '<option value="">Select description</option>' + RATE_LIST.map(function(r){
+    return '<option value="' + escHtml(r.description) + '" data-rate="' + escHtml(r.rate) + '">' +
+      escHtml(r.description) + ' (Rs. ' + escHtml(r.rate) + ')</option>';
+  }).join('');
 
   function updateTotals(lotId){
     const container = document.getElementById('desc-container-' + lotId);


### PR DESCRIPTION
Plan 04's security items, agent-built with a full audit and reviewed (stage/payment screens verified untouched — 0 files).

## FE-3 — XSS audit of every unescaped `<%- %>` in 194 views
**Fixed (user/DB data rendered unescaped):**
- `login.ejs` — flash error rendered raw
- `washingInAssignRewash.ejs` — flash echoes of user-supplied ids/errors
- `accountsChallanGeneration.ejs` + `challanGeneration.ejs` — JSON injected into HTML attributes with breakable quoting
- `washingPaymentSummary.ejs` — **DB description interpolated into a JS template literal** (backtick/`${`/`</script>` all breakable) → JSON.stringify + client-side escaping
- `searchDashboard.ejs` — reflected search term hardened (`<` escaping)
- `operatorPICReport.ejs` / `operatorSizeReport.ejs` — raw fallbacks in badge/qty helpers → escaped

**Left as safe (documented):** the standard `const x = <%- JSON.stringify(value) %>` pattern (~25 sites incl. the 5 payment screens — audited, untouched), Vite asset tags, the layout body.

## FE-2 — `public/js/api.js` (window.KottyApi)
Dependency-free client: same-origin credentials, JSON headers, `res.ok` check, **redirect to /login on 401**, throws the server's error message on failure. Migrated exactly 3 demonstration views (lotJourney, operatorLotTat, sku-categories) with behaviour preserved; the other ~80 call sites migrate incrementally.

## Verification
11/11 touched views render with route-shaped locals; every inline script parses; **XSS probes** (`</script><script>alert(1)</script>`, quote/angle payloads) injected via mock locals render escaped in all outputs; api.js behaviour smoke-tested with mocked fetch (401→redirect, 400→thrown message).

🤖 Generated with [Claude Code](https://claude.com/claude-code)