### PR TITLE
Operator: set a cutting user's denim/hosiery flow (with history freeze)

### DIFF
--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -1887,6 +1887,71 @@ const SKU_RENAME_TABLES = [
   { tableName: "pm_sku_resolution",  label: "EasyEcom SKU Mappings",   col: "cl_sku", hasLot: false, guarded: true },
 ];
 
+// ==================================================================
+//   CUTTING USERS — denim/hosiery flag management (operator)
+//   users.is_denim_cutter decides the DEFAULT flow for lots that cutter
+//   creates, and (legacy) classifies old lots whose flow_type is NULL.
+//   To keep history stable, flipping a user FIRST freezes every NULL
+//   flow_type lot of theirs to its currently-effective value, THEN flips
+//   the flag — so the change only affects lots created from now on.
+// ==================================================================
+
+router.get('/cutting-users', isAuthenticated, isOperator, async (req, res) => {
+  try {
+    const [users] = await pool.query(
+      `SELECT u.id, u.username, u.is_denim_cutter, u.is_active,
+              COUNT(cl.id) AS lot_count, MAX(cl.created_at) AS last_lot_at
+         FROM users u
+         JOIN roles r ON r.id = u.role_id AND r.name = 'cutting_manager'
+    LEFT JOIN cutting_lots cl ON cl.user_id = u.id
+        GROUP BY u.id
+        ORDER BY lot_count DESC, u.username`);
+    res.render('cuttingUsers', { user: req.session.user, users });
+  } catch (err) {
+    console.error('GET /operator/cutting-users error:', err);
+    res.status(500).send('Could not load cutting users: ' + err.message);
+  }
+});
+
+router.post('/cutting-users/flow', isAuthenticated, isOperator, async (req, res) => {
+  let conn;
+  try {
+    const userId = Number(req.body.user_id);
+    const denim = req.body.denim ? 1 : 0;
+    if (!Number.isFinite(userId) || userId <= 0) return res.status(400).json({ error: 'Invalid user' });
+
+    conn = await pool.getConnection();
+    await conn.beginTransaction();
+    const [[target]] = await conn.query(
+      `SELECT u.id, u.username, u.is_denim_cutter FROM users u
+         JOIN roles r ON r.id = u.role_id AND r.name = 'cutting_manager'
+        WHERE u.id = ? FOR UPDATE`, [userId]);
+    if (!target) { await conn.rollback(); return res.status(404).json({ error: 'Cutting user not found' }); }
+
+    // Freeze history: stamp each NULL-flow lot with what the system currently
+    // treats it as (flag → prefix fallback), so the flip can't re-classify it.
+    const [frozen] = await conn.query(
+      `UPDATE cutting_lots
+          SET flow_type = CASE
+            WHEN ? = 1 THEN 'denim'
+            WHEN ? IS NULL AND (lot_no LIKE 'AK%' OR lot_no LIKE 'UM%') THEN 'denim'
+            ELSE 'hosiery' END
+        WHERE user_id = ? AND flow_type IS NULL`,
+      [target.is_denim_cutter, target.is_denim_cutter, userId]);
+
+    await conn.query(`UPDATE users SET is_denim_cutter = ? WHERE id = ?`, [denim, userId]);
+    await conn.commit();
+    console.log(`[cutting-users] ${req.session.user.username} set ${target.username} → ${denim ? 'denim' : 'hosiery'} (froze ${frozen.affectedRows} legacy lots)`);
+    res.json({ success: true, denim, frozen_lots: frozen.affectedRows });
+  } catch (err) {
+    if (conn) try { await conn.rollback(); } catch (_) {}
+    console.error('POST /operator/cutting-users/flow error:', err);
+    res.status(500).json({ error: err.message });
+  } finally {
+    if (conn) conn.release();
+  }
+});
+
 // GET /operator/sku-management
 // Renders an EJS page with optional ?sku= query param
 router.get("/sku-management", isAuthenticated, isOperator, async (req, res) => {

--- a/views/cuttingUsers.ejs
+++ b/views/cuttingUsers.ejs
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Cutting Users — Denim / Hosiery</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@600;700&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+  <style>
+    :root{ --ink:#0f172a; --muted:#64748b; --line:#e5e7eb; --bg:#f7f8fa; --card:#fff; --blue:#2563eb; --blue-bg:#eff6ff; }
+    *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--ink);font-family:'Inter',sans-serif;font-size:15px;}
+    .material-symbols-outlined{font-variation-settings:'FILL' 0,'wght' 400;vertical-align:middle;}
+    .top{position:fixed;top:0;left:0;right:0;height:56px;z-index:50;background:var(--bg);border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between;padding:0 16px;}
+    .top .brand{display:flex;align-items:center;gap:10px;} .top .brand .material-symbols-outlined{color:var(--blue);}
+    .top h1{font-family:'Space Grotesk',sans-serif;font-weight:700;font-size:17px;text-transform:uppercase;letter-spacing:.07em;color:var(--blue);margin:0;}
+    .top a{color:var(--muted);display:flex;text-decoration:none;}
+    .wrap{max-width:760px;margin:0 auto;padding:76px 16px 40px;}
+    .note{font-size:13px;background:var(--blue-bg);color:#1e40af;border-radius:10px;padding:10px 14px;margin-bottom:14px;line-height:1.5;}
+    .card{background:var(--card);border:1px solid var(--line);border-radius:12px;padding:6px 0;}
+    .row{display:flex;align-items:center;gap:12px;padding:12px 16px;border-bottom:1px solid #f1f5f9;}
+    .row:last-child{border-bottom:0;}
+    .row .who{flex:1;min-width:0;}
+    .row .who .name{font-weight:600;} .row .who .name .inactive{color:var(--muted);font-weight:400;font-size:12px;}
+    .row .who .meta{color:var(--muted);font-size:12px;margin-top:2px;}
+    .seg{display:flex;border:1px solid var(--line);border-radius:999px;overflow:hidden;}
+    .seg button{border:0;background:var(--card);padding:7px 16px;font-family:inherit;font-size:13px;font-weight:600;cursor:pointer;color:var(--muted);}
+    .seg button.on-denim{background:#1e3a8a;color:#fff;}
+    .seg button.on-hosiery{background:#0d9488;color:#fff;}
+    .seg button:disabled{cursor:wait;opacity:.6;}
+    .toast{position:fixed;bottom:20px;left:50%;transform:translateX(-50%);background:var(--ink);color:#fff;padding:10px 18px;border-radius:10px;font-size:14px;display:none;z-index:60;}
+  </style>
+</head>
+<body>
+<header class="top">
+  <div class="brand"><span class="material-symbols-outlined">content_cut</span><h1>Cutting Users</h1></div>
+  <a href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
+</header>
+<main class="wrap">
+  <div class="note">
+    <strong>Denim</strong> lots travel cutting → stitching → assembly → washing → washing-in → finishing;
+    <strong>hosiery</strong> lots skip the middle. This flag sets the <strong>default</strong> for lots the
+    user creates from now on (the cutting screen can still override per lot). Old lots are frozen to their
+    current flow automatically when you flip — history never changes.
+  </div>
+  <div class="card">
+    <% users.forEach(function(u){ %>
+      <div class="row" data-user="<%= u.id %>">
+        <div class="who">
+          <div class="name"><%= u.username %><% if (!u.is_active) { %> <span class="inactive">(inactive)</span><% } %></div>
+          <div class="meta"><%= u.lot_count %> lots<% if (u.last_lot_at) { %> · last <%= new Date(u.last_lot_at).toLocaleDateString('en-IN',{day:'2-digit',month:'short',timeZone:'Asia/Kolkata'}) %><% } %></div>
+        </div>
+        <div class="seg">
+          <button class="b-denim <%= u.is_denim_cutter == 1 ? 'on-denim' : '' %>" onclick="setFlow(<%= u.id %>, 1, this)">Denim</button>
+          <button class="b-hosiery <%= u.is_denim_cutter == 1 ? '' : 'on-hosiery' %>" onclick="setFlow(<%= u.id %>, 0, this)">Hosiery</button>
+        </div>
+      </div>
+    <% }) %>
+  </div>
+</main>
+<div class="toast" id="toast"></div>
+<script>
+function toast(msg){ const t=document.getElementById('toast'); t.textContent=msg; t.style.display='block'; clearTimeout(t._h); t._h=setTimeout(()=>t.style.display='none', 3500); }
+async function setFlow(userId, denim, btn){
+  const row = btn.closest('.row');
+  row.querySelectorAll('button').forEach(b=>b.disabled=true);
+  try{
+    const r = await fetch('/operator/cutting-users/flow', { method:'POST',
+      headers:{'Content-Type':'application/json'}, body: JSON.stringify({ user_id:userId, denim }) });
+    const j = await r.json();
+    if(!r.ok || j.error) throw new Error(j.error || ('HTTP '+r.status));
+    row.querySelector('.b-denim').classList.toggle('on-denim', !!denim);
+    row.querySelector('.b-hosiery').classList.toggle('on-hosiery', !denim);
+    toast('Saved — new lots default to '+(denim?'denim':'hosiery')+(j.frozen_lots?(' ('+j.frozen_lots+' old lots frozen to their current flow)'):''));
+  }catch(e){ toast('Could not save: '+e.message); }
+  row.querySelectorAll('button').forEach(b=>b.disabled=false);
+}
+</script>
+</body>
+</html>

--- a/views/floorHub.ejs
+++ b/views/floorHub.ejs
@@ -104,6 +104,7 @@
         ['/po-creator/operator/dashboard','inventory_2','PO Management','Purchase orders','po purchase',false],
         ['/returns/dashboard','keyboard_return','Returns','Returns dashboard','return',false],
         ['/operator/ai','psychology','Kotty Analyst','Ask AI about production, sales & payments','ai analyst ask chat claude gemini question data',false],
+        ['/operator/cutting-users','content_cut','Cutting Users','Denim / hosiery flow per cutter','cutting user denim hosiery flow cutter flag',false],
         ['/operator/sku-categories','sell','SKU Categories','Manage categories','sku category',false],
         ['/operator/sku-management','edit_note','SKU Management','Rename a SKU across every table','sku rename edit change management update',false],
         ['/operator/system-health','monitor_heart','System Health','Uptime & service checks','uptime health status monitoring',false],


### PR DESCRIPTION
## What

**`/operator/cutting-users`** (new hub card, Management section): every cutting_manager-role user with their lot count and a **Denim / Hosiery** toggle. One tap flips the user's `is_denim_cutter` flag.

## What the flag impacts (the analysis behind the design)

1. **New lots**: it's the DEFAULT `flow_type` when that cutter creates a lot (the cutting screen's per-lot selector still overrides). This is the only *intended* effect.
2. **Legacy lots with `flow_type` NULL** (7,673 old lots — none cut in the last 60 days): stage routing and reports fall back to the cutter's flag (then the AK/UM prefix rule). A naive flip would silently re-classify a cutter's entire history — moving old lots between denim/hosiery in dashboards, TAT and consumption reports.

## The safety mechanism

The flip runs in a transaction that **first freezes** every NULL-flow lot of that cutter to its *currently-effective* value (exactly mirroring the fallback rule: flag=1 → denim; flag NULL + AK/UM prefix → denim; else hosiery), **then** changes the flag. History is stamped and immune; only lots created after the flip see the new default. The UI toast reports how many legacy lots were frozen.

Verified: 191/191 tests, view renders + script parses; prod data audit confirms zero in-flight NULL-flow lots (60-day window), so even the freeze itself only touches closed history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)