### PR TITLE
Fix double-approval: client submit guard + server idempotency (+ data repair)

### DIFF
--- a/routes/finishingRoutes.js
+++ b/routes/finishingRoutes.js
@@ -1006,18 +1006,24 @@ router.post('/event/approve', isAuthenticated, isFinishingMaster, async (req, re
     let rejectEventId  = null;
 
     if (cleanSizes.length) {
-      approveEventId = await stageEvents.recordEvent(conn, {
+      const approveRes = await stageEvents.recordEvent(conn, {
         stage: STAGE_F, cuttingLotId: lotId, eventType: 'approve',
         operatorId: userId, sizes: cleanSizes, parentEventId: null,
         remark: remark ? String(remark).trim() : null,
       });
+      // Idempotency: identical take-in seconds ago = double-submit; don't pay again.
+      if (approveRes.deduped) {
+        await conn.commit();
+        return res.json({ success: true, deduped: true, event_id: approveRes.eventId, total_pieces: 0 });
+      }
+      approveEventId = approveRes.eventId;
     }
     if (cleanRejected.length) {
-      rejectEventId = await stageEvents.recordEvent(conn, {
+      rejectEventId = (await stageEvents.recordEvent(conn, {
         stage: STAGE_F, cuttingLotId: lotId, eventType: 'reject',
         operatorId: userId, sizes: cleanRejected, parentEventId: null,
         remark: reject_reason ? String(reject_reason).trim() : null,
-      });
+      })).eventId;
     }
 
     await conn.commit();
@@ -1127,18 +1133,23 @@ router.post('/event/complete', isAuthenticated, isFinishingMaster, async (req, r
 
     let completeEventId = null, rejectEventId = null;
     if (cleanCompleted.length) {
-      completeEventId = await stageEvents.recordEvent(conn, {
+      const completeRes = await stageEvents.recordEvent(conn, {
         stage: STAGE_F, cuttingLotId: parent.cutting_lot_id, eventType: 'complete',
         operatorId: userId, sizes: cleanCompleted, parentEventId: parentId,
         remark: complete_remark ? String(complete_remark).trim() : null,
       });
+      if (completeRes.deduped) {
+        await conn.commit();
+        return res.json({ success: true, deduped: true, complete_event_id: completeRes.eventId, completed_total: 0 });
+      }
+      completeEventId = completeRes.eventId;
     }
     if (cleanRejected.length) {
-      rejectEventId = await stageEvents.recordEvent(conn, {
+      rejectEventId = (await stageEvents.recordEvent(conn, {
         stage: STAGE_F, cuttingLotId: parent.cutting_lot_id, eventType: 'reject',
         operatorId: userId, sizes: cleanRejected, parentEventId: parentId,
         remark: reject_reason ? String(reject_reason).trim() : null,
-      });
+      })).eventId;
     }
 
     if (cleanCompleted.length) {

--- a/routes/jeansAssemblyRoutes.js
+++ b/routes/jeansAssemblyRoutes.js
@@ -1311,7 +1311,7 @@ router.post('/event/approve', isAuthenticated, isJeansAssemblyMaster, async (req
     let rejectEventId  = null;
 
     if (cleanSizes.length) {
-      approveEventId = await stageEvents.recordEvent(conn, {
+      const approveRes = await stageEvents.recordEvent(conn, {
         stage: STAGE_JA,
         cuttingLotId: lotId,
         eventType: 'approve',
@@ -1320,9 +1320,16 @@ router.post('/event/approve', isAuthenticated, isJeansAssemblyMaster, async (req
         parentEventId: null,
         remark: remark ? String(remark).trim() : null,
       });
+      // Idempotency: identical take-in seconds ago = double-submit; don't pay
+      // the stitcher again.
+      if (approveRes.deduped) {
+        await conn.commit();
+        return res.json({ success: true, deduped: true, event_id: approveRes.eventId, total_pieces: 0 });
+      }
+      approveEventId = approveRes.eventId;
     }
     if (cleanRejected.length) {
-      rejectEventId = await stageEvents.recordEvent(conn, {
+      rejectEventId = (await stageEvents.recordEvent(conn, {
         stage: STAGE_JA,
         cuttingLotId: lotId,
         eventType: 'reject',
@@ -1330,7 +1337,7 @@ router.post('/event/approve', isAuthenticated, isJeansAssemblyMaster, async (req
         sizes: cleanRejected,
         parentEventId: null,
         remark: reject_reason ? String(reject_reason).trim() : null,
-      });
+      })).eventId;
     }
 
     await conn.commit();
@@ -1465,7 +1472,7 @@ router.post('/event/complete', isAuthenticated, isJeansAssemblyMaster, async (re
     let rejectEventId = null;
 
     if (cleanCompleted.length) {
-      completeEventId = await stageEvents.recordEvent(conn, {
+      const completeRes = await stageEvents.recordEvent(conn, {
         stage: STAGE_JA,
         cuttingLotId: parent.cutting_lot_id,
         eventType: 'complete',
@@ -1474,9 +1481,14 @@ router.post('/event/complete', isAuthenticated, isJeansAssemblyMaster, async (re
         parentEventId: parentId,
         remark: complete_remark ? String(complete_remark).trim() : null,
       });
+      if (completeRes.deduped) {
+        await conn.commit();
+        return res.json({ success: true, deduped: true, complete_event_id: completeRes.eventId, completed_total: 0 });
+      }
+      completeEventId = completeRes.eventId;
     }
     if (cleanRejected.length) {
-      rejectEventId = await stageEvents.recordEvent(conn, {
+      rejectEventId = (await stageEvents.recordEvent(conn, {
         stage: STAGE_JA,
         cuttingLotId: parent.cutting_lot_id,
         eventType: 'reject',
@@ -1484,7 +1496,7 @@ router.post('/event/complete', isAuthenticated, isJeansAssemblyMaster, async (re
         sizes: cleanRejected,
         parentEventId: parentId,
         remark: reject_reason ? String(reject_reason).trim() : null,
-      });
+      })).eventId;
     }
 
     // Dual-write to jeans_assembly_data for downstream compatibility

--- a/routes/stitchingRoutes.js
+++ b/routes/stitchingRoutes.js
@@ -293,7 +293,7 @@ router.post('/event/approve', isAuthenticated, isStitchingMaster, async (req, re
     let rejectEventId  = null;
 
     if (cleanSizes.length) {
-      approveEventId = await stageEvents.recordEvent(conn, {
+      const approveRes = await stageEvents.recordEvent(conn, {
         stage: STAGE,
         cuttingLotId: lotId,
         eventType: 'approve',
@@ -302,9 +302,15 @@ router.post('/event/approve', isAuthenticated, isStitchingMaster, async (req, re
         parentEventId: null,
         remark: remark ? String(remark).trim() : null,
       });
+      // Idempotency: identical take-in seconds ago = a double-submitted click.
+      if (approveRes.deduped) {
+        await conn.commit();
+        return res.json({ success: true, deduped: true, event_id: approveRes.eventId, total_pieces: 0 });
+      }
+      approveEventId = approveRes.eventId;
     }
     if (cleanRejected.length) {
-      rejectEventId = await stageEvents.recordEvent(conn, {
+      rejectEventId = (await stageEvents.recordEvent(conn, {
         stage: STAGE,
         cuttingLotId: lotId,
         eventType: 'reject',
@@ -312,7 +318,7 @@ router.post('/event/approve', isAuthenticated, isStitchingMaster, async (req, re
         sizes: cleanRejected,
         parentEventId: null,
         remark: reject_reason ? String(reject_reason).trim() : null,
-      });
+      })).eventId;
     }
 
     await conn.commit();
@@ -438,7 +444,7 @@ router.post('/event/complete', isAuthenticated, isStitchingMaster, async (req, r
     let rejectEventId = null;
 
     if (cleanCompleted.length) {
-      completeEventId = await stageEvents.recordEvent(conn, {
+      const completeRes = await stageEvents.recordEvent(conn, {
         stage: STAGE,
         cuttingLotId: parent.cutting_lot_id,
         eventType: 'complete',
@@ -447,9 +453,16 @@ router.post('/event/complete', isAuthenticated, isStitchingMaster, async (req, r
         parentEventId: parentId,
         remark: complete_remark ? String(complete_remark).trim() : null,
       });
+      // Idempotency: identical mark-done seconds ago = double-submit; don't
+      // re-record or create a duplicate stitching_data batch.
+      if (completeRes.deduped) {
+        await conn.commit();
+        return res.json({ success: true, deduped: true, complete_event_id: completeRes.eventId, completed_total: 0 });
+      }
+      completeEventId = completeRes.eventId;
     }
     if (cleanRejected.length) {
-      rejectEventId = await stageEvents.recordEvent(conn, {
+      rejectEventId = (await stageEvents.recordEvent(conn, {
         stage: STAGE,
         cuttingLotId: parent.cutting_lot_id,
         eventType: 'reject',
@@ -457,7 +470,7 @@ router.post('/event/complete', isAuthenticated, isStitchingMaster, async (req, r
         sizes: cleanRejected,
         parentEventId: parentId,
         remark: reject_reason ? String(reject_reason).trim() : null,
-      });
+      })).eventId;
     }
 
     // Dual-write: also append a stitching_data row for the COMPLETED pieces

--- a/routes/washingInRoutes.js
+++ b/routes/washingInRoutes.js
@@ -613,18 +613,26 @@ router.post('/event/approve', isAuthenticated, isWashingInMaster, async (req, re
     let rewashRequestId = null;
 
     if (cleanSizes.length) {
-      approveEventId = await stageEvents.recordEvent(conn, {
+      const approveRes = await stageEvents.recordEvent(conn, {
         stage: STAGE_WI, cuttingLotId: lotId, eventType: 'approve',
         operatorId: userId, sizes: cleanSizes, parentEventId: null,
         remark: remark ? String(remark).trim() : null,
       });
+      // Idempotency: an identical take-in seconds ago = a double-submitted click.
+      // Return the prior result WITHOUT re-recording, re-deducting rewash, or
+      // paying the washer again.
+      if (approveRes.deduped) {
+        await conn.commit();
+        return res.json({ success: true, deduped: true, event_id: approveRes.eventId, total_pieces: 0 });
+      }
+      approveEventId = approveRes.eventId;
     }
     if (cleanRejected.length) {
-      rejectEventId = await stageEvents.recordEvent(conn, {
+      rejectEventId = (await stageEvents.recordEvent(conn, {
         stage: STAGE_WI, cuttingLotId: lotId, eventType: 'reject',
         operatorId: userId, sizes: cleanRejected, parentEventId: null,
         remark: reject_reason ? String(reject_reason).trim() : null,
-      });
+      })).eventId;
     }
 
     if (cleanRewash.length) {
@@ -828,18 +836,25 @@ router.post('/event/complete', isAuthenticated, isWashingInMaster, async (req, r
 
     let completeEventId = null, rejectEventId = null;
     if (cleanCompleted.length) {
-      completeEventId = await stageEvents.recordEvent(conn, {
+      const completeRes = await stageEvents.recordEvent(conn, {
         stage: STAGE_WI, cuttingLotId: parent.cutting_lot_id, eventType: 'complete',
         operatorId: userId, sizes: cleanCompleted, parentEventId: parentId,
         remark: complete_remark ? String(complete_remark).trim() : null,
       });
+      // Idempotency: identical mark-done seconds ago = double-submit. Don't
+      // re-record or create a duplicate washing_in_data batch.
+      if (completeRes.deduped) {
+        await conn.commit();
+        return res.json({ success: true, deduped: true, complete_event_id: completeRes.eventId, completed_total: 0 });
+      }
+      completeEventId = completeRes.eventId;
     }
     if (cleanRejected.length) {
-      rejectEventId = await stageEvents.recordEvent(conn, {
+      rejectEventId = (await stageEvents.recordEvent(conn, {
         stage: STAGE_WI, cuttingLotId: parent.cutting_lot_id, eventType: 'reject',
         operatorId: userId, sizes: cleanRejected, parentEventId: parentId,
         remark: reject_reason ? String(reject_reason).trim() : null,
-      });
+      })).eventId;
     }
 
     if (cleanCompleted.length) {

--- a/routes/washingRoutes.js
+++ b/routes/washingRoutes.js
@@ -1161,7 +1161,7 @@ router.post('/event/approve', isAuthenticated, isWashingMaster, async (req, res)
     let rejectEventId  = null;
 
     if (cleanSizes.length) {
-      approveEventId = await stageEvents.recordEvent(conn, {
+      const approveRes = await stageEvents.recordEvent(conn, {
         stage: STAGE_W,
         cuttingLotId: lotId,
         eventType: 'approve',
@@ -1170,9 +1170,16 @@ router.post('/event/approve', isAuthenticated, isWashingMaster, async (req, res)
         parentEventId: null,
         remark: remark ? String(remark).trim() : null,
       });
+      // Idempotency: identical take-in seconds ago = double-submit; don't pay
+      // the assembler again.
+      if (approveRes.deduped) {
+        await conn.commit();
+        return res.json({ success: true, deduped: true, event_id: approveRes.eventId, total_pieces: 0 });
+      }
+      approveEventId = approveRes.eventId;
     }
     if (cleanRejected.length) {
-      rejectEventId = await stageEvents.recordEvent(conn, {
+      rejectEventId = (await stageEvents.recordEvent(conn, {
         stage: STAGE_W,
         cuttingLotId: lotId,
         eventType: 'reject',
@@ -1180,7 +1187,7 @@ router.post('/event/approve', isAuthenticated, isWashingMaster, async (req, res)
         sizes: cleanRejected,
         parentEventId: null,
         remark: reject_reason ? String(reject_reason).trim() : null,
-      });
+      })).eventId;
     }
 
     await conn.commit();
@@ -1295,18 +1302,23 @@ router.post('/event/complete', isAuthenticated, isWashingMaster, async (req, res
 
     let completeEventId = null, rejectEventId = null;
     if (cleanCompleted.length) {
-      completeEventId = await stageEvents.recordEvent(conn, {
+      const completeRes = await stageEvents.recordEvent(conn, {
         stage: STAGE_W, cuttingLotId: parent.cutting_lot_id, eventType: 'complete',
         operatorId: userId, sizes: cleanCompleted, parentEventId: parentId,
         remark: complete_remark ? String(complete_remark).trim() : null,
       });
+      if (completeRes.deduped) {
+        await conn.commit();
+        return res.json({ success: true, deduped: true, complete_event_id: completeRes.eventId, completed_total: 0 });
+      }
+      completeEventId = completeRes.eventId;
     }
     if (cleanRejected.length) {
-      rejectEventId = await stageEvents.recordEvent(conn, {
+      rejectEventId = (await stageEvents.recordEvent(conn, {
         stage: STAGE_W, cuttingLotId: parent.cutting_lot_id, eventType: 'reject',
         operatorId: userId, sizes: cleanRejected, parentEventId: parentId,
         remark: reject_reason ? String(reject_reason).trim() : null,
-      });
+      })).eventId;
     }
 
     // Dual-write to washing_data for downstream washing_in compatibility

--- a/test/stageEvents.test.js
+++ b/test/stageEvents.test.js
@@ -90,6 +90,9 @@ function recordStub(cutLabels) {
       if (/FROM cutting_lot_sizes WHERE cutting_lot_id/.test(sql)) {
         return [cutLabels.map(l => ({ size_label: l }))];
       }
+      // Idempotency dedup lookup — no recent duplicate in this stub.
+      if (/SELECT id FROM \w+_events\s+WHERE cutting_lot_id/.test(sql)) return [[]];
+      if (/SELECT size_label, pieces FROM \w+_event_sizes WHERE event_id/.test(sql)) return [[]];
       if (/^INSERT INTO \w+_events/.test(sql.trim())) return [{ insertId: 123 }];
       if (/^INSERT INTO \w+_event_sizes/.test(sql.trim())) return [{}];
       throw new Error('unexpected query: ' + sql);
@@ -112,10 +115,32 @@ test('recordEvent: rejects size labels not in the cutting breakdown (blocks junk
 
 test('recordEvent: accepts labels that match the cutting breakdown', async () => {
   const conn = recordStub(['26', '28', '30', '32', '34']);
-  const id = await recordEvent(conn, {
+  const res = await recordEvent(conn, {
     stage: 'stitching', cuttingLotId: 1, eventType: 'approve', operatorId: 9,
     sizes: [{ size_label: '26', pieces: 132 }, { size_label: '28', pieces: 132 }],
   });
-  assert.strictEqual(id, 123);
+  assert.deepStrictEqual(res, { eventId: 123, deduped: false });
   assert.ok(conn.q.some(x => /INSERT INTO \w+_event_sizes/.test(x.sql)));
+});
+
+test('recordEvent: returns deduped when an identical event was just recorded', async () => {
+  const q = [];
+  const conn = {
+    q,
+    async query(sql) {
+      q.push(sql.replace(/\s+/g, ' ').trim());
+      if (/FROM cutting_lot_sizes/.test(sql)) return [[{ size_label: '26' }, { size_label: '28' }]];
+      if (/SELECT id FROM \w+_events\s+WHERE cutting_lot_id/.test(sql)) return [[{ id: 555 }]];
+      if (/SELECT size_label, pieces FROM \w+_event_sizes WHERE event_id/.test(sql)) {
+        return [[{ size_label: '26', pieces: 132 }, { size_label: '28', pieces: 132 }]];
+      }
+      throw new Error('should not INSERT when deduped: ' + sql);
+    },
+  };
+  const res = await recordEvent(conn, {
+    stage: 'stitching', cuttingLotId: 1, eventType: 'approve', operatorId: 9,
+    sizes: [{ size_label: '26', pieces: 132 }, { size_label: '28', pieces: 132 }],
+  });
+  assert.deepStrictEqual(res, { eventId: 555, deduped: true });
+  assert.ok(!q.some(x => /INSERT INTO/.test(x)), 'must not insert a duplicate');
 });

--- a/utils/stageEvents.js
+++ b/utils/stageEvents.js
@@ -259,8 +259,13 @@ async function getOpenApprovals(conn, stage, cuttingLotId, operatorId = null) {
  *   - parentEventId:   required for complete/reject, must be NULL for approve
  *   - remark:          optional per-event note
  *
- * Returns the new event id.
+ * Returns { eventId, deduped }. `deduped` is true when an identical event already
+ * existed in the last few seconds and no new row was inserted — callers MUST skip
+ * side effects (payments/debits) in that case. This is the server-side guard against
+ * a double-submitted take/approve creating duplicate events + duplicate payments.
  */
+const DEDUP_WINDOW_SECONDS = 12;
+
 async function recordEvent(conn, {
   stage, cuttingLotId, eventType, operatorId, sizes, parentEventId = null, remark = null,
 }) {
@@ -302,6 +307,35 @@ async function recordEvent(conn, {
     }
   }
 
+  // Idempotency guard: if the identical event (same lot, operator, type, parent,
+  // total, AND the same per-size breakdown) was just recorded, treat this as a
+  // double-submit — return the existing id and skip the insert. Matching the size
+  // rows too avoids suppressing a genuine second batch that happens to share a total.
+  const parentMatch = parentEventId === null ? 'parent_event_id IS NULL' : 'parent_event_id = ?';
+  const dupParams = [cuttingLotId, eventType, totalPieces, operatorId];
+  if (parentEventId !== null) dupParams.push(parentEventId);
+  const [recent] = await conn.query(
+    `SELECT id FROM ${events}
+      WHERE cutting_lot_id = ? AND event_type = ? AND pieces = ? AND operator_id = ?
+        AND ${parentMatch}
+        AND created_at >= (NOW() - INTERVAL ${DEDUP_WINDOW_SECONDS} SECOND)
+      ORDER BY id DESC`,
+    dupParams
+  );
+  const wantSizes = {};
+  for (const s of sizes) {
+    if (Number(s.pieces) > 0) wantSizes[normalizeSizeLabel(s.size_label)] = Number(s.pieces);
+  }
+  for (const cand of recent) {
+    const [existSizes] = await conn.query(
+      `SELECT size_label, pieces FROM ${eventSizes} WHERE event_id = ?`, [cand.id]);
+    const gotSizes = {};
+    for (const r of existSizes) gotSizes[normalizeSizeLabel(r.size_label)] = Number(r.pieces);
+    const same = Object.keys(wantSizes).length === Object.keys(gotSizes).length
+      && Object.entries(wantSizes).every(([k, v]) => gotSizes[k] === v);
+    if (same) return { eventId: cand.id, deduped: true };
+  }
+
   const [result] = await conn.query(
     `
       INSERT INTO ${events}
@@ -322,7 +356,7 @@ async function recordEvent(conn, {
     );
   }
 
-  return eventId;
+  return { eventId, deduped: false };
 }
 
 module.exports = {

--- a/views/finishingEvents.ejs
+++ b/views/finishingEvents.ejs
@@ -2024,7 +2024,10 @@ async function doTakeFromForm(card) {
   });
 }
 
+let submitting = false;
 async function doTakeRequest(payload) {
+  if (submitting) return;   // block double-submit (double-click / slow response)
+  submitting = true;
   try {
     await api('POST', BASE + '/event/approve', { cutting_lot_id: currentLot.id, ...payload });
     const tt = (payload.sizes || []).reduce((a,s)=>a+s.pieces,0);
@@ -2032,6 +2035,7 @@ async function doTakeRequest(payload) {
     await refreshState();
     if (infoTab === 'work') loadHistory();
   } catch (err) { toast('Could not save: ' + err.message, 'error'); }
+  finally { submitting = false; }
 }
 
 function buildDoneCard(approve) {
@@ -2204,6 +2208,8 @@ async function doMarkDoneFromForm(card, approve) {
 }
 
 async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason) {
+  if (submitting) return;   // block double-submit
+  submitting = true;
   try {
     await api('POST', BASE + '/event/complete', {
       parent_event_id: parentId, completed_sizes, rejected_sizes,
@@ -2213,6 +2219,7 @@ async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, comp
     await refreshState();
     if (infoTab === 'work') loadHistory();
   } catch (err) { toast('Could not save: ' + err.message, 'error'); }
+  finally { submitting = false; }
 }
 
 // ─── My Work / My Payments ───────────────────

--- a/views/jeansAssemblyEvents.ejs
+++ b/views/jeansAssemblyEvents.ejs
@@ -1918,7 +1918,10 @@ async function doTakeFromForm(card) {
   });
 }
 
+let submitting = false;
 async function doTakeRequest(payload) {
+  if (submitting) return;   // block double-submit (double-click / slow response)
+  submitting = true;
   try {
     await api('POST', BASE + '/event/approve', { cutting_lot_id: currentLot.id, ...payload });
     const tt = (payload.sizes || []).reduce((a,s)=>a+s.pieces,0);
@@ -1926,6 +1929,7 @@ async function doTakeRequest(payload) {
     await refreshState();
     if (infoTab === 'work') loadHistory();
   } catch (err) { toast('Could not save: ' + err.message, 'error'); }
+  finally { submitting = false; }
 }
 
 function buildDoneCard(approve) {
@@ -2098,6 +2102,8 @@ async function doMarkDoneFromForm(card, approve) {
 }
 
 async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason) {
+  if (submitting) return;   // block double-submit
+  submitting = true;
   try {
     await api('POST', BASE + '/event/complete', {
       parent_event_id: parentId, completed_sizes, rejected_sizes,
@@ -2107,6 +2113,7 @@ async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, comp
     await refreshState();
     if (infoTab === 'work') loadHistory();
   } catch (err) { toast('Could not save: ' + err.message, 'error'); }
+  finally { submitting = false; }
 }
 
 // ─── My Work / My Payments ───────────────────

--- a/views/stitchingEvents.ejs
+++ b/views/stitchingEvents.ejs
@@ -1927,7 +1927,10 @@ async function doTakeFromForm(card) {
   });
 }
 
+let submitting = false;
 async function doTakeRequest(payload) {
+  if (submitting) return;   // block double-submit (double-click / slow response)
+  submitting = true;
   try {
     await api('POST', BASE + '/event/approve', { cutting_lot_id: currentLot.id, ...payload });
     const tt = (payload.sizes || []).reduce((a,s)=>a+s.pieces,0);
@@ -1935,6 +1938,7 @@ async function doTakeRequest(payload) {
     await refreshState();
     if (infoTab === 'work') loadHistory();
   } catch (err) { toast('Could not save: ' + err.message, 'error'); }
+  finally { submitting = false; }
 }
 
 function buildDoneCard(approve) {
@@ -2107,6 +2111,8 @@ async function doMarkDoneFromForm(card, approve) {
 }
 
 async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason) {
+  if (submitting) return;   // block double-submit
+  submitting = true;
   try {
     await api('POST', BASE + '/event/complete', {
       parent_event_id: parentId, completed_sizes, rejected_sizes,
@@ -2116,6 +2122,7 @@ async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, comp
     await refreshState();
     if (infoTab === 'work') loadHistory();
   } catch (err) { toast('Could not save: ' + err.message, 'error'); }
+  finally { submitting = false; }
 }
 
 // ─── My Work / My Payments ───────────────────

--- a/views/washingEvents.ejs
+++ b/views/washingEvents.ejs
@@ -1918,7 +1918,10 @@ async function doTakeFromForm(card) {
   });
 }
 
+let submitting = false;
 async function doTakeRequest(payload) {
+  if (submitting) return;   // block double-submit (double-click / slow response)
+  submitting = true;
   try {
     await api('POST', BASE + '/event/approve', { cutting_lot_id: currentLot.id, ...payload });
     const tt = (payload.sizes || []).reduce((a,s)=>a+s.pieces,0);
@@ -1926,6 +1929,7 @@ async function doTakeRequest(payload) {
     await refreshState();
     if (infoTab === 'work') loadHistory();
   } catch (err) { toast('Could not save: ' + err.message, 'error'); }
+  finally { submitting = false; }
 }
 
 function buildDoneCard(approve) {
@@ -2098,6 +2102,8 @@ async function doMarkDoneFromForm(card, approve) {
 }
 
 async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason) {
+  if (submitting) return;   // block double-submit
+  submitting = true;
   try {
     await api('POST', BASE + '/event/complete', {
       parent_event_id: parentId, completed_sizes, rejected_sizes,
@@ -2107,6 +2113,7 @@ async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, comp
     await refreshState();
     if (infoTab === 'work') loadHistory();
   } catch (err) { toast('Could not save: ' + err.message, 'error'); }
+  finally { submitting = false; }
 }
 
 // ─── My Work / My Payments ───────────────────

--- a/views/washingInEvents.ejs
+++ b/views/washingInEvents.ejs
@@ -1918,7 +1918,10 @@ async function doTakeFromForm(card) {
   });
 }
 
+let submitting = false;
 async function doTakeRequest(payload) {
+  if (submitting) return;   // block double-submit (double-click / slow response)
+  submitting = true;
   try {
     await api('POST', BASE + '/event/approve', { cutting_lot_id: currentLot.id, ...payload });
     const tt = (payload.sizes || []).reduce((a,s)=>a+s.pieces,0);
@@ -1926,6 +1929,7 @@ async function doTakeRequest(payload) {
     await refreshState();
     if (infoTab === 'work') loadHistory();
   } catch (err) { toast('Could not save: ' + err.message, 'error'); }
+  finally { submitting = false; }
 }
 
 function buildDoneCard(approve) {
@@ -2098,6 +2102,8 @@ async function doMarkDoneFromForm(card, approve) {
 }
 
 async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason) {
+  if (submitting) return;   // block double-submit
+  submitting = true;
   try {
     await api('POST', BASE + '/event/complete', {
       parent_event_id: parentId, completed_sizes, rejected_sizes,
@@ -2107,6 +2113,7 @@ async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, comp
     await refreshState();
     if (infoTab === 'work') loadHistory();
   } catch (err) { toast('Could not save: ' + err.message, 'error'); }
+  finally { submitting = false; }
 }
 
 // ─── My Work / My Payments ───────────────────


### PR DESCRIPTION
## The incident

A washing-in master approved lot **ak5432 four times in the same second** — 4 identical approve events (937 pcs) → the washing worker was **paid 4× for the same pieces** (4 payment rows). This is the reported *"users had to click approve twice"* complaint.

**Root cause (long-standing, NOT Firebase):** the take/mark-done buttons never disabled during the in-flight POST, and the server had no idempotency — so a rapid re-click (especially when a response feels slow) fired the request again and each created a duplicate event + duplicate upstream payment. Firebase is ruled out: it doesn't retry POSTs, recent approve latencies are 0.1–0.3s/200, and there were only **2 duplicate bursts in 30 days** (not the flood an infra retry would cause).

## Fix (both layers, all 5 stages)

**Client** — a `submitting` guard in `doTakeRequest` and `doMarkDoneRequest` in all 5 stage views: a second call is ignored while the first is in flight (reset in `finally`, so retry-after-error still works).

**Server** — `stageEvents.recordEvent` now dedups: if an identical event (same lot, operator, type, parent, total, **and per-size breakdown**) was recorded in the last 12s, it returns the existing id with `deduped: true` instead of inserting. The 5 approve/complete handlers **short-circuit on `deduped`** — no duplicate event, no duplicate `*_data` row, no second payment. A genuinely different quantity within the window is **not** suppressed.

## Verified

- E2E on a rolled-back prod transaction: 1st call inserts; **identical 2nd call → deduped to the same event, 0 new rows**; different-qty 3rd call → fresh event. ✓
- 192/192 tests pass (new dedup unit test + updated stub).
- All 5 views' guarded functions parse.

## Data repair (done on prod, audited)

Both corrupted lots collapsed to single clean chains — **ak5432** (9034): 4→1 approve/complete/washing_in_data/washing-payment (3 phantom payments removed); **im947** (9851): 3→1 approve (no completes/payments existed). Downstream (finishing/assembly) had consumed nothing, so piece-flow is intact. Logged to `pm_lot_audit_log` as `dup_approve_repair`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)