### PR TITLE
fix(cutting): create-lot never loses the form on validation errors (roll 1721 bug)

### DIFF
--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -287,10 +287,18 @@ router.post(
     } = req.body;
     const image = req.file;
 
+    // AJAX submits (the form's fetch handler) get JSON so a validation error never
+    // navigates away and wipes the user's typed data. Plain POSTs keep flash+redirect.
+    const isAjax = req.get('X-Requested-With') === 'XMLHttpRequest';
+    const fail = (msg) => {
+      if (isAjax) return res.json({ ok: false, error: msg });
+      req.flash('error', msg);
+      return res.redirect('/cutting-manager/dashboard');
+    };
+
     // Input validation
     if (!lot_no || !sku || !fabric_type || !manual_lot_number || !manual_lot_number.trim()) {
-      req.flash('error', 'Lot No., SKU, Fabric Type and Manual Lot Number are required.');
-      return res.redirect('/cutting-manager/dashboard');
+      return fail('Lot No., SKU, Fabric Type and Manual Lot Number are required.');
     }
 
     try {
@@ -532,18 +540,17 @@ router.post(
           'success',
           `Cutting Lot ${lot_no} created successfully with Total Pieces: ${totalPieces}.`
         );
+        if (isAjax) return res.json({ ok: true, redirect: '/cutting-manager/dashboard' });
         res.redirect('/cutting-manager/dashboard');
       } catch (err2) {
         await conn.rollback();
         conn.release();
         console.error('Error creating Cutting Lot:', err2);
-        req.flash('error', err2.message || 'Failed to create Cutting Lot.');
-        res.redirect('/cutting-manager/dashboard');
+        return fail(err2.message || 'Failed to create Cutting Lot.');
       }
     } catch (err) {
       console.error('Database Connection Error:', err);
-      req.flash('error', 'Database connection failed.');
-      res.redirect('/cutting-manager/dashboard');
+      return fail('Database connection failed.');
     }
   }
 );

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -809,7 +809,11 @@ function initializeRollNoAutocomplete(rollSection, fabricType) {
       rollSection.querySelector('.availableWeightTxt').textContent = parseFloat(selectedRoll.per_roll_weight).toFixed(2);
       fullWeightInput.value = parseFloat(selectedRoll.per_roll_weight).toFixed(2);
       fullWeightInput.readOnly = true;
+      // Server compares remaining vs the INVENTORY weight for known rolls (not the typed
+      // full weight) — keep it on the row so updateWeightUsed can mirror that rule.
+      rollSection.dataset.availableWeight = String(selectedRoll.per_roll_weight);
     } else {
+      delete rollSection.dataset.availableWeight;
       if (!ALLOW_ADHOC) {
         // Unknown roll not permitted — reset the selection
         rollNoSel.value = '';
@@ -942,7 +946,27 @@ function updateWeightUsed(rollSection) {
     if (res.used === null) { usedInput.value = ''; usedInput.classList.remove('over-weight'); return; }
     usedInput.value = res.used.toFixed(2);
   }
-  usedInput.classList.toggle('over-weight', res.over);
+  // Mirror the server's real rule (create-lot route): for inventory-known rolls,
+  // REMAINING must not exceed the roll's inventory weight. Catches it before submit.
+  let over = res.over;
+  const invAvail = parseFloat(rollSection.dataset.availableWeight);
+  const remVal = parseFloat(remInput.value);
+  if (Number.isFinite(invAvail) && Number.isFinite(remVal) && remVal > invAvail + 1e-9) over = true;
+  usedInput.classList.toggle('over-weight', over);
+  let hint = rollSection.querySelector('.over-weight-hint');
+  if (over) {
+    if (!hint) {
+      hint = document.createElement('div');
+      hint.className = 'over-weight-hint';
+      hint.style.cssText = 'color:#b91c1c;font-size:0.75rem;margin-top:4px;font-weight:600;';
+      (remInput.closest('div') || rollSection).appendChild(hint);
+    }
+    hint.textContent = Number.isFinite(invAvail)
+      ? ('Remaining cannot exceed this roll\'s available weight (' + invAvail.toFixed(2) + ')')
+      : 'Remaining cannot exceed the full weight';
+  } else if (hint) {
+    hint.remove();
+  }
 }
 
 function updateTotalPieces() {
@@ -1418,6 +1442,57 @@ document.getElementById('lotForm').addEventListener('submit', function(e) {
     alert('Please complete the SKU builder (Brand + Category + Code required)');
     return false;
   }
+});
+
+// FINAL submit listener: submit via fetch so a server-side validation error can NEVER
+// navigate away and wipe the typed form (the old flash+redirect flow lost everything —
+// e.g. "Remaining weight cannot exceed full weight for roll 1721"). Registered last so
+// every earlier listener (hosiery normalizer, button-disable, SKU check) runs first.
+document.getElementById('lotForm').addEventListener('submit', function(e) {
+  if (e.defaultPrevented) return;           // an earlier validation already blocked it
+  if (!window.fetch || !window.FormData) return; // ancient browser → normal POST fallback
+  e.preventDefault();
+
+  var form = e.target;
+  var btn = document.getElementById('createLotBtn');
+  var banner = document.getElementById('createLotAjaxError');
+  if (banner) banner.remove();
+
+  fetch(form.action, {
+    method: 'POST',
+    body: new FormData(form),               // multipart — keeps the image upload
+    credentials: 'same-origin',
+    headers: { 'X-Requested-With': 'XMLHttpRequest' }
+  })
+  .then(function (r) { return r.json().catch(function () { return { ok: false, error: 'Unexpected server response (HTTP ' + r.status + ')' }; }); })
+  .then(function (j) {
+    if (j.ok) { window.location = j.redirect || '/cutting-manager/dashboard'; return; }
+    // Error: show it inline, keep EVERY typed field exactly as it is.
+    var div = document.createElement('div');
+    div.id = 'createLotAjaxError';
+    div.className = 'kotty-alert kotty-alert-danger';
+    div.style.marginTop = '10px';
+    div.textContent = j.error || 'Could not create the lot.';
+    btn.parentNode.insertBefore(div, btn);
+    div.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    // Highlight the offending roll row if the message names one.
+    var m = /roll\s+(\S+)/i.exec(j.error || '');
+    if (m) {
+      document.querySelectorAll('#rollsContainer .rollNoSel, .rollNoSel').forEach(function (sel) {
+        if (String(sel.value).trim() === m[1]) {
+          var row = sel.closest('.roll-section') || sel.closest('[class*="roll"]');
+          var used = row && row.querySelector('.weightUsedInput');
+          if (used) used.classList.add('over-weight');
+          if (row && row.scrollIntoView) row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        }
+      });
+    }
+    btn.disabled = false;                   // the double-submit guard disabled it
+  })
+  .catch(function (err) {
+    alert('Could not reach the server: ' + err.message + '\nYour form data is still here — try again.');
+    btn.disabled = false;
+  });
 });
 
 loadSkuCategories();


### PR DESCRIPTION
**The reported bug:** fill an entire lot → submit → *"Remaining weight cannot exceed full weight for roll 1721"* → **everything wiped**, re-type from scratch. Root cause: create-lot was the only lot-entry flow still using flash+redirect on errors (edit/batch flows already return JSON and never lose data).

## Fix 1 — the form can never be wiped again
The form now submits via fetch (multipart — image upload preserved). On a server rejection:
- the error appears as an **inline banner above the Create Lot button** (same styling as flash errors),
- the **named roll row is highlighted and scrolled into view**,
- the button re-enables — and **every typed field stays exactly as it was**.
On success, normal redirect + success flash as before. Browsers without JS keep the old behaviour (progressive enhancement).

## Fix 2 — catch it before submit
The client gate previously compared remaining vs the *typed* full weight, but for inventory-known rolls the server compares vs the roll's **inventory weight**. Rows now carry the inventory weight and flag instantly — red field + hint *"Remaining cannot exceed this roll's available weight (24.60)"* — and the existing button-gating blocks submission. (Stale-inventory races between page load and submit are impossible to catch client-side — that's exactly what Fix 1 covers.)

No server validation logic changed; the cutting screen's look is untouched per the standing rule.

**Verified:** route parses; view renders with route-accurate locals, all 4 inline scripts parse; the JSON/redirect negotiation simulated for both request types; 167 tests pass.

**Manual test after deploy:** pick a roll, type remaining > its available → instant red flag + disabled button; fix it, submit with a duplicate manual lot number → inline error, form intact; correct it, submit → lot created.

🤖 Generated with [Claude Code](https://claude.com/claude-code)