### PR TITLE
fix(ee-po): resolve the underscore EE SKU convention too

### DIFF
--- a/utils/eeDispatchPo.js
+++ b/utils/eeDispatchPo.js
@@ -86,12 +86,16 @@ async function resolveLine(db, lotSku, sizeLabel) {
   let source = eeSku ? 'map' : null;
 
   if (!eeSku) {
-    const candidate = sku + size; // EE convention observed across the live catalog
-    const [hit] = await db.query(
-      `SELECT sku, cost, mrp FROM ee_product_master WHERE sku=? AND active=1 LIMIT 1`,
-      [candidate]
-    );
-    if (hit.length) return { ee_sku: hit[0].sku, source: 'concat-verified', cost: hit[0].cost, mrp: hit[0].mrp };
+    // Two live EE conventions: plain concat (KTTBLUETOP768M) and underscore
+    // (KTTWOMENSPANT981_3XL). Both are EXISTENCE-VERIFIED against the master
+    // mirror — still never guessed.
+    for (const candidate of [sku + size, sku + '_' + size]) {
+      const [hit] = await db.query(
+        `SELECT sku, cost, mrp FROM ee_product_master WHERE sku=? AND active=1 LIMIT 1`,
+        [candidate]
+      );
+      if (hit.length) return { ee_sku: hit[0].sku, source: 'concat-verified', cost: hit[0].cost, mrp: hit[0].mrp };
+    }
     return { ee_sku: null, source: null, cost: null, mrp: null };
   }
 


### PR DESCRIPTION
EasyEcom has two live size-SKU conventions: plain concat (`KTTBLUETOP768M`) and underscore (`KTTWOMENSPANT981_3XL`). The pipeline's resolver now tries both — each still **existence-verified** against the 98k-SKU master mirror, never guessed. Shrinks the blocked set to genuinely ambiguous cases (waist→letter styles), which the resolver sheet covers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)