### PR TITLE
Fix stale-page failures: no-store on HTML + refresh hint on size-label mismatch

### DIFF
--- a/app.js
+++ b/app.js
@@ -148,6 +148,19 @@ app.use(flash());
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'views'));
 
+// HTML pages must never be cached: floor tabs stay open for days, and a
+// browser serving a stale page after a deploy posts outdated payloads to new
+// endpoints (seen live: washing-in completes failing with index size labels).
+// Static assets below keep their default caching — this only touches renders.
+app.use((req, res, next) => {
+  const render = res.render;
+  res.render = function (...args) {
+    res.set('Cache-Control', 'no-store, must-revalidate');
+    return render.apply(res, args);
+  };
+  next();
+});
+
 // Serve Static Files
 app.use('/uploads', express.static(path.join(__dirname, 'uploads')));
 app.use('/css', express.static(path.join(__dirname, 'public', 'css')));

--- a/utils/stageEvents.js
+++ b/utils/stageEvents.js
@@ -296,7 +296,8 @@ async function recordEvent(conn, {
       .filter(l => l && !allowed.has(l));
     if (bad.length) {
       throw new Error(
-        `Invalid size label(s) [${bad.join(', ')}] not in cutting breakdown for lot ${cuttingLotId}`
+        `Invalid size label(s) [${bad.join(', ')}] not in cutting breakdown for lot ${cuttingLotId}. `
+        + `If this screen has been open a long time, refresh the page (Ctrl+Shift+R) and try again.`
       );
     }
   }


### PR DESCRIPTION
## The bug (found while checking post-migration logs)

`POST /washingin/event/complete` has been intermittently failing with 500 since **July 14** (pre-dates all recent changes): one floor PC (Edge/Windows) runs a stale cached version of the page whose JS builds size payloads by array index — the server correctly rejects labels `[0,1,2,3,4]` that aren't in the lot's cutting breakdown (real labels: 28–36). The same user retried across lots 7638, 7757, 7845, 7866, 7919, 7792, 7945 and stayed blocked. Current code (client & server) is correct — washing-in completes succeed ~20×/day for everyone else.

## Fix

1. **`Cache-Control: no-store` on every HTML render** (tiny res.render wrapper in app.js): floor tabs stay open for days, and after a deploy a browser must never serve yesterday's JS. Static assets keep their caching — only page renders are affected.
2. **Actionable error**: the size-label mismatch message now ends with *"If this screen has been open a long time, refresh the page (Ctrl+Shift+R) and try again"* — which surfaces in the toast the operator actually sees.

The affected user needs **one manual hard-refresh** after this deploys; from then on stale pages can't happen.

191/191 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)