### PR TITLE
Fix: cutting SKU builder Brand dropdown was hardcoded — now reads the brands list

### DIFF
--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -842,6 +842,38 @@ router.post('/api/sku-categories', isAuthenticated, isCuttingManager, async (req
   }
 });
 
+// GET /cutting-manager/api/sku-brands - List active brand codes (feeds the SKU builder,
+// same sku_brand_codes list the PO Creator uses).
+router.get('/api/sku-brands', isAuthenticated, isCuttingManager, async (req, res) => {
+  try {
+    const [brands] = await pool.query(
+      'SELECT id, code FROM sku_brand_codes WHERE is_active = 1 ORDER BY code');
+    return res.json({ success: true, brands });
+  } catch (error) {
+    console.error('Error loading SKU brands:', error);
+    return res.status(500).json({ error: 'Failed to load brands' });
+  }
+});
+
+// POST /cutting-manager/api/sku-brands - Add a new brand code.
+router.post('/api/sku-brands', isAuthenticated, isCuttingManager, async (req, res) => {
+  try {
+    const { code } = req.body;
+    if (!code || !code.trim()) {
+      return res.status(400).json({ error: 'Brand code is required' });
+    }
+    const brandCode = code.trim().toUpperCase();
+    await pool.query('INSERT INTO sku_brand_codes (code) VALUES (?)', [brandCode]);
+    return res.json({ success: true, message: 'Brand added' });
+  } catch (error) {
+    if (error.code === 'ER_DUP_ENTRY') {
+      return res.status(400).json({ error: 'Brand already exists' });
+    }
+    console.error('Error adding SKU brand:', error);
+    return res.status(500).json({ error: 'Failed to add brand' });
+  }
+});
+
 // GET /cutting-manager/assigned-cuts — cuts the PM has approved and assigned to THIS master.
 // Shows what to cut (per size) + suggested lots + fabric; links to the lot once cut.
 router.get('/assigned-cuts', isAuthenticated, isCuttingManager, async (req, res) => {

--- a/sql/2026_07_seed_sku_brand_codes.sql
+++ b/sql/2026_07_seed_sku_brand_codes.sql
@@ -1,0 +1,10 @@
+-- The cutting SKU builder's Brand dropdown used to be hardcoded to
+-- KTT / KOTTY / NW / CC. It is now driven by sku_brand_codes (so brands added
+-- via SKU Brands / PO Creator show up in cutting too). Seed the four hardcoded
+-- classics so the switch loses nothing — NW and CC were not yet in the table.
+-- Idempotent. APPLIED TO PROD 2026-07-18.
+INSERT IGNORE INTO sku_brand_codes (code, description, is_active) VALUES
+  ('KTT',   '', 1),
+  ('KOTTY', '', 1),
+  ('NW',    '', 1),
+  ('CC',    '', 1);

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -435,14 +435,14 @@
                 <div class="col-md-8">
                   <label class="kotty-form-label"><i class="bi bi-barcode"></i><span>SKU Builder</span></label>
                   <div class="sku-builder" style="display: flex; gap: 8px; flex-wrap: wrap; align-items: flex-end;">
-                    <div style="flex: 1; min-width: 80px;">
+                    <div style="flex: 1.5; min-width: 120px;">
                       <label style="font-size: 0.7rem; color: #666;">Brand</label>
-                      <select id="skuBrand" class="kotty-input" style="padding: 8px;">
-                        <option value="KTT" selected>KTT</option>
-                        <option value="KOTTY">KOTTY</option>
-                        <option value="NW">NW</option>
-                        <option value="CC">CC</option>
-                      </select>
+                      <div style="display: flex; gap: 4px;">
+                        <select id="skuBrand" class="kotty-input" style="padding: 8px; flex: 1;">
+                          <option value="">Loading…</option>
+                        </select>
+                        <button type="button" id="btnAddBrand" class="kotty-btn" style="padding: 8px 12px; white-space: nowrap;" title="Add new brand">+</button>
+                      </div>
                     </div>
                     <div style="flex: 1; min-width: 100px;">
                       <label style="font-size: 0.7rem; color: #666;">Gender (optional)</label>
@@ -1391,6 +1391,32 @@ async function loadSkuCategories() {
   } catch (e) { console.error('Failed to load categories:', e); }
 }
 
+async function loadSkuBrands() {
+  try {
+    const res = await fetch('/cutting-manager/api/sku-brands');
+    const data = await res.json();
+    const select = document.getElementById('skuBrand');
+    var current = select.value;
+    select.textContent = '';
+    var placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Select...';
+    select.appendChild(placeholder);
+    (data.brands || []).forEach(function(b) {
+      var opt = document.createElement('option');
+      opt.value = b.code;
+      opt.textContent = b.code;
+      select.appendChild(opt);
+    });
+    // Preserve current pick if still present, else default to KTT when available.
+    if (current && [...select.options].some(function(o){ return o.value === current; })) {
+      select.value = current;
+    } else if ([...select.options].some(function(o){ return o.value === 'KTT'; })) {
+      select.value = 'KTT';
+    }
+  } catch (e) { console.error('Failed to load brands:', e); }
+}
+
 function updateSkuPreview() {
   var brand = document.getElementById('skuBrand').value;
   var gender = document.getElementById('skuGender').value;
@@ -1431,6 +1457,28 @@ document.getElementById('btnAddCategory').addEventListener('click', async functi
       updateSkuPreview();
     } else {
       alert(data.error || 'Failed to add category');
+    }
+  } catch (e) { alert('Error: ' + e.message); }
+});
+
+document.getElementById('btnAddBrand').addEventListener('click', async function() {
+  var newBrand = prompt('Enter new brand code (e.g., NW):');
+  if (!newBrand || !newBrand.trim()) return;
+  var brandCode = newBrand.trim().toUpperCase();
+  try {
+    var res = await fetch('/cutting-manager/api/sku-brands', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ code: brandCode })
+    });
+    var data = await res.json();
+    if (data.success) {
+      alert('Brand "' + brandCode + '" added!');
+      await loadSkuBrands();
+      document.getElementById('skuBrand').value = brandCode;
+      updateSkuPreview();
+    } else {
+      alert(data.error || 'Failed to add brand');
     }
   } catch (e) { alert('Error: ' + e.message); }
 });
@@ -1496,6 +1544,7 @@ document.getElementById('lotForm').addEventListener('submit', function(e) {
 });
 
 loadSkuCategories();
+loadSkuBrands();
 
 <% if (typeof prefill !== 'undefined' && prefill) { %>
 // ── Pre-fill the create-lot form from a PM cut-plan assignment ("Start this lot").


### PR DESCRIPTION
## The bug you hit

In the cutting **SKU Builder**, the **Brand** dropdown was **hardcoded** to KTT / KOTTY / NW / CC in the template. So a brand added via SKU Brands (or the PO Creator) never showed up there — only those four. Category, right next to it, was already database-driven with a **+** add button, which is why the two behaved differently.

## Fix (Brand now mirrors Category)

- **Brand loads from `sku_brand_codes`** via a new `GET /cutting-manager/api/sku-brands` (cutting-manager gated), so every brand in the list appears — including yours.
- Added a **+** button to add a brand inline (`POST /cutting-manager/api/sku-brands`), exactly like the category **+**.
- Selection is preserved on reload; defaults to KTT when present.

## No regression — seeded the classics

The table had KTT and KOTTY but was **missing NW and CC**. Seeded all four (idempotent `INSERT IGNORE`, applied to prod; recorded in `sql/2026_07_seed_sku_brand_codes.sql`) so the dropdown keeps every old option **plus** the DB brands (KOTI, KOTY, KTY, PM) **plus** anything you add. Nothing is lost.

## Verify

- `GET /cutting-manager/api/sku-brands` against prod → 200, returns `CC, KOTI, KOTTY, KOTY, KTT, KTY, NW, PM`.
- Added JS (`loadSkuBrands`, add-brand handler) parses; hardcoded options removed.
- 191/191 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)