### PR TITLE
docs(handoff): tracker + plan statuses rewritten to reality (successor map)

### DIFF
--- a/docs/plans/00-PROGRESS.md
+++ b/docs/plans/00-PROGRESS.md
@@ -1,81 +1,134 @@
 # Kotty-Track — Progress & Roadmap Tracker
 
 > Master index. Each initiative has its own detailed plan file in this folder.
-> Update the **Status** and **Last touched** columns as work lands. Anyone picking
-> this up should read this file first, then the relevant `NN-*.md` plan.
+> Anyone picking this up: read this file first, then the relevant `NN-*.md` plan.
 
-_Last updated: 2026-07-03_
+_Last updated: **2026-07-10** (major refresh — the previous owner's final week; everything
+below was verified against code and prod, not copied forward)._
 
 ---
 
 ## Plan files in this folder
-| File | What it covers |
-|------|----------------|
-| `00-PROGRESS.md` | This tracker. |
-| `01-qcpass-extension.md` | Authenticated ingestion of the QC-Capture Chrome extension into the kotty-track DB, restricted to the `jitrgp` role, with the realtime-vs-queue design. |
-| `02-cutting-planning-bugs.md` | The cutting-planning correctness backlog (audit findings), one by one. |
-| `03-ejs-to-react-migration.md` | Effort + benefits + incremental approach for moving the EJS frontend to React. |
-| `04-frontend-best-practices.md` | Frontend issues measured against best practice, with fixes. |
-| `05-architecture-testing-security.md` | Split into separate backend/React projects, full test coverage (backend+frontend), security testing + server/DB hardening, stress/load testing. |
+| File | What it covers | Status |
+|------|----------------|--------|
+| `00-PROGRESS.md` | This tracker + successor orientation. | — |
+| `01-qcpass-extension.md` | QC-Capture Chrome extension → DB ingestion. | **SHIPPED** (PRs #483–#494); one open item: live test of Myntra auto-pass |
+| `02-cutting-planning-bugs.md` | Cutting-planning correctness backlog. | CP-1/2/3/4/8 done; CP-5/6/7/9 open (code); CP-10 open (data task) |
+| `03-ejs-to-react-migration.md` | EJS → React analysis. | Analysis done; decision pending. `/tasks` + `/qc` are the first React islands |
+| `04-frontend-best-practices.md` | Frontend vs best practice. | FE-2/3/5/6 **DONE** (#539/#540); FE-1/4/7–10 open |
+| `05-architecture-testing-security.md` | Split architecture / tests / security / load. | Not started — successor program |
+
+Related design docs (repo `docs/`):
+- `EASYECOM_DISPATCH_GRN_DESIGN.md` — the dispatch→PO pipeline (live). **Read before touching anything EasyEcom.**
+- `FLOOR_REDESIGN_HANDOFF.md` — the floor design system (now implemented; keep for the design rationale).
+- `PM_CUTTING_PLANNING_HANDOFF.md` — the production-planning data pipeline.
 
 ---
 
-## A. Recently shipped (context for whoever continues)
+## A. What shipped in the final week (2026-07-07 → 07-10) — the map git can't give you
 
-All merged to `main` unless noted. These fixed the production-manager (PM) data feed and reports.
+### 1. Floor redesign — every operator/master screen (PRs #515–#534)
+All ~45 floor screens now share one design system (indigo `#2563eb`, quiet white cards,
+Space Grotesk numbers + Inter, status colours only for status).
+- **The operator hub IS the operator dashboard** (`/operator/hub`; `/operator/dashboard`
+  redirects to it; login lands operators there). Desktop-first, live feature search,
+  KPIs, SKU insights, Account Usage (mohitoperator-only). `views/operatorDashboard.ejs`
+  was deleted.
+- **5 stage lot screens** (`stitchingEvents.ejs` + 4 near-identical siblings): standalone
+  chrome (no shared navbar), body search, stage-rail journey, **type-first quantity grids**
+  (Size | Avail | Take | Reject — tap-to-type, no ± hunting), one bottom CTA per card
+  (take = blue, done = green). The take/complete/payment engine was NEVER rewritten — every
+  redesign pass was verified byte-identical on payload code.
+- **Shared pieces:** `views/partials/floorHead.ejs` + `floorNav.ejs` (Tailwind shell, hub
+  only), `views/partials/floorTokens.ejs` (style-only token override used by ~16 header-based
+  screens), per-screen `flx-top` chrome on the stage/master screens.
+- **Audience rule** (learned the hard way, PR #534): never add a link/nav without checking
+  the destination's role gate against the screen's audience. Stage screens are used by
+  MASTERS; most `/operator/*` routes are operator-only.
+- Cutting screens intentionally untouched (owner's decision).
 
-| PR | What |
-|----|------|
-| #473 | Mini-sales freeze fix — single adaptive-window report + resilient polling. |
-| #474 | 429-as-transient in mini-sales; freshness indicator. |
-| #475 | Aging feed: parallelize warehouses, honest status, dedicated deadline (later superseded — see below). |
-| #476 | In-production **size-PIC report** download on the PM style page; extracted shared `utils/picSizeReport.js` from `routes/operatorRoutes.js`. |
-| #477 | Scoped that download to the current style. |
-| #478 | Cloud Run **2Gi + min-instances=1** (durable, in `cloudbuild.yaml`) — stopped OOM + stabilized the EasyEcom auth token → un-froze the feed. |
-| #479 | PIC reports reworked: per-stage **In=approved / Out=completed / In-line=WIP / Pending=handoff** (was In=previous-stage-completed). |
-| #480 | Renamed those download columns to "Approved / Completed". |
-| #481 | Removed **aging** from the freshness banner (it only powers Dead Stock, which has a fallback). |
-| #482 | Stopped pulling `INVENTORY_AGING_REPORT` nightly — it has **never** returned data (EasyEcom won't generate it for our two secondary warehouses); reclaims ~20 min/run. |
+### 2. EasyEcom dispatch→PO pipeline — LIVE (PR #538, flag ON since 2026-07-10)
+Finishing dispatches (destination = Warehouse) → swept into batches on
+`/finishingdashboard/ee-po` (finishing role) → operator pushes → **a Purchase Order is
+created in EasyEcom** (vendor "Kotty Production", code V002, vendor_c_id 289541) → the
+**warehouse GRNs it manually in the EasyEcom UI** on physical receipt → the screen's
+"Check for warehouse GRNs" (getGrnDetails.po_id match) marks the batch confirmed.
+- **No code path writes inventory. Ever.** `bulkInventoryUpdate` was explicitly rejected.
+- Hard cutoff `EE_PO_SINCE=2026-07-11` — the 880 historical dispatch rows can never ride a PO.
+- SKU gate: `pm_sku_resolution` map → CONCAT(style,size) **verified against the
+  `ee_product_master` mirror** → else the line blocks. Never guessed.
+- Idempotency: `ee_dispatch_po_lines.dispatch_id` UNIQUE + EasyEcom's own PO-quantity cap.
+- API quirks (live-tested; in `utils/eeDispatchPo.js` comments): PO `vendorId` = vendor CODE
+  ('V002') but GRN `vendor_id` = numeric id; `expDeliveryDate` strictly > today; bin =
+  lowercase `default`; GRN-queue success `queueId` is at the TOP level; auth = account
+  X-API-Key + JWT minted with the FARIDABAD location_key (`EASYECOM_LOCATION_KEY`).
+- Weekly product-master sync now persists `cost`/`mrp` (PO unit-price source).
+- **Watch item:** the first real batch (first Warehouse dispatch after 07-11) — verify the
+  PO→GRN→confirm round-trip once, like the Phase-0 test (documented in the design doc §7–8).
 
-### Data repairs done directly on prod (uncommitted scripts, backups kept)
-- Stage-qty corruption repair (37 lots).
-- **Orphan-approve dedup**: deleted 329 duplicate `AUTO_APPROVE_ORPHAN` approve events across 328 lots (241,810 phantom pieces). 9 lots flagged for manual review (benign 0-piece pairs + `ak4972`).
+### 3. Sessions moved to MySQL (PR #539)
+`express-mysql-session` on the existing pool (`sessions` table, 24h TTL). Random logouts
+(per-instance MemoryStore) are gone. Any old doc mentioning MemoryStore is obsolete.
 
-### Verified healthy (2026-07-03, read-only vs prod)
-- Feed fresh: orders/DRR, stock, mini_sales, snapshot all refreshed 03 Jul 04:07.
-- `getCuttingRecommendations`: 26,244 size-SKU rows in 5.2 s; recommendations sane.
+### 4. Security + correctness sweeps
+- XSS audit of every unescaped `<%- %>` in 194 views; real injections fixed (#540).
+- `public/js/api.js` (`window.KottyApi`) — shared fetch client; 3 screens migrated, ~80 to go.
+- **Duplicate size-label bug class** (#541/#542): a lot cut with several patterns of the
+  same size has multiple `cutting_lot_sizes` rows per label. Everything reading those rows
+  1:1 was fixed with GROUP BY/SUM (stitching availability, PM in-flight netting — which was
+  double-subtracting dispatches → over-cut suggestions — size-PIC report, style page) and
+  all 10 stage validations hardened from `.find()` (first-match) to summed checks.
+- Search-dashboard 500 + lot-journey `?q=` fixed (#528). sku-categories page fixed (#537).
+
+### 5. Ops facts that changed this week
+- `EE_GRN_PUSH=1` is SET on the service (env). `EE_PO_SINCE` defaults in code to 2026-07-11.
+- Env changes: ONLY `--update-env-vars` / `--update-secrets`. Never `--set-*`/`--clear-*`.
+- Builds run in Cloud Build **global** region (`gcloud builds list` without --region);
+  deploys from `main` only; the frontend islands build now fails the deploy if broken.
+- The repo owner merges PRs within minutes — **never push follow-up commits to an open PR's
+  branch; open a new PR per change.**
+
+## B. Earlier context (still true, condensed)
+PM data feed is healthy (orders_api-driven DRR, snapshot SOH, freshness banner). Historical
+prod data repairs (stage-qty corruption, orphan-approve dedup) are documented in the git
+history of this file. Payment ledger is event-sourced: `{stage}_events` +
+`{stage}_event_sizes` are the truth; every stage approve pays the upstream worker via
+`stage_payments`. Cutting payments stopped 2026-05-06 (pre-dates everything here; business
+said leave it).
 
 ---
 
-## B. Open initiatives
+## C. Open work, prioritized for whoever continues
 
-| # | Initiative | Status | Plan | Priority |
-|---|-----------|--------|------|----------|
-| 1 | QC-Capture extension → authenticated DB ingestion (`jitrgp`) | **Not started** | `01-qcpass-extension.md` | High (new feature the user is adding) |
-| 2 | Cutting-planning correctness bugs | **Not started** | `02-cutting-planning-bugs.md` | High — one bug hides 107 "cut-soon" styles |
-| 3 | EJS → React migration | **Analysis only** | `03-ejs-to-react-migration.md` | Medium — decision pending |
-| 4 | Frontend best-practices cleanup | **Not started** | `04-frontend-best-practices.md` | Medium |
+| # | Item | Where | Size |
+|---|------|-------|------|
+| 1 | **Verify the first real dispatch→PO→GRN round-trip** | `/finishingdashboard/ee-po` + design doc §7–8 | 1h, watch-only |
+| 2 | **Upload the two PREFILLED resolver sheets** (`pm_sku_resolution` is EMPTY) | `POST /pm/resolver/upload-sizes` / `upload-styles`; files in repo root | data task |
+| 3 | QC auto-pass live test on the Myntra portal | Plan 01 | 1h |
+| 4 | CP-5/6/7/9 (cutting-planning math) | Plan 02 | ~1 day |
+| 5 | FE-1 (externalize 132 inline scripts) → unlocks FE-4 (CSP) | Plan 04 | incremental |
+| 6 | React decision (Plan 03), then absorb FE-7–10 per island | Plan 03/04 | program |
+| 7 | Architecture split / test coverage / load (Plan 05) | Plan 05 | program |
 
----
+## D. Successor orientation — your first week
 
-## C. Cutting-planning bug backlog — quick status (details in `02`)
-| ID | Bug / gap | Severity | Status (updated 2026-07-10) |
-|----|-----------|----------|--------|
-| CP-1 | `orange` vs `amber` trigger mismatch → 107 "cut-soon" styles shown as Covered | **High** | **DONE — PR #483** |
-| CP-2 | Closed loop not wired (assign never becomes "cut") | **High (design)** | **DONE** — Start-this-lot (#498) links assignment→cutting_lot + status 'cut'; GRN pipeline (#538) closes the dispatch end |
-| CP-3 | Marketplace-PO sign (`+ upcomingPoQty`) | High | **DONE** — business confirmed POs are OUTBOUND DEMAND; `+` is correct; semantics locked in a code comment (easyecomAnalytics) |
-| CP-4 | No transaction in `POST /api/cut-plan/assign` (per-lot mode) | Medium | **DONE** — per-lot assign refactor (#507) wrapped all inserts in one transaction |
-| CP-5 | Style-scope lead-times ignored (only `scope='sku'` loaded) | Medium | Open |
-| CP-6 | CAD size vocabulary not unified (no 5XL/6XL/numeric) | Medium | Open |
-| CP-7 | `deriveStyle` over-strip (base ending in S/M/L/XL) | Medium | Open |
-| CP-8 | Leftover `GET /pm/debug-ee` endpoint | Low | **DONE** — endpoint no longer exists |
-| CP-9 | Redundant heavy recompute in assign path | Low | Open |
-| CP-10 | Resolver gap: unresolved in-flight counted, not netted → over-cut | Medium | Open — `pm_sku_resolution` still EMPTY; upload the two PREFILLED sheets via /pm/resolver/upload-*; note the GRN pipeline (#538) has its own concat-verified fallback |
-| *(new)* | Duplicate size-label rows: netting double-subtracted dispatches; displays/validations under-counted | High | **DONE — PRs #541/#542** (2026-07-10) |
-
-## D. Known environment facts (so nobody re-discovers them)
-- Prod = GCP `kotty-track-prod`, Cloud Run, deploys from `main` via `cloudbuild.yaml` (2Gi, min-instances=1, timeout 3600).
-- Sessions use **in-process MemoryStore** (not shared across instances, lost on restart) — relevant to the extension auth choice.
-- No token/JWT/API-key auth exists; the only header-secret path is `POST /internal/run-pull` (`x-cron-secret` vs `PM_CRON_SECRET`).
-- Env changes on Cloud Run must use `--update-env-vars` (never `--set/--clear`).
-- Read-only prod inspection: cloud-sql-proxy → `127.0.0.1:3306`, creds from Secret Manager `db-password`.
+1. **Access you need:** GCP project `kotty-track-prod` (Cloud Run svc `kotty-track`,
+   region asia-south1; Cloud SQL `kotty-mysql`; Secret Manager `db-password`), the GitHub
+   repo, and an EasyEcom login (creds live as env vars on the service).
+2. **Inspect prod read-only:** `cloud-sql-proxy --port 3307
+   kotty-track-prod:asia-south1:kotty-mysql`, then mysql2 as `kotty_user` /
+   `$(gcloud secrets versions access latest --secret=db-password)`, db `kotty_db`.
+   Run node from the repo root so `mysql2` resolves.
+3. **Invariants — do not break:**
+   - The event ledger is append-only truth. Never edit `*_events`/`*_event_sizes` casually;
+     reversal/corrections go through the Lot Admin tools (audited in `pm_lot_audit_log`).
+   - Nothing may write EasyEcom inventory via API. POs only; the warehouse GRNs.
+   - Stage screens' payload code is payment-critical — visual work must leave
+     `doTake*`/`doMarkDone*`/`/event/*` payloads byte-identical (diff-filter before merging).
+   - Env via `--update-env-vars` only.
+4. **How things are verified here** (keep the bar): EJS render with route-accurate locals +
+   `new Function()` on every inline script; `NODE_ENV=test node --test` (167 tests);
+   payment-code diffs against main; read-only prod queries for data claims.
+5. **Where the bodies are buried:** `docs/plans/02` CP-10 (resolver gap),
+   `pm_open_cutting_lots` bridge (currently 0 open rows), the `SCK*`-prefixed duplicate
+   marketplace listings, Delhi warehouse not yet on the PO pipeline (Faridabad only).

--- a/docs/plans/01-qcpass-extension.md
+++ b/docs/plans/01-qcpass-extension.md
@@ -1,6 +1,6 @@
 # Plan 01 — QC-Capture Extension → Authenticated DB Ingestion (`jitrgp`)
 
-_Status: Not started. Owner: TBD. Related: `qcpass_extension/`, `routes/`, `middlewares/auth.js`._
+_Status: **SHIPPED 2026-07-03** (PRs #483–#494: token auth, dedup ingestion, QC dashboard rebuilt on captures + item_barcode join, login flow, CSV recovery; 161+ tests; rev 00411). REMAINING: one live test of the Myntra auto-pass click on the real portal. This plan is kept for the design rationale._
 
 ## Context — what prompted this
 `qcpass_extension/` is a Manifest-V3 Chrome extension ("QC Capture — Full Return Data")

--- a/docs/plans/02-cutting-planning-bugs.md
+++ b/docs/plans/02-cutting-planning-bugs.md
@@ -1,6 +1,6 @@
 # Plan 02 — Cutting-Planning Correctness Backlog
 
-_Status: Not started. Source: end-to-end audit (2026-07-03) of `/pm` cutting planning,
+_Status: **CP-1/2/3/4/8 DONE** (see 00-PROGRESS table, updated 2026-07-10); CP-5/6/7/9 open (code), CP-10 open (upload the PREFILLED resolver sheets). Source: end-to-end audit (2026-07-03) of `/pm` cutting planning,
 verified live against prod. Fix these **one by one**, each on its own branch/PR, each with a
 before/after check. Ordered by value/effort._
 

--- a/docs/plans/04-frontend-best-practices.md
+++ b/docs/plans/04-frontend-best-practices.md
@@ -1,6 +1,6 @@
 # Plan 04 — Frontend Issues vs Best Practice (one by one)
 
-_Status: Not started. Each item: **Issue → Best practice → Fix**. Prioritized. These apply to
+_Status: **FE-5 + FE-6 DONE** (#539: MySQL session store, CI island build), **FE-3 + FE-2 DONE** (#540: XSS audit/fixes, `public/js/api.js` client — 3 screens migrated, ~80 call sites remain). FE-1 open (unlocks FE-4/CSP); FE-7–10 best absorbed by Plan 03 islands. Each item: **Issue → Best practice → Fix**. These apply to
 the current EJS frontend and are largely independent of the React question (Plan 03); doing
 them makes an eventual React migration easier, not harder._
 


### PR DESCRIPTION
The handoff refresh — docs only.

**`00-PROGRESS.md` rewritten** as the map git can't provide:
- The final week's architecture: floor redesign (hub-as-dashboard, stage-screen design, floorTokens/floorHead partials, the audience rule), the **live** dispatch→PO pipeline (model, every live-tested API quirk, `EE_GRN_PUSH`/`EE_PO_SINCE` state), MySQL sessions, the XSS + duplicate-size sweeps.
- Verified plan statuses (01 shipped, 02's CP table, 04's FE wins) — no more "Not started" lies.
- **Prioritized open work** (first: watch the first real PO round-trip; second: upload the resolver sheets).
- **Successor orientation**: access list, read-only prod inspection recipe, the four do-not-break invariants (append-only ledger, no API inventory writes, byte-identical payment payloads, `--update-env-vars` only), the verification bar, and where the bodies are buried.

Plan 01/02/04 headers corrected to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)