### PR TITLE
fix(pm): precompute cutting recommendations — kills the "<?xml" timeout, DB saturation, and high-ageing noise

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -1311,4 +1311,24 @@ router.delete('/high-ageing/manual/:style', async (req, res) => {
   catch (err) { res.status(400).json({ ok: false, error: err.message }); }
 });
 
+// GET /pm/api/cut-recs/status — when the materialized recommendations were last
+// computed (for the dashboard freshness note + "warming up" state).
+router.get('/api/cut-recs/status', async (req, res) => {
+  try {
+    const info = await analytics.getCutRecsComputedAt(pool);
+    res.json({ ok: true, computed_at: info?.computed_at || null, row_count: info?.row_count || 0 });
+  } catch (err) { res.status(500).json({ ok: false, error: err.message }); }
+});
+
+// POST /pm/api/cut-recs/refresh — rebuild the materialized recommendations now.
+// The heavy compute runs in the background (fire-and-forget, single-flight); the
+// request returns immediately so it can never hit the edge timeout. Poll /status.
+router.post('/api/cut-recs/refresh', async (req, res) => {
+  try {
+    analytics.refreshCutRecommendations(pool)
+      .catch((err) => console.error('[pm] manual cut-recs refresh failed:', err.message));
+    res.json({ ok: true, started: true });
+  } catch (err) { res.status(500).json({ ok: false, error: err.message }); }
+});
+
 module.exports = router;

--- a/sql/2026_07_pm_cut_recommendations_cache.sql
+++ b/sql/2026_07_pm_cut_recommendations_cache.sql
@@ -1,0 +1,12 @@
+-- Materialized cutting recommendations. computeCuttingRecommendations() is a
+-- 300-2700s all-SKU aggregation; running it per dashboard load blew past the 60s
+-- edge timeout (the "<?xml" JSON-parse error) and saturated the DB. The underlying
+-- data (ee_sales_daily DRR, daily snapshot SOH) only changes nightly, so we compute
+-- ONCE (nightly + on demand) and store the JSON result; the dashboard reads this.
+CREATE TABLE IF NOT EXISTS pm_cut_recommendations_cache (
+  cache_key   VARCHAR(40) NOT NULL PRIMARY KEY,   -- e.g. '30d:plain'
+  payload     LONGTEXT NOT NULL,                  -- JSON array of recommendation rows
+  row_count   INT NOT NULL DEFAULT 0,
+  duration_ms INT NULL,                           -- how long the compute took
+  computed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+);

--- a/test/highAgeing.test.js
+++ b/test/highAgeing.test.js
@@ -36,6 +36,16 @@ test('flagHighAgeingStyles: sorts worst-first (dead/highest cover first)', () =>
   assert.strictEqual(flagged[1].style, 'SLOW');
 });
 
+test('flagHighAgeingStyles: MIN_SOH floor drops tiny dead remnants', () => {
+  // A 4-unit dead remnant is high-ageing by cover but below the 50-unit floor →
+  // not worth blocking a re-cut over, so it must NOT be flagged.
+  const f = flagHighAgeingStyles([{ style: 'REMNANT', soh: 4, drr: 0 }]);
+  assert.deepStrictEqual(f, []);
+  // With an explicit low floor it comes back (floor is configurable).
+  const f2 = flagHighAgeingStyles([{ style: 'REMNANT', soh: 4, drr: 0 }], 90, 0);
+  assert.deepStrictEqual(f2.map((x) => x.style), ['REMNANT']);
+});
+
 test('flagHighAgeingStyles: threshold is configurable', () => {
   // At threshold 500, SLOW (300d) drops out; DEAD (∞) stays
   const flagged = flagHighAgeingStyles(rows, 500);

--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -724,15 +724,93 @@ async function computeCleanDayMetrics(pool, windowStart) {
   return metrics;
 }
 
-// Public entry — single-flight, 5-min cached. The full company-wide computation
-// (a ~24s query on a good day, 300s+ under load) previously ran on EVERY dashboard
-// load and stacked under concurrency, saturating the DB. Now the first caller
-// computes and everyone else (concurrent + within the TTL) shares the result.
-// Keyed on shadow so the shadow-diff path is never served a plain-mode cache.
+// ── Materialized cutting recommendations ────────────────────────────────────
+// computeCuttingRecommendations is a 300-2700s all-SKU aggregation. Running it per
+// dashboard load blew past the 60s edge timeout (the "<?xml" error) and saturated
+// the DB. The underlying data only changes with the nightly pull, so we PRECOMPUTE
+// once (nightly + on demand) into pm_cut_recommendations_cache and READ that here.
+// A request NEVER blocks on the heavy compute — if the cache is missing/stale it
+// serves what it has (or empty) and refreshes in the background.
+const CUTRECS_KEY = '30d:plain';
+const CUTRECS_MEM_TTL = 60 * 1000;             // re-read the DB row at most once/min
+const CUTRECS_STALE_MS = 26 * 60 * 60 * 1000;  // > this old → refresh in background
+let _cutRecsMem = null;                         // { rows, at } parsed in-memory copy
+let _cutRecsRefreshing = null;                  // single-flight background refresh
+
+// Public entry. Fast: in-mem → materialized table. Non-default combos (other period
+// / shadow) still compute live (rare, e.g. a shadow diff), memoized.
 async function getCuttingRecommendations(pool, opts = {}) {
   const { periodKey = '30d', shadow = false } = opts;
-  return memoize(`cutrecs:${periodKey}:${shadow ? 'shadow' : 'plain'}`, CACHE_TTL_MS,
-    () => computeCuttingRecommendations(pool, { periodKey, shadow }));
+  if (periodKey !== '30d' || shadow) {
+    return memoize(`cutrecs:${periodKey}:${shadow ? 'shadow' : 'plain'}`, CACHE_TTL_MS,
+      () => computeCuttingRecommendations(pool, { periodKey, shadow }));
+  }
+  if (_cutRecsMem && Date.now() - _cutRecsMem.at < CUTRECS_MEM_TTL) return _cutRecsMem.rows;
+
+  let row = null;
+  try {
+    const [[r]] = await pool.query(
+      'SELECT payload, computed_at FROM pm_cut_recommendations_cache WHERE cache_key = ?', [CUTRECS_KEY]);
+    row = r;
+  } catch (err) { console.error('[pm] cut-recs cache read failed:', err.message); }
+
+  if (row && row.payload) {
+    let rows = [];
+    try { rows = JSON.parse(row.payload); } catch (_) { rows = []; }
+    _cutRecsMem = { rows, at: Date.now() };
+    if (Date.now() - new Date(row.computed_at).getTime() > CUTRECS_STALE_MS) {
+      triggerCutRecsRefresh(pool); // serve current, refresh in background
+    }
+    return rows;
+  }
+  // Never materialized yet → kick a background refresh and serve empty (warming up).
+  triggerCutRecsRefresh(pool);
+  return [];
+}
+
+// Fire-and-forget wrapper used by request/read paths. Never awaited by a request.
+function triggerCutRecsRefresh(pool) {
+  return refreshCutRecommendations(pool)
+    .catch((e) => console.error('[pm] cut-recs background refresh failed:', e.message));
+}
+
+// Compute the heavy recommendations ONCE and store the JSON snapshot. Single-flight
+// across every caller (nightly scheduler, manual "Refresh" endpoint, stale-read
+// trigger) so the 300s+ compute never runs more than once at a time. Only the
+// default 30d/plain combo is materialized; anything else computes without caching.
+function refreshCutRecommendations(pool, opts = {}) {
+  const { periodKey = '30d', shadow = false } = opts;
+  if (periodKey !== '30d' || shadow) return doRefreshCutRecommendations(pool, opts);
+  if (_cutRecsRefreshing) return _cutRecsRefreshing;
+  _cutRecsRefreshing = doRefreshCutRecommendations(pool, opts)
+    .finally(() => { _cutRecsRefreshing = null; });
+  return _cutRecsRefreshing;
+}
+
+async function doRefreshCutRecommendations(pool, { periodKey = '30d', shadow = false } = {}) {
+  const started = Date.now();
+  const rows = await computeCuttingRecommendations(pool, { periodKey, shadow });
+  const key = `${periodKey}:${shadow ? 'shadow' : 'plain'}`;
+  try {
+    await pool.query(
+      `INSERT INTO pm_cut_recommendations_cache (cache_key, payload, row_count, duration_ms)
+       VALUES (?,?,?,?)
+       ON DUPLICATE KEY UPDATE payload=VALUES(payload), row_count=VALUES(row_count),
+         duration_ms=VALUES(duration_ms), computed_at=CURRENT_TIMESTAMP`,
+      [key, JSON.stringify(rows), rows.length, Date.now() - started]);
+  } catch (err) { console.error('[pm] cut-recs cache write failed:', err.message); }
+  if (key === CUTRECS_KEY) _cutRecsMem = { rows, at: Date.now() };
+  console.log(`[pm] cut-recs refreshed: ${rows.length} rows in ${Date.now() - started}ms`);
+  return rows;
+}
+
+// When was the materialized snapshot last computed? (for the dashboard freshness note)
+async function getCutRecsComputedAt(pool) {
+  try {
+    const [[r]] = await pool.query(
+      'SELECT computed_at, row_count FROM pm_cut_recommendations_cache WHERE cache_key = ?', [CUTRECS_KEY]);
+    return r ? { computed_at: r.computed_at, row_count: r.row_count } : null;
+  } catch (_) { return null; }
 }
 
 async function computeCuttingRecommendations(pool, { periodKey = '30d', shadow = false } = {}) {
@@ -1043,6 +1121,8 @@ module.exports = {
   getSlowMovers,
   getDohForSku,
   getCuttingRecommendations,
+  refreshCutRecommendations,
+  getCutRecsComputedAt,
   getDeadStock,
   recomputeAllHealth,
   deriveStyle,

--- a/utils/highAgeing.js
+++ b/utils/highAgeing.js
@@ -11,12 +11,17 @@
 const { getStoreSetting, setStoreSetting } = require('./storeSettings');
 
 const THRESHOLD_DOC = 90;                       // days of cover
+// Minimum style-level stock to be worth blocking a re-cut over. Without this floor
+// the auto-flagger surfaced ~5,200 styles — almost all 1-4 unit dead remnants that
+// nobody would re-cut anyway. A style needs at least this many aged units on hand
+// before we stop a cutting master. (Tune here; manual-add covers anything below it.)
+const MIN_SOH = 50;
 const SETTING_KEY = 'high_ageing_block_enabled';
 
 // ── Pure helpers (unit-tested) ──────────────────────────────────────────────
 // Aggregate per-size cut-rec rows (each { style, soh, drr, doh }) to per-style and
 // flag the high-ageing ones. Returns [{ style, soh, drr, days_of_cover, dead }].
-function flagHighAgeingStyles(rows, threshold = THRESHOLD_DOC) {
+function flagHighAgeingStyles(rows, threshold = THRESHOLD_DOC, minSoh = MIN_SOH) {
   const byStyle = new Map();
   for (const r of rows || []) {
     const style = String(r.style || '').trim().toUpperCase();
@@ -28,7 +33,7 @@ function flagHighAgeingStyles(rows, threshold = THRESHOLD_DOC) {
   }
   const out = [];
   for (const a of byStyle.values()) {
-    if (a.soh <= 0) continue;                    // nothing in stock → nothing to age
+    if (a.soh < minSoh) continue;                // too little stock to be worth blocking
     const dead = a.drr <= 1e-9;                  // stock but ~zero sales
     const days_of_cover = dead ? Infinity : a.soh / a.drr;
     if (dead || days_of_cover > threshold) {
@@ -165,6 +170,7 @@ async function removeDecision(pool, style, mode) {
 
 module.exports = {
   THRESHOLD_DOC,
+  MIN_SOH,
   // pure
   flagHighAgeingStyles, partitionBlocklist, computeEffective, autoReason,
   // db

--- a/utils/scheduler.js
+++ b/utils/scheduler.js
@@ -8,6 +8,7 @@ const { syncAjioShipments } = require('./ajioShipmentSync');
 const { runMailAutoReply } = require('./mailAutoReplyJob');
 const { runPullWorker } = require('./easyecomPullWorker');
 const { sweepLotBatches, autoPushDrafts, confirmGrns, pushEnabled } = require('./eeDispatchPo');
+const { refreshCutRecommendations } = require('./easyecomAnalytics');
 const { pool } = require('../config/db');
 
 const TZ = process.env.CRON_TIMEZONE || 'Asia/Kolkata';
@@ -98,6 +99,14 @@ function startCronJobs() {
           await runPullWorker(pool);
         } catch (err) {
           console.error('[cron] easyecom pull worker failed:', err);
+        }
+        // Rebuild the materialized cutting recommendations off the freshly pulled
+        // data so the PM dashboard reads the precomputed snapshot (never the 300s+
+        // live query). Separate try/catch: a refresh failure must not mask the pull.
+        try {
+          await refreshCutRecommendations(pool);
+        } catch (err) {
+          console.error('[cron] cut-recs refresh failed:', err);
         }
       },
       { timezone: TZ }

--- a/views/productionManagerDashboard.ejs
+++ b/views/productionManagerDashboard.ejs
@@ -175,10 +175,14 @@
       <div class="pm-card-body">
         <p style="font-size:0.8rem; color: var(--text-2); margin:0 0 0.75rem;">
           A style is high-ageing when its stock will take more than <strong>90 days</strong> to sell at the
-          current rate, or it has stock with no recent sales. When <em>Enforce block</em> is on, cutting
-          masters cannot create a lot for a <strong>Blocked</strong> style. Use <em>Allow</em> to let one
-          through, or add a style manually below.
+          current rate, or it has stock with no recent sales (with at least <strong>50 units</strong> on hand).
+          When <em>Enforce block</em> is on, cutting masters cannot create a lot for a <strong>Blocked</strong>
+          style. Use <em>Allow</em> to let one through, or add a style manually below.
         </p>
+        <div style="display:flex; align-items:center; gap:10px; flex-wrap:wrap; margin:0 0 0.75rem; font-size:0.78rem; color:var(--text-3);">
+          <span id="cutRecsFreshness">Recommendations: loading…</span>
+          <button class="pm-btn" id="cutRecsRecompute" style="padding:4px 10px; font-size:0.75rem;">Recompute now</button>
+        </div>
         <div class="pm-toolbar" style="margin-bottom:0.75rem; gap:6px;">
           <input type="text" id="ageingAddStyle" placeholder="Style code e.g. KTTWOMENSPANT981" style="flex:1; max-width:340px; padding:7px 10px;">
           <input type="text" id="ageingAddReason" placeholder="Reason (optional)" style="flex:1; max-width:240px; padding:7px 10px;">
@@ -416,6 +420,7 @@ window.addEventListener('hashchange', () => showPanel(viewFromHash()));
 
 // ── HIGH AGEING ─────────────────────────────────────────────────
 async function loadAgeing() {
+  loadCutRecsFreshness();
   const tbody = $('ageingTable').querySelector('tbody');
   tbody.innerHTML = '<tr><td colspan="7" style="color:var(--text-3);">Loading…</td></tr>';
   try {
@@ -462,6 +467,23 @@ document.getElementById('ageingEnforce').addEventListener('change', async (e) =>
   catch (err) { alert('Failed: ' + err.message); e.target.checked = !e.target.checked; }
 });
 document.getElementById('ageingRefresh').addEventListener('click', loadAgeing);
+async function loadCutRecsFreshness() {
+  const el = $('cutRecsFreshness'); if (!el) return;
+  try {
+    const j = await (await fetch('/pm/api/cut-recs/status')).json();
+    if (!j.ok || !j.computed_at) { el.textContent = 'Recommendations: warming up — click Recompute now.'; return; }
+    el.textContent = 'Recommendations computed ' + new Date(j.computed_at).toLocaleString() +
+      ' (' + (j.row_count || 0).toLocaleString() + ' SKUs)';
+  } catch (_) { el.textContent = 'Recommendations: status unavailable.'; }
+}
+document.getElementById('cutRecsRecompute').addEventListener('click', async (e) => {
+  const btn = e.target; const el = $('cutRecsFreshness');
+  btn.disabled = true; const old = btn.textContent; btn.textContent = 'Recomputing…';
+  if (el) el.textContent = 'Recomputing in the background — this can take a few minutes. Reopen this tab to see the update.';
+  try { await ageingPost('/pm/api/cut-recs/refresh', {}); }
+  catch (err) { alert('Failed: ' + err.message); }
+  finally { setTimeout(() => { btn.disabled = false; btn.textContent = old; }, 4000); }
+});
 document.getElementById('ageingAddBtn').addEventListener('click', async () => {
   const style = $('ageingAddStyle').value.trim();
   if (!style) { alert('Enter a style code'); return; }


### PR DESCRIPTION
## Why
`computeCuttingRecommendations` is a **300–2700s all-SKU aggregation**. It ran on **every** PM dashboard load (`/api/summary`, `/api/styles` — logged at 2,771s, `/api/sizes`, `/api/cut-plan`) **and** on the cut-time high-ageing gate. So a single dashboard open:
- blew past Firebase's ~60s edge timeout → the Google infra **XML** error page → the frontend `Unexpected token '<', "<?xml vers"... is not valid JSON`,
- pegged `db-g1-small`, queuing session writes → **site-wide slowness** (the "overwhelming" outage).

The underlying data only changes with the **nightly** EasyEcom pull, so computing it per request was pure waste.

## What
Compute **once**, read the snapshot.

- **New table** `pm_cut_recommendations_cache` — holds the JSON result (one row per period/shadow combo). Migration applied to prod.
- `refreshCutRecommendations()` computes once and stores it, **single-flight** so the nightly cron, the manual "Recompute now" button, and stale-read triggers can never stack the heavy query.
- `getCuttingRecommendations()` now **reads the snapshot** (ms, then a 1-min in-mem copy) and **never blocks a request on the compute**: missing → serve empty ("warming up") + refresh in background; stale (>26h) → serve current + refresh in background. Non-default combos still compute live (rare).
- `scheduler.js` rebuilds the snapshot right after the nightly pull.
- `/pm/api/cut-recs/status` + `/refresh` endpoints; dashboard shows freshness + a **Recompute now** button.

## High-ageing (same snapshot)
- `computeHighAgeingStyles` / `isStyleBlocked` now read the fast snapshot — the cut-time gate is no longer a 300s query.
- Added a **`MIN_SOH` floor** to `flagHighAgeingStyles` to drop 1–4 unit dead remnants. **On real prod data this is a business-tuning knob** (see below) — the value in this PR is a starting point pending sign-off.

## Verified on prod (read-only)
- Migration applied; read-path parses a snapshot row in <1s over the proxy (the query itself is sub-ms).
- `MIN_SOH` impact on real `ee_inventory_health` (aggregated to style level), high-ageing = >90d cover **or** zero 30-day sales:

  | floor | flagged | dead (0 sales) | slow-selling |
  |------:|--------:|---------------:|-------------:|
  | 0     | 8,987   | 8,837          | 150 |
  | 50    | 2,345   | 2,196          | 149 |
  | 200   | 1,159   | 1,026          | 133 |
  | 500   | 534     | 428            | 106 |
  | 1000  | 203     | 132            | 71  |

  The "dead" pile dominates — at floor 50, 2,196 styles hold **768k** aged units. Blocking re-cuts of those is arguably correct, but the exact floor is a business call.

## Tests
`node --test` green (200 tests). Added a MIN_SOH-floor unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)