### PR TITLE
Perf: covering index on snapshot table (records the prod index; no cost impact)

### DIFF
--- a/sql/2026_07_snapshot_covering_index.sql
+++ b/sql/2026_07_snapshot_covering_index.sql
@@ -1,0 +1,11 @@
+-- Covering index for the selling-days aggregation over ee_inventory_daily_snapshot
+-- (2.78M rows). The query `SELECT sku, COUNT(DISTINCT snapshot_date) ...
+-- WHERE snapshot_date >= ? AND qty > 0 GROUP BY sku` previously did a range scan
+-- on idx_snapshot_date + a temporary table + filesort. With (sku, snapshot_date, qty)
+-- it becomes a COVERING index scan grouped by sku — no temp table, no filesort
+-- (EXPLAIN: "Using index"). Adds ~116MB; DB stays ~1.6GB of 15GB provisioned.
+--
+-- APPLIED TO PROD 2026-07-17 via online DDL (ALGORITHM=INPLACE, LOCK=NONE, ~30s,
+-- non-blocking). Idempotent-ish: drop first if re-running.
+ALTER TABLE ee_inventory_daily_snapshot
+  ADD INDEX idx_snap_sku_date_qty (sku, snapshot_date, qty), ALGORITHM=INPLACE, LOCK=NONE;


### PR DESCRIPTION
## What

Adds `idx_snap_sku_date_qty (sku, snapshot_date, qty)` to `ee_inventory_daily_snapshot` (2.78M rows). **Already applied to prod today** via online DDL (non-blocking, ~30s); this file puts it in version control so a fresh DB gets it too.

## Measured effect (prod)

- The selling-days aggregation's EXPLAIN goes from *range scan + temporary table + filesort* → **"Using index"** (covering scan, no temp, no filesort).
- Cutting-recommendations selling-days query: **~10s → 7.2s**.
- Removes the temp-table/filesort memory pressure that hurt under concurrency.

## Honest scope

This does **not** fully fix the all-SKU `getOrderAggregates` dashboard path (still ~5s warm) — that query's dominant cost is scanning ~560k `ee_suborders` rows + the per-row EXISTS, a separate issue from the selling-days piece this index covers. The big win was already shipped in #574 (the 1,900×/week single-SKU path, 24–48× faster). This index is the smaller, safe complement.

## Cost

+116MB on disk → DB is now **1.62GB of 15GB provisioned**. Well within paid space, so **no change to the bill** (Cloud SQL disk is pre-provisioned; this doesn't approach the 15GB ceiling that would trigger a permanent grow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)