### PR TITLE
fix(pm): CP-3 semantics locked + cutting-planning tracker truth-up

### DIFF
--- a/docs/plans/00-PROGRESS.md
+++ b/docs/plans/00-PROGRESS.md
@@ -59,18 +59,19 @@ All merged to `main` unless noted. These fixed the production-manager (PM) data 
 ---
 
 ## C. Cutting-planning bug backlog — quick status (details in `02`)
-| ID | Bug / gap | Severity | Status |
+| ID | Bug / gap | Severity | Status (updated 2026-07-10) |
 |----|-----------|----------|--------|
-| CP-1 | `orange` vs `amber` trigger mismatch → 107 "cut-soon" styles shown as Covered | **High** | **DONE — PR #483** (107 amber styles now surface) |
-| CP-2 | Closed loop not wired (assign never becomes "cut") | **High (design)** | Open |
-| CP-3 | Marketplace-PO sign (`+ upcomingPoQty`) — verify demand vs supply | High | Open (needs decision) |
-| CP-4 | No transaction in `POST /api/cut-plan/assign` (per-lot mode) | Medium | Open |
+| CP-1 | `orange` vs `amber` trigger mismatch → 107 "cut-soon" styles shown as Covered | **High** | **DONE — PR #483** |
+| CP-2 | Closed loop not wired (assign never becomes "cut") | **High (design)** | **DONE** — Start-this-lot (#498) links assignment→cutting_lot + status 'cut'; GRN pipeline (#538) closes the dispatch end |
+| CP-3 | Marketplace-PO sign (`+ upcomingPoQty`) | High | **DONE** — business confirmed POs are OUTBOUND DEMAND; `+` is correct; semantics locked in a code comment (easyecomAnalytics) |
+| CP-4 | No transaction in `POST /api/cut-plan/assign` (per-lot mode) | Medium | **DONE** — per-lot assign refactor (#507) wrapped all inserts in one transaction |
 | CP-5 | Style-scope lead-times ignored (only `scope='sku'` loaded) | Medium | Open |
 | CP-6 | CAD size vocabulary not unified (no 5XL/6XL/numeric) | Medium | Open |
 | CP-7 | `deriveStyle` over-strip (base ending in S/M/L/XL) | Medium | Open |
-| CP-8 | Leftover `GET /pm/debug-ee` endpoint | Low | Open |
+| CP-8 | Leftover `GET /pm/debug-ee` endpoint | Low | **DONE** — endpoint no longer exists |
 | CP-9 | Redundant heavy recompute in assign path | Low | Open |
-| CP-10 | Resolver gap: unresolved in-flight counted, not netted → over-cut | Medium | Open (monitor) |
+| CP-10 | Resolver gap: unresolved in-flight counted, not netted → over-cut | Medium | Open — `pm_sku_resolution` still EMPTY; upload the two PREFILLED sheets via /pm/resolver/upload-*; note the GRN pipeline (#538) has its own concat-verified fallback |
+| *(new)* | Duplicate size-label rows: netting double-subtracted dispatches; displays/validations under-counted | High | **DONE — PRs #541/#542** (2026-07-10) |
 
 ## D. Known environment facts (so nobody re-discovers them)
 - Prod = GCP `kotty-track-prod`, Cloud Run, deploys from `main` via `cloudbuild.yaml` (2Gi, min-instances=1, timeout 3600).

--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -843,6 +843,9 @@ async function getCuttingRecommendations(pool, { periodKey = '30d', shadow = fal
     const upcomingPoQty = (poMap.get(sku) || [])
       .reduce((s, p) => s + (p.daysOut <= horizon ? p.qty : 0), 0);
 
+    // CP-3 (confirmed with the business 2026-07-10): marketplace PO lines are OUTBOUND
+    // DEMAND — pieces we must produce and ship (e.g. Myntra JIT POs) — NOT inbound supply.
+    // They therefore ADD to the suggested cut. Do not flip this sign.
     const suggested = Math.max(
       0,
       horizon * drr - soh - openLotQty + upcomingPoQty


### PR DESCRIPTION
Closes CP-3 and corrects the plan tracker to reality.

**CP-3 — your decision applied:** marketplace POs are **outbound demand** (pieces to produce), so the existing `+ upcomingPoQty` in the suggested-cut formula is **already correct**. The change is a locked-in code comment stating the confirmed semantics so nobody ever "fixes" the sign backwards. (The `pm_marketplace_po_lines` table is currently empty, so behaviour is unchanged until POs are uploaded.)

**CP-4 — verified already done:** the per-lot assign refactor (#507) wrapped all assign inserts in one transaction — commit/rollback/release all present in current code. No change needed.

**Tracker truth-up** (`docs/plans/00-PROGRESS.md`): CP-2 ✓ (#498 + #538), CP-3 ✓, CP-4 ✓ (#507), CP-8 ✓ (endpoint gone), plus today's duplicate-size fixes (#541/#542) recorded. **Genuinely open:** CP-5 (style-scope lead-times), CP-6 (size vocab), CP-7 (deriveStyle), CP-9 (perf), CP-10 (upload the two PREFILLED resolver sheets — data task).

167 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)