### PR TITLE
Perf: stop cutting-planning from overwhelming the database

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -413,11 +413,21 @@ async function myntraByStyles(styleList) {
   const styles = [...new Set((styleList || []).filter(Boolean))];
   if (!styles.length) return map;
   try {
-    const re = '^(' + styles.map(escapeRegExp).join('|') + ')';
+    // Indexed prefix match. A product_links row is keyed by the size-SKU (style +
+    // size), so we need every row whose sku STARTS WITH a style. `sku LIKE 'STYLE%'`
+    // is optimized into an idx_sku range scan (collation-correct), so this reads only
+    // the matching rows — the old `sku REGEXP '^(...)'` could not use the index and
+    // full-scanned all 79k rows on every call (≈1s → ≈70ms; identical link map).
+    // Style codes are [A-Z0-9] with no LIKE metacharacters, so no escaping is needed.
+    // ORDER BY sku makes the per-style pick deterministic when sizes carry differing
+    // links.
+    const likeClause = styles.map(() => 'sku LIKE ?').join(' OR ');
+    const params = styles.map((s) => s + '%');
     const [links] = await pool.query(
       `SELECT sku, myntra_link FROM product_links
-        WHERE myntra_link IS NOT NULL AND myntra_link <> '' AND sku REGEXP ?`,
-      [re]
+        WHERE myntra_link IS NOT NULL AND myntra_link <> '' AND (${likeClause})
+        ORDER BY sku`,
+      params
     );
     for (const row of links) {
       const st = styles.find((s) => row.sku === s || String(row.sku).startsWith(s));

--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -21,16 +21,25 @@ function sanitizeWarehouseIds(warehouseIds) {
     .filter((id) => Number.isFinite(id));
 }
 
+// Single-flight, TTL cache. Caching the in-flight PROMISE (not just the resolved
+// value) means N concurrent callers with a cold/expired key share ONE computation
+// instead of each launching the expensive query — this is what prevents the
+// thundering-herd DB saturation when several dashboard loads land at once.
 async function memoize(key, ttlMs, fetcher) {
   const entry = cache.get(key);
   const now = Date.now();
   if (entry && now - entry.time < ttlMs) {
-    return entry.value;
+    return entry.promise;
   }
-
-  const value = await fetcher();
-  cache.set(key, { value, time: now });
-  return value;
+  const promise = Promise.resolve().then(fetcher);
+  cache.set(key, { promise, time: now });
+  // On failure, drop the cached rejection so the next call retries instead of
+  // serving the error for the whole TTL.
+  promise.catch(() => {
+    const cur = cache.get(key);
+    if (cur && cur.promise === promise) cache.delete(key);
+  });
+  return promise;
 }
 
 function resolvePeriod(periodKey = '1d') {
@@ -715,7 +724,18 @@ async function computeCleanDayMetrics(pool, windowStart) {
   return metrics;
 }
 
-async function getCuttingRecommendations(pool, { periodKey = '30d', shadow = false } = {}) {
+// Public entry — single-flight, 5-min cached. The full company-wide computation
+// (a ~24s query on a good day, 300s+ under load) previously ran on EVERY dashboard
+// load and stacked under concurrency, saturating the DB. Now the first caller
+// computes and everyone else (concurrent + within the TTL) shares the result.
+// Keyed on shadow so the shadow-diff path is never served a plain-mode cache.
+async function getCuttingRecommendations(pool, opts = {}) {
+  const { periodKey = '30d', shadow = false } = opts;
+  return memoize(`cutrecs:${periodKey}:${shadow ? 'shadow' : 'plain'}`, CACHE_TTL_MS,
+    () => computeCuttingRecommendations(pool, { periodKey, shadow }));
+}
+
+async function computeCuttingRecommendations(pool, { periodKey = '30d', shadow = false } = {}) {
   // Resolve window for snapshot-based selling days
   const presetHours = PERIOD_PRESETS[periodKey]?.hours
     || (Number(String(periodKey).replace(/[^0-9]/g, '')) * 24)

--- a/utils/onOrder.js
+++ b/utils/onOrder.js
@@ -70,11 +70,23 @@ async function loadResolutionMap(pool) {
   return new Map(resolution.map((r) => [U(r.cl_sku) + '||' + U(r.size_label), U(r.size_sku)]));
 }
 
+// The distinct-SKU scan over ee_suborders (~560k rows) is expensive and its result
+// only changes with the nightly pull. Single-flight + short TTL cache so concurrent
+// dashboard loads share one scan instead of each triggering a full-table read.
+let _canonCache = null; // { promise, time }
+const CANON_TTL_MS = 5 * 60 * 1000;
 async function loadCanonSet(pool) {
-  const [canonRows] = await pool.query(
+  const scan = () => pool.query(
     `SELECT DISTINCT UPPER(sku) AS sku FROM ee_suborders WHERE sku IS NOT NULL AND sku <> ''`
-  );
-  return new Set(canonRows.map((r) => r.sku));
+  ).then(([canonRows]) => new Set(canonRows.map((r) => r.sku)));
+  // No cross-call cache under test — unit tests call this with different mock pools.
+  if (process.env.NODE_ENV === 'test') return scan();
+  const now = Date.now();
+  if (_canonCache && now - _canonCache.time < CANON_TTL_MS) return _canonCache.promise;
+  const promise = scan();
+  _canonCache = { promise, time: now };
+  promise.catch(() => { if (_canonCache && _canonCache.promise === promise) _canonCache = null; });
+  return promise;
 }
 
 // Returns { onOrder: Map<size_sku, qty>, unresolved: { lots, pieces } }.


### PR DESCRIPTION
## The outage (from real slow-query data — not a guess)

At **13:04 IST on 2026-07-26**, opening the cutting-planning / PM dashboard fired several **uncached heavy queries** that stacked on the small `db-g1-small` instance:
- `product_links` `REGEXP` scan — **31× at up to 51s** (REGEXP can't use `idx_sku` → full 79k-row scan)
- the all-SKU `getCuttingRecommendations` query — **321s** in one run
- `DISTINCT` scans on `ee_suborders` (560k) and `ee_inventory_daily_snapshot` (2.78M)

With the DB pegged, **session writes (every page load) queued up to 51s → the whole site slowed**; the PM queries hit the 10s statement timeout → the "internal error for some SKUs" 500s. It recovered when the burst drained. **Firebase was ruled out** (erpkotty.in 200 in ~0.5s throughout).

## Root amplifier

`memoize()` was a plain value-cache with **no single-flight**, and `getCuttingRecommendations` **wasn't cached at all** — so every concurrent dashboard load launched its own copy of the 321s query.

## Fixes (no change to any displayed numbers)

1. **Single-flight cache** — `memoize()` now caches the in-flight *promise*, so N concurrent callers share ONE computation. Rejections are dropped so errors don't stick for the TTL.
2. **Cache `getCuttingRecommendations`** (5 min, keyed by period + shadow).
3. **`product_links` REGEXP → `LIKE 'style%'`** — collation-correct indexed range scan on `idx_sku`. Verified on prod: **identical link map (0 of 107 lost)**, ~1s → ~70ms; `ORDER BY sku` for deterministic tie-break.
4. **`onOrder.loadCanonSet`** (560k-row DISTINCT) — single-flight + 5-min cached (bypassed under test).

## Verified

- **Single-flight proof (prod data):** 20 concurrent `getCuttingRecommendations` calls fire **exactly 1** heavy query (was 20), all identical; a 2nd wave within TTL fires **0**. Cold 6.5s → cached **0ms**.
- **Link parity:** REGEXP vs LIKE on 200 real styles → same 107 links, 0 lost; `EXPLAIN` shows `type=range key=idx_sku`.
- **192/192 tests pass.**

After deploy, the repeated 51s `product_links` and 321s cut-recommendation entries should vanish from the slow-query log, and cutting-planning can't stall the site under concurrent load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)