### PR TITLE
Analyst fixes: style-SKU sales matching, double-count trap, timeout paths, Gemini Pro

### DIFF
--- a/utils/aiAnalyst.js
+++ b/utils/aiAnalyst.js
@@ -23,7 +23,8 @@ const env = global.env || process.env;
 const GCP_PROJECT = env.AI_GCP_PROJECT || 'kotty-track-prod';
 const CLAUDE_MODEL = env.AI_CLAUDE_MODEL || 'claude-sonnet-5';
 const CLAUDE_REGION = env.AI_CLAUDE_REGION || 'global';
-const GEMINI_MODEL = env.AI_GEMINI_MODEL || 'gemini-2.5-flash';
+const GEMINI_MODEL = env.AI_GEMINI_MODEL || 'gemini-2.5-pro';
+const GEMINI_FALLBACK_MODEL = env.AI_GEMINI_FALLBACK_MODEL || 'gemini-2.5-flash';
 const GEMINI_REGION = env.AI_GEMINI_REGION || 'us-central1';
 
 const MAX_TOOL_CALLS = 6;
@@ -151,6 +152,21 @@ function getGemini() {
 }
 
 async function askGemini(history, question, steps, deadline) {
+  try {
+    const answer = await askGeminiModel(GEMINI_MODEL, history, question, steps, deadline);
+    return { answer, model: GEMINI_MODEL };
+  } catch (err) {
+    if (GEMINI_FALLBACK_MODEL && GEMINI_FALLBACK_MODEL !== GEMINI_MODEL) {
+      console.error(`[ai] ${GEMINI_MODEL} unavailable, falling back to ${GEMINI_FALLBACK_MODEL}:`, err.message && err.message.slice(0, 160));
+      steps.length = 0;
+      const answer = await askGeminiModel(GEMINI_FALLBACK_MODEL, history, question, steps, deadline);
+      return { answer, model: GEMINI_FALLBACK_MODEL };
+    }
+    throw err;
+  }
+}
+
+async function askGeminiModel(model, history, question, steps, deadline) {
   const ai = getGemini();
   const contents = [
     ...history.map((m) => ({ role: m.role === 'assistant' ? 'model' : 'user', parts: [{ text: m.content }] })),
@@ -167,7 +183,7 @@ async function askGemini(history, question, steps, deadline) {
     }],
   };
   for (let i = 0; i <= MAX_TOOL_CALLS; i++) {
-    const response = await ai.models.generateContent({ model: GEMINI_MODEL, contents, config });
+    const response = await ai.models.generateContent({ model, contents, config });
     const calls = response.functionCalls || [];
     if (!calls.length) {
       const text = (response.text || '').trim();
@@ -201,8 +217,8 @@ async function ask(history, question) {
     console.error('[ai] Claude unavailable, falling back to Gemini:', err.message && err.message.slice(0, 200));
   }
   steps.length = 0;
-  const answer = await askGemini(history, question, steps, deadline);
-  return { answer, steps, model: GEMINI_MODEL };
+  const { answer, model } = await askGemini(history, question, steps, deadline);
+  return { answer, steps, model };
 }
 
 module.exports = { ask, runSqlTool, SYSTEM_PROMPT };

--- a/utils/aiSchemaDoc.js
+++ b/utils/aiSchemaDoc.js
@@ -57,15 +57,32 @@ Stage order: cutting → stitching → [jeans_assembly → washing → washing_i
   DESCRIBE the table first if you need exact column names.
 
 ## Sales & inventory (EasyEcom mirror — size-SKU space)
-- ee_orders / ee_suborders: marketplace orders; suborders carry sku (size-SKU),
-  quantity, order_date/created_at, marketplace, status.
-- ee_sales_daily: per size-SKU per day sales qty (the DRR source).
+⚠ THE #1 MISTAKE: sales tables use SIZE-SKUs. A question about a STYLE
+(e.g. 'KTTWOMENSPANT261') finds NOTHING with sku = 'KTTWOMENSPANT261'.
+ALWAYS match styles with sku LIKE 'KTTWOMENSPANT261%'. If any SKU lookup
+returns 0 rows, retry with LIKE before concluding "no sales".
+
+- ee_sales_daily — USE THIS FOR ALL SALES QUESTIONS (small + indexed on
+  sale_date). Columns: sku, warehouse_id, sale_date (DATE), qty, revenue,
+  source. ⚠ source has TWO values ('orders_api', 'mini_sales_report') that
+  are two feeds of the SAME sales — summing both DOUBLE-COUNTS. Always
+  filter source = 'orders_api' (the source of record).
+  Top sellers: SELECT sku, SUM(qty) FROM ee_sales_daily WHERE source='orders_api'
+  AND sale_date >= CURDATE() - INTERVAL 7 DAY GROUP BY sku ORDER BY 2 DESC LIMIT 10.
+- ee_suborders: order LINES (sku size-SKU, quantity, selling_price, status,
+  order_date, marketplace_sku, size, order_id → ee_orders). ⚠ order_date here
+  is NOT indexed — a date-range scan TIMES OUT (10s cap). For date-bounded
+  order questions JOIN ee_orders o ON o.order_id = s.order_id and filter
+  o.order_date (indexed); or filter by sku first (indexed). Exclude
+  status = 'Cancelled' when counting real sales; 'Returned' exists too.
+- ee_orders: order headers (order_id, marketplace, order_status, order_date
+  [indexed], total_amount, order_quantity, warehouse_id).
 - ee_inventory_daily_snapshot: per size-SKU per day stock-on-hand snapshots.
 - ee_stock_status / ee_inventory_health / ee_inventory_aging: current SOH,
   day cover, aging.
 - ee_product_master: all ~90k EasyEcom SKUs (sku, active, cost, mrp).
-Metrics: DRR = average daily sales (e.g. 30-day AVG of ee_sales_daily.qty);
-DOH/day-cover = SOH ÷ DRR.
+Metrics: DRR = average daily sales (30-day AVG of ee_sales_daily.qty with
+source='orders_api'); DOH/day-cover = SOH ÷ DRR.
 
 ## Users & roles
 - users: id, username, is_active, role via roles table (users.role_id →
@@ -81,5 +98,10 @@ DOH/day-cover = SOH ÷ DRR.
   "taken/accepted" → approve events; "completed/done" → complete events;
   "in hand / inline / WIP" → approved − completed − inline rejects.
 - Prefer answering with small aggregated tables, not row dumps.
+- Queries are killed at 10 seconds. On big tables (ee_suborders ~560k,
+  ee_orders ~490k, ee_inventory_daily_snapshot ~3M rows) always filter on an
+  indexed column (sku, order_id, sale_date, order_date on ee_orders) BEFORE
+  aggregating. If a query times out, rewrite it against a smaller/indexed
+  table (usually ee_sales_daily) instead of retrying the same query.
 - If unsure a table/column exists: SHOW TABLES LIKE '%…%' or DESCRIBE <table>.
 `;


### PR DESCRIPTION
## What the user caught (live, minutes after merge)

1. *"There were no sales for KTTWOMENSPANT261 this week"* — **wrong**. It matched the STYLE name exactly against EasyEcom size-SKUs (`KTTWOMENSPANT261M/L/XL…`). True answer: **5,538 pcs in 7 days**.
2. *"Highest-selling product this week"* — **timed out**: it aggregated `ee_suborders` by `order_date`, which has no index (560k-row scan > 10s cap).

## Fixes (all in the schema brief + model bump — no engine changes)

- **The #1 rule, top of the sales section**: styles must be matched with `sku LIKE 'STYLE%'`; any 0-row SKU lookup retries with LIKE before concluding "no sales".
- **`ee_sales_daily` is THE sales table** — and it carries TWO feeds of the same sales (`orders_api` + `mini_sales_report`): summing both **double-counts** (~10.8k vs the true 5.5k for this very style). Brief mandates `source='orders_api'`, with a worked top-sellers query.
- **Timeout playbook**: `ee_suborders.order_date` is unindexed — date questions join `ee_orders` (indexed) or filter by sku first; exclude `Cancelled`; on timeout, rewrite against a smaller/indexed table instead of retrying.
- **Fallback model upgraded to `gemini-2.5-pro`** (with automatic flash retry, and correct model attribution in the UI). Claude Sonnet stays primary once the Vertex quota lands.

## Verified live (same questions, against prod)

- "How many pieces of KTTWOMENSPANT261 did we sell this week?" → 1 query, 211ms → **5,538 pcs** ✓
- "Which product sold the most this week?" → 1 query, 1.7s → **KTTWOMENSPANT677XL, 2,609 pcs** ✓ (no timeout)
- 191/191 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)