### PR TITLE
Analyst: never answer from chat memory — every question forces a fresh query

### DIFF
--- a/utils/aiAnalyst.js
+++ b/utils/aiAnalyst.js
@@ -70,6 +70,10 @@ production ERP. You answer questions from operators and the production manager b
 querying the live MySQL database with the run_sql tool (read-only).
 
 How to work:
+- EVERY number you state must come from a run_sql result in THIS turn. Never
+  answer a data question from memory or from earlier messages in the chat —
+  earlier answers may be stale or wrong. If the user repeats or doubts a
+  question, re-query from scratch rather than restating a previous answer.
 - Think about which tables answer the question, query, and iterate if a query
   errors or a table/column differs from the brief (DESCRIBE it, then retry).
 - Keep queries aggregated and small. Never dump raw tables.
@@ -115,6 +119,9 @@ async function askClaude(history, question, steps, deadline) {
       max_tokens: 3000,
       system: SYSTEM_PROMPT,
       tools: [SQL_TOOL_DEF],
+      // First round MUST query — answering from chat history is how stale
+      // wrong answers get repeated.
+      tool_choice: i === 0 ? { type: 'any' } : { type: 'auto' },
       messages,
     });
     const toolUses = response.content.filter((b) => b.type === 'tool_use');
@@ -172,7 +179,7 @@ async function askGeminiModel(model, history, question, steps, deadline) {
     ...history.map((m) => ({ role: m.role === 'assistant' ? 'model' : 'user', parts: [{ text: m.content }] })),
     { role: 'user', parts: [{ text: question }] },
   ];
-  const config = {
+  const baseConfig = {
     systemInstruction: SYSTEM_PROMPT,
     tools: [{
       functionDeclarations: [{
@@ -183,6 +190,11 @@ async function askGeminiModel(model, history, question, steps, deadline) {
     }],
   };
   for (let i = 0; i <= MAX_TOOL_CALLS; i++) {
+    // First round MUST query (mode ANY) — answering from chat history is how
+    // stale wrong answers get repeated. Later rounds are free to conclude.
+    const config = i === 0
+      ? { ...baseConfig, toolConfig: { functionCallingConfig: { mode: 'ANY', allowedFunctionNames: ['run_sql'] } } }
+      : baseConfig;
     const response = await ai.models.generateContent({ model, contents, config });
     const calls = response.functionCalls || [];
     if (!calls.length) {


### PR DESCRIPTION
## The bug (from the built-in audit trail)

The repeated wrong answer (*"no sales for KTTWOMENSPANT261"* — after #568 was already deployed) ran **zero SQL queries**: `ai_chat_messages` shows an empty `steps` array. The chat's history contained the model's own earlier wrong answer, and it simply restated it. Classic history poisoning — the schema fixes never got a chance to run.

## Fix

1. **Every question now forces at least one query**: first round uses Claude `tool_choice: any` / Gemini `functionCallingConfig.mode: ANY`. It is structurally impossible to answer a question without touching the database.
2. **System prompt rule**: every stated number must come from a run_sql result *in this turn*; when the user repeats or doubts a question, re-query from scratch.

## Verified on the exact failure scenario

Replayed a chat whose history contains the wrong "no sales" answer, then asked again → **2 fresh queries → "You are correct, my apologies… We sold 5,538 pieces of style KTTWOMENSPANT261 in the last 7 days"** with a per-size table. 191/191 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)