### PR TITLE
Rename session cookie to __session (prerequisite for retiring the load balancer)

### DIFF
--- a/app.js
+++ b/app.js
@@ -125,6 +125,10 @@ if (!sessionSecret && process.env.NODE_ENV === 'production') {
 const isProduction = !!(process.env.K_SERVICE || process.env.NODE_ENV === 'production');
 
 app.use(session({
+    // '__session' is the ONLY cookie Firebase Hosting's CDN forwards to a rewritten
+    // Cloud Run backend — erpkotty.in is served through it (LB retired 2026-07).
+    // Renaming logs every user out exactly once at deploy. Do not change it back.
+    name: '__session',
     secret: sessionSecret || 'dev-only-secret-not-for-production',
     store: sessionStore,
     resave: false,


### PR DESCRIPTION
## Why

We're replacing the external load balancer (**₹1,154/mo**, 32% of the project's GCP bill) with a free Firebase Hosting rewrite in front of the same Cloud Run service. Firebase's CDN forwards **only** a cookie named `__session` to the backend — with the default `connect.sid` name, login would break behind the new front.

## What

One config line in [app.js](app.js): `name: '__session'` on the session middleware. No other code references the cookie name (verified — no `connect.sid`/`clearCookie` anywhere).

## Impact

⚠️ **Every user is logged out exactly once when this deploys** (their old cookie name is no longer read). They log back in and everything is normal. Best merged at a quiet hour.

Works identically on the current LB path — this is safe to deploy before the DNS cutover, and must be.

181/181 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)