### PR TITLE
Kotty Analyst: Stitch redesign — evidence receipts + collapsible/resizable sidebar

### DIFF
--- a/views/aiAnalyst.ejs
+++ b/views/aiAnalyst.ejs
@@ -4,71 +4,113 @@
   <meta charset="UTF-8" />
   <title>Kotty Analyst</title>
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Space+Grotesk:wght@500;600;700&family=JetBrains+Mono:wght@400;500&family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
   <style>
-    :root{ --ink:#0f172a; --muted:#64748b; --line:#e5e7eb; --bg:#f7f8fa; --card:#fff;
-           --blue:#2563eb; --blue-bg:#eff6ff; --green:#16a34a; --amber-bg:#fef3c7; --amber:#b45309; }
+    :root{ --ink:#0f172a; --muted:#64748b; --faint:#94a3b8; --line:#e5e7eb; --line-soft:#f1f5f9; --bg:#f7f8fa; --card:#fff;
+           --blue:#2563eb; --blue-dk:#1d4ed8; --blue-bg:#eff6ff; --green:#16a34a; --red:#dc2626; --amber:#b45309; --amber-bg:#fef3c7; }
     *{box-sizing:border-box} html,body{height:100%}
     body{margin:0;background:var(--bg);color:var(--ink);font-family:'Inter',sans-serif;font-size:15px;display:flex;flex-direction:column;}
     .material-symbols-outlined{font-variation-settings:'FILL' 0,'wght' 400;vertical-align:middle;}
-    .top{flex:0 0 56px;background:var(--bg);border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between;padding:0 16px;}
+    .mono{font-family:'JetBrains Mono',ui-monospace,monospace;}
+    /* ── top bar ── */
+    .top{flex:0 0 56px;background:var(--card);border-bottom:1px solid var(--line);display:flex;align-items:center;justify-content:space-between;padding:0 16px;}
     .top .brand{display:flex;align-items:center;gap:10px;} .top .brand .material-symbols-outlined{color:var(--blue);}
-    .top h1{font-family:'Space Grotesk',sans-serif;font-weight:700;font-size:17px;text-transform:uppercase;letter-spacing:.07em;color:var(--blue);margin:0;}
-    .top .acts{display:flex;align-items:center;gap:12px;}
+    .top h1{font-family:'Space Grotesk',sans-serif;font-weight:700;font-size:16px;text-transform:uppercase;letter-spacing:.08em;color:var(--blue);margin:0;}
+    .top .acts{display:flex;align-items:center;gap:14px;}
     .top .home{color:var(--muted);display:flex;text-decoration:none;}
-    .top .who{font-size:13px;font-weight:600;}
-    .layout{flex:1;display:flex;min-height:0;}
-    .side{width:250px;border-right:1px solid var(--line);background:var(--card);display:flex;flex-direction:column;min-height:0;}
-    .side .newbtn{margin:12px;padding:10px;border:1px solid var(--line);border-radius:10px;background:var(--blue);color:#fff;font-weight:700;font-size:14px;cursor:pointer;font-family:inherit;display:flex;align-items:center;justify-content:center;gap:6px;}
-    .side .list{flex:1;overflow-y:auto;padding:0 8px 12px;}
-    .side .chat-item{display:block;width:100%;text-align:left;border:0;background:none;padding:9px 10px;border-radius:8px;cursor:pointer;font-family:inherit;font-size:13px;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
-    .side .chat-item:hover{background:var(--bg);} .side .chat-item.active{background:var(--blue-bg);color:var(--blue);font-weight:600;}
+    .top .who{display:flex;align-items:center;gap:8px;font-size:13px;font-weight:600;}
+    .top .who .avatar{width:28px;height:28px;border-radius:50%;background:var(--blue);color:#fff;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:700;}
+    /* ── layout ── */
+    .layout{flex:1;display:flex;min-height:0;position:relative;}
+    .side{width:var(--sidew,256px);border-right:1px solid var(--line);background:var(--card);display:flex;flex-direction:column;min-height:0;flex-shrink:0;transition:margin-left .2s ease;position:relative;}
+    body.side-closed .side{margin-left:calc(0px - var(--sidew,256px));}
+    .side .resizer{position:absolute;top:0;right:-3px;width:6px;height:100%;cursor:col-resize;z-index:5;}
+    .side .resizer:hover{background:var(--blue-bg);}
+    .top .menu{border:0;background:none;color:var(--muted);cursor:pointer;display:flex;padding:4px;border-radius:8px;}
+    .top .menu:hover{background:var(--bg);color:var(--blue);}
+    .side .newbtn{margin:12px 12px 6px;padding:10px;border:0;border-radius:10px;background:var(--blue);color:#fff;font-weight:700;font-size:14px;cursor:pointer;font-family:inherit;display:flex;align-items:center;justify-content:center;gap:6px;}
+    .side .newbtn:hover{background:var(--blue-dk);}
+    .side .list{flex:1;overflow-y:auto;padding:4px 8px 12px;}
+    .side .group{font-size:10px;font-weight:700;letter-spacing:.08em;text-transform:uppercase;color:var(--faint);padding:12px 10px 4px;}
+    .side .chat-item{display:block;width:100%;text-align:left;border:0;border-left:3px solid transparent;background:none;padding:9px 10px;border-radius:8px;cursor:pointer;font-family:inherit;font-size:13px;color:var(--ink);white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+    .side .chat-item:hover{background:var(--bg);}
+    .side .chat-item.active{background:var(--blue-bg);border-left-color:var(--blue);color:var(--blue);font-weight:600;}
+    /* ── conversation ── */
     .main{flex:1;display:flex;flex-direction:column;min-width:0;min-height:0;}
-    .msgs{flex:1;overflow-y:auto;padding:20px 16px 8px;}
-    .msgwrap{max-width:840px;margin:0 auto;}
-    .msg{margin-bottom:14px;display:flex;}
+    .msgs{flex:1;overflow-y:auto;padding:24px 20px 8px;}
+    .msgwrap{max-width:880px;margin:0 auto;}
+    .msg{margin-bottom:18px;display:flex;gap:12px;}
     .msg.user{justify-content:flex-end;}
-    .bubble{max-width:85%;padding:11px 14px;border-radius:14px;line-height:1.55;overflow-wrap:break-word;}
-    .msg.user .bubble{background:var(--blue);color:#fff;border-bottom-right-radius:4px;}
-    .msg.ai .bubble{background:var(--card);border:1px solid var(--line);border-bottom-left-radius:4px;width:100%;}
-    .bubble p{margin:.35em 0;} .bubble p:first-child{margin-top:0;} .bubble p:last-child{margin-bottom:0;}
-    .bubble table{border-collapse:collapse;margin:.5em 0;font-size:13px;max-width:100%;display:block;overflow-x:auto;}
-    .bubble th{border-bottom:2px solid var(--ink);text-align:left;padding:4px 10px;font-size:11px;text-transform:uppercase;letter-spacing:.04em;}
-    .bubble td{border-bottom:1px solid var(--line);padding:4px 10px;}
-    .model-tag{font-size:10px;color:var(--muted);text-transform:uppercase;letter-spacing:.05em;margin-top:8px;}
-    details.step{margin-top:8px;border:1px solid var(--line);border-radius:9px;background:var(--bg);font-size:13px;}
-    details.step summary{cursor:pointer;padding:7px 10px;color:var(--muted);font-weight:600;display:flex;align-items:center;gap:6px;}
+    .msg.user .bubble{background:var(--blue);color:#fff;border-radius:16px 16px 4px 16px;padding:11px 16px;max-width:78%;font-size:14.5px;line-height:1.55;box-shadow:0 1px 2px rgba(37,99,235,.25);overflow-wrap:break-word;}
+    .ai-avatar{width:32px;height:32px;border-radius:50%;background:var(--blue-bg);color:var(--blue);display:flex;align-items:center;justify-content:center;flex-shrink:0;margin-top:2px;}
+    .ai-avatar .material-symbols-outlined{font-size:18px;}
+    .ai-col{flex:1;min-width:0;}
+    .ai-card{background:var(--card);border:1px solid var(--line);border-radius:12px;overflow:hidden;}
+    .ai-body{padding:14px 18px;line-height:1.6;font-size:14.5px;overflow-wrap:break-word;}
+    .ai-body p{margin:.4em 0;} .ai-body p:first-child{margin-top:0;} .ai-body p:last-child{margin-bottom:0;}
+    .ai-body code{background:var(--bg);border:1px solid var(--line-soft);border-radius:4px;padding:0 4px;font-family:'JetBrains Mono',monospace;font-size:12.5px;}
+    .ai-body table{border-collapse:collapse;margin:.6em 0;font-size:13px;max-width:100%;display:block;overflow-x:auto;}
+    .ai-body th{text-align:left;padding:6px 12px;font-size:10.5px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);border-bottom:1px solid var(--line);background:var(--bg);}
+    .ai-body td{border-bottom:1px solid var(--line-soft);padding:6px 12px;}
+    .ai-body td.num, .ai-body th.num{text-align:right;font-family:'Space Grotesk',sans-serif;}
+    .ai-foot{padding:7px 18px;background:var(--bg);border-top:1px solid var(--line-soft);display:flex;justify-content:space-between;align-items:center;font-size:10px;color:var(--faint);text-transform:uppercase;letter-spacing:.08em;}
+    /* ── evidence receipts ── */
+    .receipts{margin-top:8px;display:flex;flex-direction:column;gap:6px;}
+    details.step{border:1px dashed var(--line);border-radius:8px;background:var(--card);}
+    details.step[open]{border-style:solid;}
+    details.step summary{list-style:none;cursor:pointer;padding:7px 10px;display:flex;align-items:center;gap:8px;font-family:'JetBrains Mono',monospace;font-size:11.5px;color:var(--muted);}
+    details.step summary::-webkit-details-marker{display:none;}
+    details.step summary .material-symbols-outlined{font-size:15px;color:var(--blue);flex-shrink:0;}
+    details.step summary .sqlprev{flex:1;min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;}
+    details.step summary .rmeta{flex-shrink:0;margin-left:10px;white-space:nowrap;}
+    details.step summary .rmeta.err{color:var(--red);}
     details.step .step-body{padding:0 10px 10px;overflow-x:auto;}
-    details.step pre{background:#0f172a;color:#e2e8f0;padding:8px 10px;border-radius:8px;font-size:12px;overflow-x:auto;margin:6px 0;}
-    details.step table{border-collapse:collapse;font-size:12px;}
-    details.step th{border-bottom:1px solid var(--muted);padding:3px 8px;text-align:left;}
-    details.step td{border-bottom:1px solid var(--line);padding:3px 8px;white-space:nowrap;max-width:280px;overflow:hidden;text-overflow:ellipsis;}
-    .stepnote{color:var(--muted);font-size:11px;margin-top:4px;}
-    .suggest{display:flex;gap:8px;flex-wrap:wrap;margin:10px 0 4px;}
-    .suggest button{border:1px solid var(--line);background:var(--card);border-radius:999px;padding:7px 14px;font-size:13px;cursor:pointer;font-family:inherit;color:var(--ink);}
-    .suggest button:hover{border-color:var(--blue);color:var(--blue);}
-    .composer{flex:0 0 auto;border-top:1px solid var(--line);background:var(--card);padding:12px 16px calc(12px + env(safe-area-inset-bottom));}
-    .composer .row{max-width:840px;margin:0 auto;display:flex;gap:10px;}
-    .composer textarea{flex:1;resize:none;border:1px solid var(--line);border-radius:12px;padding:11px 13px;font-family:inherit;font-size:15px;max-height:130px;background:var(--bg);color:var(--ink);}
-    .composer textarea:focus{outline:none;border-color:var(--blue);box-shadow:0 0 0 3px var(--blue-bg);}
-    .composer button{border:0;background:var(--blue);color:#fff;border-radius:12px;width:48px;display:flex;align-items:center;justify-content:center;cursor:pointer;}
-    .composer button:disabled{opacity:.5;cursor:not-allowed;}
-    .thinking{display:flex;gap:5px;padding:6px 2px;}
-    .thinking span{width:8px;height:8px;border-radius:50%;background:var(--blue);opacity:.4;animation:th 1.2s infinite;}
-    .thinking span:nth-child(2){animation-delay:.2s} .thinking span:nth-child(3){animation-delay:.4s}
+    details.step pre{background:var(--ink);color:#e2e8f0;padding:10px 12px;border-radius:8px;font-size:11.5px;line-height:1.55;overflow-x:auto;margin:4px 0 8px;font-family:'JetBrains Mono',monospace;white-space:pre-wrap;word-break:break-word;}
+    details.step table{border-collapse:collapse;font-size:11.5px;font-family:'JetBrains Mono',monospace;}
+    details.step th{border-bottom:1px solid var(--muted);padding:3px 8px;text-align:left;font-weight:500;color:var(--muted);}
+    details.step td{border-bottom:1px solid var(--line-soft);padding:3px 8px;white-space:nowrap;max-width:280px;overflow:hidden;text-overflow:ellipsis;}
+    .stepnote{color:var(--faint);font-size:10.5px;margin-top:4px;font-family:'JetBrains Mono',monospace;}
+    /* ── thinking ── */
+    .thinking{display:flex;align-items:center;gap:10px;padding:14px 18px;}
+    .thinking .dots{display:flex;gap:5px;}
+    .thinking span.d{width:7px;height:7px;border-radius:50%;background:var(--blue);opacity:.4;animation:th 1.2s infinite;}
+    .thinking span.d:nth-child(2){animation-delay:.2s} .thinking span.d:nth-child(3){animation-delay:.4s}
+    .thinking .t{color:var(--muted);font-size:13px;}
     @keyframes th{0%,100%{opacity:.25;transform:translateY(0)}50%{opacity:1;transform:translateY(-3px)}}
-    .empty{color:var(--muted);text-align:center;margin-top:9vh;}
+    /* ── empty state ── */
+    .empty{color:var(--muted);text-align:center;margin-top:8vh;}
     .empty .material-symbols-outlined{font-size:44px;color:var(--blue);}
-    .empty h2{font-family:'Space Grotesk',sans-serif;margin:8px 0 4px;color:var(--ink);}
-    @media(max-width:760px){ .side{display:none;} }
+    .empty h2{font-family:'Space Grotesk',sans-serif;margin:10px 0 4px;color:var(--ink);}
+    /* ── composer ── */
+    .composer{flex:0 0 auto;border-top:1px solid var(--line);background:var(--card);padding:10px 16px calc(10px + env(safe-area-inset-bottom));}
+    .composer .inner{max-width:880px;margin:0 auto;}
+    .suggest{display:flex;gap:8px;flex-wrap:wrap;justify-content:center;margin:2px 0 10px;}
+    .suggest button{border:1px solid var(--line);background:var(--card);border-radius:999px;padding:6px 14px;font-size:12.5px;cursor:pointer;font-family:inherit;color:var(--muted);}
+    .suggest button:hover{border-color:var(--blue);color:var(--blue);background:var(--blue-bg);}
+    .composer .row{display:flex;gap:10px;align-items:flex-end;background:var(--bg);border:1px solid var(--line);border-radius:24px;padding:6px 6px 6px 18px;}
+    .composer .row:focus-within{border-color:var(--blue);box-shadow:0 0 0 3px var(--blue-bg);}
+    .composer textarea{flex:1;resize:none;border:0;background:none;padding:8px 0;font-family:inherit;font-size:14.5px;max-height:130px;color:var(--ink);outline:none;}
+    .composer button.send{border:0;background:var(--blue);color:#fff;border-radius:50%;width:38px;height:38px;flex-shrink:0;display:flex;align-items:center;justify-content:center;cursor:pointer;}
+    .composer button.send:hover{background:var(--blue-dk);}
+    .composer button.send:disabled{opacity:.5;cursor:not-allowed;}
+    .composer .disclaimer{text-align:center;color:var(--faint);font-size:10.5px;margin-top:7px;}
+    @media(max-width:760px){
+      .side{position:absolute;left:0;top:0;bottom:0;z-index:40;box-shadow:4px 0 16px rgba(15,23,42,.12);}
+      body.side-closed .side{margin-left:-110%;}
+      .side .resizer{display:none;}
+      .msg.user .bubble{max-width:90%;}
+    }
   </style>
 </head>
 <body>
 <header class="top">
-  <div class="brand"><span class="material-symbols-outlined">psychology</span><h1>Kotty Analyst</h1></div>
+  <div class="brand">
+    <button class="menu" id="sideToggle" title="Toggle chat list" onclick="toggleSide()"><span class="material-symbols-outlined">menu</span></button>
+    <span class="material-symbols-outlined">psychology</span><h1>Kotty Analyst</h1>
+  </div>
   <div class="acts">
     <a class="home" href="/operator/hub" title="Home"><span class="material-symbols-outlined">home</span></a>
-    <span class="who"><%= user && user.username %></span>
+    <span class="who"><span class="avatar"><%= (user && user.username ? user.username : 'U').slice(0,2).toUpperCase() %></span><%= user && user.username %></span>
   </div>
 </header>
 
@@ -76,10 +118,22 @@
   <aside class="side">
     <button class="newbtn" onclick="newChat()"><span class="material-symbols-outlined" style="font-size:18px;">add</span> New chat</button>
     <div class="list" id="chatList">
-      <% chats.forEach(function(c){ %>
-        <button class="chat-item" data-chat="<%= c.id %>" onclick="openChat(<%= c.id %>)"><%= c.title %></button>
+      <%
+        const DAY = 86400000;
+        const groups = [['Today', []], ['Previous 7 days', []], ['Older', []]];
+        chats.forEach(function(c){
+          const age = Date.now() - new Date(c.updated_at).getTime();
+          (age < DAY ? groups[0][1] : age < 7*DAY ? groups[1][1] : groups[2][1]).push(c);
+        });
+      %>
+      <% groups.forEach(function(g){ if (!g[1].length) return; %>
+        <div class="group"><%= g[0] %></div>
+        <% g[1].forEach(function(c){ %>
+          <button class="chat-item" data-chat="<%= c.id %>" title="<%= c.title %>" onclick="openChat(<%= c.id %>)"><%= c.title %></button>
+        <% }) %>
       <% }) %>
     </div>
+    <div class="resizer" id="sideResizer" title="Drag to resize"></div>
   </aside>
 
   <main class="main">
@@ -87,20 +141,23 @@
       <div class="empty" id="empty">
         <span class="material-symbols-outlined">psychology</span>
         <h2>Ask anything about production, sales or payments</h2>
-        <div>I query the live database and show you the data behind every answer.</div>
-        <div class="suggest">
-          <button onclick="suggest(this)">Where is lot ak5473 right now?</button>
-          <button onclick="suggest(this)">How many pieces did stitching complete this week?</button>
-          <button onclick="suggest(this)">Top 10 selling SKUs in the last 30 days</button>
-          <button onclick="suggest(this)">Which challans has the warehouse not received yet?</button>
-          <button onclick="suggest(this)">How much did we pay finishing workers this month?</button>
-        </div>
+        <div>I query the live database and show the data behind every answer.</div>
       </div>
     </div></div>
     <div class="composer">
-      <div class="row">
-        <textarea id="q" rows="1" placeholder="Ask about lots, stages, sales, stock, payments…"></textarea>
-        <button id="sendBtn" onclick="send()" title="Ask"><span class="material-symbols-outlined">arrow_upward</span></button>
+      <div class="inner">
+        <div class="suggest" id="chips">
+          <button onclick="suggest(this)">Where is lot ak5473?</button>
+          <button onclick="suggest(this)">Stitching output this week</button>
+          <button onclick="suggest(this)">Top 10 sellers — 30 days</button>
+          <button onclick="suggest(this)">Pending challans at warehouse</button>
+          <button onclick="suggest(this)">Payments this month by stage</button>
+        </div>
+        <div class="row">
+          <textarea id="q" rows="1" placeholder="Ask about lots, stages, sales, stock, payments…"></textarea>
+          <button class="send" id="sendBtn" onclick="send()" title="Ask"><span class="material-symbols-outlined">arrow_upward</span></button>
+        </div>
+        <div class="disclaimer">AI can make mistakes — every answer shows the queries behind it. Verify critical numbers.</div>
       </div>
     </div>
   </main>
@@ -115,25 +172,29 @@ const q = document.getElementById('q');
 const sendBtn = document.getElementById('sendBtn');
 const esc = s => String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
 
-// Minimal safe markdown: escape first, then bold / tables / paragraphs.
+// Minimal safe markdown: escape first, then bold / code / tables / paragraphs.
 function md(text){
   const lines = esc(text).split('\n');
   let html = '', tbl = [];
+  const inline = s => s.replace(/\*\*([^*]+)\*\*/g,'<strong>$1</strong>').replace(/`([^`]+)`/g,'<code>$1</code>');
   const flushTbl = () => {
     if(!tbl.length) return;
     const rows = tbl.filter(r => !/^\s*\|?[\s:|-]+\|?\s*$/.test(r));
     html += '<table>' + rows.map((r,i)=>{
       const cells = r.replace(/^\s*\|/,'').replace(/\|\s*$/,'').split('|');
       const tag = i===0?'th':'td';
-      return '<tr>'+cells.map(c=>'<'+tag+'>'+inline(c.trim())+'</'+tag+'>').join('')+'</tr>';
+      return '<tr>'+cells.map(c=>{
+        const v = c.trim();
+        const num = /^[\d,.\s%+\-−₹]*\d[\d,.\s%+\-−₹]*$/.test(v) && v !== '';
+        return '<'+tag+(num?' class="num"':'')+'>'+inline(v)+'</'+tag+'>';
+      }).join('')+'</tr>';
     }).join('') + '</table>';
     tbl = [];
   };
-  const inline = s => s.replace(/\*\*([^*]+)\*\*/g,'<strong>$1</strong>').replace(/`([^`]+)`/g,'<code>$1</code>');
   for(const line of lines){
     if(/^\s*\|.*\|\s*$/.test(line)){ tbl.push(line); continue; }
     flushTbl();
-    if(line.trim()==='') { html += ''; continue; }
+    if(line.trim()==='') { continue; }
     if(/^\s*[-*] /.test(line)) html += '<p>• '+inline(line.replace(/^\s*[-*] /,''))+'</p>';
     else if(/^#+ /.test(line)) html += '<p><strong>'+inline(line.replace(/^#+ /,''))+'</strong></p>';
     else html += '<p>'+inline(line)+'</p>';
@@ -142,18 +203,23 @@ function md(text){
   return html;
 }
 
+// Evidence receipt: dashed mono row → expands to dark SQL + mini result table.
 function stepHtml(s, i){
+  const prev = (s.sql||'').replace(/\s+/g,' ').slice(0,90);
+  const meta = s.error ? 'failed · retried' : ((s.row_count||0)+' rows · '+(s.ms||0)+' ms');
   let body = '<pre>'+esc(s.sql||'')+'</pre>';
-  if(s.error){ body += '<div class="stepnote" style="color:#b91c1c;">Error: '+esc(s.error)+'</div>'; }
+  if(s.error){ body += '<div class="stepnote" style="color:var(--red);">Error: '+esc(s.error)+'</div>'; }
   else if(s.rows && s.rows.length){
     const cols = Object.keys(s.rows[0]);
     body += '<table><tr>'+cols.map(c=>'<th>'+esc(c)+'</th>').join('')+'</tr>'+
       s.rows.slice(0,20).map(r=>'<tr>'+cols.map(c=>'<td>'+esc(r[c])+'</td>').join('')+'</tr>').join('')+'</table>';
-    body += '<div class="stepnote">'+s.row_count+' row(s)'+(s.rows.length>20?' · showing 20':'')+(s.truncated?' · truncated':'')+' · '+(s.ms||0)+' ms</div>';
-  } else {
-    body += '<div class="stepnote">'+(s.row_count||0)+' row(s) · '+(s.ms||0)+' ms</div>';
+    body += '<div class="stepnote">'+s.row_count+' row(s)'+(s.rows.length>20?' · showing 20':'')+(s.truncated?' · truncated':'')+'</div>';
   }
-  return '<details class="step"><summary><span class="material-symbols-outlined" style="font-size:16px;">database</span> Query '+(i+1)+(s.error?' (failed, retried)':'')+'</summary><div class="step-body">'+body+'</div></details>';
+  return '<details class="step"><summary>'+
+    '<span class="material-symbols-outlined">database</span>'+
+    '<span class="sqlprev">'+esc(prev)+'</span>'+
+    '<span class="rmeta'+(s.error?' err':'')+'">'+esc(meta)+'</span>'+
+  '</summary><div class="step-body">'+body+'</div></details>';
 }
 
 function addUser(text){
@@ -163,9 +229,12 @@ function addUser(text){
 }
 function addAssistant(m){
   hideEmpty();
-  const steps = (m.steps||[]).map(stepHtml).join('');
-  wrap.insertAdjacentHTML('beforeend','<div class="msg ai"><div class="bubble">'+md(m.answer||'')+steps+
-    (m.model?('<div class="model-tag">'+esc(m.model)+'</div>'):'')+'</div></div>');
+  const steps = (m.steps||[]).length ? '<div class="receipts">'+(m.steps||[]).map(stepHtml).join('')+'</div>' : '';
+  wrap.insertAdjacentHTML('beforeend',
+    '<div class="msg ai"><div class="ai-avatar"><span class="material-symbols-outlined">psychology</span></div>'+
+    '<div class="ai-col"><div class="ai-card"><div class="ai-body">'+md(m.answer||'')+'</div>'+
+    (m.model?('<div class="ai-foot"><span>'+esc(m.model)+'</span></div>'):'')+
+    '</div>'+steps+'</div></div>');
   scrollDown();
 }
 function hideEmpty(){ const e=document.getElementById('empty'); if(e) e.style.display='none'; }
@@ -174,9 +243,11 @@ function scrollDown(){ msgs.scrollTop = msgs.scrollHeight; }
 async function send(){
   const question = q.value.trim();
   if(!question || busy) return;
-  busy = true; sendBtn.disabled = true; q.value='';
+  busy = true; sendBtn.disabled = true; q.value=''; q.style.height='auto';
   addUser(question);
-  wrap.insertAdjacentHTML('beforeend','<div class="msg ai" id="pending"><div class="bubble"><div class="thinking"><span></span><span></span><span></span></div></div></div>');
+  wrap.insertAdjacentHTML('beforeend',
+    '<div class="msg ai" id="pending"><div class="ai-avatar"><span class="material-symbols-outlined">psychology</span></div>'+
+    '<div class="ai-col"><div class="ai-card"><div class="thinking"><span class="dots"><span class="d"></span><span class="d"></span><span class="d"></span></span><span class="t">querying the database…</span></div></div></div></div>');
   scrollDown();
   try{
     const r = await fetch('/operator/ai/ask',{method:'POST',headers:{'Content-Type':'application/json'},
@@ -197,9 +268,36 @@ async function send(){
 
 function addChatToList(id, title){
   const list = document.getElementById('chatList');
-  list.insertAdjacentHTML('afterbegin','<button class="chat-item active" data-chat="'+id+'" onclick="openChat('+id+')">'+esc(title.slice(0,60))+'</button>');
+  list.insertAdjacentHTML('afterbegin','<div class="group">Today</div><button class="chat-item active" data-chat="'+id+'" title="'+esc(title)+'" onclick="openChat('+id+')">'+esc(title.slice(0,60))+'</button>');
   markActive(id);
 }
+
+/* ── sidebar: collapse + resize (both persisted) ── */
+function toggleSide(){
+  const closed = document.body.classList.toggle('side-closed');
+  try{ localStorage.setItem('ai_side_closed', closed ? '1' : '0'); }catch(_e){}
+}
+(function initSide(){
+  try{
+    if(localStorage.getItem('ai_side_closed') === '1' || window.innerWidth <= 760) document.body.classList.add('side-closed');
+    const w = parseInt(localStorage.getItem('ai_side_w'), 10);
+    if(w >= 200 && w <= 440) document.documentElement.style.setProperty('--sidew', w + 'px');
+  }catch(_e){}
+  const rz = document.getElementById('sideResizer');
+  if(!rz) return;
+  let dragging = false;
+  rz.addEventListener('mousedown', (e) => { dragging = true; e.preventDefault(); document.body.style.userSelect='none'; });
+  window.addEventListener('mousemove', (e) => {
+    if(!dragging) return;
+    const w = Math.min(440, Math.max(200, e.clientX));
+    document.documentElement.style.setProperty('--sidew', w + 'px');
+  });
+  window.addEventListener('mouseup', () => {
+    if(!dragging) return;
+    dragging = false; document.body.style.userSelect='';
+    try{ localStorage.setItem('ai_side_w', parseInt(getComputedStyle(document.querySelector('.side')).width, 10)); }catch(_e){}
+  });
+})();
 function markActive(id){
   document.querySelectorAll('.chat-item').forEach(b=>b.classList.toggle('active', String(b.dataset.chat)===String(id)));
 }
@@ -212,7 +310,7 @@ async function openChat(id){
     if(j.ok){ for(const m of j.messages){ m.role==='user' ? addUser(m.answer) : addAssistant(m); } }
   }catch(e){ addAssistant({answer:'⚠ Could not load chat: '+e.message}); }
 }
-function newChat(){ if(busy) return; chatId=null; wrap.innerHTML=''; location.reload(); }
+function newChat(){ if(busy) return; location.reload(); }
 function suggest(btn){ q.value = btn.textContent; send(); }
 
 q.addEventListener('keydown', e => { if(e.key==='Enter' && !e.shiftKey){ e.preventDefault(); send(); } });


### PR DESCRIPTION
## What

Implements the Stitch design (screen *Kotty Analyst - AI Production Chat* in the Kotty Floor project) over the existing chat logic — no endpoint or engine changes.

- **Evidence receipts** (the design's signature): each query the AI ran renders as a dashed machine-receipt row — database icon, truncated SQL in monospace, right-aligned `6 rows · 41 ms` — expanding to a dark SQL block and a mini result table.
- **Answer cards**: AI avatar + white card, model tag in a footer strip, tables with uppercase headers and right-aligned Space Grotesk numerals.
- **Sidebar**: date-grouped (Today / Previous 7 days / Older) — and per review feedback: **collapsible** via a menu button (state persisted), **drag-resizable** 200–440px on the right edge (width persisted), and full-title **hover tooltips** so long conversation titles are always readable. On mobile it overlays and starts closed.
- Pill composer with centered suggestion chips and the honest footer: *"AI can make mistakes — every answer shows the queries behind it."*

191/191 tests pass; view renders with all three date groups, tooltips, and the resizer; inline script parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)