### PR TITLE
fix(pm): kill the myntraByStyles query stampede + harden cut-recs refresh

### DIFF
--- a/routes/productionManagerRoutes.js
+++ b/routes/productionManagerRoutes.js
@@ -404,37 +404,56 @@ router.get('/api/summary', async (req, res) => {
   res.json({ ok: true, ...out });
 });
 
-// Marketplace links per style, from the existing product_links table. A product_links
-// sku may be the style code itself or a full size-SKU, so match either; degrade quietly
-// (returns {} if the table is absent or the query fails).
-function escapeRegExp(s) { return String(s).replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); }
+// Marketplace links per style, from the existing product_links table.
+//
+// This used to build ONE `sku LIKE ?` clause per requested style and OR them all
+// together in a single query. /api/styles calls it with the ENTIRE (unpaginated)
+// style list — thousands of styles — so the query ballooned to thousands of OR'd
+// LIKE clauses that took 140-206s and, under concurrent dashboard loads, stacked
+// and exhausted the DB connection pool (site down).
+//
+// Instead we memoize the WHOLE product_links table once every 5 minutes into a
+// Map<style, myntra_link> (single-flight, shared across all concurrent callers),
+// then `myntraByStyles` is a pure in-memory lookup. This reads the ~79k-row table
+// at most once per TTL regardless of how many styles/callers ask. A product_links
+// sku may be the style code itself or a full size-SKU, so we key the map by
+// analytics.deriveStyle(sku); the FIRST link seen for a style wins (ORDER BY sku
+// makes that deterministic). Degrades quietly: a missing/failed table yields an
+// empty map, same as before.
+let _linkMap = null;         // { map: Map<style, link>, at: <ms> }
+let _linkMapPromise = null;  // in-flight load, for single-flight
+const LINK_MAP_TTL = 5 * 60 * 1000;
+async function loadMyntraLinkMap() {
+  if (_linkMap && Date.now() - _linkMap.at < LINK_MAP_TTL) return _linkMap.map;
+  if (_linkMapPromise) return _linkMapPromise;
+  _linkMapPromise = (async () => {
+    const map = new Map();
+    try {
+      const [links] = await pool.query(
+        `SELECT sku, myntra_link FROM product_links
+          WHERE myntra_link IS NOT NULL AND myntra_link <> ''
+          ORDER BY sku`
+      );
+      for (const row of links) {
+        const st = analytics.deriveStyle(row.sku);
+        if (st && !map.has(st)) map.set(st, row.myntra_link);
+      }
+    } catch (_) { /* table missing or query failed — no links */ }
+    _linkMap = { map, at: Date.now() };
+    return map;
+  })().finally(() => { _linkMapPromise = null; });
+  return _linkMapPromise;
+}
 async function myntraByStyles(styleList) {
-  const map = {};
+  const out = {};
   const styles = [...new Set((styleList || []).filter(Boolean))];
-  if (!styles.length) return map;
-  try {
-    // Indexed prefix match. A product_links row is keyed by the size-SKU (style +
-    // size), so we need every row whose sku STARTS WITH a style. `sku LIKE 'STYLE%'`
-    // is optimized into an idx_sku range scan (collation-correct), so this reads only
-    // the matching rows — the old `sku REGEXP '^(...)'` could not use the index and
-    // full-scanned all 79k rows on every call (≈1s → ≈70ms; identical link map).
-    // Style codes are [A-Z0-9] with no LIKE metacharacters, so no escaping is needed.
-    // ORDER BY sku makes the per-style pick deterministic when sizes carry differing
-    // links.
-    const likeClause = styles.map(() => 'sku LIKE ?').join(' OR ');
-    const params = styles.map((s) => s + '%');
-    const [links] = await pool.query(
-      `SELECT sku, myntra_link FROM product_links
-        WHERE myntra_link IS NOT NULL AND myntra_link <> '' AND (${likeClause})
-        ORDER BY sku`,
-      params
-    );
-    for (const row of links) {
-      const st = styles.find((s) => row.sku === s || String(row.sku).startsWith(s));
-      if (st && !map[st]) map[st] = row.myntra_link;
-    }
-  } catch (_) { /* table missing or query failed — no links */ }
-  return map;
+  if (!styles.length) return out;
+  const map = await loadMyntraLinkMap();
+  for (const s of styles) {
+    const link = map.get(s) || map.get(analytics.deriveStyle(s));
+    if (link) out[s] = link;
+  }
+  return out;
 }
 
 router.get('/api/styles', async (req, res) => {

--- a/utils/easyecomAnalytics.js
+++ b/utils/easyecomAnalytics.js
@@ -725,20 +725,30 @@ async function computeCleanDayMetrics(pool, windowStart) {
 }
 
 // ── Materialized cutting recommendations ────────────────────────────────────
-// computeCuttingRecommendations is a 300-2700s all-SKU aggregation. Running it per
-// dashboard load blew past the 60s edge timeout (the "<?xml" error) and saturated
-// the DB. The underlying data only changes with the nightly pull, so we PRECOMPUTE
-// once (nightly + on demand) into pm_cut_recommendations_cache and READ that here.
-// A request NEVER blocks on the heavy compute — if the cache is missing/stale it
-// serves what it has (or empty) and refreshes in the background.
+// computeCuttingRecommendations is an all-SKU aggregation that's cheap on an idle DB
+// (~15s) but stacks catastrophically under concurrency: running it per dashboard load
+// pushed db-g1-small into a saturation death-spiral (every query slows → more pile on),
+// blowing past the 60s edge timeout (the "<?xml" error) and taking the whole site down.
+// The underlying data only changes with the nightly pull, so we PRECOMPUTE once into
+// pm_cut_recommendations_cache and READ that here.
+//
+// Two hard rules keep this from ever re-saturating the DB:
+//   1. A READ NEVER COMPUTES. getCuttingRecommendations only ever reads the snapshot.
+//      An empty/stale cache serves what it has (or empty "warming up") — it does NOT
+//      kick a rebuild. Rebuilds happen only via the nightly cron and the manual button.
+//   2. A REBUILD IS SINGLE-FLIGHT CLUSTER-WIDE. refreshCutRecommendations takes a MySQL
+//      advisory lock, so even with N Cloud Run instances (cron fires on each) only ONE
+//      compute can run at a time; the rest no-op. (Per-instance guards alone failed —
+//      10 instances = 10 concurrent computes = the outage we just had.)
 const CUTRECS_KEY = '30d:plain';
+const CUTRECS_LOCK = 'pm_cut_recs_refresh';
 const CUTRECS_MEM_TTL = 60 * 1000;             // re-read the DB row at most once/min
-const CUTRECS_STALE_MS = 26 * 60 * 60 * 1000;  // > this old → refresh in background
 let _cutRecsMem = null;                         // { rows, at } parsed in-memory copy
-let _cutRecsRefreshing = null;                  // single-flight background refresh
+let _cutRecsRefreshing = null;                  // per-instance single-flight (cheap short-circuit)
 
-// Public entry. Fast: in-mem → materialized table. Non-default combos (other period
-// / shadow) still compute live (rare, e.g. a shadow diff), memoized.
+// Public entry — READ ONLY. Fast: in-mem → materialized table. Never triggers a compute.
+// Non-default combos (other period / shadow) still compute live (rare, e.g. a shadow
+// diff), memoized; those are bounded and not part of the hot dashboard path.
 async function getCuttingRecommendations(pool, opts = {}) {
   const { periodKey = '30d', shadow = false } = opts;
   if (periodKey !== '30d' || shadow) {
@@ -750,7 +760,7 @@ async function getCuttingRecommendations(pool, opts = {}) {
   let row = null;
   try {
     const [[r]] = await pool.query(
-      'SELECT payload, computed_at FROM pm_cut_recommendations_cache WHERE cache_key = ?', [CUTRECS_KEY]);
+      'SELECT payload FROM pm_cut_recommendations_cache WHERE cache_key = ?', [CUTRECS_KEY]);
     row = r;
   } catch (err) { console.error('[pm] cut-recs cache read failed:', err.message); }
 
@@ -758,50 +768,55 @@ async function getCuttingRecommendations(pool, opts = {}) {
     let rows = [];
     try { rows = JSON.parse(row.payload); } catch (_) { rows = []; }
     _cutRecsMem = { rows, at: Date.now() };
-    if (Date.now() - new Date(row.computed_at).getTime() > CUTRECS_STALE_MS) {
-      triggerCutRecsRefresh(pool); // serve current, refresh in background
-    }
     return rows;
   }
-  // Never materialized yet → kick a background refresh and serve empty (warming up).
-  triggerCutRecsRefresh(pool);
-  return [];
+  return []; // not materialized yet → "warming up"; a read must NEVER kick a rebuild
 }
 
-// Fire-and-forget wrapper used by request/read paths. Never awaited by a request.
-function triggerCutRecsRefresh(pool) {
-  return refreshCutRecommendations(pool)
-    .catch((e) => console.error('[pm] cut-recs background refresh failed:', e.message));
-}
-
-// Compute the heavy recommendations ONCE and store the JSON snapshot. Single-flight
-// across every caller (nightly scheduler, manual "Refresh" endpoint, stale-read
-// trigger) so the 300s+ compute never runs more than once at a time. Only the
-// default 30d/plain combo is materialized; anything else computes without caching.
+// Compute the heavy recommendations ONCE and store the JSON snapshot. Called ONLY by
+// the nightly scheduler and the manual "Recompute now" endpoint — never by a read.
+// Cluster-wide single-flight via a MySQL advisory lock so concurrent callers (multiple
+// instances' crons, a button click during a cron) can never stack the heavy query.
 function refreshCutRecommendations(pool, opts = {}) {
   const { periodKey = '30d', shadow = false } = opts;
   if (periodKey !== '30d' || shadow) return doRefreshCutRecommendations(pool, opts);
-  if (_cutRecsRefreshing) return _cutRecsRefreshing;
+  if (_cutRecsRefreshing) return _cutRecsRefreshing;   // this instance already computing
   _cutRecsRefreshing = doRefreshCutRecommendations(pool, opts)
     .finally(() => { _cutRecsRefreshing = null; });
   return _cutRecsRefreshing;
 }
 
 async function doRefreshCutRecommendations(pool, { periodKey = '30d', shadow = false } = {}) {
-  const started = Date.now();
-  const rows = await computeCuttingRecommendations(pool, { periodKey, shadow });
   const key = `${periodKey}:${shadow ? 'shadow' : 'plain'}`;
+  // Cluster-wide lock: only one refresh runs across all instances/processes. timeout 0
+  // = try once and give up immediately if someone else holds it. Held on a dedicated
+  // connection for the whole compute, released in finally.
+  let conn;
+  try { conn = await pool.getConnection(); }
+  catch (err) { console.error('[pm] cut-recs: no connection for lock:', err.message); return _cutRecsMem?.rows || []; }
   try {
-    await pool.query(
-      `INSERT INTO pm_cut_recommendations_cache (cache_key, payload, row_count, duration_ms)
-       VALUES (?,?,?,?)
-       ON DUPLICATE KEY UPDATE payload=VALUES(payload), row_count=VALUES(row_count),
-         duration_ms=VALUES(duration_ms), computed_at=CURRENT_TIMESTAMP`,
-      [key, JSON.stringify(rows), rows.length, Date.now() - started]);
-  } catch (err) { console.error('[pm] cut-recs cache write failed:', err.message); }
-  if (key === CUTRECS_KEY) _cutRecsMem = { rows, at: Date.now() };
-  console.log(`[pm] cut-recs refreshed: ${rows.length} rows in ${Date.now() - started}ms`);
-  return rows;
+    const [[lk]] = await conn.query('SELECT GET_LOCK(?, 0) AS got', [CUTRECS_LOCK]);
+    if (!lk || Number(lk.got) !== 1) {
+      console.log('[pm] cut-recs refresh already running elsewhere — skipping');
+      return _cutRecsMem?.rows || [];
+    }
+    const started = Date.now();
+    const rows = await computeCuttingRecommendations(pool, { periodKey, shadow });
+    try {
+      await pool.query(
+        `INSERT INTO pm_cut_recommendations_cache (cache_key, payload, row_count, duration_ms)
+         VALUES (?,?,?,?)
+         ON DUPLICATE KEY UPDATE payload=VALUES(payload), row_count=VALUES(row_count),
+           duration_ms=VALUES(duration_ms), computed_at=CURRENT_TIMESTAMP`,
+        [key, JSON.stringify(rows), rows.length, Date.now() - started]);
+    } catch (err) { console.error('[pm] cut-recs cache write failed:', err.message); }
+    if (key === CUTRECS_KEY) _cutRecsMem = { rows, at: Date.now() };
+    console.log(`[pm] cut-recs refreshed: ${rows.length} rows in ${Date.now() - started}ms`);
+    return rows;
+  } finally {
+    try { await conn.query('SELECT RELEASE_LOCK(?)', [CUTRECS_LOCK]); } catch (_) { /* connection may be gone */ }
+    conn.release();
+  }
 }
 
 // When was the materialized snapshot last computed? (for the dashboard freshness note)


### PR DESCRIPTION
## Why (live incident, 22:08 IST)
The precompute cache (#582) made `getCuttingRecommendations` instant — which **unmasked a second unbounded query on the same hot path**. `/pm/api/styles` calls `myntraByStyles()` with the **entire** aggregated style list (thousands, no pagination), building one SQL statement with **thousands of `sku LIKE ? OR …` clauses**. Each ran **140–206s**; every dashboard reload fired one; they **stacked**, exhausted the DB connection pool (limit 50), starved every other PM query, and the browser aborted the hung requests with `ERR_NETWORK_IO_SUSPENDED`. Same site-wide slowness — a different query doing the saturating.

Confirmed live: 16 concurrent `product_links … LIKE` queries at 18–206s (killed to recover).

## Fix 1 — `myntraByStyles` → memoized style→link map
Read `product_links` **once** into a `Map<style, myntra_link>` (keyed by `analytics.deriveStyle(sku)`, first link wins) behind a **5-min single-flight cache**; `myntraByStyles` is now a pure in-memory lookup. One ~79k-row read per 5 min shared across all callers, instead of a thousands-clause `LIKE` query per request. Same response shape (no UX/pagination change), and more correct than the old prefix match (no style-prefix collisions). Removed now-dead `escapeRegExp`.

## Fix 2 — cut-recs refresh hardening (stops the *first* bug class recurring)
- **A read never computes:** `getCuttingRecommendations` only reads the snapshot; empty/stale serves what it has (or `[]` "warming up"). Only the nightly cron + manual button rebuild.
- **Rebuilds are cluster-wide single-flight:** `refreshCutRecommendations` takes a MySQL `GET_LOCK` on a dedicated connection, so N Cloud Run instances (cron fires on each) can never stack the compute; non-holders no-op. Lock + connection released on every path. (Per-instance guards alone let 10 instances stampede — that was the afternoon outage.)

## Verification
- `node --test` → **200/200 pass**.
- Two independent review passes confirmed: no `triggerCutRecsRefresh`/`CUTRECS_STALE_MS` dangling refs; `GET_LOCK` connection released on every path; all 3 `myntraByStyles` callers unchanged.
- Post-deploy: `SHOW FULL PROCESSLIST` should show **no** `product_links … LIKE` stack — at most one full `product_links` read per 5 min; `/api/styles` + `/api/summary` < 1s.

Follow-up after merge/deploy: restore Cloud Run `--max-instances` from the temporary 1 back to 10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)