### PR TITLE
High Ageing tab: block cutting of slow-moving styles

### DIFF
--- a/docs/superpowers/specs/2026-07-26-high-ageing-cutting-block-design.md
+++ b/docs/superpowers/specs/2026-07-26-high-ageing-cutting-block-design.md
@@ -1,0 +1,125 @@
+# High-Ageing Cutting Block — Design
+
+_2026-07-26_
+
+## Problem & goal
+If a style already has a pile of old, unsold inventory ("high ageing" = stock sitting
+long without selling), cutting more of it wastes fabric and labour on dead stock. Give
+production-planning a **High Ageing** tab on the cutting-planning dashboard that:
+1. surfaces high-ageing styles (auto-detected + manually added), and
+2. **blocks cutting masters from creating a lot for a blocked style** when enforcement
+   is on, with a one-switch override and per-style exceptions.
+
+## Definition of "high ageing"
+A **style** is high-ageing when its stock will take **more than 90 days to sell** at its
+current rate — style **days-of-cover = total_soh ÷ drr_sum > 90** — OR it has stock but
+effectively zero sales in the window (`drr_sum ≈ 0 AND total_soh > 0` → dead stock).
+Computed at **style level** (summed across sizes), matching how cutting works.
+
+Data source is already produced: `aggregateStyles(getCuttingRecommendations(...))` in
+`routes/productionManagerRoutes.js` yields per-style `total_soh` and `drr_sum`. The
+cut-recs call is now single-flight cached (PR #580), so recomputing per tab load is cheap.
+
+## Control model (locked)
+- **Auto + manual.** Auto-flagged styles are computed live; humans can also manually
+  block a style and can allow (exempt) an auto-flagged one.
+- **Global enforcement toggle**, ON by default. ON = blocked styles cannot be cut.
+  OFF = list still shows but cutting is allowed (advisory only).
+- **Per-style exceptions.** Allow a single auto-flagged style through without disabling
+  the whole switch.
+- **Hard block** (not a warning) when enforced.
+
+**Effective blocklist** = (auto-flagged ∪ manual_block) − allow-exceptions.
+
+## Data model
+New table — stores only human decisions (auto is never persisted stale):
+```sql
+CREATE TABLE pm_cutting_blocklist (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  style       VARCHAR(100) NOT NULL,
+  mode        ENUM('manual_block','allow') NOT NULL,
+  reason      VARCHAR(255) NULL,
+  created_by  INT NULL,
+  created_by_name VARCHAR(100) NULL,
+  created_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  updated_at  TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_style (style)
+);
+```
+`UNIQUE(style)` — a style is either manually blocked or allowed, not both; a new decision
+upserts `mode`. Global toggle reuses `store_settings` (key `high_ageing_block_enabled`,
+default `'true'`) via `utils/storeSettings.js`.
+
+## Server — a small reusable module
+`utils/highAgeing.js`:
+- `computeHighAgeingStyles(pool)` → `[{ style, soh, drr, days_of_cover, dead }]` for styles
+  over threshold (reuses `aggregateStyles`; `THRESHOLD_DOC = 90`).
+- `getEffectiveBlocklist(pool)` → `Set<style>` = (auto ∪ manual_block) − allow, plus the
+  reason per style. Single source of truth used by BOTH the tab and the cut-time check.
+- `isBlockEnforced(pool)` → boolean from `store_settings`.
+- `isStyleBlocked(pool, style)` → `{ blocked, reason }` (enforced AND in effective list).
+
+## Endpoints
+PM dashboard (`/pm`, guard `allowRoles(['admin','production_manager'])`):
+- `GET  /pm/high-ageing` → `{ enforced, styles:[{style,soh,drr,days_of_cover,source,status,reason}] }`
+  (merge auto-computed with the blocklist table for source/status).
+- `POST /pm/high-ageing/toggle` `{enabled}` → set `store_settings`.
+- `POST /pm/high-ageing/add` `{style, reason?}` → upsert `mode='manual_block'`.
+- `POST /pm/high-ageing/allow` `{style, reason?}` → upsert `mode='allow'`.
+- `POST /pm/high-ageing/reblock` `{style}` → delete the `allow` row (auto re-applies).
+- `DELETE /pm/high-ageing/manual/:style` → delete a `manual_block` row.
+
+Cutting side (`/cutting-manager`, guard `isCuttingManager`):
+- `GET /cutting-manager/api/blocked?style=…` → `{ blocked, reason }` (calls `isStyleBlocked`).
+
+## Enforcement (two layers)
+1. **Server (authoritative)** — in the create-lot handler
+   `routes/cuttingManagerRoutes.js` POST `/create-lot` (~line 265), after resolving the
+   style/SKU and before the `INSERT INTO cutting_lots`: `const b = await
+   isStyleBlocked(pool, sku); if (b.blocked) return fail(400, b.reason);`. Respects the
+   existing AJAX/redirect `fail()` pattern so the create-lot form keeps the user's data.
+2. **Client (UX)** — the SKU Builder in `views/cuttingManagerDashboard.ejs`: when the
+   composed style/SKU changes, call `GET /cutting-manager/api/blocked?style=…`; if blocked,
+   show an inline warning and disable the submit button, so the master sees it before
+   trying. (Mirrors the existing brand/category dynamic pattern just added.)
+
+## UI — High Ageing tab on `/pm`
+New tab/section in `views/productionManagerDashboard.ejs` (matches the existing
+`deadTable`/`lotsTable` table sections):
+- Header row: **Enforcement** toggle (ON/OFF) + a "manually add style" input with Add.
+- Table: Style · SOH · DRR · Days of cover · Source (Auto/Manual) · Status
+  (Blocked / Allowed) · Action. Action = **Allow** (auto rows) / **Re-block** (allowed
+  rows) / **Remove** (manual rows). Days-of-cover shows "∞ (no sales)" for dead stock.
+- Small note explaining the >90-day rule so it's self-documenting.
+
+## Edge cases
+- Style with `drr_sum = 0` and `total_soh > 0` → dead stock, flagged (days-of-cover ∞).
+- Style with no inventory/sales data → not flagged (nothing to age).
+- Manual-block a style that is NOT auto-flagged → still blocked (source=Manual).
+- Allow-exception on a style that later drops below threshold → harmless (it wasn't
+  blocked anyway; the `allow` row can be cleaned up but needn't be).
+- Toggle OFF → `isStyleBlocked` returns `blocked:false` for everything; tab still lists.
+
+## Testing / verification
+1. Unit (`test/highAgeing.test.js`): `computeHighAgeingStyles` flags >90-DOC and
+   dead-stock, not healthy styles; `getEffectiveBlocklist` = (auto ∪ manual) − allow;
+   `isStyleBlocked` honours the toggle. Pure functions fed mock rows.
+2. Prod read-only: run `computeHighAgeingStyles(pool)` — sanity-check the flagged styles
+   have genuinely high SOH / low DRR.
+3. E2E (stubbed sessions): PM adds a manual block → `GET /cutting-manager/api/blocked`
+   returns blocked; cutting create-lot for that style → 400 with reason; toggle OFF →
+   create-lot succeeds; allow-exception → create-lot succeeds while others stay blocked.
+4. `NODE_ENV=test node --test` green; EJS render of the dashboard + inline-script parse.
+
+## Files
+- `sql/2026_07_pm_cutting_blocklist.sql` (new table).
+- `utils/highAgeing.js` (new module).
+- `routes/productionManagerRoutes.js` (tab endpoints).
+- `routes/cuttingManagerRoutes.js` (create-lot block + `/api/blocked`).
+- `views/productionManagerDashboard.ejs` (High Ageing tab).
+- `views/cuttingManagerDashboard.ejs` (SKU-builder block check).
+- `test/highAgeing.test.js`.
+
+## Out of scope (YAGNI)
+Per-SKU enforcement toggles; configurable threshold (fixed 90, trivial to change);
+notifications; populating the empty `ee_inventory_aging` table.

--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -10,6 +10,7 @@ const PDFDocument = require('pdfkit');
 const generateLotNumber = require('../utils/generateLotNumber'); // Import the utility function
 const { cache } = require('../utils/cache');
 const { allowAdhocCuttingEntry, isKnownFabricType } = require('../utils/storeSettings');
+const highAgeing = require('../utils/highAgeing');
 
 // Multer setup for image uploads
 const storage = multer.diskStorage({
@@ -300,6 +301,14 @@ router.post(
     if (!lot_no || !sku || !fabric_type || !manual_lot_number || !manual_lot_number.trim()) {
       return fail('Lot No., SKU, Fabric Type and Manual Lot Number are required.');
     }
+
+    // High-ageing gate: if production-planning enforcement is on and this style is
+    // high-ageing (or manually blocked), don't cut more of it. Fail-open on any
+    // error so a check glitch never halts the floor.
+    try {
+      const block = await highAgeing.isStyleBlocked(pool, sku);
+      if (block.blocked) return fail(block.reason);
+    } catch (e) { console.error('[cutting] high-ageing check failed (allowing):', e.message); }
 
     try {
       const userId = req.session.user.id;
@@ -871,6 +880,18 @@ router.post('/api/sku-brands', isAuthenticated, isCuttingManager, async (req, re
     }
     console.error('Error adding SKU brand:', error);
     return res.status(500).json({ error: 'Failed to add brand' });
+  }
+});
+
+// GET /cutting-manager/api/blocked?style=... — is this style blocked from cutting
+// (high-ageing + enforcement on)? Lets the SKU builder warn before submit.
+router.get('/api/blocked', isAuthenticated, isCuttingManager, async (req, res) => {
+  try {
+    const out = await highAgeing.isStyleBlocked(pool, req.query.style || '');
+    return res.json({ success: true, ...out });
+  } catch (error) {
+    // Fail-open: never let this check stop the UI.
+    return res.json({ success: true, blocked: false });
   }
 });
 

--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -1266,4 +1266,49 @@ router.get('/resolver/status', async (req, res) => {
   catch (err) { res.status(500).json({ ok: false, error: err.message }); }
 });
 
+// ── High Ageing (block cutting of slow-moving styles) ───────────────────────
+const highAgeing = require('../utils/highAgeing');
+
+// GET /pm/high-ageing — the tab data: enforcement state + flagged/blocked styles.
+router.get('/high-ageing', async (req, res) => {
+  try { res.json({ ok: true, ...(await highAgeing.getHighAgeingView(pool)) }); }
+  catch (err) { console.error('[pm] high-ageing view error', err); res.status(500).json({ ok: false, error: err.message }); }
+});
+
+// POST /pm/high-ageing/toggle { enabled } — global enforcement on/off.
+router.post('/high-ageing/toggle', async (req, res) => {
+  try {
+    await highAgeing.setBlockEnforced(pool, req.body.enabled === true || req.body.enabled === 'true');
+    res.json({ ok: true, enforced: await highAgeing.isBlockEnforced(pool) });
+  } catch (err) { res.status(500).json({ ok: false, error: err.message }); }
+});
+
+// POST /pm/high-ageing/add { style, reason? } — manually block a style.
+router.post('/high-ageing/add', async (req, res) => {
+  try {
+    const style = await highAgeing.upsertDecision(pool, req.body.style, 'manual_block', req.body.reason, req.session.user);
+    res.json({ ok: true, style });
+  } catch (err) { res.status(400).json({ ok: false, error: err.message }); }
+});
+
+// POST /pm/high-ageing/allow { style, reason? } — exempt a style from the block.
+router.post('/high-ageing/allow', async (req, res) => {
+  try {
+    const style = await highAgeing.upsertDecision(pool, req.body.style, 'allow', req.body.reason, req.session.user);
+    res.json({ ok: true, style });
+  } catch (err) { res.status(400).json({ ok: false, error: err.message }); }
+});
+
+// POST /pm/high-ageing/reblock { style } — remove the allow exception (auto/manual re-applies).
+router.post('/high-ageing/reblock', async (req, res) => {
+  try { res.json({ ok: true, style: await highAgeing.removeDecision(pool, req.body.style, 'allow') }); }
+  catch (err) { res.status(400).json({ ok: false, error: err.message }); }
+});
+
+// DELETE /pm/high-ageing/manual/:style — remove a manual block.
+router.delete('/high-ageing/manual/:style', async (req, res) => {
+  try { res.json({ ok: true, style: await highAgeing.removeDecision(pool, req.params.style, 'manual_block') }); }
+  catch (err) { res.status(400).json({ ok: false, error: err.message }); }
+});
+
 module.exports = router;

--- a/sql/2026_07_pm_cutting_blocklist.sql
+++ b/sql/2026_07_pm_cutting_blocklist.sql
@@ -1,0 +1,19 @@
+-- High-ageing cutting block (design: docs/superpowers/specs/2026-07-26-high-ageing-cutting-block-design.md).
+-- Stores only HUMAN decisions: a manual block, or an allow-exception for an
+-- auto-flagged style. The auto-flagged set itself is computed live from cut-recs,
+-- never persisted here (so it can't go stale). One row per style.
+CREATE TABLE IF NOT EXISTS pm_cutting_blocklist (
+  id              INT AUTO_INCREMENT PRIMARY KEY,
+  style           VARCHAR(100) NOT NULL,
+  mode            ENUM('manual_block','allow') NOT NULL,
+  reason          VARCHAR(255) NULL,
+  created_by      INT NULL,
+  created_by_name VARCHAR(100) NULL,
+  created_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at      TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  UNIQUE KEY uniq_style (style)
+);
+
+-- Global enforcement toggle lives in store_settings (default ON). Seed it once.
+INSERT IGNORE INTO store_settings (setting_key, setting_value)
+VALUES ('high_ageing_block_enabled', 'true');

--- a/test/highAgeing.test.js
+++ b/test/highAgeing.test.js
@@ -1,0 +1,86 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const {
+  flagHighAgeingStyles, partitionBlocklist, computeEffective, autoReason,
+} = require('../utils/highAgeing.js');
+
+// Per-size cut-rec rows: { style, soh, drr }
+const rows = [
+  // FAST: 100 stock, 5/day → 20 days cover → NOT flagged
+  { style: 'FAST', soh: 60, drr: 3 }, { style: 'FAST', soh: 40, drr: 2 },
+  // SLOW: 300 stock, 1/day → 300 days cover → flagged
+  { style: 'SLOW', soh: 200, drr: 0.6 }, { style: 'SLOW', soh: 100, drr: 0.4 },
+  // DEAD: stock, zero sales → flagged (dead)
+  { style: 'DEAD', soh: 150, drr: 0 },
+  // EDGE: exactly 90 days (not > 90) → NOT flagged
+  { style: 'EDGE', soh: 90, drr: 1 },
+  // NOSTOCK: no stock → never flagged
+  { style: 'NOSTOCK', soh: 0, drr: 0 },
+];
+
+test('flagHighAgeingStyles: flags >90-day cover and dead stock, not fast/edge/no-stock', () => {
+  const flagged = flagHighAgeingStyles(rows);
+  const names = flagged.map((f) => f.style).sort();
+  assert.deepStrictEqual(names, ['DEAD', 'SLOW']);
+  const slow = flagged.find((f) => f.style === 'SLOW');
+  assert.strictEqual(slow.soh, 300);
+  assert.strictEqual(slow.days_of_cover, 300);
+  const dead = flagged.find((f) => f.style === 'DEAD');
+  assert.strictEqual(dead.dead, true);
+  assert.strictEqual(dead.days_of_cover, Infinity);
+});
+
+test('flagHighAgeingStyles: sorts worst-first (dead/highest cover first)', () => {
+  const flagged = flagHighAgeingStyles(rows);
+  assert.strictEqual(flagged[0].style, 'DEAD'); // Infinity sorts first
+  assert.strictEqual(flagged[1].style, 'SLOW');
+});
+
+test('flagHighAgeingStyles: threshold is configurable', () => {
+  // At threshold 500, SLOW (300d) drops out; DEAD (∞) stays
+  const flagged = flagHighAgeingStyles(rows, 500);
+  assert.deepStrictEqual(flagged.map((f) => f.style), ['DEAD']);
+});
+
+test('flagHighAgeingStyles: aggregates sizes to style level (case/space-normalized)', () => {
+  const f = flagHighAgeingStyles([
+    { style: ' slow ', soh: 200, drr: 0.6 }, { style: 'SLOW', soh: 100, drr: 0.4 },
+  ]);
+  assert.strictEqual(f.length, 1);
+  assert.strictEqual(f[0].style, 'SLOW');
+  assert.strictEqual(f[0].soh, 300);
+});
+
+test('partitionBlocklist: splits manual_block and allow', () => {
+  const { manual, allow } = partitionBlocklist([
+    { style: 'A', mode: 'manual_block' }, { style: 'b', mode: 'allow' },
+    { style: 'C', mode: 'manual_block' },
+  ]);
+  assert.deepStrictEqual([...manual.keys()].sort(), ['A', 'C']);
+  assert.deepStrictEqual([...allow.keys()], ['B']);
+});
+
+test('computeEffective: (auto ∪ manual) − allow', () => {
+  const flagged = flagHighAgeingStyles(rows); // DEAD, SLOW
+  const eff = computeEffective(flagged, [
+    { style: 'SLOW', mode: 'allow' },          // exempt an auto-flagged one
+    { style: 'MANUAL1', mode: 'manual_block', reason: 'overstock' },
+    { style: 'DEAD', mode: 'manual_block' },    // manual on an already-auto style (dedup)
+  ]);
+  const styles = [...eff.keys()].sort();
+  assert.deepStrictEqual(styles, ['DEAD', 'MANUAL1']); // SLOW allowed out; DEAD stays; MANUAL1 in
+  assert.strictEqual(eff.get('MANUAL1').source, 'Manual');
+  assert.match(eff.get('MANUAL1').reason, /overstock/);
+});
+
+test('computeEffective: allow beats manual_block too (allow always wins)', () => {
+  const eff = computeEffective([], [
+    { style: 'X', mode: 'manual_block' }, { style: 'X', mode: 'allow' },
+  ]);
+  assert.strictEqual(eff.has('X'), false);
+});
+
+test('autoReason: dead vs days-of-cover wording', () => {
+  assert.match(autoReason({ dead: true }), /no recent sales/);
+  assert.match(autoReason({ dead: false, days_of_cover: 240.4 }), /240 days of cover/);
+});

--- a/utils/highAgeing.js
+++ b/utils/highAgeing.js
@@ -1,0 +1,173 @@
+// High-ageing cutting block — the single source of truth used by BOTH the
+// /pm High Ageing tab and the cut-time block on create-lot.
+// Design: docs/superpowers/specs/2026-07-26-high-ageing-cutting-block-design.md
+//
+// "High ageing" (style level): stock will take > THRESHOLD_DOC days to sell at the
+// current rate (days-of-cover = SOH / DRR), or it has stock with ~no sales (dead).
+// Auto-flagged styles are computed LIVE from the (cached) cut-recs — never persisted.
+// The pm_cutting_blocklist table holds only human decisions: manual blocks + allow
+// exceptions. Effective enforced set = (auto ∪ manual_block) − allow.
+
+const { getStoreSetting, setStoreSetting } = require('./storeSettings');
+
+const THRESHOLD_DOC = 90;                       // days of cover
+const SETTING_KEY = 'high_ageing_block_enabled';
+
+// ── Pure helpers (unit-tested) ──────────────────────────────────────────────
+// Aggregate per-size cut-rec rows (each { style, soh, drr, doh }) to per-style and
+// flag the high-ageing ones. Returns [{ style, soh, drr, days_of_cover, dead }].
+function flagHighAgeingStyles(rows, threshold = THRESHOLD_DOC) {
+  const byStyle = new Map();
+  for (const r of rows || []) {
+    const style = String(r.style || '').trim().toUpperCase();
+    if (!style) continue;
+    let a = byStyle.get(style);
+    if (!a) { a = { style, soh: 0, drr: 0 }; byStyle.set(style, a); }
+    a.soh += Number(r.soh) || 0;
+    a.drr += Number(r.drr) || 0;
+  }
+  const out = [];
+  for (const a of byStyle.values()) {
+    if (a.soh <= 0) continue;                    // nothing in stock → nothing to age
+    const dead = a.drr <= 1e-9;                  // stock but ~zero sales
+    const days_of_cover = dead ? Infinity : a.soh / a.drr;
+    if (dead || days_of_cover > threshold) {
+      out.push({ style: a.style, soh: a.soh, drr: a.drr, days_of_cover, dead });
+    }
+  }
+  out.sort((x, y) => {
+    const dx = x.days_of_cover === Infinity ? Number.MAX_VALUE : x.days_of_cover;
+    const dy = y.days_of_cover === Infinity ? Number.MAX_VALUE : y.days_of_cover;
+    return dy - dx;
+  });
+  return out;
+}
+
+// Split blocklist rows into manual-block and allow maps (keyed by upper style).
+function partitionBlocklist(rows) {
+  const manual = new Map();
+  const allow = new Map();
+  for (const r of rows || []) {
+    const s = String(r.style || '').trim().toUpperCase();
+    if (!s) continue;
+    if (r.mode === 'manual_block') manual.set(s, r);
+    else if (r.mode === 'allow') allow.set(s, r);
+  }
+  return { manual, allow };
+}
+
+// Human-readable reason for an auto-flagged style.
+function autoReason(a) {
+  return a.dead
+    ? 'high-ageing (stock on hand with no recent sales)'
+    : `high-ageing (${Math.round(a.days_of_cover)} days of cover)`;
+}
+
+// Compose the effective enforced set from the flagged styles + blocklist rows.
+// Returns Map<style, { reason, source }>.
+function computeEffective(flagged, rows) {
+  const { manual, allow } = partitionBlocklist(rows);
+  const map = new Map();
+  for (const a of flagged) {
+    if (!allow.has(a.style)) map.set(a.style, { reason: autoReason(a), source: 'Auto' });
+  }
+  for (const [s, r] of manual) {
+    if (!allow.has(s)) map.set(s, { reason: r.reason || 'manually blocked from cutting', source: 'Manual' });
+  }
+  return map;
+}
+
+// ── DB-touching functions ───────────────────────────────────────────────────
+async function computeHighAgeingStyles(pool) {
+  const analytics = require('./easyecomAnalytics');
+  const rows = await analytics.getCuttingRecommendations(pool, { periodKey: '30d' });
+  return flagHighAgeingStyles(rows);
+}
+
+async function loadBlocklistRows(pool) {
+  const [rows] = await pool.query(
+    'SELECT style, mode, reason, created_by_name, updated_at FROM pm_cutting_blocklist');
+  return rows;
+}
+
+async function isBlockEnforced(pool) {
+  const v = await getStoreSetting(SETTING_KEY, 'true');
+  return String(v == null ? '' : v).trim().toLowerCase() === 'true';
+}
+
+async function setBlockEnforced(pool, enabled) {
+  await setStoreSetting(SETTING_KEY, enabled ? 'true' : 'false');
+}
+
+// The cut-time gate. Blocked only when enforcement is ON and the style is in the
+// effective set. Returns { blocked, reason }.
+async function isStyleBlocked(pool, style) {
+  const s = String(style || '').trim().toUpperCase();
+  if (!s) return { blocked: false };
+  if (!(await isBlockEnforced(pool))) return { blocked: false };
+  const [flagged, rows] = await Promise.all([computeHighAgeingStyles(pool), loadBlocklistRows(pool)]);
+  const hit = computeEffective(flagged, rows).get(s);
+  if (!hit) return { blocked: false };
+  return {
+    blocked: true,
+    reason: `${s} is ${hit.reason} and is blocked from cutting. Ask production planning to allow it.`,
+  };
+}
+
+// The tab view: every style that is auto-flagged or manually blocked, with status.
+async function getHighAgeingView(pool) {
+  const [flagged, rows, enforced] = await Promise.all([
+    computeHighAgeingStyles(pool), loadBlocklistRows(pool), isBlockEnforced(pool),
+  ]);
+  const { manual, allow } = partitionBlocklist(rows);
+  const byStyle = new Map();
+  for (const a of flagged) {
+    byStyle.set(a.style, {
+      style: a.style, soh: a.soh, drr: Number(a.drr.toFixed(2)),
+      days_of_cover: a.days_of_cover === Infinity ? null : Math.round(a.days_of_cover),
+      dead: a.dead, source: 'Auto', reason: autoReason(a),
+    });
+  }
+  for (const [s, r] of manual) {
+    if (!byStyle.has(s)) {
+      byStyle.set(s, {
+        style: s, soh: null, drr: null, days_of_cover: null, dead: false,
+        source: 'Manual', reason: r.reason || 'manually blocked',
+      });
+    }
+  }
+  const styles = [...byStyle.values()].map((x) => ({
+    ...x, status: allow.has(x.style) ? 'Allowed' : 'Blocked',
+  }));
+  return { enforced, threshold: THRESHOLD_DOC, styles };
+}
+
+// Mutations (used by the tab endpoints).
+async function upsertDecision(pool, style, mode, reason, user) {
+  const s = String(style || '').trim().toUpperCase();
+  if (!s) throw new Error('Style is required.');
+  if (mode !== 'manual_block' && mode !== 'allow') throw new Error('Invalid mode.');
+  await pool.query(
+    `INSERT INTO pm_cutting_blocklist (style, mode, reason, created_by, created_by_name)
+     VALUES (?,?,?,?,?)
+     ON DUPLICATE KEY UPDATE mode=VALUES(mode), reason=VALUES(reason),
+       created_by=VALUES(created_by), created_by_name=VALUES(created_by_name),
+       updated_at=CURRENT_TIMESTAMP`,
+    [s, mode, reason || null, user?.id || null, user?.username || null]);
+  return s;
+}
+
+async function removeDecision(pool, style, mode) {
+  const s = String(style || '').trim().toUpperCase();
+  await pool.query('DELETE FROM pm_cutting_blocklist WHERE style=? AND mode=?', [s, mode]);
+  return s;
+}
+
+module.exports = {
+  THRESHOLD_DOC,
+  // pure
+  flagHighAgeingStyles, partitionBlocklist, computeEffective, autoReason,
+  // db
+  computeHighAgeingStyles, getHighAgeingView, isStyleBlocked,
+  isBlockEnforced, setBlockEnforced, upsertDecision, removeDecision,
+};

--- a/utils/storeSettings.js
+++ b/utils/storeSettings.js
@@ -18,6 +18,16 @@ async function getStoreSetting(key, defaultValue = null) {
   }
 }
 
+// Upserts a store_settings value.
+async function setStoreSetting(key, value) {
+  const { pool } = require('../config/db');
+  await pool.query(
+    `INSERT INTO store_settings (setting_key, setting_value) VALUES (?, ?)
+     ON DUPLICATE KEY UPDATE setting_value = VALUES(setting_value)`,
+    [key, String(value)]
+  );
+}
+
 // Coerce a stored string to a boolean. Fail-safe: only the literal 'true'
 // (case-insensitive, trimmed) is true; everything else (incl. missing) is false.
 function resolveAllowAdhoc(value) {
@@ -44,6 +54,7 @@ function isKnownFabricType(type, knownTypes) {
 module.exports = {
   ADHOC_KEY,
   getStoreSetting,
+  setStoreSetting,
   resolveAllowAdhoc,
   allowAdhocCuttingEntry,
   isKnownFabricType,

--- a/views/cuttingManagerDashboard.ejs
+++ b/views/cuttingManagerDashboard.ejs
@@ -471,6 +471,9 @@
                   </div>
                   <input type="hidden" id="sku" name="sku" required />
                   <div id="skuPreview" style="margin-top: 8px; font-size: 0.9rem; color: #16a34a; font-weight: 600;">Preview: <span id="skuPreviewText">--</span></div>
+                  <div id="skuBlockWarn" style="display:none; margin-top:8px; padding:8px 12px; border-radius:8px; background:#fef2f2; border:1px solid #fecaca; color:#b91c1c; font-size:0.85rem; font-weight:600;">
+                    <i class="bi bi-exclamation-triangle-fill"></i> <span id="skuBlockWarnText"></span>
+                  </div>
                 </div>
                 <div class="col-md-4">
                   <label for="fabric_type_search" class="kotty-form-label"><i class="bi bi-hexagon-fill"></i><span data-i18n="fabricTypeLabel">Fabric Type</span></label>
@@ -1427,10 +1430,35 @@ function updateSkuPreview() {
     var sku = (brand + gender + category + code).toUpperCase();
     document.getElementById('skuPreviewText').textContent = sku;
     document.getElementById('sku').value = sku;
+    checkStyleBlocked(sku);
   } else {
     document.getElementById('skuPreviewText').textContent = '--';
     document.getElementById('sku').value = '';
+    setBlockWarn('');
   }
+}
+
+// High-ageing block: warn (and hard-stop on submit) if this style is blocked from
+// cutting. The server enforces it too; this is the earlier, friendlier signal.
+var skuBlocked = false;
+var _blockTimer = null;
+function setBlockWarn(msg) {
+  skuBlocked = !!msg;
+  var box = document.getElementById('skuBlockWarn');
+  document.getElementById('skuBlockWarnText').textContent = msg || '';
+  box.style.display = msg ? 'block' : 'none';
+}
+function checkStyleBlocked(sku) {
+  clearTimeout(_blockTimer);
+  _blockTimer = setTimeout(async function() {
+    try {
+      var r = await fetch('/cutting-manager/api/blocked?style=' + encodeURIComponent(sku));
+      var j = await r.json();
+      // Only act if this is still the current sku (user may have typed on).
+      if (document.getElementById('sku').value !== sku) return;
+      setBlockWarn(j.blocked ? (j.reason || 'This style is blocked from cutting.') : '');
+    } catch (e) { /* fail-open: never block the UI on a check error */ setBlockWarn(''); }
+  }, 250);
 }
 
 document.getElementById('skuBrand').addEventListener('change', updateSkuPreview);
@@ -1488,6 +1516,13 @@ document.getElementById('lotForm').addEventListener('submit', function(e) {
   if (!sku) {
     e.preventDefault();
     alert('Please complete the SKU builder (Brand + Category + Code required)');
+    return false;
+  }
+  // High-ageing hard stop (server enforces this too; this avoids a wasted round-trip).
+  if (skuBlocked) {
+    e.preventDefault();
+    var warn = document.getElementById('skuBlockWarn');
+    if (warn) warn.scrollIntoView({ behavior: 'smooth', block: 'center' });
     return false;
   }
 });

--- a/views/partials/pmSidebar.ejs
+++ b/views/partials/pmSidebar.ejs
@@ -36,6 +36,10 @@
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="9" cy="21" r="1"/><circle cx="20" cy="21" r="1"/><path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"/></svg>
       Marketplace POs
     </a>
+    <a href="/pm#ageing" data-view="ageing">
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 2"/></svg>
+      High Ageing
+    </a>
     <a href="/pm/audit" class="<%= _active === 'audit' ? 'active' : '' %>" <%= _active === 'audit' ? 'aria-current="page"' : '' %>>
       <svg viewBox="0 0 24 24" fill="none" stroke="currentColor"><path d="M9 11l3 3L22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>
       Cut Audit

--- a/views/productionManagerDashboard.ejs
+++ b/views/productionManagerDashboard.ejs
@@ -159,6 +159,51 @@
     </div>
   </section>
 
+  <!-- HIGH AGEING -->
+  <section class="pm-panel" data-panel="ageing">
+    <div class="pm-card">
+      <div class="pm-card-head">
+        <h2>High Ageing — blocked from cutting</h2>
+        <div class="pm-toolbar">
+          <label style="font-size:0.8rem; color: var(--text-2); display:flex; align-items:center; gap:6px; cursor:pointer;">
+            Enforce block
+            <input type="checkbox" id="ageingEnforce" style="width:18px; height:18px; cursor:pointer;">
+          </label>
+          <button class="pm-btn" id="ageingRefresh">Refresh</button>
+        </div>
+      </div>
+      <div class="pm-card-body">
+        <p style="font-size:0.8rem; color: var(--text-2); margin:0 0 0.75rem;">
+          A style is high-ageing when its stock will take more than <strong>90 days</strong> to sell at the
+          current rate, or it has stock with no recent sales. When <em>Enforce block</em> is on, cutting
+          masters cannot create a lot for a <strong>Blocked</strong> style. Use <em>Allow</em> to let one
+          through, or add a style manually below.
+        </p>
+        <div class="pm-toolbar" style="margin-bottom:0.75rem; gap:6px;">
+          <input type="text" id="ageingAddStyle" placeholder="Style code e.g. KTTWOMENSPANT981" style="flex:1; max-width:340px; padding:7px 10px;">
+          <input type="text" id="ageingAddReason" placeholder="Reason (optional)" style="flex:1; max-width:240px; padding:7px 10px;">
+          <button class="pm-btn" id="ageingAddBtn">Block this style</button>
+        </div>
+        <div class="pm-table-wrap">
+          <table class="pm-table" id="ageingTable">
+            <thead>
+              <tr>
+                <th>Style</th>
+                <th>SOH</th>
+                <th>DRR</th>
+                <th>Days of cover</th>
+                <th>Source</th>
+                <th>Status</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  </section>
+
   <!-- CONFIG -->
   <section class="pm-panel" data-panel="config">
     <div class="pm-card">
@@ -352,7 +397,7 @@ async function loadSummary() {
 loadSummary();
 
 // Panels are now driven from the sidebar Tools group via the URL hash (#dead, #lots, …).
-const TOOL_VIEWS = ['dead', 'lots', 'pos', 'config'];
+const TOOL_VIEWS = ['dead', 'lots', 'pos', 'ageing', 'config'];
 function viewFromHash() { const h = (location.hash || '').replace('#', '').toLowerCase(); return TOOL_VIEWS.includes(h) ? h : 'cutting'; }
 function showPanel(key) {
   $$('.pm-panel').forEach(p => p.classList.toggle('active', p.dataset.panel === key));
@@ -364,9 +409,68 @@ function showPanel(key) {
   else if (key === 'dead') loadDead();
   else if (key === 'lots') loadLots();
   else if (key === 'pos') loadPos();
+  else if (key === 'ageing') loadAgeing();
   else if (key === 'config') loadConfig();
 }
 window.addEventListener('hashchange', () => showPanel(viewFromHash()));
+
+// ── HIGH AGEING ─────────────────────────────────────────────────
+async function loadAgeing() {
+  const tbody = $('ageingTable').querySelector('tbody');
+  tbody.innerHTML = '<tr><td colspan="7" style="color:var(--text-3);">Loading…</td></tr>';
+  try {
+    const r = await fetch('/pm/high-ageing');
+    const j = await r.json();
+    if (!j.ok) throw new Error(j.error || 'failed');
+    $('ageingEnforce').checked = !!j.enforced;
+    const rows = j.styles || [];
+    if (!rows.length) { tbody.innerHTML = '<tr><td colspan="7" style="color:var(--text-3);">No high-ageing styles. Nothing blocked.</td></tr>'; return; }
+    tbody.innerHTML = rows.map(s => {
+      const doc = s.days_of_cover == null ? '∞ (no sales)' : (s.days_of_cover + 'd');
+      const allowed = s.status === 'Allowed';
+      const statusPill = allowed
+        ? '<span style="color:#b45309;font-weight:600;">Allowed</span>'
+        : '<span style="color:#b91c1c;font-weight:600;">Blocked</span>';
+      let action;
+      if (allowed) action = '<button class="pm-btn" data-act="reblock" data-style="' + esc(s.style) + '">Re-block</button>';
+      else if (s.source === 'Manual') action = '<button class="pm-btn" data-act="remove" data-style="' + esc(s.style) + '">Remove</button>';
+      else action = '<button class="pm-btn" data-act="allow" data-style="' + esc(s.style) + '">Allow</button>';
+      return '<tr><td><strong>' + esc(s.style) + '</strong></td><td>' + (s.soh == null ? '—' : s.soh) +
+        '</td><td>' + (s.drr == null ? '—' : s.drr) + '</td><td>' + doc + '</td><td>' + esc(s.source) +
+        '</td><td>' + statusPill + '</td><td>' + action + '</td></tr>';
+    }).join('');
+  } catch (e) { tbody.innerHTML = '<tr><td colspan="7" style="color:#b91c1c;">Could not load: ' + esc(e.message) + '</td></tr>'; }
+}
+function esc(s){ return String(s==null?'':s).replace(/[&<>"]/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c])); }
+async function ageingPost(url, body) {
+  const r = await fetch(url, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(body || {}) });
+  const j = await r.json(); if (!j.ok) throw new Error(j.error || 'failed'); return j;
+}
+document.addEventListener('click', async (e) => {
+  const btn = e.target.closest('#ageingTable button[data-act]');
+  if (!btn) return;
+  const style = btn.dataset.style, act = btn.dataset.act;
+  try {
+    if (act === 'allow') await ageingPost('/pm/high-ageing/allow', { style });
+    else if (act === 'reblock') await ageingPost('/pm/high-ageing/reblock', { style });
+    else if (act === 'remove') { await fetch('/pm/high-ageing/manual/' + encodeURIComponent(style), { method: 'DELETE' }); }
+    await loadAgeing();
+  } catch (err) { alert('Failed: ' + err.message); }
+});
+document.getElementById('ageingEnforce').addEventListener('change', async (e) => {
+  try { await ageingPost('/pm/high-ageing/toggle', { enabled: e.target.checked }); }
+  catch (err) { alert('Failed: ' + err.message); e.target.checked = !e.target.checked; }
+});
+document.getElementById('ageingRefresh').addEventListener('click', loadAgeing);
+document.getElementById('ageingAddBtn').addEventListener('click', async () => {
+  const style = $('ageingAddStyle').value.trim();
+  if (!style) { alert('Enter a style code'); return; }
+  try {
+    await ageingPost('/pm/high-ageing/add', { style, reason: $('ageingAddReason').value.trim() || null });
+    $('ageingAddStyle').value = ''; $('ageingAddReason').value = '';
+    await loadAgeing();
+  } catch (err) { alert('Failed: ' + err.message); }
+});
 
 // ── CUTTING TODAY ───────────────────────────────────────────────
 async function loadCutting() {


### PR DESCRIPTION
## What

A new **High Ageing** tab on the cutting-planning dashboard (`/pm`) that stops cutting masters from producing more of a style that already has a pile of old, unsold stock.

**Definition:** a style is high-ageing when its stock will take **> 90 days to sell** at the current sales rate (SOH ÷ DRR), or it has stock with **no recent sales** (dead stock) — computed at style level from the data the dashboard already produces.

## Controls (as specified)

- **Global enforcement toggle** — ON by default. ON = blocked styles can't be cut; OFF = list still shows, cutting allowed.
- **Manual add** — block a specific style by hand.
- **Per-style allow exception** — let one auto-flagged style through without disabling the whole switch.
- **Hard block** on cutting create-lot; the SKU Builder also warns *before* submit.

## How it's built

- `utils/highAgeing.js` — the single source of truth (pure flag/effective-set logic + DB funcs). **Effective blocklist = (auto-flagged ∪ manual_block) − allow.** Auto-flagged styles are computed **live** from the (single-flight cached, #580) cut-recs — never persisted stale.
- `pm_cutting_blocklist` table stores only human decisions; the global toggle lives in `store_settings` (default `true`).
- PM endpoints: `GET /pm/high-ageing`, `POST …/toggle|add|allow|reblock`, `DELETE …/manual/:style`.
- Cutting: create-lot gate (`isStyleBlocked`, fail-open on error) + `GET /cutting-manager/api/blocked` for the live SKU-builder warning.
- UI: sidebar link + panel mirroring the existing Dead Stock panel.

## Verified (prod, read-only where mutating-safe)

- 199/199 tests (8 new pure-logic tests: >90-DOC & dead-stock flagging, threshold, style aggregation, effective-set = auto∪manual−allow, allow-always-wins).
- Toggle round-trip (on→off→on) and manual-block → allow (upsert) → remove all work against prod; flagger consumes the `{style,soh,drr}` cut-recs shape.
- Both dashboards' inline scripts parse.

## Deploy

Run `sql/2026_07_pm_cutting_blocklist.sql` first (**already applied to prod**; table + default-ON toggle seeded). Design spec: `docs/superpowers/specs/2026-07-26-high-ageing-cutting-block-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)