### PR TITLE
fix(reports): raise the operator size-report row cap (5000 silently chopped wide date windows)

### DIFF
--- a/utils/picSizeReport.js
+++ b/utils/picSizeReport.js
@@ -1017,10 +1017,11 @@ async function buildPicSizeRows({
   inProductionOnly = false,
   style = '',
 } = {}) {
-  // Row cap: the operator (date-windowed) path keeps its historical 5000 cap; the
-  // unwindowed "all in-production" path needs headroom for the full lot history
-  // (~45k lot×size rows all-time and growing — watch the cap-hit warning below).
-  const rowLimit = inProductionOnly ? 50000 : 5000;
+  // Row cap: pure runaway backstop, NOT a paging mechanism. The old operator cap
+  // of 5000 silently chopped a Jan→Aug window (11k+ rows) to the newest 5000,
+  // hiding older lots (how lot A639 vanished). Full history is ~45k lot×size
+  // rows — keep the cap above it and watch the cap-hit warning below.
+  const rowLimit = 50000;
   // Optional style scope (e.g. the PM style page). Matches via deriveStyle() so both
   // style-level and size-suffixed cutting_lots.sku values resolve correctly — the SQL
   // LIKE is a prefilter; the exact match happens per-row in the assembly loop below.


### PR DESCRIPTION
Follow-up to #584 — this commit was pushed to that branch minutes after it was merged, so it never landed in main.

A 1 Jan → today operator size-report download (11,115 lot×size rows) kept only the newest 5,000 (`ORDER BY created_at DESC LIMIT 5000`) and silently discarded the rest — the second, independent way lot A639 (cut 9 Jun, 5,082 rows newer than it) vanished from the report, and why it was still missing from a download made right after #584 deployed.

The cap is now the same 50k runaway backstop the in-production path uses, with the existing cap-hit warning when it triggers.

Verified read-only against prod: `2026-01-01 → today` returns all 11,107 rows in ~6s and includes ak5416 (A639).

🤖 Generated with [Claude Code](https://claude.com/claude-code)