### PR TITLE
Excel export for the lot Activity log

### DIFF
--- a/routes/lotJourneyRoutes.js
+++ b/routes/lotJourneyRoutes.js
@@ -9,6 +9,7 @@
 
 const express = require('express');
 const router = express.Router();
+const ExcelJS = require('exceljs');
 const { pool } = require('../config/db');
 const { isAuthenticated, isOperator } = require('../middlewares/auth');
 const stageEvents = require('../utils/stageEvents');
@@ -204,6 +205,61 @@ router.get('/data', isAuthenticated, isOperator, async (req, res) => {
   } catch (err) {
     console.error('GET /operator/lot-journey/data error:', err);
     res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// GET /export?q= — the same activity feed as the screen, as an Excel report.
+// One row per update: date, time, flow, what happened, pieces, who, note.
+router.get('/export', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const q = String(req.query.q || '').trim();
+    if (!q) return res.status(400).send('Missing lot query (?q=)');
+    const matches = await resolveLot(q);
+    if (!matches.length) return res.status(404).send(`No lot found for "${q}"`);
+    const lot = matches[0];
+    const activity = await buildActivity(lot);
+
+    const ACT_STAGE_LABEL = {
+      ...STAGE_LABEL, dispatch: 'Dispatch', admin: 'Lot Admin',
+    };
+    const wb = new ExcelJS.Workbook();
+    const sheet = wb.addWorksheet('Lot Activity');
+    sheet.columns = [
+      { header: 'Lot No',        key: 'lot_no',  width: 14 },
+      { header: 'Manual Lot No', key: 'manual',  width: 14 },
+      { header: 'SKU',           key: 'sku',     width: 22 },
+      { header: 'Date',          key: 'date',    width: 13 },
+      { header: 'Time',          key: 'time',    width: 10 },
+      { header: 'Flow',          key: 'flow',    width: 14 },
+      { header: 'Update',        key: 'update',  width: 18 },
+      { header: 'Pieces',        key: 'pieces',  width: 9 },
+      { header: 'By',            key: 'by',      width: 16 },
+      { header: 'Note',          key: 'note',    width: 40 },
+    ];
+    const dateOpts = { day: '2-digit', month: 'short', year: 'numeric', timeZone: 'Asia/Kolkata' };
+    const timeOpts = { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: 'Asia/Kolkata' };
+    for (const a of activity) {
+      sheet.addRow({
+        lot_no: lot.lot_no, manual: lot.manual_lot_number || '', sku: lot.sku,
+        date: new Date(a.when).toLocaleDateString('en-IN', dateOpts),
+        time: new Date(a.when).toLocaleTimeString('en-IN', timeOpts),
+        flow: ACT_STAGE_LABEL[a.stage] || a.stage,
+        update: a.label,
+        pieces: a.pieces != null ? a.pieces : '',
+        by: a.by || '', note: a.note || '',
+      });
+    }
+    sheet.getRow(1).font = { bold: true, color: { argb: 'FFFFFFFF' } };
+    sheet.getRow(1).fill = { type: 'pattern', pattern: 'solid', fgColor: { argb: 'FF1F2937' } };
+
+    res.setHeader('Content-Type', 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet');
+    res.setHeader('Content-Disposition',
+      `attachment; filename="LotActivity-${String(lot.lot_no).replace(/[^\w.-]/g, '_')}.xlsx"`);
+    await wb.xlsx.write(res);
+    res.end();
+  } catch (err) {
+    console.error('GET /operator/lot-journey/export error:', err);
+    res.status(500).send('Failed to export lot activity');
   }
 });
 

--- a/views/lotJourney.ejs
+++ b/views/lotJourney.ejs
@@ -196,16 +196,20 @@ function render(j){
       '</tbody></table>':'<div class="muted small">No finishing/dispatch records yet.</div>')+
     '</div>';
 
-  h += renderActivity(j.activity||[]);
+  h += renderActivity(j.activity||[], L.lot_no);
   return h;
 }
 
 // Every individual update — one row per event/dispatch/admin correction, oldest first.
 const ACT_STAGE_LABEL = { cutting:'Cutting', stitching:'Stitching', jeans_assembly:'Jeans Assembly',
   washing:'Washing', washing_in:'Washing-In', finishing:'Finishing', dispatch:'Dispatch', admin:'Lot Admin' };
-function renderActivity(activity){
-  let h = '<div class="act-card"><h5><i class="bi bi-clock-history"></i> Activity log'+
-    ' <span class="muted small fw-normal">· '+activity.length+' update'+(activity.length===1?'':'s')+'</span></h5>';
+function renderActivity(activity, lotNo){
+  let h = '<div class="act-card"><div class="d-flex justify-content-between align-items-center mb-2">'+
+    '<h5 class="mb-0"><i class="bi bi-clock-history"></i> Activity log'+
+    ' <span class="muted small fw-normal">· '+activity.length+' update'+(activity.length===1?'':'s')+'</span></h5>'+
+    (activity.length?('<a class="btn btn-sm btn-outline-primary" href="/operator/lot-journey/export?q='+encodeURIComponent(lotNo)+'">'+
+      '<i class="bi bi-file-earmark-excel"></i> Excel</a>'):'')+
+    '</div>';
   if(!activity.length){
     return h+'<div class="muted small">No updates recorded for this lot.</div></div>';
   }


### PR DESCRIPTION
## What

Follow-up to #560: the Activity log is now downloadable as a report, not just viewable on the screen.

- **`GET /operator/lot-journey/export?q=<lot>`** — Excel with one row per update: Lot No, Manual Lot No, SKU, **Date, Time (IST), Flow, Update, Pieces, By, Note**. Same data as the on-screen feed (reuses `buildActivity`), same ExcelJS styling conventions as the Lot TAT report.
- **Excel button** on the Activity log card (operator-only, existing guards).

## Verification

- E2E against prod (read-only via cloud-sql-proxy) with a stubbed operator session: ke396 → 200, valid xlsx, 12 rows matching the screen exactly (`LotActivity-ke396.xlsx`); ma144 → 2 rows; unknown lot → 404; JSON `/data` endpoint unchanged.
- `NODE_ENV=test node --test`: 172/172 pass. EJS render + inline-script parse: OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)