### PR TITLE
Perf: fix the DRR blunder query (95% of DB time → 24-48x faster, identical results)

### DIFF
--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -54,7 +54,34 @@ async function getOrderAggregates(pool, { periodKey = '1d', marketplaceId, wareh
   const snapshotStart = new Date(window.start);
   snapshotStart.setHours(0, 0, 0, 0);
 
-  const params = [snapshotStart, window.start];
+  // selling_days = distinct in-stock snapshot days for the SKU. HOW it's computed
+  // depends on whether one SKU or all SKUs are queried — this is a real hot path
+  // (~1,900 single-SKU calls/day; it was 95% of all DB time before this branch):
+  //   • Single SKU  → a CORRELATED scalar subquery keyed on es.sku hits the
+  //     snapshot PRIMARY KEY (sku,…) directly: ~77ms vs ~5,700ms for the derived
+  //     table, which scanned ~433k rows + temp table + filesort on EVERY call to
+  //     compute all 27k SKUs and keep one.
+  //   • All SKUs    → the grouped derived table is correct (you genuinely need
+  //     every SKU's selling_days once), so keep it.
+  const params = [];
+  const sellingDaysExpr = sku
+    ? `COALESCE((
+         SELECT COUNT(DISTINCT s.snapshot_date)
+           FROM ee_inventory_daily_snapshot s
+          WHERE s.sku = es.sku AND s.snapshot_date >= ? AND s.qty > 0
+       ), 0)`
+    : 'COALESCE(MAX(sd.selling_days), 0)';
+  params.push(snapshotStart);
+
+  const sellingDaysJoin = sku ? '' : `
+    LEFT JOIN (
+      SELECT sku, COUNT(DISTINCT snapshot_date) AS selling_days
+      FROM ee_inventory_daily_snapshot
+      WHERE snapshot_date >= ? AND qty > 0
+      GROUP BY sku
+    ) sd ON sd.sku = es.sku`;
+  if (!sku) params.push(snapshotStart);
+
   let sql = `
     SELECT
       es.sku,
@@ -62,15 +89,9 @@ async function getOrderAggregates(pool, { periodKey = '1d', marketplaceId, wareh
       eo.marketplace_id,
       COALESCE(SUM(es.quantity), 0) AS order_count,
       MAX(eo.order_date) AS last_order_date,
-      COALESCE(MAX(sd.selling_days), 0) AS selling_days
+      ${sellingDaysExpr} AS selling_days
     FROM ee_suborders es
-    INNER JOIN ee_orders eo ON es.order_id = eo.order_id
-    LEFT JOIN (
-      SELECT sku, COUNT(DISTINCT snapshot_date) AS selling_days
-      FROM ee_inventory_daily_snapshot
-      WHERE snapshot_date >= ? AND qty > 0
-      GROUP BY sku
-    ) sd ON sd.sku = es.sku
+    INNER JOIN ee_orders eo ON es.order_id = eo.order_id${sellingDaysJoin}
     WHERE eo.order_date >= ?
       AND EXISTS (
         SELECT 1 FROM ee_replenishment_rules r
@@ -79,6 +100,7 @@ async function getOrderAggregates(pool, { periodKey = '1d', marketplaceId, wareh
           AND r.making_time_days IS NOT NULL
       )
   `;
+  params.push(window.start);
 
   if (sku) {
     sql += ' AND es.sku = ?';


### PR DESCRIPTION
## The finding

A 7-day audit of the Cloud SQL slow-query log (72,034 entries) found **one query responsible for ~95% of all slow-query time**: **13,606 seconds/week — 3.8 hours** — from **1,901 calls** (every PM dashboard, DRR lookup, and inventory-planning read).

`getOrderAggregates`'s single-SKU branch computed "selling days" with a derived table:
```sql
LEFT JOIN (SELECT sku, COUNT(DISTINCT snapshot_date) … FROM ee_inventory_daily_snapshot
           WHERE snapshot_date >= ? AND qty > 0 GROUP BY sku) sd ON sd.sku = es.sku
```
EXPLAIN: **~433,000 rows scanned + temporary table + filesort on every single call** — it computed the answer for all 27,000 SKUs and kept one. That's why per-SKU reads took 3–36 seconds.

## The fix

For the single-SKU hot path, a **correlated scalar subquery** keyed on `es.sku` uses the snapshot table's PRIMARY KEY `(sku,…)` directly. The all-SKU aggregation path (rare, genuinely needs every SKU) keeps its grouped derived table. No schema or index change.

## Verified on prod (read-only, before merging)

| SKU | Result parity | Speed |
|---|---|---|
| KTTWOMENSWEATSHIRT410XL | ✅ byte-identical | 2,885ms → 60ms (**48×**) |
| KTTLADIESJEANS721M | ✅ byte-identical | 1,954ms → 82ms (**24×**) |
| (zero-order SKUs) | ✅ identical | already fast |

Both code paths exercised through the real function; 191/191 tests pass.

## Note (not in this PR)

The **all-SKU** `getOrderAggregates` call (dashboard-load, low frequency) still takes ~24s — it needs a covering index on `ee_inventory_daily_snapshot(sku, snapshot_date, qty)`, which is a prod DDL on a 2.78M-row / 346MB table (the biggest table, one we're watching for disk growth). Flagged for a deliberate decision rather than bundled here.

## Costing honesty

Cloud SQL is flat-rate, so this saves **₹0 on the bill** — it's a **performance + reliability** win: PM/inventory screens go from seconds to instant, and it frees the CPU headroom that protects against overload. (The bill savings came from the LB/registry/bucket work.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)