### PR TITLE
Lot Activity log: every update with date + flow (+ fix broken lot-journey query)

### DIFF
--- a/routes/lotJourneyRoutes.js
+++ b/routes/lotJourneyRoutes.js
@@ -13,7 +13,7 @@ const { pool } = require('../config/db');
 const { isAuthenticated, isOperator } = require('../middlewares/auth');
 const stageEvents = require('../utils/stageEvents');
 const {
-  orderedStages, deriveStageStatus, dispatchSummary, currentStage,
+  orderedStages, deriveStageStatus, dispatchSummary, currentStage, mergeActivity,
 } = require('../utils/lotJourney');
 
 const TAT_DAYS = { cutting: 3, stitching: 7, jeans_assembly: 7, washing: 15, washing_in: 7, finishing: 7 };
@@ -67,6 +67,52 @@ const EVENT_TABLE = {
   washing: 'washing_events', washing_in: 'washing_in_events', finishing: 'finishing_events',
 };
 
+// Every individual update to the lot, across ALL stage tables (not just the lot's
+// current flow — a flow-changed lot keeps its history in the old chain's tables),
+// plus dispatches and Lot Admin corrections. Merged/sorted by utils/lotJourney.
+async function buildActivity(lot) {
+  const stageEventRows = {};
+  for (const stage of stageEvents.STAGES) {
+    const [rows] = await pool.query(
+      `SELECT e.event_type, e.pieces, e.remark, e.created_at, u.username
+         FROM \`${EVENT_TABLE[stage]}\` e LEFT JOIN users u ON u.id = e.operator_id
+        WHERE e.cutting_lot_id = ? ORDER BY e.created_at, e.id`,
+      [lot.id]
+    );
+    if (rows.length) stageEventRows[stage] = rows;
+  }
+  // Note: custom destinations are folded into `destination` at insert time
+  // (routes/finishingRoutes.js dispatch handler) — there is no custom_destination column.
+  const [dispatches] = await pool.query(
+    `SELECT destination, size_label, quantity, created_at
+       FROM finishing_dispatches WHERE lot_no = ? ORDER BY created_at, id`,
+    [lot.lot_no]
+  );
+  // Lot Admin corrections. Guarded: this table is newer than some environments.
+  let audits = [];
+  try {
+    const [rows] = await pool.query(
+      `SELECT action, detail, performed_by_name, created_at
+         FROM pm_lot_audit_log
+        WHERE cutting_lot_id = ? OR (lot_no IS NOT NULL AND lot_no = ?)
+     ORDER BY created_at, id`,
+      [lot.id, lot.lot_no]
+    );
+    audits = rows;
+  } catch (err) {
+    console.error('lot-journey: pm_lot_audit_log unavailable:', err.message);
+  }
+  return mergeActivity({
+    cutting: {
+      created_at: lot.created_at, by: lot.cutter_name,
+      total_pieces: lot.total_pieces, note: lot.remark || '',
+    },
+    stageEvents: stageEventRows,
+    dispatches,
+    audits,
+  });
+}
+
 async function buildJourney(lot) {
   const stages = orderedStages(lot.flow_type);
   const now = Date.now();
@@ -115,7 +161,7 @@ async function buildJourney(lot) {
     for (const [s, v] of Object.entries(sz)) finishedBySize[s] = v.completed || 0;
   }
   const [dispRows] = await pool.query(
-    `SELECT size_label, SUM(quantity) AS qty, GROUP_CONCAT(DISTINCT COALESCE(NULLIF(custom_destination,''), destination)) AS dests
+    `SELECT size_label, SUM(quantity) AS qty, GROUP_CONCAT(DISTINCT destination) AS dests
        FROM finishing_dispatches WHERE lot_no = ? GROUP BY size_label`,
     [lot.lot_no]
   );
@@ -137,6 +183,7 @@ async function buildJourney(lot) {
     timeline,
     current_stage: dispatch.complete ? 'Dispatched' : currentStage(timeline),
     dispatch,
+    activity: await buildActivity(lot),
   };
 }
 

--- a/test/lotJourney.test.js
+++ b/test/lotJourney.test.js
@@ -1,7 +1,7 @@
 const { test } = require('node:test');
 const assert = require('node:assert');
 const {
-  orderedStages, deriveStageStatus, dispatchSummary, currentStage,
+  orderedStages, deriveStageStatus, dispatchSummary, currentStage, mergeActivity,
 } = require('../utils/lotJourney.js');
 
 const DAY = 86400000;
@@ -59,6 +59,79 @@ test('dispatchSummary: nothing finished is not complete', () => {
   const r = dispatchSummary({}, {});
   assert.strictEqual(r.totalFinished, 0);
   assert.strictEqual(r.complete, false);
+});
+
+test('mergeActivity: merges all sources into one ascending feed', () => {
+  const feed = mergeActivity({
+    cutting: { created_at: '2026-06-01T10:00:00Z', by: 'cutter1', total_pieces: 300, note: 'first cut' },
+    stageEvents: {
+      stitching: [
+        { event_type: 'approve', pieces: 300, remark: '', created_at: '2026-06-03T09:00:00Z', username: 'stitchA' },
+        { event_type: 'complete', pieces: 290, remark: 'ok', created_at: '2026-06-08T17:00:00Z', username: 'stitchA' },
+      ],
+      finishing: [
+        { event_type: 'reject', pieces: 5, remark: 'stains', created_at: '2026-06-12T11:00:00Z', username: 'finB' },
+      ],
+    },
+    dispatches: [
+      { destination: 'Warehouse', quantity: 100, size_label: 'M', created_at: '2026-06-14T08:00:00Z' },
+    ],
+    audits: [
+      { action: 'qty_edit', detail: '{"size":"L","from":50,"to":40}', performed_by_name: 'op1', created_at: '2026-06-05T12:00:00Z' },
+    ],
+  });
+  assert.deepStrictEqual(feed.map((f) => f.kind),
+    ['created', 'approve', 'admin', 'complete', 'reject', 'dispatch']);
+  assert.deepStrictEqual(feed.map((f) => f.stage),
+    ['cutting', 'stitching', 'admin', 'stitching', 'finishing', 'dispatch']);
+  assert.strictEqual(feed[0].pieces, 300);
+  assert.strictEqual(feed[0].by, 'cutter1');
+  assert.strictEqual(feed[2].label, 'Qty edit');
+  assert.strictEqual(feed[2].note, 'size: L, from: 50, to: 40');
+  assert.strictEqual(feed[4].note, 'stains');
+  assert.strictEqual(feed[5].note, '→ Warehouse · size M');
+  assert.strictEqual(feed[5].pieces, 100);
+});
+
+test('mergeActivity: empty/missing sources produce an empty feed, not a crash', () => {
+  assert.deepStrictEqual(mergeActivity(), []);
+  assert.deepStrictEqual(mergeActivity({ cutting: null, stageEvents: {}, dispatches: [], audits: [] }), []);
+  // rows missing created_at are skipped rather than sorted to a bogus position
+  const feed = mergeActivity({ stageEvents: { stitching: [{ event_type: 'approve', pieces: 10 }] } });
+  assert.deepStrictEqual(feed, []);
+});
+
+test('mergeActivity: audit-only lot still gets a feed; object detail is summarized', () => {
+  const feed = mergeActivity({
+    audits: [{ action: 'flow_change', detail: { from: 'hosiery', to: 'denim' }, performed_by_name: 'op2', created_at: '2026-06-02T10:00:00Z' }],
+  });
+  assert.strictEqual(feed.length, 1);
+  assert.strictEqual(feed[0].label, 'Flow change');
+  assert.strictEqual(feed[0].note, 'from: hosiery, to: denim');
+  assert.strictEqual(feed[0].by, 'op2');
+});
+
+test('mergeActivity: equal timestamps keep source order (stable sort)', () => {
+  const t = '2026-06-10T10:00:00Z';
+  const feed = mergeActivity({
+    stageEvents: {
+      stitching: [
+        { event_type: 'approve', pieces: 1, created_at: t, username: 'a' },
+        { event_type: 'complete', pieces: 1, created_at: t, username: 'a' },
+      ],
+    },
+    dispatches: [{ destination: 'Warehouse', quantity: 1, size_label: 'S', created_at: t }],
+  });
+  assert.deepStrictEqual(feed.map((f) => f.kind), ['approve', 'complete', 'dispatch']);
+});
+
+test('mergeActivity: unknown admin action and unparseable detail pass through raw', () => {
+  const feed = mergeActivity({
+    audits: [{ action: 'something_new', detail: 'free text', performed_by_name: null, created_at: '2026-06-02T10:00:00Z' }],
+  });
+  assert.strictEqual(feed[0].label, 'something_new');
+  assert.strictEqual(feed[0].note, 'free text');
+  assert.strictEqual(feed[0].by, null);
 });
 
 test('currentStage: first in-progress or not-started stage; Done when all finished', () => {

--- a/utils/lotJourney.js
+++ b/utils/lotJourney.js
@@ -58,6 +58,80 @@ function dispatchSummary(finishedBySize, dispatchedBySize) {
   };
 }
 
+// ── Activity feed ──────────────────────────────────────────────────────────
+// Every individual update to a lot, across every flow, as one chronological list.
+// Sources: lot creation (cutting_lots), every *_events row, every finishing
+// dispatch, and every Lot Admin correction (pm_lot_audit_log).
+
+const ACTIVITY_LABEL = {
+  created: 'Lot created', approve: 'Taken (approved)', complete: 'Completed', reject: 'Rejected',
+};
+const ADMIN_ACTION_LABEL = {
+  flow_change: 'Flow change', stage_reversal: 'Stage reversal', qty_edit: 'Qty edit',
+};
+
+// Human-readable one-liner from a pm_lot_audit_log detail JSON (object or string).
+function auditNote(detail) {
+  let d = detail;
+  if (typeof d === 'string') {
+    try { d = JSON.parse(d); } catch (_e) { return d; }
+  }
+  if (!d || typeof d !== 'object') return '';
+  return Object.entries(d)
+    .map(([k, v]) => `${k}: ${v !== null && typeof v === 'object' ? JSON.stringify(v) : v}`)
+    .join(', ');
+}
+
+// Merge all update sources into one chronological feed. Pure — the route supplies
+// the rows. Stable: equal timestamps keep their source/insert order.
+//   cutting:     { created_at, by, total_pieces, note }
+//   stageEvents: { [stage]: [{ event_type, pieces, remark, created_at, username }] }
+//   dispatches:  [{ destination, quantity, size_label, created_at }]
+//   audits:      [{ action, detail, performed_by_name, created_at }]
+// Returns [{ when, stage, kind, label, pieces, by, note }] sorted ascending.
+function mergeActivity({ cutting, stageEvents, dispatches, audits } = {}) {
+  const rows = [];
+  if (cutting && cutting.created_at) {
+    rows.push({
+      when: cutting.created_at, stage: 'cutting', kind: 'created', label: ACTIVITY_LABEL.created,
+      pieces: cutting.total_pieces != null ? Number(cutting.total_pieces) : null,
+      by: cutting.by || null, note: cutting.note || '',
+    });
+  }
+  for (const [stage, events] of Object.entries(stageEvents || {})) {
+    for (const e of events || []) {
+      if (!e || !e.created_at) continue;
+      rows.push({
+        when: e.created_at, stage, kind: e.event_type,
+        label: ACTIVITY_LABEL[e.event_type] || e.event_type,
+        pieces: e.pieces != null ? Number(e.pieces) : null,
+        by: e.username || null, note: e.remark || '',
+      });
+    }
+  }
+  for (const d of dispatches || []) {
+    if (!d || !d.created_at) continue;
+    const dest = d.destination || '';
+    rows.push({
+      when: d.created_at, stage: 'dispatch', kind: 'dispatch', label: 'Dispatched',
+      pieces: d.quantity != null ? Number(d.quantity) : null, by: d.by || null,
+      note: [dest && `→ ${dest}`, d.size_label && `size ${d.size_label}`].filter(Boolean).join(' · '),
+    });
+  }
+  for (const a of audits || []) {
+    if (!a || !a.created_at) continue;
+    rows.push({
+      when: a.created_at, stage: 'admin', kind: 'admin',
+      label: ADMIN_ACTION_LABEL[a.action] || a.action,
+      pieces: null, by: a.performed_by_name || null, note: auditNote(a.detail),
+    });
+  }
+  return rows
+    .map((r, i) => ({ r, i }))
+    .sort((x, y) => (new Date(x.r.when).getTime() - new Date(y.r.when).getTime()) || (x.i - y.i))
+    .map((x) => x.r);
+}
+
 // The stage the lot is sitting at: the first one in progress or not yet started.
 // 'Done' when every stage is finished.
 function currentStage(timeline) {
@@ -73,5 +147,6 @@ module.exports = {
   deriveStageStatus,
   dispatchSummary,
   currentStage,
+  mergeActivity,
   DAY_MS,
 };

--- a/views/lotJourney.ejs
+++ b/views/lotJourney.ejs
@@ -49,6 +49,24 @@
     .size-table td, .size-table th { padding:4px 10px; font-size:.82rem; }
     .muted { color:#94a3b8; }
 
+    /* ── Activity log (every update, every flow) ── */
+    .act-card { background:#fff; border:1px solid #e5e7eb; border-radius:12px; padding:16px 18px; margin-top:16px; }
+    .act-card h5 { margin:0 0 10px; font-size:1rem; }
+    .act-row { display:flex; align-items:baseline; gap:10px; padding:8px 0; border-top:1px solid #f1f5f9; font-size:.85rem; flex-wrap:wrap; }
+    .act-row:first-of-type { border-top:0; }
+    .act-when { color:#0f172a; font-weight:600; font-variant-numeric:tabular-nums; white-space:nowrap; min-width:150px; }
+    .act-pill { font-size:.68rem; padding:2px 9px; border-radius:999px; font-weight:600; text-transform:uppercase; letter-spacing:.3px; white-space:nowrap; }
+    .act-stage { background:#eef2ff; color:#3730a3; }
+    .act-k-created { background:#f1f5f9; color:#475569; }
+    .act-k-approve { background:#dbeafe; color:#1d4ed8; }
+    .act-k-complete { background:#dcfce7; color:#166534; }
+    .act-k-reject { background:#fee2e2; color:#b91c1c; }
+    .act-k-dispatch { background:#ede9fe; color:#6d28d9; }
+    .act-k-admin { background:#fef3c7; color:#b45309; }
+    .act-meta { color:#64748b; }
+    .act-note { color:#94a3b8; font-size:.8rem; flex-basis:100%; padding-left:160px; }
+    @media (max-width: 560px) { .act-when { min-width:0; } .act-note { padding-left:0; } }
+
     /* ── Kotty Floor chrome (matches stitchingEvents.ejs / operator hub) ── */
     .flx-top { position: fixed; top: 0; left: 0; right: 0; z-index: 50; background: #f7f8fa; border-bottom: 1px solid #e5e7eb; }
     .flx-top-main { height: 56px; display: flex; align-items: center; justify-content: space-between; padding: 0 16px; }
@@ -100,6 +118,7 @@
 <script src="/public/js/api.js"></script>
 <script>
 const fmtDate = d => d ? new Date(d).toLocaleDateString('en-IN',{day:'2-digit',month:'short',year:'numeric',timeZone:'Asia/Kolkata'}) : '—';
+const fmtWhen = d => d ? new Date(d).toLocaleString('en-IN',{day:'2-digit',month:'short',year:'numeric',hour:'2-digit',minute:'2-digit',hour12:true,timeZone:'Asia/Kolkata'}) : '—';
 const esc = s => String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
 
 async function go(){
@@ -176,7 +195,33 @@ function render(j){
       Object.entries(d.bySize).map(([s,v])=>'<tr><td>'+esc(s)+'</td><td>'+v.finished+'</td><td>'+v.dispatched+'</td><td>'+v.remaining+'</td></tr>').join('')+
       '</tbody></table>':'<div class="muted small">No finishing/dispatch records yet.</div>')+
     '</div>';
+
+  h += renderActivity(j.activity||[]);
   return h;
+}
+
+// Every individual update — one row per event/dispatch/admin correction, oldest first.
+const ACT_STAGE_LABEL = { cutting:'Cutting', stitching:'Stitching', jeans_assembly:'Jeans Assembly',
+  washing:'Washing', washing_in:'Washing-In', finishing:'Finishing', dispatch:'Dispatch', admin:'Lot Admin' };
+function renderActivity(activity){
+  let h = '<div class="act-card"><h5><i class="bi bi-clock-history"></i> Activity log'+
+    ' <span class="muted small fw-normal">· '+activity.length+' update'+(activity.length===1?'':'s')+'</span></h5>';
+  if(!activity.length){
+    return h+'<div class="muted small">No updates recorded for this lot.</div></div>';
+  }
+  h += activity.map(a=>
+    '<div class="act-row">'+
+      '<span class="act-when">'+fmtWhen(a.when)+'</span>'+
+      '<span class="act-pill act-stage">'+esc(ACT_STAGE_LABEL[a.stage]||a.stage)+'</span>'+
+      '<span class="act-pill act-k-'+esc(a.kind)+'">'+esc(a.label)+'</span>'+
+      '<span class="act-meta">'+
+        (a.pieces!=null?(a.pieces+' pcs'):'')+
+        (a.by?((a.pieces!=null?' · ':'')+'by '+esc(a.by)):'')+
+      '</span>'+
+      (a.note?('<span class="act-note">'+esc(a.note.length>220?a.note.slice(0,220)+'…':a.note)+'</span>'):'')+
+    '</div>'
+  ).join('');
+  return h+'</div>';
 }
 
 document.getElementById('q').addEventListener('keydown',e=>{ if(e.key==='Enter') go(); });


### PR DESCRIPTION
## What

For any lot on **/operator/lot-journey**, a new **Activity log** below the stage rail lists **every individual update, chronologically, with exact date+time and the flow it happened in**:

- Lot created (cutting) — pieces, cutter, remark
- Every take / complete / reject event in **every** stage — pieces, operator, remark. All five event tables are read regardless of the lot's current flow, so a flow-changed lot keeps its old-chain history.
- Every finishing dispatch — pieces, destination, size
- Every Lot Admin correction (flow change / stage reversal / qty edit) from `pm_lot_audit_log` — which was **write-only until now** (recorded but shown nowhere).

## Bug fix included

The existing journey dispatch query selected a non-existent `custom_destination` column (custom destinations are folded into `destination` at insert time by the finishing dispatch handler). On prod this made **every** `/operator/lot-journey/data` lookup 500. Both queries now use `destination`.

## How

- `utils/lotJourney.js`: pure `mergeActivity()` — merges the four sources into one stable-sorted ascending feed (unit-tested, no SQL).
- `routes/lotJourneyRoutes.js`: `buildActivity()` feeds it; response gains `activity` alongside the untouched `timeline`/`dispatch` shape.
- `views/lotJourney.ejs`: Activity log card — timestamp, stage pill, event pill (approve=blue, complete=green, reject=red, dispatch=violet, admin=amber), pieces, operator, note (truncated at 220 chars).

Operator-only (existing guard). Read-only screen — no payment/engine code touched.

## Verification

- `NODE_ENV=test node --test`: **172/172 pass** (14 lotJourney tests incl. 5 new `mergeActivity` cases: source merging, empty inputs, audit-only lots, stable sort on equal timestamps, raw passthrough of unknown actions).
- EJS render with route-accurate locals + `new Function()` on the inline script: OK.
- Read-only prod spot-check via cloud-sql-proxy: **ma144** (2 updates) and **ke396** (12 updates: cut → stitch take/complete → finish take/complete → 7 dispatches) — feed counts match raw table counts exactly; audit path verified on ak5326 (today's stage reversal renders correctly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)