### PR TITLE
feat(ee-po): inline SKU resolution on the finishing review screen

### DIFF
--- a/routes/eeDispatchRoutes.js
+++ b/routes/eeDispatchRoutes.js
@@ -5,7 +5,7 @@ const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/db');
 const { isAuthenticated, isFinishingMaster } = require('../middlewares/auth');
-const { buildBatch, reResolveBatch, pushBatch, confirmGrns, pushEnabled, EE_PO_SINCE } = require('../utils/eeDispatchPo');
+const { buildBatch, reResolveBatch, resolveLineManually, pushBatch, confirmGrns, pushEnabled, EE_PO_SINCE } = require('../utils/eeDispatchPo');
 
 // GET / — review screen: batches + how many dispatch rows await sweeping.
 router.get('/', isAuthenticated, isFinishingMaster, async (req, res) => {
@@ -25,9 +25,21 @@ router.get('/', isAuthenticated, isFinishingMaster, async (req, res) => {
          LEFT JOIN ee_dispatch_po_lines l ON l.dispatch_id = fd.id
         WHERE l.id IS NULL AND LOWER(fd.destination)='warehouse'
           AND fd.created_at >= ?`, [EE_PO_SINCE]);
+    // For blocked lines: that style's REAL EasyEcom variants, so the finishing user
+    // can resolve inline from a dropdown (never free text).
+    const blockedStyles = [...new Set(
+      Object.values(linesByBatch).flat().filter(l => !l.ee_sku && l.lot_sku).map(l => String(l.lot_sku).toUpperCase())
+    )];
+    const variantsByStyle = {};
+    for (const st of blockedStyles) {
+      const [v] = await pool.query(
+        `SELECT sku FROM ee_product_master WHERE active=1 AND sku LIKE CONCAT(?, '%') ORDER BY sku LIMIT 40`, [st]);
+      variantsByStyle[st] = v.map(r => r.sku);
+    }
+
     res.render('eeDispatchPo', {
       user: req.session.user,
-      batches, linesByBatch,
+      batches, linesByBatch, variantsByStyle,
       pendingRows: pending.c, pendingQty: Number(pending.qty),
       pushEnabled: pushEnabled(),
     });
@@ -55,6 +67,17 @@ router.post('/reresolve/:id', isAuthenticated, isFinishingMaster, async (req, re
     res.json({ success: true, ...out });
   } catch (err) {
     res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /resolve-line — map ONE blocked line to an existing EasyEcom SKU (dropdown-picked).
+// Writes only our own tables; nothing is created in EasyEcom.
+router.post('/resolve-line', isAuthenticated, isFinishingMaster, async (req, res) => {
+  try {
+    const out = await resolveLineManually(Number(req.body.line_id), req.body.size_sku, req.session.user);
+    res.json({ success: true, ...out });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
   }
 });
 

--- a/utils/eeDispatchPo.js
+++ b/utils/eeDispatchPo.js
@@ -160,6 +160,44 @@ async function buildBatch(user) {
   }
 }
 
+// Inline manual resolution from the finishing review screen. The chosen SKU must
+// EXIST in the ee_product_master mirror AND belong to the same style (prefix guard) —
+// no free text, nothing is ever created in EasyEcom. The mapping is persisted to
+// pm_sku_resolution (source: finishing-ui), so PM planning learns it too.
+async function resolveLineManually(lineId, sizeSku, user) {
+  const chosen = String(sizeSku || '').trim().toUpperCase();
+  if (!chosen) throw new Error('Pick a SKU.');
+  const [[line]] = await pool.query(
+    `SELECT id, batch_id, lot_sku, size_label, ee_sku FROM ee_dispatch_po_lines WHERE id=?`, [lineId]);
+  if (!line) throw new Error('Line not found');
+  if (line.ee_sku) throw new Error('Line is already resolved.');
+  const style = String(line.lot_sku || '').trim().toUpperCase();
+  if (!style) throw new Error('Line has no lot style SKU.');
+  if (!chosen.startsWith(style)) throw new Error('That SKU belongs to a different style.');
+  const [[hit]] = await pool.query(
+    `SELECT sku, cost, mrp FROM ee_product_master WHERE sku=? AND active=1`, [chosen]);
+  if (!hit) throw new Error('That SKU does not exist (active) in the EasyEcom master.');
+
+  // Persist the mapping for everything (pipeline + PM planning). UNIQUE(cl_sku, size_label).
+  await pool.query(
+    `INSERT INTO pm_sku_resolution (cl_sku, size_label, size_sku, state, source, loaded_by)
+     VALUES (?, ?, ?, 'resolved', 'finishing-ui', ?)
+     ON DUPLICATE KEY UPDATE size_sku=VALUES(size_sku), state='resolved',
+       source='finishing-ui', loaded_by=VALUES(loaded_by), updated_at=CURRENT_TIMESTAMP`,
+    [style, String(line.size_label).trim().toUpperCase(), hit.sku, user?.id || null]);
+
+  await pool.query(
+    `UPDATE ee_dispatch_po_lines SET ee_sku=?, resolve_source='map', unit_cost=?, mrp=? WHERE id=?`,
+    [hit.sku, hit.cost, hit.mrp, lineId]);
+
+  const [[b]] = await pool.query(
+    `SELECT COUNT(*) AS blocked FROM ee_dispatch_po_lines WHERE batch_id=? AND ee_sku IS NULL`, [line.batch_id]);
+  await pool.query(
+    `UPDATE ee_dispatch_po SET blocked_count=?, status=IF(?=0 AND status='blocked','draft',status) WHERE id=?`,
+    [b.blocked, b.blocked, line.batch_id]);
+  return { ee_sku: hit.sku, stillBlocked: b.blocked, batchId: line.batch_id };
+}
+
 // Re-resolve a blocked batch's lines (after the resolver map / master sync improves).
 async function reResolveBatch(batchId) {
   const [lines] = await pool.query(
@@ -250,4 +288,4 @@ async function confirmGrns() {
   return { checked: pushed.length, confirmed };
 }
 
-module.exports = { buildBatch, reResolveBatch, pushBatch, confirmGrns, pushEnabled, FARIDABAD_WAREHOUSE_ID, EE_PO_SINCE };
+module.exports = { buildBatch, reResolveBatch, resolveLineManually, pushBatch, confirmGrns, pushEnabled, FARIDABAD_WAREHOUSE_ID, EE_PO_SINCE };

--- a/views/eeDispatchPo.ejs
+++ b/views/eeDispatchPo.ejs
@@ -119,12 +119,24 @@
         <table>
           <thead><tr><th>Lot</th><th>Size</th><th>Qty</th><th>EasyEcom SKU</th><th>Via</th><th>Cost</th><th>MRP</th></tr></thead>
           <tbody>
-            <% lines.forEach(function(l){ %>
+            <% lines.forEach(function(l){ var vars = (!l.ee_sku && l.lot_sku) ? (variantsByStyle[String(l.lot_sku).toUpperCase()] || []) : []; %>
               <tr class="<%= l.ee_sku ? '' : 'blocked' %>">
                 <td><%= (l.lot_no || '').toUpperCase() %></td>
                 <td><%= l.size_label %></td>
                 <td class="q"><%= l.quantity %></td>
-                <td><%= l.ee_sku || '— unresolved —' %></td>
+                <td>
+                  <% if (l.ee_sku) { %><%= l.ee_sku %><% } else if (vars.length) { %>
+                    <div style="display:flex;gap:6px;align-items:center;flex-wrap:wrap;">
+                      <select id="resSel<%= l.id %>" style="max-width:260px;border:1px solid var(--line);border-radius:8px;padding:6px 8px;font-size:12px;background:#fff;">
+                        <option value="">— pick the EasyEcom SKU for size <%= l.size_label %> —</option>
+                        <% vars.forEach(function(v){ %><option value="<%= v %>"><%= v %></option><% }) %>
+                      </select>
+                      <button class="btn btn-ghost" style="padding:6px 10px;font-size:12px;" onclick="resolveLine(<%= l.id %>)">Save mapping</button>
+                    </div>
+                  <% } else { %>
+                    — unresolved — <span style="color:var(--muted);font-size:11px;">(style not in EasyEcom under <%= l.lot_sku || 'this name' %> — needs cataloguing in EE first)</span>
+                  <% } %>
+                </td>
                 <td style="color:var(--muted);"><%= l.resolve_source || '' %></td>
                 <td><%= l.unit_cost != null ? l.unit_cost : '—' %></td>
                 <td><%= l.mrp != null ? l.mrp : '—' %></td>
@@ -161,6 +173,20 @@
     try { const j = await post('/finishingdashboard/ee-po/reresolve/' + id);
       alert('Resolved ' + j.fixed + ' line(s); still blocked: ' + j.stillBlocked); location.reload();
     } catch (e) { alert('Re-resolve failed: ' + e.message); }
+  }
+  async function resolveLine(lineId) {
+    const sel = document.getElementById('resSel' + lineId);
+    if (!sel || !sel.value) { alert('Pick the EasyEcom SKU first.'); return; }
+    if (!confirm('Map this size to ' + sel.value + '? The mapping is saved permanently and reused everywhere.')) return;
+    try {
+      const r = await fetch('/finishingdashboard/ee-po/resolve-line', { method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ line_id: lineId, size_sku: sel.value }) });
+      const j = await r.json().catch(() => ({}));
+      if (!r.ok || j.error) throw new Error(j.error || ('HTTP ' + r.status));
+      alert('Mapped to ' + j.ee_sku + (j.stillBlocked ? (' — ' + j.stillBlocked + ' line(s) still blocked') : ' — batch is now ready to push'));
+      location.reload();
+    } catch (e) { alert('Could not save mapping: ' + e.message); }
   }
   async function refreshConfirmations() {
     try { const j = await post('/finishingdashboard/ee-po/refresh');


### PR DESCRIPTION
Your proposal from the first live batch — implemented with the agreed boundary: **nothing touches EasyEcom except creating the PO.**

## What the finishing team gets
Blocked lines now show a **dropdown of that style's real EasyEcom SKUs** (pulled from the master mirror — for KE396 it lists `KTTWOMENSPANT981XXL, _3XL, _4XL, _5XL, _6XL`) + a **Save mapping** button. Pick, save, and:
- the mapping is stored **permanently** in `pm_sku_resolution` (with who mapped it) — reused by every future batch **and by PM planning**, so the resolver gap closes organically with daily use;
- the line resolves and the batch flips **blocked → draft** (push-ready) the moment the last line clears.

## Guardrails (why this is safe)
- Dropdown only — no free text; the SKU must **exist, active, in EasyEcom** and **belong to the same style** (prefix-guarded server-side too).
- **No SKU creation** — per your decision: if a style/size isn't catalogued in EE, the line says "needs cataloguing in EE first" and stays blocked. The only EasyEcom write in the entire pipeline remains `CreatePurchaseOrder`.

## Try it on KT-DISP-1
Merge → open the screen → KE396's size-34 row shows the dropdown → pick the right letter SKU → Save → batch becomes draft → Push.

Verified: renders, scripts parse, 167 tests, prefix+existence validation on the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)