### PR TITLE
Lot-wise dispatch: one tap → challan + per-lot EasyEcom PO (no more multi-lot batches)

### DIFF
--- a/docs/EASYECOM_DISPATCH_GRN_DESIGN.md
+++ b/docs/EASYECOM_DISPATCH_GRN_DESIGN.md
@@ -220,3 +220,41 @@ SKU before any real lot:
   location_key (already the pull-worker model).
 - From the business: just **name the test SKU** (ideally listed on at most one low-risk
   marketplace).
+
+## 9. MODEL REVISION 2 (2026-07-16): lot-wise "challan at dispatch"
+
+The all-lots-in-one-batch sweep (§3/§8) failed operationally on its first real use:
+KT-DISP-2 mixed 12 lots (83 lines, 10,449 pcs) and sat **blocked** because 9 lots had
+unresolved SKUs — the 3 fully-resolved lots (2,271 pcs) were held hostage. The flow also
+required visiting a second, unlinked screen and re-typing quantities.
+
+**The revised model — one lot = one batch = one PO = one printable challan:**
+
+1. The finishing screen's dispatch card is **one card per lot**, pre-filled with every
+   finished undispatched piece; destination defaults to Warehouse. Unmapped sizes are
+   resolved **inline in the card** (dropdown of verified `ee_product_master` SKUs for the
+   style; persisted to `pm_sku_resolution` via the shared `saveSkuMapping`) — once per
+   style-size, forever. No confirm popup; the CTA itself states the exact action.
+2. One tap (`POST /finishingdashboard/event/dispatch-lot`) allocates the lot-level
+   quantities across the operator's finishing batches FIFO (pure
+   `utils/dispatchAllocation.js`), inserts `finishing_dispatches` rows, and — for
+   Warehouse — creates that lot's batch (`KT-DISP-<id>-<lot_no>`, `ee_dispatch_po.lot_no`)
+   in the same transaction, then attempts the EasyEcom push AFTER commit. EasyEcom being
+   down never fails a dispatch; the batch stays `draft` and retries in background.
+3. The **printable challan** (`GET /finishingdashboard/ee-po/challan/:id`) opens
+   immediately and travels with the goods; its reference IS the PO referenceCode. The
+   warehouse GRNs challan-by-challan.
+4. The old review screen is now the **Warehouse Transfers** status tab (linked from the
+   finishing top bar): per-challan status chips (PO pending / At EasyEcom / Received),
+   reprint, inline resolution for legacy blocked lines, retry for failed pushes.
+5. Housekeeping cron (every 30 min, armed by `EE_GRN_PUSH`): sweep stray dispatches into
+   per-lot batches (`sweepLotBatches`), push drafts (`autoPushDrafts`), detect GRNs
+   (`confirmGrns`). The happy path never needs it.
+
+Unchanged invariants: PO-only (nothing ever writes EE inventory), warehouse approves by
+manual GRN, `EE_PO_SINCE` cutoff, `dispatch_id` UNIQUE idempotency, EE PO-quantity cap as
+the second double-push layer.
+
+**Migration:** `sql/2026_07_ee_dispatch_po_lotwise.sql` (adds `ee_dispatch_po.lot_no`) must
+run before deploying this code. **KT-DISP-2 remediation:** cancel batch 2, delete its 83
+lines (releases the dispatch_id idempotency locks), let the sweep rebuild them lot-wise.

--- a/docs/plans/00-PROGRESS.md
+++ b/docs/plans/00-PROGRESS.md
@@ -99,6 +99,15 @@ created in EasyEcom** (vendor "Kotty Production", code V002, vendor_c_id 289541)
   decisions).
 - **First real PO through the pipeline**: KT-DISP-1 → EasyEcom PO 2063861 (KE396, size 34
   mapped to 981XXL by the finishing team). Underscore SKU convention auto-resolves (#547).
+- **2026-07-16 — LOT-WISE "challan at dispatch"** (design doc §9): the all-lots sweep is
+  gone. Dispatching a lot to Warehouse is ONE pre-filled tap on the finishing screen that
+  writes the dispatch, creates that lot's own `KT-DISP-<id>-<lot_no>` batch + EasyEcom PO
+  (EE-down safe: stays draft, background retry), and opens a printable challan. Unmapped
+  SKUs are fixed inline in the dispatch card. The ee-po screen is now the linked
+  "Warehouse Transfers" status tab; a 30-min cron (armed by EE_GRN_PUSH) sweeps strays,
+  pushes drafts, and confirms GRNs. Requires `sql/2026_07_ee_dispatch_po_lotwise.sql`
+  before deploy; KT-DISP-2 (12 lots frozen by 9 lots' blocked SKUs) to be remediated by
+  cancel + line-delete + lot-wise re-sweep.
 - Operator hub gained System Health / Documentation / Usage Analytics cards (Security Logs
   was already there).
 - README rewritten to match reality.

--- a/routes/eeDispatchRoutes.js
+++ b/routes/eeDispatchRoutes.js
@@ -1,11 +1,13 @@
-// Finishing → EasyEcom PO review screen (the approval gate).
-// Audience: the FINISHING role (user decision 2026-07-10) — they dispatch, they push.
+// Warehouse transfers — status screen for the lot-wise challan pipeline
+// (2026-07-16 redesign: one lot = one batch = one PO/challan, created at dispatch).
+// Audience: the FINISHING role. This screen is for status, reprints, and fixing
+// blocked SKUs — the routine path never needs a button here.
 // The pipeline never writes inventory: it creates a PO; the warehouse GRNs manually.
 const express = require('express');
 const router = express.Router();
 const { pool } = require('../config/db');
 const { isAuthenticated, isFinishingMaster } = require('../middlewares/auth');
-const { buildBatch, reResolveBatch, resolveLineManually, pushBatch, confirmGrns, pushEnabled, EE_PO_SINCE } = require('../utils/eeDispatchPo');
+const { sweepLotBatches, reResolveBatch, resolveLineManually, pushBatch, confirmGrns, pushEnabled, EE_PO_SINCE } = require('../utils/eeDispatchPo');
 
 // GET / — review screen: batches + how many dispatch rows await sweeping.
 router.get('/', isAuthenticated, isFinishingMaster, async (req, res) => {
@@ -49,14 +51,39 @@ router.get('/', isAuthenticated, isFinishingMaster, async (req, res) => {
   }
 });
 
-// POST /build — sweep unswept Warehouse dispatches into a new batch.
+// POST /build — sweep any unswept Warehouse dispatches into per-lot batches.
+// Fallback only: the dispatch action creates its lot's batch inline, and the
+// background job sweeps strays; this button just forces it now.
 router.post('/build', isAuthenticated, isFinishingMaster, async (req, res) => {
   try {
-    const out = await buildBatch(req.session.user);
+    const out = await sweepLotBatches(req.session.user);
     res.json({ success: true, ...out });
   } catch (err) {
-    console.error('ee-po build error:', err);
+    console.error('ee-po sweep error:', err);
     res.status(500).json({ error: err.message });
+  }
+});
+
+// GET /challan/:id — the printable lot challan that travels with the goods.
+router.get('/challan/:id', isAuthenticated, isFinishingMaster, async (req, res) => {
+  try {
+    const id = Number(req.params.id);
+    const [[batch]] = await pool.query(`SELECT * FROM ee_dispatch_po WHERE id=?`, [id]);
+    if (!batch) return res.status(404).send('Challan not found');
+    const [lines] = await pool.query(
+      `SELECT lot_no, size_label, quantity, lot_sku, ee_sku FROM ee_dispatch_po_lines
+        WHERE batch_id=? ORDER BY id`, [id]);
+    const lotNo = batch.lot_no || (lines[0] && lines[0].lot_no) || '';
+    const [[lot]] = await pool.query(
+      `SELECT lot_no, manual_lot_number, sku FROM cutting_lots WHERE lot_no=? LIMIT 1`, [lotNo]);
+    res.render('eeChallan', {
+      user: req.session.user,
+      batch, lines, lot: lot || { lot_no: lotNo, manual_lot_number: '', sku: '' },
+      autoPrint: String(req.query.print || '') === '1',
+    });
+  } catch (err) {
+    console.error('ee-po challan error:', err);
+    res.status(500).send('Could not load the challan: ' + err.message);
   }
 });
 

--- a/routes/finishingRoutes.js
+++ b/routes/finishingRoutes.js
@@ -8,6 +8,8 @@ const { isAuthenticated, isFinishingMaster } = require('../middlewares/auth');
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
 const { getLotStageUsers } = require('../utils/lotStageUsers');
+const eePo = require('../utils/eeDispatchPo');
+const { aggregateLotSizes, allocateAcrossBatches } = require('../utils/dispatchAllocation');
 
 /* ---------------------------------------------------
    MULTER FOR IMAGE UPLOAD & BULK EXCEL UPLOAD
@@ -683,6 +685,198 @@ router.post('/event/dispatch', isAuthenticated, isFinishingMaster, async (req, r
   } catch (err) {
     if (conn) try { await conn.rollback(); } catch (_) {}
     console.error('[ERROR] POST /finishingdashboard/event/dispatch =>', err);
+    res.status(500).json({ error: err.message });
+  } finally {
+    if (conn) conn.release();
+  }
+});
+
+// ==================================================================
+//   LOT-WISE DISPATCH (2026-07-16 redesign): one card per lot, one tap,
+//   one challan/PO per lot. The old per-finishing-batch endpoint above
+//   stays for compatibility; the UI now uses these.
+// ==================================================================
+
+// Internal: this operator's finishing batches for a lot, FIFO, with per-size
+// produced/dispatched/available. Shared by preview + dispatch (same shape the
+// pure allocator consumes).
+async function ownerBatchesForLot(conn, userId, lotNo, forUpdate) {
+  const [batches] = await conn.query(
+    `SELECT id, lot_no, sku, created_at FROM finishing_data
+      WHERE user_id = ? AND lot_no = ? ORDER BY created_at ASC, id ASC${forUpdate ? ' FOR UPDATE' : ''}`,
+    [userId, lotNo]
+  );
+  if (!batches.length) return [];
+  const ids = batches.map(b => b.id);
+  const [sizeRows] = await conn.query(
+    `SELECT fds.finishing_data_id, fds.size_label, fds.pieces,
+            COALESCE(d.qty, 0) AS dispatched
+       FROM finishing_data_sizes fds
+       LEFT JOIN (
+         SELECT finishing_data_id, size_label, SUM(quantity) AS qty
+           FROM finishing_dispatches WHERE finishing_data_id IN (?)
+          GROUP BY finishing_data_id, size_label
+       ) d ON d.finishing_data_id = fds.finishing_data_id AND d.size_label = fds.size_label
+      WHERE fds.finishing_data_id IN (?)
+      ORDER BY fds.finishing_data_id, fds.id`,
+    [ids, ids]
+  );
+  const byBatch = new Map(batches.map(b => [b.id, { finishing_data_id: b.id, created_at: b.created_at, sizes: [] }]));
+  for (const r of sizeRows) {
+    const produced = Number(r.pieces) || 0;
+    const dispatched = Number(r.dispatched) || 0;
+    byBatch.get(r.finishing_data_id).sizes.push({
+      size_label: r.size_label, produced, dispatched,
+      available: Math.max(0, produced - dispatched),
+    });
+  }
+  return [...byBatch.values()];
+}
+
+// GET /finishingdashboard/event/dispatch-preview/:cuttingLotId
+// Everything the one-card-per-lot dispatch UI needs: lot-level size availability
+// (pre-fill), per-size EasyEcom SKU resolution status, and the style's verified
+// variants for inline mapping of any unresolved size.
+router.get('/event/dispatch-preview/:cuttingLotId', isAuthenticated, isFinishingMaster, async (req, res) => {
+  try {
+    const lotId = parseInt(req.params.cuttingLotId, 10);
+    if (!Number.isFinite(lotId) || lotId <= 0) return res.status(400).json({ error: 'Invalid cutting_lot_id' });
+    const [[lot]] = await pool.query(`SELECT id, lot_no, sku FROM cutting_lots WHERE id = ?`, [lotId]);
+    if (!lot) return res.status(404).json({ error: 'Lot not found' });
+
+    const batches = await ownerBatchesForLot(pool, req.session.user.id, lot.lot_no, false);
+    const sizes = aggregateLotSizes(batches);
+    const style = String(lot.sku || '').trim().toUpperCase();
+
+    let anyUnresolved = false;
+    for (const s of sizes) {
+      const r = await eePo.resolveLine(pool, style, s.size_label);
+      s.ee_sku = r.ee_sku;
+      if (!r.ee_sku && s.available > 0) anyUnresolved = true;
+    }
+    let variants = [];
+    if (anyUnresolved && style) {
+      const [v] = await pool.query(
+        `SELECT sku FROM ee_product_master WHERE active=1 AND sku LIKE CONCAT(?, '%') ORDER BY sku LIMIT 40`,
+        [style]);
+      variants = v.map(r => r.sku);
+    }
+    res.json({
+      lot, style, sizes, variants,
+      available: sizes.reduce((a, s) => a + s.available, 0),
+      po_enabled: eePo.pushEnabled(),
+    });
+  } catch (err) {
+    console.error('[ERROR] GET /finishingdashboard/event/dispatch-preview =>', err);
+    res.status(500).json({ error: err.message });
+  }
+});
+
+// POST /finishingdashboard/event/resolve-sku
+// Body: { style, size_label, size_sku } — persist a picked mapping (verified,
+// prefix-guarded, dropdown-only) BEFORE dispatch, so the lot's PO is born resolved.
+router.post('/event/resolve-sku', isAuthenticated, isFinishingMaster, async (req, res) => {
+  try {
+    const hit = await eePo.saveSkuMapping(req.body.style, req.body.size_label, req.body.size_sku, req.session.user);
+    res.json({ success: true, ee_sku: hit.sku });
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
+// POST /finishingdashboard/event/dispatch-lot
+// Body: { cutting_lot_id, destination, custom_destination?, sizes: [{size_label, pieces}] }
+// One tap: allocates the lot-level quantities across this operator's finishing
+// batches (FIFO), inserts finishing_dispatches rows, and — for Warehouse — creates
+// that LOT's PO batch in the same transaction, then tries the EasyEcom push
+// (dispatch never fails because EasyEcom is down; the PO retries in background).
+router.post('/event/dispatch-lot', isAuthenticated, isFinishingMaster, async (req, res) => {
+  let conn;
+  try {
+    const userId = req.session.user.id;
+    const lotId = parseInt(req.body.cutting_lot_id, 10);
+    if (!Number.isFinite(lotId) || lotId <= 0) return res.status(400).json({ error: 'Invalid cutting_lot_id' });
+
+    let dest = String(req.body.destination || '').trim();
+    if (dest === 'other' || !dest) dest = String(req.body.custom_destination || '').trim();
+    if (!dest) return res.status(400).json({ error: 'Destination is required' });
+    const isWarehouse = dest.toLowerCase() === 'warehouse';
+
+    const [[lot]] = await pool.query(`SELECT id, lot_no, sku FROM cutting_lots WHERE id = ?`, [lotId]);
+    if (!lot) return res.status(404).json({ error: 'Lot not found' });
+
+    conn = await pool.getConnection();
+    await conn.beginTransaction();
+
+    const batches = await ownerBatchesForLot(conn, userId, lot.lot_no, true);
+    if (!batches.length) {
+      await conn.rollback();
+      return res.status(403).json({ error: 'You have no finishing batches for this lot' });
+    }
+    const alloc = allocateAcrossBatches(req.body.sizes, batches);
+    if (alloc.error) {
+      await conn.rollback();
+      return res.status(400).json({ error: alloc.error });
+    }
+
+    // total_sent bookkeeping mirrors the legacy endpoint: running per
+    // (finishing_data_id, destination, size) total.
+    const fdIds = [...new Set(alloc.rows.map(r => r.finishing_data_id))];
+    const [destRows] = await conn.query(
+      `SELECT finishing_data_id, size_label, SUM(quantity) AS qty
+         FROM finishing_dispatches
+        WHERE finishing_data_id IN (?) AND destination = ?
+        GROUP BY finishing_data_id, size_label`,
+      [fdIds, dest]
+    );
+    const destSent = new Map(destRows.map(r =>
+      [`${r.finishing_data_id}|${stageEvents.normalizeSizeLabel(r.size_label)}`, Number(r.qty) || 0]));
+
+    const dispatchRows = [];
+    let totalDispatch = 0;
+    for (const r of alloc.rows) {
+      const key = `${r.finishing_data_id}|${stageEvents.normalizeSizeLabel(r.size_label)}`;
+      const newTotalSent = (destSent.get(key) || 0) + r.pieces;
+      destSent.set(key, newTotalSent);
+      const [ins] = await conn.query(
+        `INSERT INTO finishing_dispatches
+           (finishing_data_id, lot_no, destination, size_label, quantity, total_sent, sent_at, created_at)
+         VALUES (?,?,?,?,?,?,NOW(),NOW())`,
+        [r.finishing_data_id, lot.lot_no, dest, r.size_label, r.pieces, newTotalSent]
+      );
+      dispatchRows.push({
+        dispatch_id: ins.insertId, lot_no: lot.lot_no,
+        size_label: r.size_label, quantity: r.pieces, lot_sku: lot.sku,
+      });
+      totalDispatch += r.pieces;
+    }
+
+    // Warehouse → this lot's PO batch is born in the same transaction.
+    let challan = null;
+    if (isWarehouse) {
+      const b = await eePo.createLotBatch(conn, lot.lot_no, dispatchRows, req.session.user);
+      challan = { batch_id: b.batchId, batch_ref: b.batchRef, blocked: b.blocked, status: b.blocked > 0 ? 'blocked' : 'draft' };
+    }
+    await conn.commit();
+
+    // Push AFTER commit — EasyEcom being down must never roll back a dispatch.
+    if (challan && challan.status === 'draft' && eePo.pushEnabled()) {
+      try {
+        const p = await eePo.pushBatch(challan.batch_id);
+        challan.po_id = p.poId;
+        challan.status = 'pushed';
+      } catch (err) {
+        console.error('[ee-po] inline push failed (background job will retry):', err.message);
+        challan.status = 'po_pending';
+      }
+    } else if (challan && challan.status === 'draft') {
+      challan.status = 'po_pending';
+    }
+
+    res.json({ success: true, dispatched_total: totalDispatch, destination: dest, challan });
+  } catch (err) {
+    if (conn) try { await conn.rollback(); } catch (_) {}
+    console.error('[ERROR] POST /finishingdashboard/event/dispatch-lot =>', err);
     res.status(500).json({ error: err.message });
   } finally {
     if (conn) conn.release();

--- a/sql/2026_07_ee_dispatch_po_lotwise.sql
+++ b/sql/2026_07_ee_dispatch_po_lotwise.sql
@@ -1,0 +1,6 @@
+-- Lot-wise challan model (2026-07-16): one batch = one lot = one PO/challan.
+-- batch_ref becomes 'KT-DISP-<id>-<lot_no>'; lot_no is denormalized onto the batch
+-- for display/filtering. Legacy all-lots batches keep lot_no NULL.
+ALTER TABLE ee_dispatch_po
+  ADD COLUMN lot_no VARCHAR(50) NULL AFTER batch_ref,
+  ADD INDEX idx_lot_no (lot_no);

--- a/sql/2026_07_ktdisp2_remediation.sql
+++ b/sql/2026_07_ktdisp2_remediation.sql
@@ -1,0 +1,14 @@
+-- One-time remediation for KT-DISP-2 (run manually AFTER deploying the lot-wise
+-- challan model and applying 2026_07_ee_dispatch_po_lotwise.sql).
+--
+-- KT-DISP-2 mixed 12 lots (83 lines, 10,449 pcs) and sat blocked because 9 lots had
+-- unresolved SKUs — freezing the 3 fully-resolved lots. Cancelling the batch and
+-- releasing its lines lets the lot-wise sweep (cron, or "Sweep now" on the transfers
+-- screen) rebuild them as one batch per lot: resolved lots push immediately, blocked
+-- lots block only themselves.
+--
+-- Safe because: batch 2 was never pushed (no PO exists in EasyEcom), and deleting the
+-- lines releases the dispatch_id UNIQUE locks so the same dispatches can re-sweep.
+
+UPDATE ee_dispatch_po SET status='cancelled', error='superseded by lot-wise challans (design doc §9)' WHERE id = 2 AND status = 'blocked';
+DELETE FROM ee_dispatch_po_lines WHERE batch_id = 2;

--- a/test/dispatchAllocation.test.js
+++ b/test/dispatchAllocation.test.js
@@ -1,0 +1,74 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { aggregateLotSizes, allocateAcrossBatches } = require('../utils/dispatchAllocation.js');
+
+const batches = [
+  { finishing_data_id: 10, sizes: [
+    { size_label: 'M', produced: 100, dispatched: 40, available: 60 },
+    { size_label: 'L', produced: 50, dispatched: 50, available: 0 },
+  ] },
+  { finishing_data_id: 11, sizes: [
+    { size_label: 'm', produced: 30, dispatched: 0, available: 30 },
+    { size_label: 'XL', produced: 20, dispatched: 5, available: 15 },
+  ] },
+];
+
+test('aggregateLotSizes: merges duplicate labels across batches, case-insensitively', () => {
+  const agg = aggregateLotSizes(batches);
+  const m = agg.find((s) => s.size_label.toUpperCase() === 'M');
+  assert.deepStrictEqual(m, { size_label: 'M', produced: 130, dispatched: 40, available: 90 });
+  assert.strictEqual(agg.length, 3); // M, L, XL
+  const l = agg.find((s) => s.size_label === 'L');
+  assert.strictEqual(l.available, 0);
+});
+
+test('allocateAcrossBatches: FIFO — drains the oldest batch before the next', () => {
+  const { rows, error } = allocateAcrossBatches([{ size_label: 'M', pieces: 75 }], batches);
+  assert.strictEqual(error, undefined);
+  assert.deepStrictEqual(rows, [
+    { finishing_data_id: 10, size_label: 'M', pieces: 60 },
+    { finishing_data_id: 11, size_label: 'm', pieces: 15 },
+  ]);
+});
+
+test('allocateAcrossBatches: exact fit in one batch produces one row', () => {
+  const { rows } = allocateAcrossBatches([{ size_label: 'XL', pieces: 15 }], batches);
+  assert.deepStrictEqual(rows, [{ finishing_data_id: 11, size_label: 'XL', pieces: 15 }]);
+});
+
+test('allocateAcrossBatches: over-ask fails with the lot-level available count', () => {
+  const { error } = allocateAcrossBatches([{ size_label: 'M', pieces: 91 }], batches);
+  assert.match(error, /only 90 pieces available/);
+});
+
+test('allocateAcrossBatches: fully-dispatched size fails clearly', () => {
+  const { error } = allocateAcrossBatches([{ size_label: 'L', pieces: 1 }], batches);
+  assert.match(error, /nothing available/);
+});
+
+test('allocateAcrossBatches: unknown size fails', () => {
+  const { error } = allocateAcrossBatches([{ size_label: 'XXL', pieces: 1 }], batches);
+  assert.match(error, /nothing available/);
+});
+
+test('allocateAcrossBatches: empty / zero / negative requests are rejected', () => {
+  assert.match(allocateAcrossBatches([], batches).error, /No positive/);
+  assert.match(allocateAcrossBatches([{ size_label: 'M', pieces: 0 }], batches).error, /No positive/);
+  assert.match(allocateAcrossBatches([{ size_label: 'M', pieces: -5 }], batches).error, /No positive/);
+});
+
+test('allocateAcrossBatches: duplicate size in the request is rejected, not merged', () => {
+  const { error } = allocateAcrossBatches(
+    [{ size_label: 'M', pieces: 10 }, { size_label: 'm', pieces: 10 }], batches);
+  assert.match(error, /more than once/);
+});
+
+test('allocateAcrossBatches: multi-size request allocates each independently', () => {
+  const { rows } = allocateAcrossBatches(
+    [{ size_label: 'M', pieces: 61 }, { size_label: 'XL', pieces: 10 }], batches);
+  assert.deepStrictEqual(rows, [
+    { finishing_data_id: 10, size_label: 'M', pieces: 60 },
+    { finishing_data_id: 11, size_label: 'm', pieces: 1 },
+    { finishing_data_id: 11, size_label: 'XL', pieces: 10 },
+  ]);
+});

--- a/utils/dispatchAllocation.js
+++ b/utils/dispatchAllocation.js
@@ -1,0 +1,70 @@
+// Lot-level dispatch allocation — pure helpers (no DB) for the one-card-per-lot
+// dispatch flow. The route supplies the operator's finishing batches (FIFO by
+// created_at) with per-size availability; these helpers aggregate them for the
+// card and split a lot-level dispatch request back across the batches.
+//
+// A "size key" is the normalized label (trim+uppercase — same rule as
+// utils/stageEvents.normalizeSizeLabel); display labels keep their first-seen form.
+
+function normalize(label) {
+  return String(label || '').trim().toUpperCase();
+}
+
+// batches: [{ finishing_data_id, sizes: [{ size_label, produced, dispatched, available }] }]
+// → lot-level rows, FIFO first-seen order: [{ size_label, produced, dispatched, available }]
+function aggregateLotSizes(batches) {
+  const byKey = new Map();
+  for (const b of batches || []) {
+    for (const s of b.sizes || []) {
+      const k = normalize(s.size_label);
+      if (!k) continue;
+      if (!byKey.has(k)) byKey.set(k, { size_label: String(s.size_label).trim(), produced: 0, dispatched: 0, available: 0 });
+      const agg = byKey.get(k);
+      agg.produced += Number(s.produced) || 0;
+      agg.dispatched += Number(s.dispatched) || 0;
+      agg.available += Number(s.available) || 0;
+    }
+  }
+  return [...byKey.values()];
+}
+
+// Split a lot-level request across batches, oldest batch first (FIFO).
+//   requested: [{ size_label, pieces }]
+//   batches:   [{ finishing_data_id, sizes: [{ size_label, available }] }] in FIFO order
+// Returns { rows: [{ finishing_data_id, size_label, pieces }] } — size_label is the
+// batch's own display label (finishing_dispatches stores it as produced).
+// Returns { error } if any size is unknown or asks for more than the lot has.
+function allocateAcrossBatches(requested, batches) {
+  const req = (Array.isArray(requested) ? requested : [])
+    .map((s) => ({ key: normalize(s.size_label), label: String(s.size_label || '').trim(), pieces: Math.trunc(Number(s.pieces)) || 0 }))
+    .filter((s) => s.key && s.pieces > 0);
+  if (!req.length) return { error: 'No positive size quantities provided' };
+  // Reject duplicate size labels in the request — ambiguity, not a merge.
+  const seen = new Set();
+  for (const s of req) {
+    if (seen.has(s.key)) return { error: `Size ${s.label} appears more than once in the request` };
+    seen.add(s.key);
+  }
+
+  const rows = [];
+  for (const s of req) {
+    let remaining = s.pieces;
+    let lotAvailable = 0;
+    for (const b of batches || []) {
+      for (const bs of b.sizes || []) {
+        if (normalize(bs.size_label) !== s.key) continue;
+        const avail = Number(bs.available) || 0;
+        lotAvailable += avail;
+        if (remaining <= 0 || avail <= 0) continue;
+        const take = Math.min(remaining, avail);
+        rows.push({ finishing_data_id: b.finishing_data_id, size_label: String(bs.size_label).trim(), pieces: take });
+        remaining -= take;
+      }
+    }
+    if (lotAvailable === 0 && remaining > 0) return { error: `Size ${s.label} has nothing available to dispatch` };
+    if (remaining > 0) return { error: `Size ${s.label}: only ${lotAvailable} pieces available to dispatch (requested ${s.pieces})` };
+  }
+  return { rows };
+}
+
+module.exports = { aggregateLotSizes, allocateAcrossBatches, normalize };

--- a/utils/eeDispatchPo.js
+++ b/utils/eeDispatchPo.js
@@ -103,89 +103,139 @@ async function resolveLine(db, lotSku, sizeLabel) {
   return { ee_sku: eeSku, source, cost: pm.length ? pm[0].cost : null, mrp: pm.length ? pm[0].mrp : null };
 }
 
-// ── Batch building ────────────────────────────────────────────────────────
-// Sweep every Warehouse-destination finishing_dispatches row not yet in any batch
-// into ONE new batch (draft if fully resolved, blocked otherwise).
-async function buildBatch(user) {
-  const conn = await pool.getConnection();
-  try {
-    await conn.beginTransaction();
-    const [rows] = await conn.query(
-      `SELECT fd.id AS dispatch_id, fd.lot_no, fd.size_label, fd.quantity, cl.sku AS lot_sku
-         FROM finishing_dispatches fd
-         LEFT JOIN ee_dispatch_po_lines l ON l.dispatch_id = fd.id
-         LEFT JOIN cutting_lots cl ON cl.lot_no = fd.lot_no
-        WHERE l.id IS NULL AND LOWER(fd.destination) = 'warehouse'
-          AND fd.created_at >= ?
-        ORDER BY fd.id
-        LIMIT 500`,
-      [EE_PO_SINCE]
-    );
-    if (!rows.length) { await conn.rollback(); return { created: false, reason: 'No new Warehouse dispatches to sweep.' }; }
+// ── Batch building — LOT-WISE (2026-07-16 redesign) ──────────────────────
+// One batch = one lot = one PO/challan. batch_ref 'KT-DISP-<id>-<lot_no>'.
+// A blocked SKU in one lot can never hold another lot's pieces hostage.
 
-    const [ins] = await conn.query(
-      `INSERT INTO ee_dispatch_po (batch_ref, status, warehouse_id, created_by, created_by_name)
-       VALUES ('PENDING', 'draft', ?, ?, ?)`,
-      [FARIDABAD_WAREHOUSE_ID, user?.id || null, user?.username || null]
-    );
-    const batchId = ins.insertId;
-    const batchRef = `KT-DISP-${batchId}`;
+// Create ONE batch for ONE lot from the given unswept dispatch rows.
+// Runs on the caller's connection/transaction. rows: [{dispatch_id, lot_no,
+// size_label, quantity, lot_sku}].
+async function createLotBatch(conn, lotNo, rows, user) {
+  const [ins] = await conn.query(
+    `INSERT INTO ee_dispatch_po (batch_ref, lot_no, status, warehouse_id, created_by, created_by_name)
+     VALUES ('PENDING', ?, 'draft', ?, ?, ?)`,
+    [lotNo, FARIDABAD_WAREHOUSE_ID, user?.id || null, user?.username || null]
+  );
+  const batchId = ins.insertId;
+  // batch_ref is VARCHAR(40) UNIQUE; the id keeps it unique even if the lot part clips.
+  const batchRef = `KT-DISP-${batchId}-${String(lotNo)}`.slice(0, 40);
 
-    let blocked = 0, totalQty = 0;
-    for (const r of rows) {
-      const res = await resolveLine(conn, r.lot_sku, r.size_label);
-      if (!res.ee_sku) blocked++;
-      totalQty += Number(r.quantity) || 0;
-      await conn.query(
-        `INSERT INTO ee_dispatch_po_lines
-           (batch_id, dispatch_id, lot_no, size_label, quantity, lot_sku, ee_sku, resolve_source, unit_cost, mrp)
-         VALUES (?,?,?,?,?,?,?,?,?,?)`,
-        [batchId, r.dispatch_id, r.lot_no, r.size_label, r.quantity, r.lot_sku || null,
-         res.ee_sku, res.source, res.cost, res.mrp]
-      );
-    }
+  let blocked = 0, totalQty = 0;
+  for (const r of rows) {
+    const res = await resolveLine(conn, r.lot_sku, r.size_label);
+    if (!res.ee_sku) blocked++;
+    totalQty += Number(r.quantity) || 0;
     await conn.query(
-      `UPDATE ee_dispatch_po
-          SET batch_ref=?, status=?, total_qty=?, line_count=?, blocked_count=?
-        WHERE id=?`,
-      [batchRef, blocked > 0 ? 'blocked' : 'draft', totalQty, rows.length, blocked, batchId]
+      `INSERT INTO ee_dispatch_po_lines
+         (batch_id, dispatch_id, lot_no, size_label, quantity, lot_sku, ee_sku, resolve_source, unit_cost, mrp)
+       VALUES (?,?,?,?,?,?,?,?,?,?)`,
+      [batchId, r.dispatch_id, r.lot_no, r.size_label, r.quantity, r.lot_sku || null,
+       res.ee_sku, res.source, res.cost, res.mrp]
     );
-    await conn.commit();
-    return { created: true, batchId, batchRef, lines: rows.length, blocked };
-  } catch (err) {
-    await conn.rollback();
-    throw err;
-  } finally {
-    conn.release();
   }
+  await conn.query(
+    `UPDATE ee_dispatch_po
+        SET batch_ref=?, status=?, total_qty=?, line_count=?, blocked_count=?
+      WHERE id=?`,
+    [batchRef, blocked > 0 ? 'blocked' : 'draft', totalQty, rows.length, blocked, batchId]
+  );
+  return { batchId, batchRef, lines: rows.length, blocked };
 }
 
-// Inline manual resolution from the finishing review screen. The chosen SKU must
-// EXIST in the ee_product_master mirror AND belong to the same style (prefix guard) —
-// no free text, nothing is ever created in EasyEcom. The mapping is persisted to
-// pm_sku_resolution (source: 'manual' — the enum's value for hand-mapping; the
-// mapper is recorded in loaded_by), so PM planning learns it too.
-async function resolveLineManually(lineId, sizeSku, user) {
+// Sweep every unswept Warehouse dispatch row into per-lot batches (one batch per
+// lot). Used by the background job and as a manual fallback; the dispatch action
+// itself creates its lot's batch inline. Each lot commits independently.
+async function sweepLotBatches(user) {
+  const [rows] = await pool.query(
+    `SELECT fd.id AS dispatch_id, fd.lot_no, fd.size_label, fd.quantity, cl.sku AS lot_sku
+       FROM finishing_dispatches fd
+       LEFT JOIN ee_dispatch_po_lines l ON l.dispatch_id = fd.id
+       LEFT JOIN cutting_lots cl ON cl.lot_no = fd.lot_no
+      WHERE l.id IS NULL AND LOWER(fd.destination) = 'warehouse'
+        AND fd.created_at >= ?
+      ORDER BY fd.lot_no, fd.id
+      LIMIT 500`,
+    [EE_PO_SINCE]
+  );
+  if (!rows.length) return { created: 0, batches: [], reason: 'No new Warehouse dispatches to sweep.' };
+
+  const byLot = new Map();
+  for (const r of rows) {
+    if (!byLot.has(r.lot_no)) byLot.set(r.lot_no, []);
+    byLot.get(r.lot_no).push(r);
+  }
+  const batches = [];
+  for (const [lotNo, lotRows] of byLot) {
+    const conn = await pool.getConnection();
+    try {
+      await conn.beginTransaction();
+      const b = await createLotBatch(conn, lotNo, lotRows, user);
+      await conn.commit();
+      batches.push({ lot_no: lotNo, ...b });
+    } catch (err) {
+      await conn.rollback();
+      console.error(`[ee-po] sweep failed for lot ${lotNo}:`, err.message);
+    } finally {
+      conn.release();
+    }
+  }
+  return { created: batches.length, batches };
+}
+
+// Push every fully-resolved draft batch. One batch's failure never stops the next;
+// EasyEcom being down just leaves drafts for the next run. No-op unless EE_GRN_PUSH=1.
+async function autoPushDrafts() {
+  if (!pushEnabled()) return { pushed: 0, failed: 0, skipped: 'push disabled' };
+  const [drafts] = await pool.query(
+    `SELECT id FROM ee_dispatch_po WHERE status='draft' ORDER BY id`);
+  let pushed = 0, failed = 0;
+  for (const d of drafts) {
+    try {
+      await pushBatch(d.id);
+      pushed++;
+    } catch (err) {
+      failed++;
+      console.error(`[ee-po] auto-push failed for batch ${d.id}:`, err.message);
+    }
+  }
+  return { pushed, failed, drafts: drafts.length };
+}
+
+// Persist a style+size → EasyEcom-SKU mapping picked by a human. The chosen SKU
+// must EXIST (active) in the ee_product_master mirror AND belong to the same style
+// (prefix guard) — no free text, nothing is ever created in EasyEcom. Written to
+// pm_sku_resolution (source: 'manual', mapper in loaded_by) so the pipeline AND
+// PM planning learn it permanently. Shared by the pre-dispatch inline resolver
+// (finishing card) and the transfers-screen line resolver.
+async function saveSkuMapping(styleSku, sizeLabel, sizeSku, user) {
   const chosen = String(sizeSku || '').trim().toUpperCase();
   if (!chosen) throw new Error('Pick a SKU.');
-  const [[line]] = await pool.query(
-    `SELECT id, batch_id, lot_sku, size_label, ee_sku FROM ee_dispatch_po_lines WHERE id=?`, [lineId]);
-  if (!line) throw new Error('Line not found');
-  if (line.ee_sku) throw new Error('Line is already resolved.');
-  const style = String(line.lot_sku || '').trim().toUpperCase();
-  if (!style) throw new Error('Line has no lot style SKU.');
+  const style = String(styleSku || '').trim().toUpperCase();
+  const size = String(sizeLabel || '').trim().toUpperCase();
+  if (!style || !size) throw new Error('Style and size are required.');
   if (!chosen.startsWith(style)) throw new Error('That SKU belongs to a different style.');
   const [[hit]] = await pool.query(
     `SELECT sku, cost, mrp FROM ee_product_master WHERE sku=? AND active=1`, [chosen]);
   if (!hit) throw new Error('That SKU does not exist (active) in the EasyEcom master.');
 
-  // Persist the mapping for everything (pipeline + PM planning). UNIQUE(cl_sku, size_label).
+  // UNIQUE(cl_sku, size_label).
   await pool.query(
     `INSERT INTO pm_sku_resolution (cl_sku, size_label, size_sku, state, source, loaded_by)
      VALUES (?, ?, ?, 'resolved', 'manual', ?)
      ON DUPLICATE KEY UPDATE size_sku=VALUES(size_sku), state='resolved',
        source='manual', loaded_by=VALUES(loaded_by), updated_at=CURRENT_TIMESTAMP`,
-    [style, String(line.size_label).trim().toUpperCase(), hit.sku, user?.id || null]);
+    [style, size, hit.sku, user?.id || null]);
+  return hit;
+}
+
+// Inline manual resolution of one blocked batch line (transfers screen).
+async function resolveLineManually(lineId, sizeSku, user) {
+  const [[line]] = await pool.query(
+    `SELECT id, batch_id, lot_sku, size_label, ee_sku FROM ee_dispatch_po_lines WHERE id=?`, [lineId]);
+  if (!line) throw new Error('Line not found');
+  if (line.ee_sku) throw new Error('Line is already resolved.');
+  if (!String(line.lot_sku || '').trim()) throw new Error('Line has no lot style SKU.');
+  const hit = await saveSkuMapping(line.lot_sku, line.size_label, sizeSku, user);
 
   await pool.query(
     `UPDATE ee_dispatch_po_lines SET ee_sku=?, resolve_source='map', unit_cost=?, mrp=? WHERE id=?`,
@@ -226,7 +276,11 @@ async function pushBatch(batchId) {
   if (!pushEnabled()) throw new Error('EE_GRN_PUSH is not enabled on this environment.');
   const [[batch]] = await pool.query(`SELECT * FROM ee_dispatch_po WHERE id=?`, [batchId]);
   if (!batch) throw new Error('Batch not found');
-  if (batch.status !== 'draft') throw new Error(`Batch is ${batch.status}, only draft batches can be pushed.`);
+  // 'failed' is human-retryable from the transfers screen (the error stays visible
+  // on the card); everything else must never push twice.
+  if (batch.status !== 'draft' && batch.status !== 'failed') {
+    throw new Error(`Batch is ${batch.status}, only draft/failed batches can be pushed.`);
+  }
 
   const [lines] = await pool.query(
     `SELECT ee_sku, SUM(quantity) AS qty, MAX(unit_cost) AS cost
@@ -289,4 +343,8 @@ async function confirmGrns() {
   return { checked: pushed.length, confirmed };
 }
 
-module.exports = { buildBatch, reResolveBatch, resolveLineManually, pushBatch, confirmGrns, pushEnabled, FARIDABAD_WAREHOUSE_ID, EE_PO_SINCE };
+module.exports = {
+  createLotBatch, sweepLotBatches, autoPushDrafts, reResolveBatch,
+  resolveLineManually, saveSkuMapping, resolveLine, pushBatch, confirmGrns,
+  pushEnabled, FARIDABAD_WAREHOUSE_ID, EE_PO_SINCE,
+};

--- a/utils/scheduler.js
+++ b/utils/scheduler.js
@@ -7,6 +7,7 @@ const cron = require('node-cron');
 const { syncAjioShipments } = require('./ajioShipmentSync');
 const { runMailAutoReply } = require('./mailAutoReplyJob');
 const { runPullWorker } = require('./easyecomPullWorker');
+const { sweepLotBatches, autoPushDrafts, confirmGrns, pushEnabled } = require('./eeDispatchPo');
 const { pool } = require('../config/db');
 
 const TZ = process.env.CRON_TIMEZONE || 'Asia/Kolkata';
@@ -57,6 +58,35 @@ function startCronJobs() {
   );
 
   console.log(`[cron] scheduled mail auto-reply (9 AM, 9 PM ${TZ})`);
+
+  // Warehouse-transfer housekeeping (lot-wise challan pipeline): sweep any stray
+  // unswept dispatches into per-lot batches, retry pending POs, and detect the
+  // warehouse's GRNs. The dispatch action does all of this inline on the happy
+  // path — this job only heals EasyEcom-outage leftovers and updates statuses.
+  // Rides EE_GRN_PUSH (same flag that arms the pipeline); no separate switch.
+  // Cloud Run caveat: runs only while an instance is alive, which is all working
+  // hours — exactly when dispatches and GRNs happen.
+  if (pushEnabled()) {
+    cron.schedule(
+      process.env.EE_TRANSFER_CRON || '*/30 * * * *',
+      async () => {
+        try {
+          const swept = await sweepLotBatches(null);
+          const pushed = await autoPushDrafts();
+          const grns = await confirmGrns();
+          if (swept.created || pushed.pushed || grns.confirmed) {
+            console.log(`[cron] ee transfers: swept ${swept.created || 0} lot(s), pushed ${pushed.pushed || 0} PO(s), confirmed ${grns.confirmed || 0} GRN(s)`);
+          }
+        } catch (err) {
+          console.error('[cron] ee transfer housekeeping failed:', err);
+        }
+      },
+      { timezone: TZ }
+    );
+    console.log(`[cron] scheduled ee transfer housekeeping (every 30 min, TZ=${TZ})`);
+  } else {
+    console.log('[cron] ee transfer housekeeping DISABLED (EE_GRN_PUSH is off)');
+  }
 
   // EasyEcom pull worker: nightly 02:30 IST. Opt-in via PM_PULL_ENABLED=1.
   // Replaces the retired EasyEcom webhook ingestion.

--- a/views/eeChallan.ejs
+++ b/views/eeChallan.ejs
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Challan <%= batch.batch_ref %></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@600;700&display=swap" rel="stylesheet">
+  <style>
+    * { box-sizing: border-box; }
+    body { font-family: 'Inter', -apple-system, sans-serif; color: #0f172a; background: #f7f8fa; margin: 0; padding: 24px; }
+    .sheet { background: #fff; max-width: 720px; margin: 0 auto; border: 1px solid #e5e7eb; border-radius: 12px; padding: 28px 32px; }
+    .head { display: flex; justify-content: space-between; align-items: flex-start; border-bottom: 2px solid #0f172a; padding-bottom: 14px; }
+    .head h1 { font-family: 'Space Grotesk', sans-serif; font-size: 20px; margin: 0; letter-spacing: 0.02em; }
+    .head .co { font-size: 12px; color: #64748b; margin-top: 4px; }
+    .ref { text-align: right; }
+    .ref .rn { font-family: 'Space Grotesk', monospace; font-weight: 700; font-size: 18px; }
+    .ref .rd { font-size: 12px; color: #64748b; margin-top: 2px; }
+    .meta { display: grid; grid-template-columns: 1fr 1fr; gap: 6px 24px; margin: 16px 0; font-size: 13.5px; }
+    .meta .k { color: #64748b; }
+    .meta .v { font-weight: 600; }
+    .route { display: flex; gap: 10px; align-items: center; margin: 4px 0 16px; font-size: 13.5px; font-weight: 600; }
+    .route .arrow { color: #2563eb; }
+    table { width: 100%; border-collapse: collapse; margin-top: 4px; font-size: 13.5px; }
+    th { text-align: left; border-bottom: 2px solid #0f172a; padding: 7px 8px; font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; }
+    td { border-bottom: 1px solid #e5e7eb; padding: 7px 8px; }
+    td.n, th.n { text-align: right; font-variant-numeric: tabular-nums; }
+    tfoot td { border-bottom: 0; border-top: 2px solid #0f172a; font-weight: 700; }
+    .po-note { margin-top: 14px; font-size: 12.5px; color: #64748b; }
+    .po-note strong { color: #0f172a; }
+    .pending { display: inline-block; background: #fef3c7; color: #b45309; font-size: 11px; font-weight: 700; padding: 2px 8px; border-radius: 999px; }
+    .sign { display: flex; justify-content: space-between; margin-top: 48px; font-size: 12.5px; color: #64748b; }
+    .sign div { border-top: 1px solid #94a3b8; padding-top: 6px; width: 180px; text-align: center; }
+    .toolbar { max-width: 720px; margin: 0 auto 14px; display: flex; justify-content: flex-end; gap: 8px; }
+    .toolbar button, .toolbar a { border: 0; background: #2563eb; color: #fff; font-weight: 600; font-size: 13.5px; padding: 8px 16px; border-radius: 8px; cursor: pointer; text-decoration: none; font-family: inherit; }
+    .toolbar a.quiet { background: #fff; color: #0f172a; border: 1px solid #e5e7eb; }
+    @media print {
+      body { background: #fff; padding: 0; }
+      .sheet { border: 0; border-radius: 0; max-width: none; padding: 8px 4px; }
+      .toolbar { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <div class="toolbar">
+    <a class="quiet" href="/finishingdashboard/ee-po">← Transfers</a>
+    <button onclick="window.print()">Print</button>
+  </div>
+  <div class="sheet">
+    <div class="head">
+      <div>
+        <h1>DELIVERY CHALLAN</h1>
+        <div class="co">KOTTY LIFESTYLE — Finishing → Warehouse transfer</div>
+      </div>
+      <div class="ref">
+        <div class="rn"><%= batch.batch_ref %></div>
+        <div class="rd"><%= new Date(batch.created_at).toLocaleString('en-IN', { day:'2-digit', month:'short', year:'numeric', hour:'2-digit', minute:'2-digit', hour12:true, timeZone:'Asia/Kolkata' }) %></div>
+      </div>
+    </div>
+
+    <div class="route">
+      <span>Finishing floor</span><span class="arrow">→</span><span>Faridabad warehouse</span>
+    </div>
+
+    <div class="meta">
+      <div><span class="k">Lot no:</span> <span class="v"><%= lot.lot_no %></span></div>
+      <div><span class="k">Manual lot no:</span> <span class="v"><%= lot.manual_lot_number || '—' %></span></div>
+      <div><span class="k">Style:</span> <span class="v"><%= lot.sku || '—' %></span></div>
+      <div><span class="k">Dispatched by:</span> <span class="v"><%= batch.created_by_name || '—' %></span></div>
+    </div>
+
+    <table>
+      <thead>
+        <tr><th>#</th><th>Size</th><th>EasyEcom SKU</th><th class="n">Pieces</th></tr>
+      </thead>
+      <tbody>
+        <% let total = 0; lines.forEach((l, i) => { total += Number(l.quantity) || 0; %>
+          <tr>
+            <td><%= i + 1 %></td>
+            <td><%= l.size_label %></td>
+            <td><%= l.ee_sku || '' %><% if (!l.ee_sku) { %><span class="pending">SKU pending</span><% } %></td>
+            <td class="n"><%= l.quantity %></td>
+          </tr>
+        <% }); %>
+      </tbody>
+      <tfoot>
+        <tr><td colspan="3">Total pieces</td><td class="n"><%= total %></td></tr>
+      </tfoot>
+    </table>
+
+    <div class="po-note">
+      EasyEcom PO reference: <strong><%= batch.batch_ref %></strong>
+      <% if (batch.po_id) { %> · PO ID <strong><%= batch.po_id %></strong><% } else { %> · <span class="pending">PO pending — will appear in EasyEcom shortly</span><% } %>
+      <br>Warehouse: match this challan to the PO above and GRN the received quantities in EasyEcom.
+    </div>
+
+    <div class="sign">
+      <div>Dispatched by (Finishing)</div>
+      <div>Driver / Vehicle</div>
+      <div>Received by (Warehouse)</div>
+    </div>
+  </div>
+  <% if (autoPrint) { %><script>window.addEventListener('load', () => setTimeout(() => window.print(), 300));</script><% } %>
+</body>
+</html>

--- a/views/eeDispatchPo.ejs
+++ b/views/eeDispatchPo.ejs
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-<title>EasyEcom PO — Dispatch to Warehouse</title>
+<title>Warehouse Transfers</title>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
 <style>
   :root{ --ink:#0f172a; --muted:#64748b; --line:#e5e7eb; --bg:#f7f8fa; --card:#fff;
@@ -44,7 +44,7 @@
 </head>
 <body>
 <header class="top">
-  <div class="brand"><span class="material-symbols-outlined">local_shipping</span><h1>EasyEcom PO</h1></div>
+  <div class="brand"><span class="material-symbols-outlined">local_shipping</span><h1>Warehouse Transfers</h1></div>
   <div class="acts">
     <a class="home" href="/finishingdashboard" title="Finishing"><span class="material-symbols-outlined">home</span></a>
     <span class="who"><%= user && user.username %></span>
@@ -53,59 +53,71 @@
 </header>
 
 <main class="wrap">
-  <!-- Sweep card -->
   <section class="card">
-    <div class="head-row">
-      <div class="twoline">
-        <div class="l">Warehouse dispatches not yet on a PO</div>
-        <div><span class="stat" id="pendQty"><%= pendingQty.toLocaleString('en-IN') %></span>
-             <span class="meta"><%= pendingRows %> dispatch rows</span></div>
+    <div class="note info" style="margin-top:0;">Every Warehouse dispatch creates its own
+      <strong>lot challan + Purchase Order</strong> the moment you dispatch on the finishing screen —
+      nothing to operate here. The <strong>warehouse team GRNs each challan in EasyEcom</strong> when the
+      goods physically arrive; statuses below update automatically. Stock only enters the OMS through
+      the warehouse's own GRN.</div>
+    <% if (pendingRows) { %>
+      <div class="head-row" style="margin-top:10px;">
+        <div class="twoline">
+          <div class="l">Older dispatches not yet on a challan</div>
+          <div><span class="stat" id="pendQty"><%= pendingQty.toLocaleString('en-IN') %></span>
+               <span class="meta"><%= pendingRows %> dispatch rows — swept automatically within 30 min</span></div>
+        </div>
+        <button class="btn btn-ghost" id="buildBtn" onclick="buildBatch()">
+          <span class="material-symbols-outlined" style="font-size:18px;">post_add</span> Sweep now
+        </button>
       </div>
-      <button class="btn btn-primary" id="buildBtn" <%= pendingRows ? '' : 'disabled' %> onclick="buildBatch()">
-        <span class="material-symbols-outlined" style="font-size:18px;">post_add</span> Create PO batch
-      </button>
-    </div>
-    <div class="note info">Flow: dispatches are swept into a batch → you review and <strong>Push</strong> it →
-      EasyEcom gets the Purchase Order (challan) → the <strong>warehouse team makes the GRN in EasyEcom</strong>
-      when the goods physically arrive → this screen marks the batch <strong>confirmed</strong>.
-      Stock only enters the OMS through the warehouse's own GRN.</div>
+    <% } %>
     <% if (!pushEnabled) { %>
       <div class="note warn">Pushing is disabled on this environment (<code>EE_GRN_PUSH</code> is off).
-        Batches can be built and reviewed, but not sent.</div>
+        Challans can be created and reviewed, but POs won't reach EasyEcom.</div>
     <% } %>
   </section>
 
   <div class="head-row" style="margin:4px 2px 10px;">
-    <span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);">Batches</span>
+    <span style="font-size:11px;font-weight:700;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);">Challans</span>
     <button class="btn btn-ghost" onclick="refreshConfirmations()" style="padding:8px 12px;font-size:13px;">
-      <span class="material-symbols-outlined" style="font-size:17px;">sync</span> Check for warehouse GRNs
+      <span class="material-symbols-outlined" style="font-size:17px;">sync</span> Check GRNs now
     </button>
   </div>
 
   <% if (!batches.length) { %>
-    <section class="card" style="text-align:center;color:var(--muted);padding:34px;">No batches yet.</section>
+    <section class="card" style="text-align:center;color:var(--muted);padding:34px;">No challans yet — dispatch a lot to Warehouse on the finishing screen and it will appear here.</section>
   <% } %>
+  <%
+    // Floor vocabulary for the pipeline statuses.
+    const STATUS_LABEL = { draft: 'PO pending', blocked: 'Needs SKU', pushed: 'At EasyEcom',
+                           confirmed: 'Received (GRN)', failed: 'Failed', cancelled: 'Cancelled' };
+  %>
 
   <% batches.forEach(function(b){ var lines = linesByBatch[b.id] || []; %>
     <section class="card">
       <div class="head-row">
         <div>
-          <strong class="num" style="font-size:17px;"><%= b.batch_ref %></strong>
-          <span class="pill <%= b.status %>"><%= b.status %></span>
+          <strong class="num" style="font-size:17px;"><%= (b.lot_no || '').toUpperCase() || b.batch_ref %></strong>
+          <span class="pill <%= b.status %>"><%= STATUS_LABEL[b.status] || b.status %></span>
           <div class="meta">
-            <%= b.line_count %> lines · <span class="num"><%= Number(b.total_qty).toLocaleString('en-IN') %></span> pcs
+            <%= b.batch_ref %> · <%= b.line_count %> lines · <span class="num"><%= Number(b.total_qty).toLocaleString('en-IN') %></span> pcs
             <% if (b.po_id) { %> · PO <strong><%= b.po_id %></strong><% } %>
             <% if (b.grn_id) { %> · GRN <strong><%= b.grn_id %></strong> (<%= b.grn_status %>)<% } %>
             · by <%= b.created_by_name || '—' %> · <%= new Date(b.created_at).toLocaleString('en-IN', {timeZone:'Asia/Kolkata'}) %>
           </div>
         </div>
         <div style="display:flex;gap:8px;">
+          <% if (!['cancelled','failed'].includes(b.status)) { %>
+            <a class="btn btn-ghost" href="/finishingdashboard/ee-po/challan/<%= b.id %>" target="_blank" style="text-decoration:none;">
+              <span class="material-symbols-outlined" style="font-size:17px;">print</span> Challan
+            </a>
+          <% } %>
           <% if (b.status === 'blocked') { %>
             <button class="btn btn-ghost" onclick="reResolve(<%= b.id %>)">Re-resolve SKUs</button>
           <% } %>
-          <% if (b.status === 'draft') { %>
+          <% if (b.status === 'draft' || b.status === 'failed') { %>
             <button class="btn btn-primary" <%= pushEnabled ? '' : 'disabled' %> onclick="pushBatch(<%= b.id %>, '<%= b.batch_ref %>')">
-              Push to EasyEcom
+              Retry PO now
             </button>
           <% } %>
         </div>
@@ -159,12 +171,11 @@
   async function buildBatch() {
     const btn = document.getElementById('buildBtn'); btn.disabled = true;
     try { const j = await post('/finishingdashboard/ee-po/build');
-      alert(j.created ? ('Batch ' + j.batchRef + ' created: ' + j.lines + ' lines' + (j.blocked ? (', ' + j.blocked + ' blocked') : '')) : j.reason);
+      alert(j.created ? ('Created ' + j.created + ' lot challan(s)') : (j.reason || 'Nothing to sweep'));
       location.reload();
-    } catch (e) { alert('Could not build batch: ' + e.message); btn.disabled = false; }
+    } catch (e) { alert('Could not sweep: ' + e.message); btn.disabled = false; }
   }
   async function pushBatch(id, ref) {
-    if (!confirm('Create Purchase Order ' + ref + ' in EasyEcom? The warehouse will then GRN it on receipt.')) return;
     try { const j = await post('/finishingdashboard/ee-po/push/' + id);
       alert('PO created in EasyEcom: ' + j.poId); location.reload();
     } catch (e) { alert('Push failed: ' + e.message); }
@@ -177,7 +188,6 @@
   async function resolveLine(lineId) {
     const sel = document.getElementById('resSel' + lineId);
     if (!sel || !sel.value) { alert('Pick the EasyEcom SKU first.'); return; }
-    if (!confirm('Map this size to ' + sel.value + '? The mapping is saved permanently and reused everywhere.')) return;
     try {
       const r = await fetch('/finishingdashboard/ee-po/resolve-line', { method: 'POST',
         headers: { 'Content-Type': 'application/json' },

--- a/views/finishingEvents.ejs
+++ b/views/finishingEvents.ejs
@@ -602,6 +602,22 @@
     .sx-dest-row { grid-template-columns: 1fr; }
   }
 
+  /* Inline SKU mapping row under an unmapped size (Warehouse dispatch) */
+  .sx-resolve-row {
+    display: flex; align-items: center; gap: 0.5rem;
+    margin: 0.25rem 0 0.5rem; padding: 0.5rem 0.625rem;
+    background: #fffbeb; border: 1px solid #fde68a; border-radius: var(--r-sm);
+    font-size: 0.8125rem; color: #b45309;
+  }
+  .sx-resolve-row .material-symbols-outlined { font-size: 18px; }
+  .sx-resolve-row .rl { font-weight: 600; white-space: nowrap; }
+  .sx-resolve-row select {
+    flex: 1; min-width: 0; padding: 0.375rem 0.5rem;
+    border: 1px solid #fde68a; border-radius: var(--r-sm);
+    background: #fff; font-family: inherit; font-size: 0.8125rem; color: var(--c-text);
+  }
+  .sx-resolve-row.done { background: #f0fdf4; border-color: #bbf7d0; color: #166534; }
+
   .sx-form-row { margin-top: 0.625rem; }
   .sx-form-row input[type="text"] {
     width: 100%; padding: 0.625rem 0.75rem; box-sizing: border-box;
@@ -1231,6 +1247,7 @@
     </div>
     <div class="flx-actions">
       <a class="flx-home" href="/finishingdashboard" title="Home"><span class="material-symbols-outlined">home</span></a>
+      <a class="flx-home" href="/finishingdashboard/ee-po" title="Warehouse transfers"><span class="material-symbols-outlined">local_shipping</span></a>
       <span class="flx-user"><%= (user && user.username) ? user.username : 'Operator' %></span>
       <a class="flx-logout" href="/logout"><span class="material-symbols-outlined">logout</span><span class="flx-logout-t">Log out</span></a>
     </div>
@@ -1578,17 +1595,16 @@ async function renderActions() {
     cards++;
     wrap.appendChild(buildDoneCard(a));
   });
-  // Dispatch (finishing only) — show card if there's anything ready to ship
+  // Dispatch (finishing only) — one lot-level card, pre-filled, one tap.
   if (STAGE_FEATURES.dispatch) {
     try {
-      const ds = await api('GET', BASE + '/event/dispatch-state/' + currentLot.id);
-      const summary = ds.lot_summary || { available: 0 };
-      if ((summary.available || 0) > 0) {
+      const dp = await api('GET', BASE + '/event/dispatch-preview/' + currentLot.id);
+      if ((dp.available || 0) > 0) {
         cards++;
-        wrap.appendChild(buildDispatchCard(ds));
+        wrap.appendChild(buildDispatchCard(dp));
       }
     } catch (err) {
-      console.warn('dispatch-state failed', err.message);
+      console.warn('dispatch-preview failed', err.message);
     }
   }
   if (cards === 0) {
@@ -1632,37 +1648,22 @@ async function renderActions() {
 }
 
 // ─── Dispatch card (finishing only) ───────────────────────────
-function buildDispatchCard(state) {
+// One card per LOT: pre-filled with everything finished & undispatched, destination
+// defaults to Warehouse, unmapped sizes are fixed inline (once per style-size,
+// permanent), single tap, no popup. Warehouse dispatch returns a challan whose
+// print view opens immediately.
+function buildDispatchCard(preview) {
   const card = document.createElement('div');
-  card.className = 'sx-action-card is-dispatch';
-  const summary = state.lot_summary || { available: 0 };
-
-  card.classList.add('always-open');
+  card.className = 'sx-action-card is-dispatch always-open';
   card.innerHTML = `
     <div class="sx-take-panel">
       <h3 class="sx-panel-h">Dispatch finished pieces
-        <span class="sub">${fmt(summary.available)} ready · ${state.batches.length} batch${state.batches.length === 1 ? '' : 'es'}</span>
+        <span class="sub">${fmt(preview.available)} ready</span>
       </h3>
-      <div id="dispatchForm"></div>
-    </div>
-  `;
-
-  const form = card.querySelector('#dispatchForm');
-  state.batches.forEach((b, idx) => {
-    if ((b.available || 0) === 0) return;
-    const block = document.createElement('div');
-    block.className = 'sx-dispatch-batch';
-    block.dataset.fdId = String(b.finishing_data_id);
-    const created = b.created_at ? new Date(b.created_at).toLocaleDateString(undefined, { day: 'numeric', month: 'short' }) : '';
-    block.innerHTML = `
-      <div class="sx-dispatch-batch-head">
-        Batch <span class="b">#${b.finishing_data_id}</span> · ${fmt(b.available)} available${created ? ' · completed ' + escapeText(created) : ''}
-      </div>
-      <div class="sx-input-list" data-list="dispatch-sizes-${idx}"></div>
+      <div class="sx-input-list" data-list="dispatch-sizes"></div>
       <div class="sx-dest-row">
-        <select data-input="destination-${idx}">
-          <option value="">— Select destination —</option>
-          <option value="Warehouse">Warehouse</option>
+        <select data-input="destination">
+          <option value="Warehouse" selected>Warehouse</option>
           <option value="Ajio">Ajio</option>
           <option value="Myntra">Myntra</option>
           <option value="Amazon">Amazon</option>
@@ -1670,78 +1671,147 @@ function buildDispatchCard(state) {
           <option value="Shopify">Shopify (own store)</option>
           <option value="other">Other…</option>
         </select>
-        <input type="text" placeholder="Custom destination" data-input="custom-dest-${idx}" />
+        <input type="text" placeholder="Custom destination" data-input="custom-dest" style="display:none;" />
       </div>
       <div class="sx-grand">
-        <span class="gl">Dispatching from this batch</span>
-        <span class="gv"><strong data-display="dispatch-total-${idx}">0</strong> pcs</span>
+        <span class="gl">Dispatching</span>
+        <span class="gv"><strong data-display="dispatch-total">0</strong> pcs</span>
       </div>
-      <button class="sx-action-cta" data-action="dispatch-submit" data-idx="${idx}">Dispatch from batch #${b.finishing_data_id}</button>
+      <button class="sx-action-cta" data-action="dispatch-submit"></button>
+    </div>
+  `;
+
+  const sizeList = card.querySelector('[data-list="dispatch-sizes"]');
+  (preview.sizes || []).forEach(s => {
+    if ((s.available || 0) === 0) return;
+    const sRow = document.createElement('div');
+    sRow.className = 'sx-input-row sx-dng';
+    sRow.innerHTML = `
+      <span class="sx-input-label">${escapeText(s.size_label)}</span>
+      <span class="sx-input-avail"><span class="n">${fmt(s.available)}</span> ready</span>
+      <div class="sx-stepper sx-dng-cell">
+        <input type="number" inputmode="numeric" min="0" max="${s.available}" value="${s.available}"
+               data-size="${escapeText(s.size_label)}" data-avail="${s.available}" />
+      </div>
     `;
-
-    const sizeList = block.querySelector(`[data-list="dispatch-sizes-${idx}"]`);
-    b.sizes.forEach(s => {
-      if ((s.available || 0) === 0) return;
-      const sRow = document.createElement('div');
-      sRow.className = 'sx-input-row sx-dng';
-      sRow.innerHTML = `
-        <span class="sx-input-label">${escapeText(s.size_label)}</span>
-        <span class="sx-input-avail"><span class="n">${fmt(s.available)}</span> ready</span>
-        <div class="sx-stepper sx-dng-cell">
-          <input type="number" inputmode="numeric" min="0" max="${s.available}" value="${s.available}"
-                 data-size="${escapeText(s.size_label)}" data-avail="${s.available}" data-batch="${idx}" />
-        </div>
+    bindStepper(sRow, () => recalcDispatchTotal(card));
+    sizeList.appendChild(sRow);
+    // Unmapped size → the fix lives right here in the card. Dropdown of the style's
+    // REAL EasyEcom SKUs only (verified server-side too); saved on pick, forever.
+    if (!s.ee_sku) {
+      const rRow = document.createElement('div');
+      rRow.className = 'sx-resolve-row';
+      rRow.dataset.resolveSize = s.size_label;
+      const opts = (preview.variants || [])
+        .map(v => `<option value="${escapeText(v)}">${escapeText(v)}</option>`).join('');
+      rRow.innerHTML = `
+        <span class="material-symbols-outlined">link</span>
+        <span class="rl">Size ${escapeText(s.size_label)} → EasyEcom SKU</span>
+        <select data-resolve-for="${escapeText(s.size_label)}">
+          <option value="">Pick SKU…</option>${opts}
+        </select>
       `;
-      bindStepper(sRow, () => recalcDispatchTotal(card, idx));
-      sizeList.appendChild(sRow);
-    });
-    form.appendChild(block);
-
-    block.querySelector(`[data-action="dispatch-submit"]`).addEventListener('click',
-      () => doDispatch(card, idx, b.finishing_data_id));
-    recalcDispatchTotal(card, idx);
+      rRow.querySelector('select').addEventListener('change', async (e) => {
+        const sku = e.target.value;
+        if (!sku) return;
+        e.target.disabled = true;
+        try {
+          await api('POST', BASE + '/event/resolve-sku', {
+            style: preview.style, size_label: s.size_label, size_sku: sku,
+          });
+          rRow.classList.add('done');
+          rRow.innerHTML = `<span class="material-symbols-outlined">check_circle</span>
+            <span class="rl">Size ${escapeText(s.size_label)} → ${escapeText(sku)} saved</span>`;
+          delete rRow.dataset.resolveSize;
+          recalcDispatchTotal(card);
+        } catch (err) {
+          e.target.disabled = false;
+          e.target.value = '';
+          toast('Could not save mapping: ' + err.message, 'error');
+        }
+      });
+      sizeList.appendChild(rRow);
+    }
   });
 
+  const destSel = card.querySelector('[data-input="destination"]');
+  const customInput = card.querySelector('[data-input="custom-dest"]');
+  destSel.addEventListener('change', () => {
+    customInput.style.display = destSel.value === 'other' ? '' : 'none';
+    recalcDispatchTotal(card);
+  });
+  card.querySelector('[data-action="dispatch-submit"]').addEventListener('click',
+    () => doDispatchLot(card, preview));
+  recalcDispatchTotal(card);
   return card;
 }
 
-function recalcDispatchTotal(card, idx) {
-  const inputs = card.querySelectorAll(`[data-list="dispatch-sizes-${idx}"] input[data-size]`);
+// Keeps the total AND the CTA honest: the button says exactly what one tap does,
+// and stays off while a Warehouse dispatch still has an unmapped size in play.
+function recalcDispatchTotal(card) {
+  const inputs = card.querySelectorAll('[data-list="dispatch-sizes"] input[data-size]');
   let total = 0;
+  const active = new Set();
   inputs.forEach(i => {
     let v = parseInt(i.value, 10);
     if (!Number.isFinite(v) || v < 0) v = 0;
     const max = Number(i.dataset.avail) || 0;
     if (v > max) { v = max; i.value = v; }
     total += v;
+    if (v > 0) active.add(i.dataset.size);
   });
-  const t = card.querySelector(`[data-display="dispatch-total-${idx}"]`);
+  const t = card.querySelector('[data-display="dispatch-total"]');
   if (t) t.textContent = fmt(total);
+
+  const destSel = card.querySelector('[data-input="destination"]');
+  const dest = destSel ? destSel.value : 'Warehouse';
+  const unresolved = [...card.querySelectorAll('[data-resolve-size]')]
+    .map(r => r.dataset.resolveSize).filter(sz => active.has(sz));
+  const btn = card.querySelector('[data-action="dispatch-submit"]');
+  if (!btn) return;
+  if (dest === 'Warehouse' && unresolved.length) {
+    btn.disabled = true;
+    btn.textContent = `Pick EasyEcom SKU for ${unresolved.join(', ')} first`;
+  } else {
+    btn.disabled = total === 0;
+    const destLabel = dest === 'other' ? 'destination' : dest;
+    btn.textContent = `Dispatch ${fmt(total)} pcs → ${destLabel}`;
+  }
 }
 
-async function doDispatch(card, idx, finishing_data_id) {
-  const inputs = card.querySelectorAll(`[data-list="dispatch-sizes-${idx}"] input[data-size]`);
+async function doDispatchLot(card, preview) {
+  const inputs = card.querySelectorAll('[data-list="dispatch-sizes"] input[data-size]');
   const sizes = [];
   inputs.forEach(i => {
     const p = parseInt(i.value, 10) || 0;
     if (p > 0) sizes.push({ size_label: i.dataset.size, pieces: p });
   });
   if (!sizes.length) { toast('No pieces selected', 'error'); return; }
-  const destSel = card.querySelector(`[data-input="destination-${idx}"]`);
-  const customInput = card.querySelector(`[data-input="custom-dest-${idx}"]`);
+  const destSel = card.querySelector('[data-input="destination"]');
+  const customInput = card.querySelector('[data-input="custom-dest"]');
   let dest = (destSel && destSel.value) || '';
   if (dest === 'other') dest = (customInput && customInput.value || '').trim();
   if (!dest) { toast('Pick a destination', 'error'); return; }
-  const total = sizes.reduce((a, s) => a + s.pieces, 0);
-  if (!confirm('Dispatch ' + fmt(total) + ' pieces from batch #' + finishing_data_id + ' to ' + dest + '?')) return;
+  const btn = card.querySelector('[data-action="dispatch-submit"]');
+  btn.disabled = true;
   try {
-    await api('POST', BASE + '/event/dispatch', {
-      finishing_data_id, destination: dest === 'other' ? 'other' : dest,
+    const out = await api('POST', BASE + '/event/dispatch-lot', {
+      cutting_lot_id: currentLot.id,
+      destination: destSel.value === 'other' ? 'other' : dest,
       custom_destination: dest, sizes,
     });
-    toast('Dispatched ' + fmt(total) + ' pieces ✓', 'success');
+    toast('Dispatched ' + fmt(out.dispatched_total) + ' pieces → ' + dest + ' ✓', 'success');
+    if (out.challan && out.challan.batch_id) {
+      window.open(BASE + '/ee-po/challan/' + out.challan.batch_id + '?print=1', '_blank');
+      if (out.challan.status === 'po_pending') {
+        toast('Challan ' + out.challan.batch_ref + ' saved — PO will reach EasyEcom shortly', 'success');
+      }
+    }
     await refreshState();
-  } catch (err) { toast('Could not dispatch: ' + err.message, 'error'); }
+  } catch (err) {
+    btn.disabled = false;
+    toast('Could not dispatch: ' + err.message, 'error');
+  }
 }
 
 function buildTakeCard() {


### PR DESCRIPTION
## Why

- **KT-DISP-2 proved the all-lots batch model wrong**: 12 lots / 83 lines / 10,449 pcs frozen as one blocked batch because 9 lots had unresolved SKUs — the 3 fully-resolved lots (2,271 pcs) were held hostage.
- The flow was 9 manual things across 2 screens (one unlinked): triple quantity re-typing, destination re-picked every time, a confirm popup, then Build/Push/Check-GRN clicks on a URL nobody can find.

## The new flow (design approved in-session)

**Search → Accept → Complete → ONE tap.** The dispatch card is now one card per LOT:

- Pre-filled with every finished undispatched piece (edit only if holding back), aggregated across the operator's finishing batches and allocated FIFO internally (pure, unit-tested `utils/dispatchAllocation.js`).
- Destination defaults to **Warehouse**; no confirm popup — the CTA says exactly what it does (`Dispatch 1,224 pcs → Warehouse`).
- Unmapped sizes are fixed **inline in the card** (verified dropdown, saved to `pm_sku_resolution` forever via shared `saveSkuMapping`). The CTA stays off until the sizes in play are mapped.
- The tap writes `finishing_dispatches`, creates that lot's own batch **`KT-DISP-<id>-<lot_no>`** in the same transaction, pushes the PO **after commit** (EasyEcom down ⇒ dispatch still succeeds, batch stays draft, background retry), and **opens a printable challan** that travels with the goods (reference = PO referenceCode; warehouse GRNs challan-by-challan).

**Transfers tab** (old ee-po screen, now linked from the finishing top bar): status chips (PO pending / Needs SKU / At EasyEcom / Received (GRN)), challan reprint, inline resolution for legacy blocked lines, retry for failed pushes. Build/Check-GRN buttons replaced by a **30-min housekeeping cron** (armed by `EE_GRN_PUSH`): `sweepLotBatches` → `autoPushDrafts` → `confirmGrns`.

## Invariants untouched

- Accept/Complete payment engine **byte-identical** (diff-checked — no take/complete payload code in this diff).
- Nothing ever writes EasyEcom inventory; PO-only, warehouse approves by manual GRN.
- `EE_PO_SINCE` cutoff + `dispatch_id` UNIQUE idempotency + EE's PO-quantity cap all stay.

## ⚠️ Deploy order

1. **Before merging/deploying**: apply `sql/2026_07_ee_dispatch_po_lotwise.sql` (adds `ee_dispatch_po.lot_no` — additive, instant).
2. After deploy: run `sql/2026_07_ktdisp2_remediation.sql` (cancels KT-DISP-2, releases its 83 lines; the sweep rebuilds them lot-wise — resolved lots push immediately).

## Verification

- 181/181 tests pass (9 new allocator tests: FIFO across batches, over-ask, duplicates, unknown sizes).
- All 3 touched/new views render with route-accurate locals + every inline script parses (`new Function`), including blocked/failed/empty transfer states and the challan with/without PO.
- E2E against prod read-only (stubbed finishing session, real data): `dispatch-preview` for sw541 → 872 pcs, L/M/XL all auto-resolved via concat convention; challan for KT-DISP-1 renders; transfers screen renders.
- Design doc §9 + 00-PROGRESS updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)