### PR TITLE
Fix sku-management 500: user missing from render locals

### DIFF
--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -1896,6 +1896,7 @@ router.get("/sku-management", isAuthenticated, isOperator, async (req, res) => {
     // If no sku specified, just render the page with empty results
     if (!sku) {
       return res.render("skuManagement", {
+        user: req.session.user,
         sku: "",
         results: [],
         message: "",
@@ -1920,6 +1921,7 @@ router.get("/sku-management", isAuthenticated, isOperator, async (req, res) => {
 
     // Render the EJS template with the found results
     return res.render("skuManagement", {
+      user: req.session.user,
       sku,
       results,
       message: "",


### PR DESCRIPTION
## What

`/operator/sku-management` 500'd in prod with `ReferenceError: user is not defined` at [views/skuManagement.ejs:2](views/skuManagement.ejs#L2) — the navbar include needs `user`, but the route never passed it (app.js only puts `error`/`success` on `res.locals`, not `user`). Pre-existing break, surfaced when #563 restored the hub link. Both render calls now pass `user: req.session.user`.

My earlier E2E missed it because the test stub set `res.locals.user` — now the stub mirrors prod exactly and the page renders 200 with real data (KTTWOMENSPANT677 → Cutting Lots 121, Stitching 88, Finishing 4, Payment Ledger 78). 181/181 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)