### PR TITLE
fix(lots): duplicate size rows under-showed availability (ma144: 219 vs 876)

### DIFF
--- a/routes/finishingRoutes.js
+++ b/routes/finishingRoutes.js
@@ -2226,7 +2226,7 @@ router.get('/lot-details/:lotNo', isAuthenticated, isFinishingMaster, async (req
     }
 
     const [cuttingSizes] = await pool.query(`
-      SELECT size_label, total_pieces as pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ?
+      SELECT size_label, SUM(total_pieces) as pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ? GROUP BY size_label
     `, [cuttingLot.id]);
 
     const [[finishingData]] = await pool.query(`

--- a/routes/jeansAssemblyRoutes.js
+++ b/routes/jeansAssemblyRoutes.js
@@ -1862,7 +1862,7 @@ router.get('/lot-details/:lotNo', isAuthenticated, isJeansAssemblyMaster, async 
     }
 
     const [cuttingSizes] = await pool.query(`
-      SELECT size_label, total_pieces as pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ?
+      SELECT size_label, SUM(total_pieces) as pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ? GROUP BY size_label
     `, [cuttingLot.id]);
 
     const [[assemblyData]] = await pool.query(`

--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -466,7 +466,7 @@ router.get("/dashboard/api/lot", isAuthenticated, isOperator, async (req, res) =
       );
       if (!lot) return null;
       const [sizes] = await pool.query(
-        `SELECT size_label, total_pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ?`,
+        `SELECT size_label, SUM(total_pieces) AS total_pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ? GROUP BY size_label`,
         [lot.id]
       );
       return { lot, sizes };

--- a/routes/stitchingRoutes.js
+++ b/routes/stitchingRoutes.js
@@ -173,7 +173,7 @@ router.get('/event/lot-state/:cuttingLotId', isAuthenticated, isStitchingMaster,
     if (!lot) return res.status(404).json({ error: 'Lot not found' });
 
     const [cutSizes] = await pool.query(
-      `SELECT size_label, total_pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ? ORDER BY id`,
+      `SELECT size_label, SUM(total_pieces) AS total_pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ? GROUP BY size_label ORDER BY MIN(id)`,
       [lotId]
     );
 
@@ -2200,7 +2200,7 @@ router.get('/lot-details/:lotNo', isAuthenticated, isStitchingMaster, async (req
 
     // Get cutting sizes
     const [cuttingSizes] = await pool.query(`
-      SELECT size_label, total_pieces as pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ?
+      SELECT size_label, SUM(total_pieces) as pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ? GROUP BY size_label
     `, [cuttingLot.id]);
 
     // Get stitching data for this user


### PR DESCRIPTION
**Your ma144 question, root-caused.** The lot was cut with **4 marker patterns of the same size L** → 4 rows of `L:219` in `cutting_lot_sizes` (876 total — the cutting math is perfectly consistent: 219 layers × 4 patterns = 876, roll sums match).

**The bug:** the stitching lot-state endpoint returned those 4 rows **1:1** to the screen; the take-in grid keys inputs by size label, so the four rows collapsed into one **219** — hence "Take 219 pieces". Worse: after taking 219, *every* L row would have computed available = 219−219 = **0**, silently stranding the remaining 657 pieces in the cutting pool.

**Not a money bug:** the approve *validation* already summed per label correctly — no over-take was ever possible. This was under-display/under-availability only.

**Scope:** 16 lots in prod have duplicated size labels (one cut just today) — this is a recurring entry pattern, so the fix is in code: `GROUP BY size_label + SUM(total_pieces)` in all five 1:1 readers (stitching lot-state + lot-sizes expander, jeans-assembly + finishing expanders, operator lot API).

**Verified:** the fixed query against prod returns `L:876` for ma144; all 4 route files parse; 167 tests pass.

After merge, ma144 will show **876 available** on the stitching screen, and the take-in flow works on the full quantity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)