### PR TITLE
fix(qcpass): driver drives the real portal inputs + stop stealing page focus (v0.5.1)

### DIFF
--- a/qcpass_extension/content.js
+++ b/qcpass_extension/content.js
@@ -148,16 +148,46 @@
     });
   }
 
-  // Emulate a hardware scan into the portal: set the hidden scanner buffer and fire Enter.
-  function emitToPortalScanner(v) {
-    const si = document.getElementById('scanner-input');
-    if (!si) return false;
+  // The visible "Scan/Type Item Barcode" box on the RTO item step (id="scan-Input").
+  function findItemInput() {
+    return document.getElementById('scan-Input')
+      || document.querySelector('input[placeholder*="Item Barcode" i]')
+      || (function () { const bar = findItemBarcodeInput(); return isUsableInput(bar) ? bar : null; })();
+  }
+  function fireEnter(el) {
+    for (const type of ['keydown', 'keypress', 'keyup']) {
+      try { el.dispatchEvent(new KeyboardEvent(type, { key: 'Enter', code: 'Enter', keyCode: 13, which: 13, bubbles: true })); } catch (e) {}
+    }
+  }
+  // Put a scanned value into the portal and trigger its search — the way the operator would.
+  // The portal has no single hidden scan buffer we can rely on across screens, so we drive the
+  // real, visible field for this step (tracking field, or the item box), React-safely, then fire
+  // Enter on both the field and document.body (the portal may listen at either) + submit the form.
+  function driveInput(kind, v) {
+    // If a hidden scanner buffer happens to exist, prefer it (some screens use it).
+    const buf = document.getElementById('scanner-input');
+    if (buf) {
+      try {
+        buf.focus(); nativeValueSetter.call(buf, String(v));
+        buf.dispatchEvent(new Event('input', { bubbles: true }));
+        fireEnter(buf); fireEnter(document.body);
+        return true;
+      } catch (e) {}
+    }
+    const inp = kind === 'item' ? findItemInput() : findTrackingInput();
+    if (!inp) return false;
     try {
-      si.focus();
-      nativeValueSetter.call(si, String(v));
-      si.dispatchEvent(new Event('input', { bubbles: true }));
-      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-      document.body.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }));
+      const wasRO = inp.readOnly;
+      if (wasRO) inp.readOnly = false;
+      inp.focus();
+      nativeValueSetter.call(inp, String(v));
+      inp.dispatchEvent(new Event('input', { bubbles: true }));
+      inp.dispatchEvent(new Event('change', { bubbles: true }));
+      fireEnter(inp);
+      const form = inp.closest('form');
+      if (form) { try { form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true })); } catch (e) {} }
+      fireEnter(document.body);
+      if (wasRO) inp.readOnly = wasRO;
     } catch (e) { return false; }
     return true;
   }
@@ -224,22 +254,22 @@
       // 2. Drive the tracking scan into the portal and wait for its search response.
       driveStatus('searching ' + value + '…');
       const cap = waitForCapture(9000);
-      if (!emitToPortalScanner(value)) { driveStatus('scanner-input not found — is the QC screen open?', true); return; }
+      if (!driveInput('tracking', value)) { driveStatus('Tracking field not found — is the QC screen open?', true); return; }
       const rec = await cap;
       if (!rec) { driveStatus('no data for ' + value + ' (check the screen)', true); return; }
-      // 3. Reveal Pass. RTO always needs the item-barcode step, so emit it right away; a customer
+      // 3. Reveal Pass. RTO always needs the item-barcode step, so fill it right away; a customer
       //    return shows Pass straight after the tracking scan (fall back to the item step if not).
       let btn = null;
       if (rec.return_flow === 'rto' && rec.item_barcode) {
         driveStatus('item ' + rec.item_barcode + '…');
-        await delay(300);
-        emitToPortalScanner(rec.item_barcode);
+        await delay(400);
+        driveInput('item', rec.item_barcode);
         btn = await waitForPassButton(6000);
       } else {
         btn = await waitForPassButton(1500);
         if (!btn && rec.item_barcode) {
           driveStatus('item ' + rec.item_barcode + '…');
-          emitToPortalScanner(rec.item_barcode);
+          driveInput('item', rec.item_barcode);
           btn = await waitForPassButton(6000);
         }
       }
@@ -397,15 +427,14 @@
   }
   // Permanent watchdog: whenever focus is dropped entirely (portal re-render leaves it on
   // <body>), re-aim at the scan target. Never fires while any input is focused, so it can't
-  // fight a deliberate click into Return ID. In driver mode the operator scans into OUR box,
-  // so keep focus there instead of the portal's input.
+  // fight a deliberate click into Return ID.
+  // In DRIVER mode we do NOT continuously steal focus — that made the whole page unclickable
+  // and text unselectable. The driver box is focused only when the mode is set and after each
+  // driven scan; the operator can click/select freely in between, and click the box to scan.
   setInterval(() => {
+    if (DRIVE_MODE !== 'off') return;
     const a = document.activeElement;
     if (a && a.tagName === 'INPUT') return;   // don't fight active typing anywhere
-    if (DRIVE_MODE !== 'off') {
-      const box = panel && panel.querySelector('#qc-drivescan');
-      if (box) { try { box.focus(); } catch (e) {} return; }
-    }
     if (!a || a === document.body || a === document.documentElement) focusScanTarget(false);
   }, 1000);
 

--- a/qcpass_extension/manifest.json
+++ b/qcpass_extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "QC Capture — Full Return + RTO Data",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "On rejoyui QC, captures the FULL return record (search details + logistics) and queues it durably, then syncs it to the kotty-track backend with authentication. Nothing is missed.",
   "permissions": ["storage", "alarms", "downloads"],
   "host_permissions": [


### PR DESCRIPTION
**Follow-up to #556** (merged at v0.5.0). This commit was pushed to #556's branch after it merged, so it never landed — hence this PR. It fixes the two live-test bugs on the real RTO/return screens.

## Bugs
1. **"input not found"** — the driver targeted a hidden `#scanner-input` that doesn't exist on these screens. The real fields are the labeled **"Return Tracking ID"** input and the visible **`#scan-Input`** ("Scan/Type Item Barcode").
2. **Page unclickable/unselectable while Driver On** — the focus watchdog was re-grabbing the extension's scan box every second, stealing focus from the whole page.

## Fix
- `driveInput(kind, v)` fills the actual field for each step (React-safe native setter + input/change), fires a full Enter key sequence on the field **and** `document.body`, and submits the enclosing `<form>` — temporarily clearing `readonly` (the RTO tracking field is readonly after fill). Still prefers a hidden `#scanner-input` if a screen has one.
- Focus watchdog no longer runs in driver mode; the box is focused only when the mode is set and after each driven scan, so the operator can click/copy freely.

## Verification
Harness updated to the **real** DOM (labeled tracking field + `#scan-Input`, Enter-on-field) so it exercises the production path. 58 checks green (9 driver + 17 RTO + 17 sort + 15 focus). Manifest 0.5.1.

Confirmed from the live DOM the extraction lands (Style ID, item barcode, size, JIT lane) and Pass = `#Q1`/`.btnPass`. Sort confirmed working live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)