### PR TITLE
Analyst: full lot dossier by lot or manual number, faster + date-aware

### DIFF
--- a/utils/aiAnalyst.js
+++ b/utils/aiAnalyst.js
@@ -27,7 +27,7 @@ const GEMINI_MODEL = env.AI_GEMINI_MODEL || 'gemini-2.5-pro';
 const GEMINI_FALLBACK_MODEL = env.AI_GEMINI_FALLBACK_MODEL || 'gemini-2.5-flash';
 const GEMINI_REGION = env.AI_GEMINI_REGION || 'us-central1';
 
-const MAX_TOOL_CALLS = 6;
+const MAX_TOOL_CALLS = 10; // rounds; each round may batch several run_sql calls
 const DEADLINE_MS = 45000; // stay under the 60s edge timeout with margin
 const HISTORY_TURNS = 12;  // prior messages replayed to the model
 
@@ -65,6 +65,12 @@ async function runSqlTool(rawSql) {
   }
 }
 
+// Built per request so the model knows today's date (models don't).
+function systemPrompt() {
+  const today = new Date().toLocaleDateString('en-IN', { weekday: 'long', day: '2-digit', month: 'short', year: 'numeric', timeZone: 'Asia/Kolkata' });
+  return `Today is ${today} (IST).\n\n${SYSTEM_PROMPT}`;
+}
+
 const SYSTEM_PROMPT = `You are Kotty Analyst, the data analyst for KOTTY's garment
 production ERP. You answer questions from operators and the production manager by
 querying the live MySQL database with the run_sql tool (read-only).
@@ -74,6 +80,10 @@ How to work:
   answer a data question from memory or from earlier messages in the chat —
   earlier answers may be stale or wrong. If the user repeats or doubts a
   question, re-query from scratch rather than restating a previous answer.
+- Your reply is the ONLY one the user gets — you cannot post follow-ups.
+  NEVER say "I will retrieve/post/gather X" — gather EVERYTHING first, then
+  answer completely. When many queries are needed (e.g. a lot dossier),
+  BATCH them: issue several run_sql calls together in one round.
 - Think about which tables answer the question, query, and iterate if a query
   errors or a table/column differs from the brief (DESCRIBE it, then retry).
 - Keep queries aggregated and small. Never dump raw tables.
@@ -117,7 +127,7 @@ async function askClaude(history, question, steps, deadline) {
     const response = await client.messages.create({
       model: CLAUDE_MODEL,
       max_tokens: 3000,
-      system: SYSTEM_PROMPT,
+      system: systemPrompt(),
       tools: [SQL_TOOL_DEF],
       // First round MUST query — answering from chat history is how stale
       // wrong answers get repeated.
@@ -180,7 +190,7 @@ async function askGeminiModel(model, history, question, steps, deadline) {
     { role: 'user', parts: [{ text: question }] },
   ];
   const baseConfig = {
-    systemInstruction: SYSTEM_PROMPT,
+    systemInstruction: systemPrompt(),
     tools: [{
       functionDeclarations: [{
         name: SQL_TOOL_DEF.name,

--- a/utils/aiSchemaDoc.js
+++ b/utils/aiSchemaDoc.js
@@ -47,14 +47,19 @@ Stage order: cutting → stitching → [jeans_assembly → washing → washing_i
   batch_ref 'KT-DISP-<id>-<lot_no>', lot_no, status ENUM draft/blocked/pushed/
   confirmed/failed/cancelled ('blocked' = a size has no EasyEcom SKU mapping;
   'confirmed' = warehouse GRN'd it in EasyEcom), po_id, total_qty, created_at.
-- pm_lot_audit_log: admin corrections (flow_change/stage_reversal/qty_edit).
+- pm_lot_audit_log: admin corrections. EXACT columns: cutting_lot_id, lot_no,
+  action ('flow_change'/'stage_reversal'/'qty_edit'), detail (JSON),
+  performed_by_name, created_at.
 
 ## Payments (per-piece piecework)
-- stage_payments: the ledger of what workers earned (user_id worker, lot_no,
-  sku, stage, pieces, rate, amount, created_at). One row per approve handover.
-- stage_debits: deductions. stage_rates / stage_extra_rates: rate cards keyed
-  by (sku, stage). If a rate is missing the payment row may be pending.
-  DESCRIBE the table first if you need exact column names.
+- stage_payments (worker earnings, one row per approve handover). EXACT
+  columns: user_id, username, lot_no, sku, stage, qty, base_rate,
+  extra_amount, total_amount, rate_configured, status, paid_on, created_at.
+  Amount earned = total_amount; pieces = qty. rate_configured=0 means the
+  rate card was missing and the row is pending a rate.
+- stage_debits (deductions): user_id, username, lot_no, sku, stage, qty,
+  rate, amount, reason, status, created_at.
+- stage_rates / stage_extra_rates: rate cards keyed by (sku, stage).
 
 ## Sales & inventory (EasyEcom mirror — size-SKU space)
 ⚠ THE #1 MISTAKE: sales tables use SIZE-SKUs. A question about a STYLE
@@ -88,6 +93,28 @@ source='orders_api'); DOH/day-cover = SOH ÷ DRR.
 - users: id, username, is_active, role via roles table (users.role_id →
   roles.id, roles.name: 'operator','production_manager','finishing',
   'stitching_master', 'cutting_manager', …). DESCRIBE to confirm.
+
+## LOT DOSSIER PLAYBOOK — "tell me everything about lot X"
+When asked for details of a lot (any depth), follow this:
+1. RESOLVE: the number may be lot_no OR manual_lot_number —
+   SELECT ... FROM cutting_lots WHERE lot_no = 'X' OR manual_lot_number = 'X'.
+   ⚠ manual_lot_number is NOT unique (up to 7 lots share one). If several
+   match and the user named the cutter, filter by users.username; otherwise
+   list the matches (lot_no, style, cutter, date, pieces) and ask which one.
+2. After resolving the lot id, issue ALL of the remaining queries BATCHED in
+   ONE round (multiple run_sql calls together — do not go one at a time):
+   - cutting_lots row (style, fabric, flow, pieces, cutter, dates, remark)
+   - cutting_lot_sizes GROUP BY size_label
+   - cutting_lot_rolls (roll numbers + weights)
+   - each stage's events: approved/completed/rejected totals + first/last
+     dates + operators (stitching→finishing per the lot's flow)
+   - {stage}_data batches (who produced what, when)
+   - finishing_dispatches (destination, size, qty, dates)
+   - ee_dispatch_po + lines where lot_no matches (challan/PO/GRN status)
+   - stage_payments for the lot (stage, worker, pieces, amount)
+   - pm_lot_audit_log entries (admin corrections)
+3. Present as short titled sections in pipeline order, dates inline.
+   Skip empty sections with one line ("No dispatches yet").
 
 ## Conventions & gotchas
 - The session time zone is IST (+05:30): NOW() and all TIMESTAMP columns read


### PR DESCRIPTION
## What

Ask the analyst *"I need all the details for lot 1278km"* (a MANUAL lot number) and it now delivers the complete dossier in one reply: cutting + fabric + sizes, every stage with dates and operators, dispatches, challan/PO status, **worker payments** (it even flags rate-not-configured pending payments), and the admin audit history.

- **Manual lot numbers resolve properly** — and since they duplicate (one number shared by up to 7 lots), it disambiguates by the cutter when you mention one, or lists the matches and asks.
- **Batched queries**: after resolving the lot, all dossier queries go in ONE round. Live test: 35s, 9 queries, 0 errors (was 66s — over the 60s edge timeout — with 2 column-guess errors).
- **Knows today's date** (injected per request, IST) — no more "these dates appear to be in the future".
- **No more promised follow-ups**: the prompt forbids "I will gather X and post it" — everything is fetched before answering, because there is no second message.
- Exact `stage_payments` / `pm_lot_audit_log` columns in the brief (no wasted DESCRIBE rounds).

191/191 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)