### PR TITLE
feat(stages): manual date on every stage — shadow column, validated + audited

### DIFF
--- a/routes/cuttingManagerRoutes.js
+++ b/routes/cuttingManagerRoutes.js
@@ -11,6 +11,8 @@ const generateLotNumber = require('../utils/generateLotNumber'); // Import the u
 const { cache } = require('../utils/cache');
 const { allowAdhocCuttingEntry, isKnownFabricType } = require('../utils/storeSettings');
 const highAgeing = require('../utils/highAgeing');
+const { assertManualDateNotFuture } = require('../utils/stageEvents');
+const { writeLotAudit } = require('../utils/lotAudit');
 
 // Multer setup for image uploads
 const storage = multer.diskStorage({
@@ -319,6 +321,17 @@ router.post(
       try {
         await conn.beginTransaction();
 
+        // Manual cutting date: optional; must be a real date and not in the future.
+        const manualCuttingDate = (manual_cutting_date && String(manual_cutting_date).trim())
+          ? String(manual_cutting_date).trim()
+          : null;
+        if (manualCuttingDate) {
+          if (!/^\d{4}-\d{2}-\d{2}$/.test(manualCuttingDate)) {
+            throw new Error('Invalid manual cutting date (use YYYY-MM-DD)');
+          }
+          await assertManualDateNotFuture(conn, manualCuttingDate);
+        }
+
         // Determine flow_type: honour the cutter's explicit selection on the form
         // ('denim' or 'hosiery'), otherwise fall back to the is_denim_cutter default.
         // Safe to set here because no stage events exist yet at lot creation.
@@ -357,7 +370,7 @@ router.post(
             fabric_type,
             remark || null,
             table_length ? parseFloat(table_length) : null,
-            (manual_cutting_date && String(manual_cutting_date).trim()) ? String(manual_cutting_date).trim() : null,
+            manualCuttingDate,
             image ? image.path : null,
             userId,
             flowType,
@@ -365,6 +378,15 @@ router.post(
         );
 
         const cuttingLotId = result.insertId;
+
+        if (manualCuttingDate) {
+          await writeLotAudit(conn, {
+            cutting_lot_id: cuttingLotId, lot_no,
+            action: 'manual_date',
+            detail: { stage: 'cutting', manual_cutting_date: manualCuttingDate, source: 'create' },
+            performed_by: userId, performed_by_name: username,
+          });
+        }
 
         // Handle sizes if provided (using parseFloat for decimal values)
         let sizes = [];

--- a/routes/editcuttinglots.js
+++ b/routes/editcuttinglots.js
@@ -5,6 +5,8 @@ const upload = multer(); // This will parse multipart/form-data
 const { pool } = require('../config/db');
 const { isAuthenticated, isOperator } = require('../middlewares/auth');
 const { allowAdhocCuttingEntry } = require('../utils/storeSettings');
+const { assertManualDateNotFuture } = require('../utils/stageEvents');
+const { writeLotAudit } = require('../utils/lotAudit');
 
 // simple in-memory cache for cutting masters
 const masterCache = { data: null, expires: 0 };
@@ -588,15 +590,41 @@ router.post('/editcuttinglots/update', isAuthenticated, isOperator, upload.none(
   const conn = await pool.getConnection();
   try {
     await conn.beginTransaction();
+
+    // Scope to the manager whose lot this is (mirrors the GET edit-form scoping —
+    // previously the UPDATE was scoped by lotId alone, so any operator could hit
+    // any lot id). Also grabs lot_no for the size-rename cascades and the prior
+    // manual date for the audit trail.
+    const [[lotRow]] = await conn.query(
+      `SELECT lot_no, manual_cutting_date FROM cutting_lots WHERE id = ? AND user_id = ? FOR UPDATE`,
+      [lotId, managerId]
+    );
+    if (!lotRow) throw new Error('Lot not found for this manager.');
+    const lotNo = lotRow.lot_no;
+
+    if (manualCuttingDate) {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(manualCuttingDate)) {
+        throw new Error('Invalid manual cutting date (use YYYY-MM-DD)');
+      }
+      await assertManualDateNotFuture(conn, manualCuttingDate);
+    }
+
     await conn.query(
-      `UPDATE cutting_lots SET sku = ?, fabric_type = ?, remark = ?, manual_lot_number = ?, manual_cutting_date = ? WHERE id = ?`,
-      [sku, fabric_type, remark, manualLotNumber, manualCuttingDate, lotId]
+      `UPDATE cutting_lots SET sku = ?, fabric_type = ?, remark = ?, manual_lot_number = ?, manual_cutting_date = ? WHERE id = ? AND user_id = ?`,
+      [sku, fabric_type, remark, manualLotNumber, manualCuttingDate, lotId, managerId]
     );
 
-    // Need the lot_no to cascade size renames into the legacy data tables.
-    const [[lotRow]] = await conn.query(`SELECT lot_no FROM cutting_lots WHERE id = ? FOR UPDATE`, [lotId]);
-    if (!lotRow) throw new Error('Lot not found.');
-    const lotNo = lotRow.lot_no;
+    const prevManualDate = lotRow.manual_cutting_date
+      ? new Date(lotRow.manual_cutting_date).toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' })
+      : null;
+    if (manualCuttingDate !== prevManualDate) {
+      await writeLotAudit(conn, {
+        cutting_lot_id: lotId, lot_no: lotNo,
+        action: 'manual_date',
+        detail: { stage: 'cutting', manual_cutting_date: manualCuttingDate, previous: prevManualDate, source: 'edit' },
+        performed_by: req.session.user.id, performed_by_name: req.session.user.username,
+      });
+    }
 
     // Validate the resulting labels: non-empty, within length, and unique within the lot
     // (no unique constraint exists on cutting_lot_sizes, but allowing two sizes to share

--- a/routes/finishingRoutes.js
+++ b/routes/finishingRoutes.js
@@ -8,6 +8,7 @@ const { isAuthenticated, isFinishingMaster } = require('../middlewares/auth');
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
 const { getLotStageUsers } = require('../utils/lotStageUsers');
+const { auditStageManualDate } = require('../utils/lotAudit');
 const eePo = require('../utils/eeDispatchPo');
 const { aggregateLotSizes, allocateAcrossBatches } = require('../utils/dispatchAllocation');
 
@@ -959,7 +960,7 @@ router.post('/event/approve', isAuthenticated, isFinishingMaster, async (req, re
   let conn;
   try {
     const userId = req.session.user.id;
-    const { cutting_lot_id, sizes, rejected_sizes, remark, reject_reason } = req.body;
+    const { cutting_lot_id, sizes, rejected_sizes, remark, reject_reason, manual_date } = req.body;
     const lotId = parseInt(cutting_lot_id, 10);
     if (!Number.isFinite(lotId) || lotId <= 0) return res.status(400).json({ error: 'Invalid cutting_lot_id' });
 
@@ -981,6 +982,16 @@ router.post('/event/approve', isAuthenticated, isFinishingMaster, async (req, re
        FROM cutting_lots cl JOIN users u ON u.id = cl.user_id WHERE cl.id = ?`, [lotId]
     );
     if (!lot) { await conn.rollback(); return res.status(404).json({ error: 'Lot not found' }); }
+
+    let manualDate;
+    try {
+      manualDate = await stageEvents.resolveManualDate(conn, {
+        stage: STAGE_F, cuttingLotId: lotId, manualDate: manual_date,
+      });
+    } catch (e) {
+      await conn.rollback();
+      return res.status(400).json({ error: e.message });
+    }
 
     const upstream = await fUpstreamSizes(conn, lot);
     const upstreamMap = {};
@@ -1010,6 +1021,7 @@ router.post('/event/approve', isAuthenticated, isFinishingMaster, async (req, re
         stage: STAGE_F, cuttingLotId: lotId, eventType: 'approve',
         operatorId: userId, sizes: cleanSizes, parentEventId: null,
         remark: remark ? String(remark).trim() : null,
+        manualDate,
       });
     }
     if (cleanRejected.length) {
@@ -1017,8 +1029,16 @@ router.post('/event/approve', isAuthenticated, isFinishingMaster, async (req, re
         stage: STAGE_F, cuttingLotId: lotId, eventType: 'reject',
         operatorId: userId, sizes: cleanRejected, parentEventId: null,
         remark: reject_reason ? String(reject_reason).trim() : null,
+        manualDate,
       });
     }
+
+    await auditStageManualDate(conn, {
+      cutting_lot_id: lotId, stage: STAGE_F, event_type: 'approve', manual_date: manualDate,
+      pieces: cleanSizes.reduce((a, s) => a + s.pieces, 0),
+      approve_event_id: approveEventId, reject_event_id: rejectEventId,
+      performed_by: userId, performed_by_name: req.session.user.username,
+    });
 
     await conn.commit();
 
@@ -1058,7 +1078,7 @@ router.post('/event/complete', isAuthenticated, isFinishingMaster, async (req, r
   let conn;
   try {
     const userId = req.session.user.id;
-    const { parent_event_id, completed_sizes, rejected_sizes, reject_reason, complete_remark } = req.body;
+    const { parent_event_id, completed_sizes, rejected_sizes, reject_reason, complete_remark, manual_date } = req.body;
     const parentId = parseInt(parent_event_id, 10);
     if (!Number.isFinite(parentId) || parentId <= 0) return res.status(400).json({ error: 'Invalid parent_event_id' });
 
@@ -1089,6 +1109,17 @@ router.post('/event/complete', isAuthenticated, isFinishingMaster, async (req, r
       return res.status(403).json({
         error: 'You can only complete pieces against your own approve. Ask the original approver to record the completion.',
       });
+    }
+
+    let manualDate;
+    try {
+      manualDate = await stageEvents.resolveManualDate(conn, {
+        stage: STAGE_F, cuttingLotId: parent.cutting_lot_id, manualDate: manual_date,
+        parentEventId: parentId,
+      });
+    } catch (e) {
+      await conn.rollback();
+      return res.status(400).json({ error: e.message });
     }
 
     const [parentSizesRows] = await conn.query(
@@ -1131,6 +1162,7 @@ router.post('/event/complete', isAuthenticated, isFinishingMaster, async (req, r
         stage: STAGE_F, cuttingLotId: parent.cutting_lot_id, eventType: 'complete',
         operatorId: userId, sizes: cleanCompleted, parentEventId: parentId,
         remark: complete_remark ? String(complete_remark).trim() : null,
+        manualDate,
       });
     }
     if (cleanRejected.length) {
@@ -1138,8 +1170,16 @@ router.post('/event/complete', isAuthenticated, isFinishingMaster, async (req, r
         stage: STAGE_F, cuttingLotId: parent.cutting_lot_id, eventType: 'reject',
         operatorId: userId, sizes: cleanRejected, parentEventId: parentId,
         remark: reject_reason ? String(reject_reason).trim() : null,
+        manualDate,
       });
     }
+
+    await auditStageManualDate(conn, {
+      cutting_lot_id: parent.cutting_lot_id, stage: STAGE_F, event_type: 'complete', manual_date: manualDate,
+      pieces: cleanCompleted.reduce((a, s) => a + s.pieces, 0),
+      complete_event_id: completeEventId, reject_event_id: rejectEventId,
+      performed_by: userId, performed_by_name: req.session.user.username,
+    });
 
     if (cleanCompleted.length) {
       const [[lot]] = await conn.query(`SELECT lot_no, sku FROM cutting_lots WHERE id = ?`, [parent.cutting_lot_id]);

--- a/routes/jeansAssemblyRoutes.js
+++ b/routes/jeansAssemblyRoutes.js
@@ -9,6 +9,7 @@ const { isAuthenticated, isJeansAssemblyMaster } = require('../middlewares/auth'
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
 const { getLotStageUsers } = require('../utils/lotStageUsers');
+const { auditStageManualDate } = require('../utils/lotAudit');
 
 // -------------------------------------
 // MULTER for Image Upload
@@ -1257,7 +1258,7 @@ router.post('/event/approve', isAuthenticated, isJeansAssemblyMaster, async (req
   let conn;
   try {
     const userId = req.session.user.id;
-    const { cutting_lot_id, sizes, rejected_sizes, remark, reject_reason } = req.body;
+    const { cutting_lot_id, sizes, rejected_sizes, remark, reject_reason, manual_date } = req.body;
 
     const lotId = parseInt(cutting_lot_id, 10);
     if (!Number.isFinite(lotId) || lotId <= 0) {
@@ -1283,6 +1284,16 @@ router.post('/event/approve', isAuthenticated, isJeansAssemblyMaster, async (req
     if (!lot) {
       await conn.rollback();
       return res.status(404).json({ error: 'Lot not found' });
+    }
+
+    let manualDate;
+    try {
+      manualDate = await stageEvents.resolveManualDate(conn, {
+        stage: STAGE_JA, cuttingLotId: lotId, manualDate: manual_date,
+      });
+    } catch (e) {
+      await conn.rollback();
+      return res.status(400).json({ error: e.message });
     }
 
     const upstream = await jaUpstreamSizes(conn, lotId, lot.lot_no);
@@ -1319,6 +1330,7 @@ router.post('/event/approve', isAuthenticated, isJeansAssemblyMaster, async (req
         sizes: cleanSizes,
         parentEventId: null,
         remark: remark ? String(remark).trim() : null,
+        manualDate,
       });
     }
     if (cleanRejected.length) {
@@ -1330,8 +1342,16 @@ router.post('/event/approve', isAuthenticated, isJeansAssemblyMaster, async (req
         sizes: cleanRejected,
         parentEventId: null,
         remark: reject_reason ? String(reject_reason).trim() : null,
+        manualDate,
       });
     }
+
+    await auditStageManualDate(conn, {
+      cutting_lot_id: lotId, stage: STAGE_JA, event_type: 'approve', manual_date: manualDate,
+      pieces: cleanSizes.reduce((a, s) => a + s.pieces, 0),
+      approve_event_id: approveEventId, reject_event_id: rejectEventId,
+      performed_by: userId, performed_by_name: req.session.user.username,
+    });
 
     await conn.commit();
 
@@ -1381,7 +1401,7 @@ router.post('/event/complete', isAuthenticated, isJeansAssemblyMaster, async (re
   let conn;
   try {
     const userId = req.session.user.id;
-    const { parent_event_id, completed_sizes, rejected_sizes, reject_reason, complete_remark } = req.body;
+    const { parent_event_id, completed_sizes, rejected_sizes, reject_reason, complete_remark, manual_date } = req.body;
 
     const parentId = parseInt(parent_event_id, 10);
     if (!Number.isFinite(parentId) || parentId <= 0) {
@@ -1419,6 +1439,17 @@ router.post('/event/complete', isAuthenticated, isJeansAssemblyMaster, async (re
       return res.status(403).json({
         error: 'You can only complete pieces against your own approve. Ask the original approver to record the completion.',
       });
+    }
+
+    let manualDate;
+    try {
+      manualDate = await stageEvents.resolveManualDate(conn, {
+        stage: STAGE_JA, cuttingLotId: parent.cutting_lot_id, manualDate: manual_date,
+        parentEventId: parentId,
+      });
+    } catch (e) {
+      await conn.rollback();
+      return res.status(400).json({ error: e.message });
     }
 
     const [parentSizesRows] = await conn.query(
@@ -1473,6 +1504,7 @@ router.post('/event/complete', isAuthenticated, isJeansAssemblyMaster, async (re
         sizes: cleanCompleted,
         parentEventId: parentId,
         remark: complete_remark ? String(complete_remark).trim() : null,
+        manualDate,
       });
     }
     if (cleanRejected.length) {
@@ -1484,8 +1516,16 @@ router.post('/event/complete', isAuthenticated, isJeansAssemblyMaster, async (re
         sizes: cleanRejected,
         parentEventId: parentId,
         remark: reject_reason ? String(reject_reason).trim() : null,
+        manualDate,
       });
     }
+
+    await auditStageManualDate(conn, {
+      cutting_lot_id: parent.cutting_lot_id, stage: STAGE_JA, event_type: 'complete', manual_date: manualDate,
+      pieces: cleanCompleted.reduce((a, s) => a + s.pieces, 0),
+      complete_event_id: completeEventId, reject_event_id: rejectEventId,
+      performed_by: userId, performed_by_name: req.session.user.username,
+    });
 
     // Dual-write to jeans_assembly_data for downstream compatibility
     // (washing reads jeans_assembly_data via lot_no in its existing query).

--- a/routes/lotJourneyRoutes.js
+++ b/routes/lotJourneyRoutes.js
@@ -32,7 +32,7 @@ async function resolveLot(q) {
   const like = `%${exact}%`;
   const [rows] = await pool.query(
     `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.flow_type,
-            cl.remark, cl.created_at, cl.user_id AS cutter_id, u.username AS cutter_name
+            cl.remark, cl.created_at, cl.manual_cutting_date, cl.user_id AS cutter_id, u.username AS cutter_name
        FROM cutting_lots cl
   LEFT JOIN users u ON u.id = cl.user_id
       WHERE cl.lot_no = ? OR cl.manual_lot_number = ?
@@ -47,16 +47,20 @@ async function resolveLot(q) {
 // Timing + accountable master for one stage from its events table.
 async function stageTiming(table, lotId) {
   const [rows] = await pool.query(
-    `SELECT e.event_type, e.created_at, u.username
+    `SELECT e.event_type, e.created_at, e.manual_date, u.username
        FROM \`${table}\` e LEFT JOIN users u ON u.id = e.operator_id
       WHERE e.cutting_lot_id = ? ORDER BY e.created_at`,
     [lotId]
   );
   let entered = null; let completedAt = null; let master = null;
   for (const r of rows) {
-    if (!entered) entered = r.created_at;
-    if (r.event_type === 'complete' && (!completedAt || new Date(r.created_at) > new Date(completedAt))) {
-      completedAt = r.created_at;
+    // Effective date: the user-declared floor date wins over the upload time.
+    // Manual dates can be out of created_at order, so min/max explicitly.
+    // Master stays "first approver by entry order" — accountability tracks who acted.
+    const eff = r.manual_date || r.created_at;
+    if (!entered || new Date(eff) < new Date(entered)) entered = eff;
+    if (r.event_type === 'complete' && (!completedAt || new Date(eff) > new Date(completedAt))) {
+      completedAt = eff;
     }
     if (r.event_type === 'approve' && !master) master = r.username;
   }
@@ -75,7 +79,7 @@ async function buildActivity(lot) {
   const stageEventRows = {};
   for (const stage of stageEvents.STAGES) {
     const [rows] = await pool.query(
-      `SELECT e.event_type, e.pieces, e.remark, e.created_at, u.username
+      `SELECT e.event_type, e.pieces, e.remark, e.created_at, e.manual_date, u.username
          FROM \`${EVENT_TABLE[stage]}\` e LEFT JOIN users u ON u.id = e.operator_id
         WHERE e.cutting_lot_id = ? ORDER BY e.created_at, e.id`,
       [lot.id]
@@ -107,6 +111,7 @@ async function buildActivity(lot) {
     cutting: {
       created_at: lot.created_at, by: lot.cutter_name,
       total_pieces: lot.total_pieces, note: lot.remark || '',
+      manual_date: lot.manual_cutting_date || null,
     },
     stageEvents: stageEventRows,
     dispatches,
@@ -135,7 +140,7 @@ async function buildJourney(lot) {
     const next = stages[i + 1];
     let entered; let master; let pieces; let completedAt = null;
     if (stage === 'cutting') {
-      entered = lot.created_at;
+      entered = lot.manual_cutting_date || lot.created_at;
       master = lot.cutter_name;
       pieces = { approved: lot.total_pieces, completed: lot.total_pieces, rejected: 0, inline: 0 };
     } else {
@@ -230,6 +235,7 @@ router.get('/export', isAuthenticated, isOperator, async (req, res) => {
       { header: 'SKU',           key: 'sku',     width: 22 },
       { header: 'Date',          key: 'date',    width: 13 },
       { header: 'Time',          key: 'time',    width: 10 },
+      { header: 'Manual Date',   key: 'manual_date', width: 13 },
       { header: 'Flow',          key: 'flow',    width: 14 },
       { header: 'Update',        key: 'update',  width: 18 },
       { header: 'Pieces',        key: 'pieces',  width: 9 },
@@ -243,6 +249,7 @@ router.get('/export', isAuthenticated, isOperator, async (req, res) => {
         lot_no: lot.lot_no, manual: lot.manual_lot_number || '', sku: lot.sku,
         date: new Date(a.when).toLocaleDateString('en-IN', dateOpts),
         time: new Date(a.when).toLocaleTimeString('en-IN', timeOpts),
+        manual_date: a.manual_date ? new Date(a.manual_date).toLocaleDateString('en-IN', dateOpts) : '',
         flow: ACT_STAGE_LABEL[a.stage] || a.stage,
         update: a.label,
         pieces: a.pieces != null ? a.pieces : '',

--- a/routes/operatorLotTatRoutes.js
+++ b/routes/operatorLotTatRoutes.js
@@ -63,7 +63,7 @@ async function loadLotTat({ days, search, remark, flow, overdue, limit }) {
 
   const [lots] = await pool.query(
     `SELECT cl.id, cl.lot_no, cl.manual_lot_number, cl.sku, cl.total_pieces, cl.flow_type, cl.remark,
-            cl.created_at, cl.user_id AS cutter_id, cu.username AS cutter_name
+            cl.created_at, cl.manual_cutting_date, cl.user_id AS cutter_id, cu.username AS cutter_name
        FROM cutting_lots cl
   LEFT JOIN users cu ON cu.id = cl.user_id
       WHERE ${where}
@@ -83,6 +83,8 @@ async function loadLotTat({ days, search, remark, flow, overdue, limit }) {
       flow_type: l.flow_type || 'unknown',
       remark: l.remark || '',
       created_at: l.created_at,
+      // Effective cut date: the user-declared floor date when present.
+      cut_entered: l.manual_cutting_date || l.created_at,
       cutter: { user_id: l.cutter_id, name: l.cutter_name },
       stages: {}, // per-stage timing + master
     };
@@ -93,7 +95,7 @@ async function loadLotTat({ days, search, remark, flow, overdue, limit }) {
   // master = operator of FIRST approve event (the one accountable).
   for (const [stageKey, table] of Object.entries(STAGE_EVENT_TABLE)) {
     const [rows] = await pool.query(
-      `SELECT e.cutting_lot_id, e.event_type, e.operator_id, e.created_at, u.username
+      `SELECT e.cutting_lot_id, e.event_type, e.operator_id, e.created_at, e.manual_date, u.username
          FROM \`${table}\` e
     LEFT JOIN users u ON u.id = e.operator_id
         WHERE e.cutting_lot_id IN (?)
@@ -105,10 +107,15 @@ async function loadLotTat({ days, search, remark, flow, overdue, limit }) {
       const slot = byLot[r.cutting_lot_id] || (byLot[r.cutting_lot_id] = {
         entered_at: null, completed_at: null, master_id: null, master: null,
       });
-      if (!slot.entered_at) slot.entered_at = r.created_at;
+      // Effective date: manual (floor) date wins over the upload timestamp.
+      // Manual dates can be out of created_at order, so min/max explicitly.
+      const eff = r.manual_date || r.created_at;
+      if (!slot.entered_at || new Date(eff) < new Date(slot.entered_at)) {
+        slot.entered_at = eff;
+      }
       if (r.event_type === 'complete') {
-        if (!slot.completed_at || new Date(r.created_at) > new Date(slot.completed_at)) {
-          slot.completed_at = r.created_at;
+        if (!slot.completed_at || new Date(eff) > new Date(slot.completed_at)) {
+          slot.completed_at = eff;
         }
       }
       if (r.event_type === 'approve' && !slot.master_id) {
@@ -134,8 +141,8 @@ async function loadLotTat({ days, search, remark, flow, overdue, limit }) {
     const stages = lot.flow_type === 'denim' ? STAGES_DENIM : STAGES_HOSIERY;
     const timeline = [];
 
-    // Cutting is special — no events table; created_at IS the entry point.
-    let prevExit = lot.created_at;
+    // Cutting is special — no events table; its effective cut date is the entry point.
+    let prevExit = lot.cut_entered;
 
     for (let i = 0; i < stages.length; i++) {
       const stage = stages[i];
@@ -143,7 +150,7 @@ async function loadLotTat({ days, search, remark, flow, overdue, limit }) {
 
       let entered, master, masterId, completedAt;
       if (stage === 'cutting') {
-        entered = lot.created_at;
+        entered = lot.cut_entered;
         master  = lot.cutter.name;
         masterId = lot.cutter.user_id;
       } else {
@@ -284,7 +291,7 @@ router.get('/download', isAuthenticated, isOperator, async (req, res) => {
       const row = {
         lot_no: lot.lot_no, manual_lot_number: lot.manual_lot_number || '', sku: lot.sku, dept: lot.flow_type,
         pieces: lot.pieces, remark: lot.remark || '',
-        cutter: lot.cutter.name || '', cut_date: fmt(lot.created_at),
+        cutter: lot.cutter.name || '', cut_date: fmt(lot.cut_entered),
         current_stage: lot.current_stage,
         cutting_days: dayCell(byStage.cutting),
         cutting_master: byStage.cutting ? byStage.cutting.master || '' : '',

--- a/routes/operatorRoutes.js
+++ b/routes/operatorRoutes.js
@@ -1045,7 +1045,7 @@ router.get("/dashboard/pic-report", isAuthenticated, isOperator, async (req, res
                 FROM ${evtTable} e
                WHERE e.cutting_lot_id = cl.id
                  AND e.event_type = 'approve'
-                 AND DATE(e.created_at) BETWEEN ? AND ?
+                 AND COALESCE(e.manual_date, DATE(e.created_at)) BETWEEN ? AND ?
             )
           `;
           dateParams.push(startDate, endDate);
@@ -1470,14 +1470,14 @@ router.get("/stitching-tat/:masterId", isAuthenticated, isOperator, async (req, 
                cl.sku,
                cl.total_pieces,
                cl.remark AS cutting_remark,
-               MIN(CASE WHEN se.event_type='approve'  THEN se.created_at END) AS firstApproveAt,
-               MAX(CASE WHEN se.event_type='complete' THEN se.created_at END) AS lastCompleteAt,
+               MIN(CASE WHEN se.event_type='approve'  THEN COALESCE(se.manual_date, se.created_at) END) AS firstApproveAt,
+               MAX(CASE WHEN se.event_type='complete' THEN COALESCE(se.manual_date, se.created_at) END) AS lastCompleteAt,
                SUM(CASE WHEN se.event_type='approve'  THEN se.pieces ELSE 0 END) AS approvedPcs,
                SUM(CASE WHEN se.event_type='complete' THEN se.pieces ELSE 0 END) AS completedPcs,
                SUM(CASE WHEN se.event_type='reject'   THEN se.pieces ELSE 0 END) AS rejectedPcs,
-               (SELECT MIN(ae.created_at) FROM jeans_assembly_events ae
+               (SELECT MIN(COALESCE(ae.manual_date, ae.created_at)) FROM jeans_assembly_events ae
                  WHERE ae.cutting_lot_id = cl.id AND ae.event_type='approve') AS asmFirstApproveAt,
-               (SELECT MIN(fe.created_at) FROM finishing_events fe
+               (SELECT MIN(COALESCE(fe.manual_date, fe.created_at)) FROM finishing_events fe
                  WHERE fe.cutting_lot_id = cl.id AND fe.event_type='approve') AS finFirstApproveAt,
                -- legacy downstream presence (older lots may have no events)
                (SELECT 1 FROM jeans_assembly_data jd WHERE jd.lot_no = cl.lot_no LIMIT 1) AS asmLegacyExists,
@@ -3044,7 +3044,7 @@ router.get('/day-activity/data', isAuthenticated, isOperator, async (req, res) =
               COALESCE(SUM(cl.total_pieces),0) AS pieces
          FROM cutting_lots cl
     LEFT JOIN users u ON u.id = cl.user_id
-        WHERE DATE(cl.created_at) = ?
+        WHERE COALESCE(cl.manual_cutting_date, DATE(cl.created_at)) = ?
      GROUP BY cl.user_id, cl.flow_type
      ORDER BY lots DESC, pieces DESC`,
       [day]
@@ -3089,7 +3089,7 @@ router.get('/day-activity/data', isAuthenticated, isOperator, async (req, res) =
            JOIN cutting_lots cl ON cl.id = e.cutting_lot_id
       LEFT JOIN users u ON u.id = e.operator_id
           WHERE e.event_type = 'approve'
-            AND DATE(e.created_at) = ?
+            AND COALESCE(e.manual_date, DATE(e.created_at)) = ?
        GROUP BY e.operator_id, cl.flow_type
        ORDER BY lots DESC, pieces DESC`,
         [day]

--- a/routes/stitchingRoutes.js
+++ b/routes/stitchingRoutes.js
@@ -8,6 +8,7 @@ const { isAuthenticated, isStitchingMaster } = require('../middlewares/auth');
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
 const { getLotStageUsers } = require('../utils/lotStageUsers');
+const { auditStageManualDate } = require('../utils/lotAudit');
 
 // ----------------------------
 // MULTER SETUP (for image uploads)
@@ -237,7 +238,7 @@ router.post('/event/approve', isAuthenticated, isStitchingMaster, async (req, re
   let conn;
   try {
     const userId = req.session.user.id;
-    const { cutting_lot_id, sizes, rejected_sizes, remark, reject_reason } = req.body;
+    const { cutting_lot_id, sizes, rejected_sizes, remark, reject_reason, manual_date } = req.body;
 
     const lotId = parseInt(cutting_lot_id, 10);
     if (!Number.isFinite(lotId) || lotId <= 0) {
@@ -255,6 +256,16 @@ router.post('/event/approve', isAuthenticated, isStitchingMaster, async (req, re
 
     conn = await pool.getConnection();
     await conn.beginTransaction();
+
+    let manualDate;
+    try {
+      manualDate = await stageEvents.resolveManualDate(conn, {
+        stage: STAGE, cuttingLotId: lotId, manualDate: manual_date,
+      });
+    } catch (e) {
+      await conn.rollback();
+      return res.status(400).json({ error: e.message });
+    }
 
     const [cutSizesRows] = await conn.query(
       `SELECT size_label, total_pieces FROM cutting_lot_sizes WHERE cutting_lot_id = ?`,
@@ -301,6 +312,7 @@ router.post('/event/approve', isAuthenticated, isStitchingMaster, async (req, re
         sizes: cleanSizes,
         parentEventId: null,
         remark: remark ? String(remark).trim() : null,
+        manualDate,
       });
     }
     if (cleanRejected.length) {
@@ -312,8 +324,16 @@ router.post('/event/approve', isAuthenticated, isStitchingMaster, async (req, re
         sizes: cleanRejected,
         parentEventId: null,
         remark: reject_reason ? String(reject_reason).trim() : null,
+        manualDate,
       });
     }
+
+    await auditStageManualDate(conn, {
+      cutting_lot_id: lotId, stage: STAGE, event_type: 'approve', manual_date: manualDate,
+      pieces: cleanSizes.reduce((a, s) => a + s.pieces, 0),
+      approve_event_id: approveEventId, reject_event_id: rejectEventId,
+      performed_by: userId, performed_by_name: req.session.user.username,
+    });
 
     await conn.commit();
     res.json({
@@ -351,7 +371,7 @@ router.post('/event/complete', isAuthenticated, isStitchingMaster, async (req, r
   let conn;
   try {
     const userId = req.session.user.id;
-    const { parent_event_id, completed_sizes, rejected_sizes, reject_reason, complete_remark } = req.body;
+    const { parent_event_id, completed_sizes, rejected_sizes, reject_reason, complete_remark, manual_date } = req.body;
 
     const parentId = parseInt(parent_event_id, 10);
     if (!Number.isFinite(parentId) || parentId <= 0) {
@@ -389,6 +409,17 @@ router.post('/event/complete', isAuthenticated, isStitchingMaster, async (req, r
       return res.status(403).json({
         error: 'You can only complete pieces against your own approve. Ask the original approver to record the completion.',
       });
+    }
+
+    let manualDate;
+    try {
+      manualDate = await stageEvents.resolveManualDate(conn, {
+        stage: STAGE, cuttingLotId: parent.cutting_lot_id, manualDate: manual_date,
+        parentEventId: parentId,
+      });
+    } catch (e) {
+      await conn.rollback();
+      return res.status(400).json({ error: e.message });
     }
 
     // Per-size: completed + rejected so far + new completed + new rejected <= approved (per size)
@@ -446,6 +477,7 @@ router.post('/event/complete', isAuthenticated, isStitchingMaster, async (req, r
         sizes: cleanCompleted,
         parentEventId: parentId,
         remark: complete_remark ? String(complete_remark).trim() : null,
+        manualDate,
       });
     }
     if (cleanRejected.length) {
@@ -457,8 +489,16 @@ router.post('/event/complete', isAuthenticated, isStitchingMaster, async (req, r
         sizes: cleanRejected,
         parentEventId: parentId,
         remark: reject_reason ? String(reject_reason).trim() : null,
+        manualDate,
       });
     }
+
+    await auditStageManualDate(conn, {
+      cutting_lot_id: parent.cutting_lot_id, stage: STAGE, event_type: 'complete', manual_date: manualDate,
+      pieces: cleanCompleted.reduce((a, s) => a + s.pieces, 0),
+      complete_event_id: completeEventId, reject_event_id: rejectEventId,
+      performed_by: userId, performed_by_name: req.session.user.username,
+    });
 
     // Dual-write: also append a stitching_data row for the COMPLETED pieces
     // so downstream stages still reading stitching_data keep working until

--- a/routes/washingInRoutes.js
+++ b/routes/washingInRoutes.js
@@ -13,6 +13,7 @@ const { isAuthenticated, isWashingInMaster } = require('../middlewares/auth');
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
 const { getLotStageUsers } = require('../utils/lotStageUsers');
+const { auditStageManualDate } = require('../utils/lotAudit');
 
 // ----------------------------------------------
 // MULTER SETUP (for optional image uploads)
@@ -561,7 +562,7 @@ router.post('/event/approve', isAuthenticated, isWashingInMaster, async (req, re
   let conn;
   try {
     const userId = req.session.user.id;
-    const { cutting_lot_id, sizes, rejected_sizes, rewash_sizes, remark, reject_reason, rewash_reason } = req.body;
+    const { cutting_lot_id, sizes, rejected_sizes, rewash_sizes, remark, reject_reason, rewash_reason, manual_date } = req.body;
     const lotId = parseInt(cutting_lot_id, 10);
     if (!Number.isFinite(lotId) || lotId <= 0) return res.status(400).json({ error: 'Invalid cutting_lot_id' });
 
@@ -583,6 +584,16 @@ router.post('/event/approve', isAuthenticated, isWashingInMaster, async (req, re
 
     const [[lot]] = await conn.query(`SELECT lot_no, sku FROM cutting_lots WHERE id = ?`, [lotId]);
     if (!lot) { await conn.rollback(); return res.status(404).json({ error: 'Lot not found' }); }
+
+    let manualDate;
+    try {
+      manualDate = await stageEvents.resolveManualDate(conn, {
+        stage: STAGE_WI, cuttingLotId: lotId, manualDate: manual_date,
+      });
+    } catch (e) {
+      await conn.rollback();
+      return res.status(400).json({ error: e.message });
+    }
 
     const upstream = await wiUpstreamSizes(conn, lotId, lot.lot_no);
     const upstreamMap = {};
@@ -617,6 +628,7 @@ router.post('/event/approve', isAuthenticated, isWashingInMaster, async (req, re
         stage: STAGE_WI, cuttingLotId: lotId, eventType: 'approve',
         operatorId: userId, sizes: cleanSizes, parentEventId: null,
         remark: remark ? String(remark).trim() : null,
+        manualDate,
       });
     }
     if (cleanRejected.length) {
@@ -624,8 +636,16 @@ router.post('/event/approve', isAuthenticated, isWashingInMaster, async (req, re
         stage: STAGE_WI, cuttingLotId: lotId, eventType: 'reject',
         operatorId: userId, sizes: cleanRejected, parentEventId: null,
         remark: reject_reason ? String(reject_reason).trim() : null,
+        manualDate,
       });
     }
+
+    await auditStageManualDate(conn, {
+      cutting_lot_id: lotId, stage: STAGE_WI, event_type: 'approve', manual_date: manualDate,
+      pieces: cleanSizes.reduce((a, s) => a + s.pieces, 0),
+      approve_event_id: approveEventId, reject_event_id: rejectEventId,
+      performed_by: userId, performed_by_name: req.session.user.username,
+    });
 
     if (cleanRewash.length) {
       // Rewash: pick the upstream washer's washing_data row (largest/most-recent
@@ -758,7 +778,7 @@ router.post('/event/complete', isAuthenticated, isWashingInMaster, async (req, r
   let conn;
   try {
     const userId = req.session.user.id;
-    const { parent_event_id, completed_sizes, rejected_sizes, reject_reason, complete_remark } = req.body;
+    const { parent_event_id, completed_sizes, rejected_sizes, reject_reason, complete_remark, manual_date } = req.body;
     const parentId = parseInt(parent_event_id, 10);
     if (!Number.isFinite(parentId) || parentId <= 0) return res.status(400).json({ error: 'Invalid parent_event_id' });
 
@@ -790,6 +810,17 @@ router.post('/event/complete', isAuthenticated, isWashingInMaster, async (req, r
       return res.status(403).json({
         error: 'You can only complete pieces against your own approve. Ask the original approver to record the completion.',
       });
+    }
+
+    let manualDate;
+    try {
+      manualDate = await stageEvents.resolveManualDate(conn, {
+        stage: STAGE_WI, cuttingLotId: parent.cutting_lot_id, manualDate: manual_date,
+        parentEventId: parentId,
+      });
+    } catch (e) {
+      await conn.rollback();
+      return res.status(400).json({ error: e.message });
     }
 
     const [parentSizesRows] = await conn.query(
@@ -832,6 +863,7 @@ router.post('/event/complete', isAuthenticated, isWashingInMaster, async (req, r
         stage: STAGE_WI, cuttingLotId: parent.cutting_lot_id, eventType: 'complete',
         operatorId: userId, sizes: cleanCompleted, parentEventId: parentId,
         remark: complete_remark ? String(complete_remark).trim() : null,
+        manualDate,
       });
     }
     if (cleanRejected.length) {
@@ -839,8 +871,16 @@ router.post('/event/complete', isAuthenticated, isWashingInMaster, async (req, r
         stage: STAGE_WI, cuttingLotId: parent.cutting_lot_id, eventType: 'reject',
         operatorId: userId, sizes: cleanRejected, parentEventId: parentId,
         remark: reject_reason ? String(reject_reason).trim() : null,
+        manualDate,
       });
     }
+
+    await auditStageManualDate(conn, {
+      cutting_lot_id: parent.cutting_lot_id, stage: STAGE_WI, event_type: 'complete', manual_date: manualDate,
+      pieces: cleanCompleted.reduce((a, s) => a + s.pieces, 0),
+      complete_event_id: completeEventId, reject_event_id: rejectEventId,
+      performed_by: userId, performed_by_name: req.session.user.username,
+    });
 
     if (cleanCompleted.length) {
       const [[lot]] = await conn.query(`SELECT lot_no, sku FROM cutting_lots WHERE id = ?`, [parent.cutting_lot_id]);

--- a/routes/washingRoutes.js
+++ b/routes/washingRoutes.js
@@ -9,6 +9,7 @@ const { isAuthenticated, isWashingMaster } = require('../middlewares/auth');
 const { createStagePayment } = require('../utils/stagePaymentHelper');
 const stageEvents = require('../utils/stageEvents');
 const { getLotStageUsers } = require('../utils/lotStageUsers');
+const { auditStageManualDate } = require('../utils/lotAudit');
 
 // MULTER SETUP
 const storage = multer.diskStorage({
@@ -1116,7 +1117,7 @@ router.post('/event/approve', isAuthenticated, isWashingMaster, async (req, res)
   let conn;
   try {
     const userId = req.session.user.id;
-    const { cutting_lot_id, sizes, rejected_sizes, remark, reject_reason } = req.body;
+    const { cutting_lot_id, sizes, rejected_sizes, remark, reject_reason, manual_date } = req.body;
 
     const lotId = parseInt(cutting_lot_id, 10);
     if (!Number.isFinite(lotId) || lotId <= 0) return res.status(400).json({ error: 'Invalid cutting_lot_id' });
@@ -1136,6 +1137,16 @@ router.post('/event/approve', isAuthenticated, isWashingMaster, async (req, res)
 
     const [[lot]] = await conn.query(`SELECT lot_no, sku FROM cutting_lots WHERE id = ?`, [lotId]);
     if (!lot) { await conn.rollback(); return res.status(404).json({ error: 'Lot not found' }); }
+
+    let manualDate;
+    try {
+      manualDate = await stageEvents.resolveManualDate(conn, {
+        stage: STAGE_W, cuttingLotId: lotId, manualDate: manual_date,
+      });
+    } catch (e) {
+      await conn.rollback();
+      return res.status(400).json({ error: e.message });
+    }
 
     const upstream = await wUpstreamSizes(conn, lotId, lot.lot_no);
     const upstreamMap = {};
@@ -1169,6 +1180,7 @@ router.post('/event/approve', isAuthenticated, isWashingMaster, async (req, res)
         sizes: cleanSizes,
         parentEventId: null,
         remark: remark ? String(remark).trim() : null,
+        manualDate,
       });
     }
     if (cleanRejected.length) {
@@ -1180,8 +1192,16 @@ router.post('/event/approve', isAuthenticated, isWashingMaster, async (req, res)
         sizes: cleanRejected,
         parentEventId: null,
         remark: reject_reason ? String(reject_reason).trim() : null,
+        manualDate,
       });
     }
+
+    await auditStageManualDate(conn, {
+      cutting_lot_id: lotId, stage: STAGE_W, event_type: 'approve', manual_date: manualDate,
+      pieces: cleanSizes.reduce((a, s) => a + s.pieces, 0),
+      approve_event_id: approveEventId, reject_event_id: rejectEventId,
+      performed_by: userId, performed_by_name: req.session.user.username,
+    });
 
     await conn.commit();
 
@@ -1224,7 +1244,7 @@ router.post('/event/complete', isAuthenticated, isWashingMaster, async (req, res
   let conn;
   try {
     const userId = req.session.user.id;
-    const { parent_event_id, completed_sizes, rejected_sizes, reject_reason, complete_remark } = req.body;
+    const { parent_event_id, completed_sizes, rejected_sizes, reject_reason, complete_remark, manual_date } = req.body;
 
     const parentId = parseInt(parent_event_id, 10);
     if (!Number.isFinite(parentId) || parentId <= 0) return res.status(400).json({ error: 'Invalid parent_event_id' });
@@ -1257,6 +1277,17 @@ router.post('/event/complete', isAuthenticated, isWashingMaster, async (req, res
       return res.status(403).json({
         error: 'You can only complete pieces against your own approve. Ask the original approver to record the completion.',
       });
+    }
+
+    let manualDate;
+    try {
+      manualDate = await stageEvents.resolveManualDate(conn, {
+        stage: STAGE_W, cuttingLotId: parent.cutting_lot_id, manualDate: manual_date,
+        parentEventId: parentId,
+      });
+    } catch (e) {
+      await conn.rollback();
+      return res.status(400).json({ error: e.message });
     }
 
     const [parentSizesRows] = await conn.query(
@@ -1299,6 +1330,7 @@ router.post('/event/complete', isAuthenticated, isWashingMaster, async (req, res
         stage: STAGE_W, cuttingLotId: parent.cutting_lot_id, eventType: 'complete',
         operatorId: userId, sizes: cleanCompleted, parentEventId: parentId,
         remark: complete_remark ? String(complete_remark).trim() : null,
+        manualDate,
       });
     }
     if (cleanRejected.length) {
@@ -1306,8 +1338,16 @@ router.post('/event/complete', isAuthenticated, isWashingMaster, async (req, res
         stage: STAGE_W, cuttingLotId: parent.cutting_lot_id, eventType: 'reject',
         operatorId: userId, sizes: cleanRejected, parentEventId: parentId,
         remark: reject_reason ? String(reject_reason).trim() : null,
+        manualDate,
       });
     }
+
+    await auditStageManualDate(conn, {
+      cutting_lot_id: parent.cutting_lot_id, stage: STAGE_W, event_type: 'complete', manual_date: manualDate,
+      pieces: cleanCompleted.reduce((a, s) => a + s.pieces, 0),
+      complete_event_id: completeEventId, reject_event_id: rejectEventId,
+      performed_by: userId, performed_by_name: req.session.user.username,
+    });
 
     // Dual-write to washing_data for downstream washing_in compatibility
     if (cleanCompleted.length) {

--- a/sql/2026_08_stage_events_manual_date.sql
+++ b/sql/2026_08_stage_events_manual_date.sql
@@ -1,0 +1,15 @@
+-- Manual date: the actual day the stage action happened on the floor, which can
+-- differ from created_at (masters sometimes record work a day or more after it
+-- happened). Shadow column beside the server-controlled created_at — created_at
+-- is NEVER overridden. Display/bucketing consumers read the effective date via
+-- COALESCE(manual_date, created_at); payment eligibility, in-flight windows and
+-- cache keys stay on raw created_at.
+-- Mirrors cutting_lots.manual_cutting_date (sql/cutting_manual_cutting_date_migration.sql).
+--
+-- Run BEFORE deploying the code that writes/reads manual_date.
+
+ALTER TABLE stitching_events      ADD COLUMN manual_date DATE NULL AFTER remark;
+ALTER TABLE jeans_assembly_events ADD COLUMN manual_date DATE NULL AFTER remark;
+ALTER TABLE washing_events        ADD COLUMN manual_date DATE NULL AFTER remark;
+ALTER TABLE washing_in_events     ADD COLUMN manual_date DATE NULL AFTER remark;
+ALTER TABLE finishing_events      ADD COLUMN manual_date DATE NULL AFTER remark;

--- a/test/lotJourney.test.js
+++ b/test/lotJourney.test.js
@@ -148,3 +148,22 @@ test('currentStage: first in-progress or not-started stage; Done when all finish
   ];
   assert.strictEqual(currentStage(tl2), 'Done');
 });
+
+test('mergeActivity: manual_date passes through but never reorders the feed', () => {
+  // The complete was entered AFTER the reject (real time) but its manual date is
+  // days earlier — the feed must stay in real entry order (tamper-evident).
+  const feed = mergeActivity({
+    cutting: { created_at: '2026-06-01T10:00:00Z', by: 'cutter1', total_pieces: 100, manual_date: '2026-05-30' },
+    stageEvents: {
+      stitching: [
+        { event_type: 'approve', pieces: 100, created_at: '2026-06-03T09:00:00Z', username: 'a' },
+        { event_type: 'reject', pieces: 5, created_at: '2026-06-05T09:00:00Z', username: 'a' },
+        { event_type: 'complete', pieces: 95, created_at: '2026-06-08T09:00:00Z', username: 'a', manual_date: '2026-06-04' },
+      ],
+    },
+  });
+  assert.deepStrictEqual(feed.map(f => f.kind), ['created', 'approve', 'reject', 'complete']);
+  assert.strictEqual(feed[0].manual_date, '2026-05-30');
+  assert.strictEqual(feed[1].manual_date, null);
+  assert.strictEqual(feed[3].manual_date, '2026-06-04');
+});

--- a/test/manualDate.test.js
+++ b/test/manualDate.test.js
@@ -1,0 +1,127 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { resolveManualDate, assertManualDateNotFuture } = require('../utils/stageEvents.js');
+
+// Stub a mysql2 connection: dispatch each of resolveManualDate's queries by its
+// SQL shape. `data` controls what each shape returns; `seen` records the order.
+function stubConn(data) {
+  const seen = [];
+  return {
+    seen,
+    async query(sql, params) {
+      const flat = sql.replace(/\s+/g, ' ').trim();
+      seen.push({ sql: flat, params });
+      if (/AS is_future/.test(flat)) return [[{ is_future: data.isFuture ? 1 : 0 }]];
+      if (/FROM \w+_events WHERE id = \?/.test(flat)) return [[data.parent]];
+      if (/SELECT MIN\(COALESCE\(manual_date/.test(flat)) {
+        const table = flat.match(/FROM (\w+_events)/)[1];
+        return [[{ eff: (data.stageEff || {})[table] ?? null }]];
+      }
+      if (/SELECT \(CAST\(\? AS DATE\) < CAST\(\? AS DATE\)\) AS too_early/.test(flat)) {
+        // Mirror MySQL: mysql2 serializes Date params in the +05:30 session tz,
+        // then CAST(... AS DATE) keeps only the date part of each side.
+        const day = v => v instanceof Date
+          ? v.toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' })
+          : String(v).slice(0, 10);
+        return [[{ too_early: day(params[0]) < day(params[1]) ? 1 : 0 }]];
+      }
+      if (/FROM cutting_lots WHERE id = \?/.test(flat)) {
+        return [[{ too_early: data.cuttingTooEarly ? 1 : 0 }]];
+      }
+      throw new Error('unexpected query: ' + flat);
+    },
+  };
+}
+
+test('resolveManualDate: blank/null/whitespace input resolves to null without touching the DB', async () => {
+  const conn = stubConn({});
+  assert.strictEqual(await resolveManualDate(conn, { stage: 'stitching', cuttingLotId: 1, manualDate: null }), null);
+  assert.strictEqual(await resolveManualDate(conn, { stage: 'stitching', cuttingLotId: 1, manualDate: '' }), null);
+  assert.strictEqual(await resolveManualDate(conn, { stage: 'stitching', cuttingLotId: 1, manualDate: '   ' }), null);
+  assert.strictEqual(conn.seen.length, 0);
+});
+
+test('resolveManualDate: malformed date throws before any query', async () => {
+  const conn = stubConn({});
+  await assert.rejects(
+    () => resolveManualDate(conn, { stage: 'stitching', cuttingLotId: 1, manualDate: '05-08-2026' }),
+    /Invalid manual date/
+  );
+  assert.strictEqual(conn.seen.length, 0);
+});
+
+test('resolveManualDate: future date rejected', async () => {
+  const conn = stubConn({ isFuture: true });
+  await assert.rejects(
+    () => resolveManualDate(conn, { stage: 'stitching', cuttingLotId: 1, manualDate: '2030-01-01' }),
+    /future/
+  );
+});
+
+test('assertManualDateNotFuture: passes for non-future', async () => {
+  const conn = stubConn({ isFuture: false });
+  await assert.doesNotReject(() => assertManualDateNotFuture(conn, '2026-08-01'));
+});
+
+test('resolveManualDate: complete path bounds against the parent approve effective date', async () => {
+  const tooEarly = stubConn({ parent: { too_early: 1, eff: '05-08-2026' } });
+  await assert.rejects(
+    () => resolveManualDate(tooEarly, { stage: 'washing', cuttingLotId: 1, manualDate: '2026-08-01', parentEventId: 42 }),
+    /before this batch was taken \(05-08-2026\)/
+  );
+
+  const ok = stubConn({ parent: { too_early: 0, eff: '01-08-2026' } });
+  const v = await resolveManualDate(ok, { stage: 'washing', cuttingLotId: 1, manualDate: '2026-08-05', parentEventId: 42 });
+  assert.strictEqual(v, '2026-08-05');
+  // complete path never walks upstream stages
+  assert.ok(!ok.seen.some(x => /SELECT MIN/.test(x.sql)));
+});
+
+test('resolveManualDate: approve path bounds against the nearest upstream stage with events', async () => {
+  // washing → checks jeans_assembly first; it has events starting 2026-08-03
+  const conn = stubConn({ stageEff: { jeans_assembly_events: '2026-08-03' } });
+  await assert.rejects(
+    () => resolveManualDate(conn, { stage: 'washing', cuttingLotId: 1, manualDate: '2026-08-01' }),
+    /before the jeans assembly stage started/
+  );
+
+  const ok = stubConn({ stageEff: { jeans_assembly_events: '2026-08-03' } });
+  const v = await resolveManualDate(ok, { stage: 'washing', cuttingLotId: 1, manualDate: '2026-08-03' });
+  assert.strictEqual(v, '2026-08-03');
+  // stops at the first upstream stage that has events — never reaches stitching or cutting
+  assert.ok(!ok.seen.some(x => /stitching_events/.test(x.sql)));
+  assert.ok(!ok.seen.some(x => /cutting_lots/.test(x.sql)));
+});
+
+test('resolveManualDate: hosiery-style walk skips empty stages and falls through to stitching', async () => {
+  // finishing on a hosiery lot: washing_in/washing/jeans_assembly empty, stitching has events
+  const conn = stubConn({ stageEff: { stitching_events: '2026-08-02' } });
+  await assert.rejects(
+    () => resolveManualDate(conn, { stage: 'finishing', cuttingLotId: 1, manualDate: '2026-08-01' }),
+    /before the stitching stage started/
+  );
+  assert.ok(conn.seen.some(x => /washing_in_events/.test(x.sql)));
+  assert.ok(conn.seen.some(x => /washing_events/.test(x.sql)));
+  assert.ok(conn.seen.some(x => /jeans_assembly_events/.test(x.sql)));
+});
+
+test('resolveManualDate: all upstream stages empty falls back to the cutting effective date', async () => {
+  const ok = stubConn({ stageEff: {}, cuttingTooEarly: false });
+  const v = await resolveManualDate(ok, { stage: 'stitching', cuttingLotId: 1, manualDate: '2026-08-05' });
+  assert.strictEqual(v, '2026-08-05');
+  assert.ok(ok.seen.some(x => /cutting_lots/.test(x.sql)));
+
+  const bad = stubConn({ stageEff: {}, cuttingTooEarly: true });
+  await assert.rejects(
+    () => resolveManualDate(bad, { stage: 'stitching', cuttingLotId: 1, manualDate: '2026-08-01' }),
+    /before the lot was cut/
+  );
+});
+
+test('resolveManualDate: date equal to the upstream stage start day is accepted (Date-param serialization)', async () => {
+  // The upstream MIN() arrives as a JS Date; mysql2 sends it as a datetime string.
+  // Regression: '2026-08-03' < '2026-08-03 00:00:00' compares true as strings.
+  const conn = stubConn({ stageEff: { jeans_assembly_events: new Date('2026-08-03T00:00:00+05:30') } });
+  const v = await resolveManualDate(conn, { stage: 'washing', cuttingLotId: 1, manualDate: '2026-08-03' });
+  assert.strictEqual(v, '2026-08-03');
+});

--- a/test/picSizeReport.test.js
+++ b/test/picSizeReport.test.js
@@ -128,3 +128,50 @@ test('fnv1a distinguishes lot lists with same length, first and last', () => {
   assert.notStrictEqual(fnv1a(a), fnv1a(b));
   assert.strictEqual(fnv1a(a), fnv1a(a)); // stable
 });
+
+// ── Manual date shadow columns ─────────────────────────────────────────────
+const { PIC_REPORT_V2_COLUMNS } = require('../utils/picSizeReport.js');
+
+test('manual date: assignedOn reflects the effective date and *ManualDate keys populate', () => {
+  const row = buildEnhancedRow({
+    lot: LOT, isDenim: true, totalCut: 100,
+    sums:     { stitchedQty: 0, assembledQty: 0, washedQty: 0, washingInQty: 0, finishedQty: 0 },
+    approved: { stitchApproved: 100, assemblyApproved: 0, washingApproved: 0, washInApproved: 0, finishingApproved: 0 },
+    assigns: {
+      ...NO_ASSIGNS,
+      // What fetchLotEventAggregates now produces: assigned_on/approved_on are
+      // already the effective (manual-preferred) date, manual_date is the raw shadow.
+      stAssign: {
+        is_approved: 1, assigned_on: '2026-08-03', approved_on: '2026-08-03',
+        manual_date: '2026-08-03', opName: 'stitchA', user_id: 9,
+      },
+    },
+    dispatched: 0,
+  });
+  assert.strictEqual(row.stitchManualDate, '03-08-2026');
+  assert.ok(row.stitchAssignedOn.startsWith('03-08-2026'));
+  // stages without a manual date stay blank (denim, no assign yet)
+  assert.strictEqual(row.finishingManualDate, '');
+  assert.strictEqual(row.washingManualDate, '');
+});
+
+test('manual date: non-denim lots show the N/A dash on denim-only stage manual dates', () => {
+  const row = buildEnhancedRow({
+    lot: LOT, isDenim: false, totalCut: 100,
+    sums:     { stitchedQty: 0, assembledQty: 0, washedQty: 0, washingInQty: 0, finishedQty: 0 },
+    approved: { stitchApproved: 0, assemblyApproved: 0, washingApproved: 0, washInApproved: 0, finishingApproved: 0 },
+    assigns: NO_ASSIGNS, dispatched: 0,
+  });
+  assert.strictEqual(row.assemblyManualDate, '—');
+  assert.strictEqual(row.washingManualDate, '—');
+  assert.strictEqual(row.washInManualDate, '—');
+});
+
+test('manual date: PIC_REPORT_V2_COLUMNS carries the five stage manual-date columns', () => {
+  const keys = PIC_REPORT_V2_COLUMNS.map(c => c.key);
+  for (const k of ['stitchManualDate', 'assemblyManualDate', 'washingManualDate', 'washInManualDate', 'finishingManualDate']) {
+    assert.ok(keys.includes(k), `missing column ${k}`);
+  }
+  const headers = PIC_REPORT_V2_COLUMNS.map(c => c.header);
+  assert.ok(headers.includes('Stitch Manual Date'));
+});

--- a/test/stageEvents.test.js
+++ b/test/stageEvents.test.js
@@ -119,3 +119,24 @@ test('recordEvent: accepts labels that match the cutting breakdown', async () =>
   assert.strictEqual(id, 123);
   assert.ok(conn.q.some(x => /INSERT INTO \w+_event_sizes/.test(x.sql)));
 });
+
+test('recordEvent: manual_date is bound as the 7th insert value, null when omitted', async () => {
+  const conn = recordStub(['M']);
+  await recordEvent(conn, {
+    stage: 'stitching', cuttingLotId: 1, eventType: 'approve', operatorId: 9,
+    sizes: [{ size_label: 'M', pieces: 10 }],
+    manualDate: '2026-08-05',
+  });
+  const withDate = conn.q.find(x => /INSERT INTO \w+_events/.test(x.sql));
+  assert.ok(/manual_date/.test(withDate.sql));
+  assert.strictEqual(withDate.params.length, 7);
+  assert.strictEqual(withDate.params[6], '2026-08-05');
+
+  const conn2 = recordStub(['M']);
+  await recordEvent(conn2, {
+    stage: 'stitching', cuttingLotId: 1, eventType: 'approve', operatorId: 9,
+    sizes: [{ size_label: 'M', pieces: 10 }],
+  });
+  const without = conn2.q.find(x => /INSERT INTO \w+_events/.test(x.sql));
+  assert.strictEqual(without.params[6], null);
+});

--- a/utils/aiSchemaDoc.js
+++ b/utils/aiSchemaDoc.js
@@ -32,7 +32,10 @@ Stage order: cutting → stitching → [jeans_assembly → washing → washing_i
 - Event tables (append-only ledger): stitching_events, jeans_assembly_events,
   washing_events, washing_in_events, finishing_events. Columns: cutting_lot_id,
   event_type ENUM('approve','complete','reject'), pieces, parent_event_id,
-  operator_id (join users), created_at. Per-size detail in *_event_sizes.
+  operator_id (join users), created_at, manual_date (DATE NULL — the actual
+  floor date when the master backdates an entry; for display/day-bucketing use
+  COALESCE(manual_date, DATE(created_at)); payments and in-flight windows use
+  raw created_at). Per-size detail in *_event_sizes.
   Semantics: 'approve' = pieces TAKEN INTO the stage (this is also the payment
   event — it pays the UPSTREAM stage's worker); 'complete' = pieces finished at
   the stage; 'reject' with parent_event_id NULL = rejected at handover,
@@ -48,8 +51,8 @@ Stage order: cutting → stitching → [jeans_assembly → washing → washing_i
   confirmed/failed/cancelled ('blocked' = a size has no EasyEcom SKU mapping;
   'confirmed' = warehouse GRN'd it in EasyEcom), po_id, total_qty, created_at.
 - pm_lot_audit_log: admin corrections. EXACT columns: cutting_lot_id, lot_no,
-  action ('flow_change'/'stage_reversal'/'qty_edit'), detail (JSON),
-  performed_by_name, created_at.
+  action ('flow_change'/'stage_reversal'/'qty_edit'/'manual_date'), detail
+  (JSON), performed_by_name, created_at.
 
 ## Payments (per-piece piecework)
 - stage_payments (worker earnings, one row per approve handover). EXACT

--- a/utils/lotAudit.js
+++ b/utils/lotAudit.js
@@ -21,4 +21,29 @@ async function writeLotAudit(db, { cutting_lot_id, lot_no, action, detail, perfo
   }
 }
 
-module.exports = { writeLotAudit };
+// Audit a user-supplied manual date on a stage event (approve/complete). No-op
+// when manual_date is null so callers can invoke it unconditionally. Same
+// best-effort contract as writeLotAudit; pass the transaction connection so the
+// audit row commits (or rolls back) with the events it describes.
+async function auditStageManualDate(db, {
+  cutting_lot_id, stage, event_type, manual_date, pieces = null,
+  approve_event_id = null, complete_event_id = null, reject_event_id = null,
+  performed_by, performed_by_name,
+}) {
+  if (!manual_date) return;
+  let lot_no = null;
+  try {
+    const [[row]] = await db.query('SELECT lot_no FROM cutting_lots WHERE id = ?', [cutting_lot_id]);
+    if (row) lot_no = row.lot_no;
+  } catch (_) { /* lot_no is nice-to-have; cutting_lot_id is the real key */ }
+  const detail = { stage, event_type, manual_date };
+  if (pieces != null) detail.pieces = pieces;
+  if (approve_event_id != null) detail.approve_event_id = approve_event_id;
+  if (complete_event_id != null) detail.complete_event_id = complete_event_id;
+  if (reject_event_id != null) detail.reject_event_id = reject_event_id;
+  await writeLotAudit(db, {
+    cutting_lot_id, lot_no, action: 'manual_date', detail, performed_by, performed_by_name,
+  });
+}
+
+module.exports = { writeLotAudit, auditStageManualDate };

--- a/utils/lotJourney.js
+++ b/utils/lotJourney.js
@@ -68,6 +68,7 @@ const ACTIVITY_LABEL = {
 };
 const ADMIN_ACTION_LABEL = {
   flow_change: 'Flow change', stage_reversal: 'Stage reversal', qty_edit: 'Qty edit',
+  manual_date: 'Manual date',
 };
 
 // Human-readable one-liner from a pm_lot_audit_log detail JSON (object or string).
@@ -96,6 +97,7 @@ function mergeActivity({ cutting, stageEvents, dispatches, audits } = {}) {
       when: cutting.created_at, stage: 'cutting', kind: 'created', label: ACTIVITY_LABEL.created,
       pieces: cutting.total_pieces != null ? Number(cutting.total_pieces) : null,
       by: cutting.by || null, note: cutting.note || '',
+      manual_date: cutting.manual_date || null,
     });
   }
   for (const [stage, events] of Object.entries(stageEvents || {})) {
@@ -106,6 +108,9 @@ function mergeActivity({ cutting, stageEvents, dispatches, audits } = {}) {
         label: ACTIVITY_LABEL[e.event_type] || e.event_type,
         pieces: e.pieces != null ? Number(e.pieces) : null,
         by: e.username || null, note: e.remark || '',
+        // Shadow date: shown alongside, never used for ordering — the feed
+        // stays sorted by real entry time so the chronology is tamper-evident.
+        manual_date: e.manual_date || null,
       });
     }
   }

--- a/utils/picSizeReport.js
+++ b/utils/picSizeReport.js
@@ -73,6 +73,15 @@ function fmtIST(d) {
   return dt.toLocaleString('en-GB', { timeZone: 'Asia/Kolkata' }).replace(/\//g, '-');
 }
 
+// Date-only variant for bare DATE columns (manual dates) — fmtIST would render
+// a meaningless ", 00:00:00" time on them.
+function fmtISTDate(d) {
+  if (!d) return '';
+  const dt = new Date(d);
+  if (isNaN(dt.getTime())) return '';
+  return dt.toLocaleDateString('en-GB', { timeZone: 'Asia/Kolkata' }).replace(/\//g, '-');
+}
+
 function daysSince(dateValue) {
   // NOTE: operatorRoutes.js had two top-level daysSince() declarations; in sloppy
   // mode the LAST one won, so buildEnhancedRow effectively used this version.
@@ -222,6 +231,7 @@ function buildEnhancedRow({
     stitchOp:        opName(stAssign),
     stitchAssignedOn: fmtIST(stAssign && stAssign.assigned_on),
     stitchApprovedOn: fmtIST(stAssign && stAssign.approved_on),
+    stitchManualDate: fmtISTDate(stAssign && stAssign.manual_date),
     stitchInQty:     stitch.in,
     stitchOutQty:    stitch.out,
     stitchPendingQty: stitch.pending,
@@ -232,6 +242,7 @@ function buildEnhancedRow({
     assemblyOp:        isDenim ? opName(asmAssign) : '—',
     assemblyAssignedOn: isDenim ? fmtIST(asmAssign && asmAssign.assigned_on) : '—',
     assemblyApprovedOn: isDenim ? fmtIST(asmAssign && asmAssign.approved_on) : '—',
+    assemblyManualDate: isDenim ? fmtISTDate(asmAssign && asmAssign.manual_date) : '—',
     assemblyInQty:     assembly.in,
     assemblyOutQty:    assembly.out,
     assemblyPendingQty: assembly.pending,
@@ -242,6 +253,7 @@ function buildEnhancedRow({
     washingOp:        isDenim ? opName(washAssign) : '—',
     washingAssignedOn: isDenim ? fmtIST(washAssign && washAssign.assigned_on) : '—',
     washingApprovedOn: isDenim ? fmtIST(washAssign && washAssign.approved_on) : '—',
+    washingManualDate: isDenim ? fmtISTDate(washAssign && washAssign.manual_date) : '—',
     washingInQty_in:  washing.in,
     washingOutQty:    washing.out,
     washingPendingQty: washing.pending,
@@ -252,6 +264,7 @@ function buildEnhancedRow({
     washInOp:        isDenim ? opName(washInAssign) : '—',
     washInAssignedOn: isDenim ? fmtIST(washInAssign && washInAssign.assigned_on) : '—',
     washInApprovedOn: isDenim ? fmtIST(washInAssign && washInAssign.approved_on) : '—',
+    washInManualDate: isDenim ? fmtISTDate(washInAssign && washInAssign.manual_date) : '—',
     washInInQty:     washIn.in,
     washInOutQty:    washIn.out,
     washInPendingQty: washIn.pending,
@@ -279,6 +292,7 @@ function buildEnhancedRow({
     finishingOp:        opName(finAssign),
     finishingAssignedOn: fmtIST(finAssign && finAssign.assigned_on),
     finishingApprovedOn: fmtIST(finAssign && finAssign.approved_on),
+    finishingManualDate: fmtISTDate(finAssign && finAssign.manual_date),
     finishingInQty:     finishing.in,
     finishingOutQty:    finishing.out,
     finishingPendingQty: finishing.pending,
@@ -311,6 +325,7 @@ const PIC_REPORT_V2_COLUMNS = [
   { header: 'Stitch Operator',     key: 'stitchOp',          width: 14 },
   { header: 'Stitch Assigned On',  key: 'stitchAssignedOn',  width: 19 },
   { header: 'Stitch Approved On',  key: 'stitchApprovedOn',  width: 19 },
+  { header: 'Stitch Manual Date',  key: 'stitchManualDate',  width: 13 },
   { header: 'Stitch Approved',       key: 'stitchInQty',       width: 11 },
   { header: 'Stitch Completed',      key: 'stitchOutQty',      width: 11 },
   { header: 'Stitch Pending Qty',  key: 'stitchPendingQty',  width: 12 },
@@ -320,6 +335,7 @@ const PIC_REPORT_V2_COLUMNS = [
   { header: 'Assembly Operator',     key: 'assemblyOp',          width: 14 },
   { header: 'Assembly Assigned On',  key: 'assemblyAssignedOn',  width: 19 },
   { header: 'Assembly Approved On',  key: 'assemblyApprovedOn',  width: 19 },
+  { header: 'Assembly Manual Date',  key: 'assemblyManualDate',  width: 13 },
   { header: 'Assembly Approved',       key: 'assemblyInQty',       width: 11 },
   { header: 'Assembly Completed',      key: 'assemblyOutQty',      width: 11 },
   { header: 'Assembly Pending Qty',  key: 'assemblyPendingQty',  width: 12 },
@@ -329,6 +345,7 @@ const PIC_REPORT_V2_COLUMNS = [
   { header: 'Washing Operator',     key: 'washingOp',          width: 14 },
   { header: 'Washing Assigned On',  key: 'washingAssignedOn',  width: 19 },
   { header: 'Washing Approved On',  key: 'washingApprovedOn',  width: 19 },
+  { header: 'Washing Manual Date',  key: 'washingManualDate',  width: 13 },
   { header: 'Washing Approved',       key: 'washingInQty_in',    width: 11 },
   { header: 'Washing Completed',      key: 'washingOutQty',      width: 11 },
   { header: 'Washing Pending Qty',  key: 'washingPendingQty',  width: 12 },
@@ -338,6 +355,7 @@ const PIC_REPORT_V2_COLUMNS = [
   { header: 'Wash-In Operator',     key: 'washInOp',           width: 14 },
   { header: 'Wash-In Assigned On',  key: 'washInAssignedOn',   width: 19 },
   { header: 'Wash-In Approved On',  key: 'washInApprovedOn',   width: 19 },
+  { header: 'Wash-In Manual Date',  key: 'washInManualDate',   width: 13 },
   { header: 'Wash-In Approved',       key: 'washInInQty',        width: 11 },
   { header: 'Wash-In Completed',      key: 'washInOutQty',       width: 11 },
   { header: 'Wash-In Pending Qty',  key: 'washInPendingQty',   width: 12 },
@@ -351,6 +369,7 @@ const PIC_REPORT_V2_COLUMNS = [
   { header: 'Finishing Operator',     key: 'finishingOp',          width: 14 },
   { header: 'Finishing Assigned On',  key: 'finishingAssignedOn',  width: 19 },
   { header: 'Finishing Approved On',  key: 'finishingApprovedOn',  width: 19 },
+  { header: 'Finishing Manual Date',  key: 'finishingManualDate',  width: 13 },
   { header: 'Finishing Approved',       key: 'finishingInQty',       width: 11 },
   { header: 'Finishing Completed',      key: 'finishingOutQty',      width: 11 },
   { header: 'Finishing Pending Qty',  key: 'finishingPendingQty',  width: 12 },
@@ -415,9 +434,10 @@ async function fetchLotEventAggregates(lotNos = []) {
       [lotNos, lotNos, lotNos, lotNos, lotNos]
     );
 
-    // Per-stage approve events, ordered so the first row per lot is the latest.
+    // Per-stage approve events, ordered so the first row per lot is the latest
+    // (latest by real entry time — manual_date only shifts the displayed date).
     const opSql = (table) => `
-      SELECT cl.lot_no, e.created_at, u.username AS opName, e.operator_id
+      SELECT cl.lot_no, e.created_at, e.manual_date, u.username AS opName, e.operator_id
         FROM ${table} e
         JOIN cutting_lots cl ON cl.id = e.cutting_lot_id
         JOIN users u ON u.id = e.operator_id
@@ -475,10 +495,12 @@ async function fetchLotEventAggregates(lotNos = []) {
       const m = {};
       for (const r of rows) {
         if (m[r.lot_no]) continue; // first occurrence is latest (DESC order)
+        const eff = r.manual_date || r.created_at;
         m[r.lot_no] = {
           is_approved: 1,
-          assigned_on: r.created_at,
-          approved_on: r.created_at,
+          assigned_on: eff,
+          approved_on: eff,
+          manual_date: r.manual_date || null,
           opName:      r.opName,
           user_id:     r.operator_id,
         };
@@ -1058,7 +1080,7 @@ async function buildPicSizeRows({
             SELECT 1 FROM ${evtTable} e
              WHERE e.cutting_lot_id = cl.id
                AND e.event_type = 'approve'
-               AND DATE(e.created_at) BETWEEN ? AND ?
+               AND COALESCE(e.manual_date, DATE(e.created_at)) BETWEEN ? AND ?
           )`;
         dateParams.push(sd, ed);
       }
@@ -1292,12 +1314,12 @@ function buildPicSizeWorkbook(finalData) {
     { header: 'Remark',              key: 'remark',            width: 26 },
   ];
   const stageColKeys = new Set([
-    'stitchOp','stitchAssignedOn','stitchApprovedOn','stitchInQty','stitchOutQty','stitchPendingQty','stitchStatus','stitchInline',
-    'assemblyOp','assemblyAssignedOn','assemblyApprovedOn','assemblyInQty','assemblyOutQty','assemblyPendingQty','assemblyStatus','assemblyInline',
-    'washingOp','washingAssignedOn','washingApprovedOn','washingInQty_in','washingOutQty','washingPendingQty','washingStatus','washingInline',
-    'washInOp','washInAssignedOn','washInApprovedOn','washInInQty','washInOutQty','washInPendingQty','washInStatus','washInInline',
+    'stitchOp','stitchAssignedOn','stitchApprovedOn','stitchManualDate','stitchInQty','stitchOutQty','stitchPendingQty','stitchStatus','stitchInline',
+    'assemblyOp','assemblyAssignedOn','assemblyApprovedOn','assemblyManualDate','assemblyInQty','assemblyOutQty','assemblyPendingQty','assemblyStatus','assemblyInline',
+    'washingOp','washingAssignedOn','washingApprovedOn','washingManualDate','washingInQty_in','washingOutQty','washingPendingQty','washingStatus','washingInline',
+    'washInOp','washInAssignedOn','washInApprovedOn','washInManualDate','washInInQty','washInOutQty','washInPendingQty','washInStatus','washInInline',
     'rewashRequestedQty','rewashPendingQty','rewashCompletedQty',
-    'finishingOp','finishingAssignedOn','finishingApprovedOn','finishingInQty','finishingOutQty','finishingPendingQty','finishingStatus',
+    'finishingOp','finishingAssignedOn','finishingApprovedOn','finishingManualDate','finishingInQty','finishingOutQty','finishingPendingQty','finishingStatus',
     'stitchRejectQty','stitchRejectReasons','washInRejectQty','washInRejectReasons','finishingRejectQty','finishingRejectReasons','totalRejectQty',
   ]);
   for (const c of PIC_REPORT_V2_COLUMNS) {

--- a/utils/stageEvents.js
+++ b/utils/stageEvents.js
@@ -258,11 +258,17 @@ async function getOpenApprovals(conn, stage, cuttingLotId, operatorId = null) {
  *   - sizes:           [{ size_label, pieces }] — must sum to total
  *   - parentEventId:   required for complete/reject, must be NULL for approve
  *   - remark:          optional per-event note
+ *   - manualDate:      optional 'YYYY-MM-DD' — the actual floor date of the
+ *                      action when it differs from today. Shadow value only:
+ *                      created_at stays server time. Callers must validate
+ *                      via resolveManualDate() first (once per request, since
+ *                      a handler's paired recordEvent calls share one date).
  *
  * Returns the new event id.
  */
 async function recordEvent(conn, {
   stage, cuttingLotId, eventType, operatorId, sizes, parentEventId = null, remark = null,
+  manualDate = null,
 }) {
   const { events, eventSizes } = tablesFor(stage);
 
@@ -305,10 +311,10 @@ async function recordEvent(conn, {
   const [result] = await conn.query(
     `
       INSERT INTO ${events}
-        (cutting_lot_id, event_type, parent_event_id, pieces, operator_id, remark)
-      VALUES (?, ?, ?, ?, ?, ?)
+        (cutting_lot_id, event_type, parent_event_id, pieces, operator_id, remark, manual_date)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
     `,
-    [cuttingLotId, eventType, parentEventId, totalPieces, operatorId, remark]
+    [cuttingLotId, eventType, parentEventId, totalPieces, operatorId, remark, manualDate]
   );
   const eventId = result.insertId;
 
@@ -325,6 +331,88 @@ async function recordEvent(conn, {
   return eventId;
 }
 
+/**
+ * Throw if `raw` ('YYYY-MM-DD') is after today. Date comparisons run in SQL so
+ * "today" is the DB session's IST clock, not the Node process timezone.
+ */
+async function assertManualDateNotFuture(conn, raw) {
+  const [[f]] = await conn.query('SELECT (? > CURDATE()) AS is_future', [raw]);
+  if (f && Number(f.is_future)) {
+    throw new Error('Manual date cannot be in the future');
+  }
+}
+
+/**
+ * Validate a user-supplied manual date for a stage event. Returns null when the
+ * field was left blank, or the normalized 'YYYY-MM-DD' string when valid.
+ * Throws an Error with a user-facing message on violation.
+ *
+ * Bounds (whole days, matching manual_cutting_date's DATE granularity):
+ *   - not in the future (IST via the DB session)
+ *   - complete/inline-reject (parentEventId set): not before the parent approve
+ *     event's effective date
+ *   - approve/upstream-reject: not before the nearest upstream stage's earliest
+ *     effective date. The walk uses the full denim chain regardless of flow
+ *     type — a hosiery lot simply has empty assembly/washing tables and falls
+ *     through — and terminates at cutting_lots, so a date is never rejected
+ *     just because upstream stages have no events (pre-events legacy lots).
+ *     MIN (stage start), not MAX: partial batches legitimately overlap.
+ */
+async function resolveManualDate(conn, { stage, cuttingLotId, manualDate, parentEventId = null }) {
+  const raw = (manualDate == null ? '' : String(manualDate)).trim();
+  if (!raw) return null;
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(raw)) {
+    throw new Error('Invalid manual date (use YYYY-MM-DD)');
+  }
+
+  await assertManualDateNotFuture(conn, raw);
+
+  if (parentEventId != null) {
+    const { events } = tablesFor(stage);
+    const [[p]] = await conn.query(
+      `SELECT (? < COALESCE(manual_date, DATE(created_at))) AS too_early,
+              DATE_FORMAT(COALESCE(manual_date, DATE(created_at)), '%d-%m-%Y') AS eff
+         FROM ${events} WHERE id = ?`,
+      [raw, parentEventId]
+    );
+    if (p && Number(p.too_early)) {
+      throw new Error(`Manual date is before this batch was taken (${p.eff})`);
+    }
+    return raw;
+  }
+
+  const idx = STAGES.indexOf(stage);
+  if (idx === -1) throw new Error(`Unknown stage: ${stage}`);
+  for (let i = idx - 1; i >= 0; i--) {
+    const { events } = tablesFor(STAGES[i]);
+    const [[r]] = await conn.query(
+      `SELECT MIN(COALESCE(manual_date, DATE(created_at))) AS eff FROM ${events} WHERE cutting_lot_id = ?`,
+      [cuttingLotId]
+    );
+    if (r && r.eff != null) {
+      // CAST both sides: mysql2 serializes a JS Date param as a datetime string,
+      // and a bare '2026-08-03' < '2026-08-03 00:00:00' string compare is true.
+      const [[c]] = await conn.query(
+        'SELECT (CAST(? AS DATE) < CAST(? AS DATE)) AS too_early', [raw, r.eff]
+      );
+      if (c && Number(c.too_early)) {
+        throw new Error(`Manual date is before the ${STAGES[i].replace(/_/g, ' ')} stage started for this lot`);
+      }
+      return raw;
+    }
+  }
+
+  const [[cut]] = await conn.query(
+    `SELECT (? < COALESCE(manual_cutting_date, DATE(created_at))) AS too_early
+       FROM cutting_lots WHERE id = ?`,
+    [raw, cuttingLotId]
+  );
+  if (cut && Number(cut.too_early)) {
+    throw new Error('Manual date is before the lot was cut');
+  }
+  return raw;
+}
+
 module.exports = {
   STAGES,
   tablesFor,
@@ -333,4 +421,6 @@ module.exports = {
   getOpenApprovals,
   recordEvent,
   normalizeSizeLabel,
+  assertManualDateNotFuture,
+  resolveManualDate,
 };

--- a/views/finishingEvents.ejs
+++ b/views/finishingEvents.ejs
@@ -1835,6 +1835,7 @@ function buildTakeCard() {
       </div>
       ${hasRewash ? '<div class="sx-form-row"><input type="text" data-input="rewash-reason" placeholder="Reason for rewash (e.g. still wet, improper wash)" /></div>' : ''}
       <div class="sx-form-row"><input type="text" data-input="reject-reason" placeholder="Reason for reject (e.g. fabric defect)" /></div>
+      <div class="sx-form-row"><label style="display:flex;align-items:center;gap:.5rem;width:100%;">Actual date (optional)<input type="date" data-input="take-date" max="${istToday()}" title="Actual date the work happened — leave blank for today" style="flex:1;" /></label></div>
       <div class="sx-form-row"><input type="text" data-input="take-remark" placeholder="Add remarks (optional)" /></div>
       <button class="sx-action-cta" data-action="take-confirm">
         Take ${fmt(totalAvailable)} pieces
@@ -1891,7 +1892,7 @@ function buildTakeCard() {
   card.querySelector('[data-action="take-confirm"]').addEventListener('click', () => {
     // Route based on current state: pure all-take → fast path; any exception → submit splits.
     if (cardHasException(card)) doTakeFromForm(card);
-    else                        doTakeAll();
+    else                        doTakeAll(card);
   });
 
   recalcTakeTotal(card);
@@ -1975,7 +1976,15 @@ function recalcTakeTotal(card) {
   }
 }
 
-async function doTakeAll() {
+// IST calendar day for the date-picker max (no future manual dates; server re-validates).
+function istToday() { return new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' }); }
+function cardManualDate(card, key) {
+  if (!card) return null;
+  const i = card.querySelector('[data-input="' + key + '"]');
+  return (i && i.value) ? i.value : null;
+}
+
+async function doTakeAll(card) {
   const upstream = currentState.upstream_sizes;
   const sizes = upstream
     .filter(s => (s.available || 0) > 0)
@@ -1983,7 +1992,7 @@ async function doTakeAll() {
   if (!sizes.length) return;
   const total = sizes.reduce((a, s) => a + s.pieces, 0);
   if (!confirm('Take ' + fmt(total) + ' pieces of ' + (currentLot.lot_no || '').toUpperCase() + ' into ' + STAGE_LABEL.toLowerCase() + '?')) return;
-  await doTakeRequest({ sizes, rejected_sizes: [], rewash_sizes: [] });
+  await doTakeRequest({ sizes, rejected_sizes: [], rewash_sizes: [], manual_date: cardManualDate(card, 'take-date') });
 }
 
 async function doTakeFromForm(card) {
@@ -2018,6 +2027,7 @@ async function doTakeFromForm(card) {
   if (!confirm(msg + ' for ' + (currentLot.lot_no || '').toUpperCase() + '?')) return;
   await doTakeRequest({
     sizes, rejected_sizes, rewash_sizes,
+    manual_date: cardManualDate(card, 'take-date'),
     remark: remark.trim() || null,
     reject_reason: reject_reason.trim() || null,
     rewash_reason: rewash_reason.trim() || null,
@@ -2055,6 +2065,7 @@ function buildDoneCard(approve) {
         <span class="gl">Grand Total</span>
         <span class="gv is-done-gv">Done <strong data-display="done-total">0</strong> pcs<span class="gx" data-x="reject" style="display:none;"> · <strong data-display="reject-total">0</strong> reject</span></span>
       </div>
+      <div class="sx-form-row"><label style="display:flex;align-items:center;gap:.5rem;width:100%;">Actual date (optional)<input type="date" data-input="done-date" max="${istToday()}" title="Actual date the work happened — leave blank for today" style="flex:1;" /></label></div>
       <div class="sx-form-row"><input type="text" data-input="done-remark" placeholder="Completion note (optional)" /></div>
       <button class="sx-action-cta" data-action="done-confirm">
         Mark ${fmt(approve.inline)} pieces done
@@ -2100,7 +2111,7 @@ function buildDoneCard(approve) {
   card.querySelector('[data-action="done-confirm"]').addEventListener('click', () => {
     // Reduced any size or added any reject → submit the form; otherwise fast all-done path.
     if (doneCardDirty(card)) doMarkDoneFromForm(card, approve);
-    else doMarkDoneAll(approve);
+    else doMarkDoneAll(approve, card);
   });
 
   recalcDoneTotals(card, approve);
@@ -2170,11 +2181,11 @@ function recalcDoneTotals(card, approve) {
     : ('Mark ' + fmt(done) + ' pieces done');
 }
 
-async function doMarkDoneAll(approve) {
+async function doMarkDoneAll(approve, card) {
   const completed = Object.entries(approve.remaining_sizes).map(([size_label, pieces]) => ({ size_label, pieces }));
   const total = completed.reduce((a, s) => a + s.pieces, 0);
   if (!confirm('Mark ' + fmt(total) + ' pieces of ' + (currentLot.lot_no || '').toUpperCase() + ' as done?')) return;
-  await doMarkDoneRequest(approve.event_id, completed, [], null, null);
+  await doMarkDoneRequest(approve.event_id, completed, [], null, null, cardManualDate(card, 'done-date'));
 }
 
 async function doMarkDoneFromForm(card, approve) {
@@ -2200,14 +2211,14 @@ async function doMarkDoneFromForm(card, approve) {
 
   const remark = card.querySelector('[data-input="done-remark"]').value.trim() || null;
   const reason = card.querySelector('[data-input="reject-reason"]').value.trim() || null;
-  await doMarkDoneRequest(approve.event_id, cs, rs, remark, reason);
+  await doMarkDoneRequest(approve.event_id, cs, rs, remark, reason, cardManualDate(card, 'done-date'));
 }
 
-async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason) {
+async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason, manual_date) {
   try {
     await api('POST', BASE + '/event/complete', {
       parent_event_id: parentId, completed_sizes, rejected_sizes,
-      complete_remark, reject_reason,
+      complete_remark, reject_reason, manual_date,
     });
     toast('Saved ✓', 'success');
     await refreshState();

--- a/views/jeansAssemblyEvents.ejs
+++ b/views/jeansAssemblyEvents.ejs
@@ -1729,6 +1729,7 @@ function buildTakeCard() {
       </div>
       ${hasRewash ? '<div class="sx-form-row"><input type="text" data-input="rewash-reason" placeholder="Reason for rewash (e.g. still wet, improper wash)" /></div>' : ''}
       <div class="sx-form-row"><input type="text" data-input="reject-reason" placeholder="Reason for reject (e.g. fabric defect)" /></div>
+      <div class="sx-form-row"><label style="display:flex;align-items:center;gap:.5rem;width:100%;">Actual date (optional)<input type="date" data-input="take-date" max="${istToday()}" title="Actual date the work happened — leave blank for today" style="flex:1;" /></label></div>
       <div class="sx-form-row"><input type="text" data-input="take-remark" placeholder="Add remarks (optional)" /></div>
       <button class="sx-action-cta" data-action="take-confirm">
         Take ${fmt(totalAvailable)} pieces
@@ -1785,7 +1786,7 @@ function buildTakeCard() {
   card.querySelector('[data-action="take-confirm"]').addEventListener('click', () => {
     // Route based on current state: pure all-take → fast path; any exception → submit splits.
     if (cardHasException(card)) doTakeFromForm(card);
-    else                        doTakeAll();
+    else                        doTakeAll(card);
   });
 
   recalcTakeTotal(card);
@@ -1869,7 +1870,15 @@ function recalcTakeTotal(card) {
   }
 }
 
-async function doTakeAll() {
+// IST calendar day for the date-picker max (no future manual dates; server re-validates).
+function istToday() { return new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' }); }
+function cardManualDate(card, key) {
+  if (!card) return null;
+  const i = card.querySelector('[data-input="' + key + '"]');
+  return (i && i.value) ? i.value : null;
+}
+
+async function doTakeAll(card) {
   const upstream = currentState.upstream_sizes;
   const sizes = upstream
     .filter(s => (s.available || 0) > 0)
@@ -1877,7 +1886,7 @@ async function doTakeAll() {
   if (!sizes.length) return;
   const total = sizes.reduce((a, s) => a + s.pieces, 0);
   if (!confirm('Take ' + fmt(total) + ' pieces of ' + (currentLot.lot_no || '').toUpperCase() + ' into ' + STAGE_LABEL.toLowerCase() + '?')) return;
-  await doTakeRequest({ sizes, rejected_sizes: [], rewash_sizes: [] });
+  await doTakeRequest({ sizes, rejected_sizes: [], rewash_sizes: [], manual_date: cardManualDate(card, 'take-date') });
 }
 
 async function doTakeFromForm(card) {
@@ -1912,6 +1921,7 @@ async function doTakeFromForm(card) {
   if (!confirm(msg + ' for ' + (currentLot.lot_no || '').toUpperCase() + '?')) return;
   await doTakeRequest({
     sizes, rejected_sizes, rewash_sizes,
+    manual_date: cardManualDate(card, 'take-date'),
     remark: remark.trim() || null,
     reject_reason: reject_reason.trim() || null,
     rewash_reason: rewash_reason.trim() || null,
@@ -1949,6 +1959,7 @@ function buildDoneCard(approve) {
         <span class="gl">Grand Total</span>
         <span class="gv is-done-gv">Done <strong data-display="done-total">0</strong> pcs<span class="gx" data-x="reject" style="display:none;"> · <strong data-display="reject-total">0</strong> reject</span></span>
       </div>
+      <div class="sx-form-row"><label style="display:flex;align-items:center;gap:.5rem;width:100%;">Actual date (optional)<input type="date" data-input="done-date" max="${istToday()}" title="Actual date the work happened — leave blank for today" style="flex:1;" /></label></div>
       <div class="sx-form-row"><input type="text" data-input="done-remark" placeholder="Completion note (optional)" /></div>
       <button class="sx-action-cta" data-action="done-confirm">
         Mark ${fmt(approve.inline)} pieces done
@@ -1994,7 +2005,7 @@ function buildDoneCard(approve) {
   card.querySelector('[data-action="done-confirm"]').addEventListener('click', () => {
     // Reduced any size or added any reject → submit the form; otherwise fast all-done path.
     if (doneCardDirty(card)) doMarkDoneFromForm(card, approve);
-    else doMarkDoneAll(approve);
+    else doMarkDoneAll(approve, card);
   });
 
   recalcDoneTotals(card, approve);
@@ -2064,11 +2075,11 @@ function recalcDoneTotals(card, approve) {
     : ('Mark ' + fmt(done) + ' pieces done');
 }
 
-async function doMarkDoneAll(approve) {
+async function doMarkDoneAll(approve, card) {
   const completed = Object.entries(approve.remaining_sizes).map(([size_label, pieces]) => ({ size_label, pieces }));
   const total = completed.reduce((a, s) => a + s.pieces, 0);
   if (!confirm('Mark ' + fmt(total) + ' pieces of ' + (currentLot.lot_no || '').toUpperCase() + ' as done?')) return;
-  await doMarkDoneRequest(approve.event_id, completed, [], null, null);
+  await doMarkDoneRequest(approve.event_id, completed, [], null, null, cardManualDate(card, 'done-date'));
 }
 
 async function doMarkDoneFromForm(card, approve) {
@@ -2094,14 +2105,14 @@ async function doMarkDoneFromForm(card, approve) {
 
   const remark = card.querySelector('[data-input="done-remark"]').value.trim() || null;
   const reason = card.querySelector('[data-input="reject-reason"]').value.trim() || null;
-  await doMarkDoneRequest(approve.event_id, cs, rs, remark, reason);
+  await doMarkDoneRequest(approve.event_id, cs, rs, remark, reason, cardManualDate(card, 'done-date'));
 }
 
-async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason) {
+async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason, manual_date) {
   try {
     await api('POST', BASE + '/event/complete', {
       parent_event_id: parentId, completed_sizes, rejected_sizes,
-      complete_remark, reject_reason,
+      complete_remark, reject_reason, manual_date,
     });
     toast('Saved ✓', 'success');
     await refreshState();

--- a/views/lotJourney.ejs
+++ b/views/lotJourney.ejs
@@ -215,7 +215,8 @@ function renderActivity(activity, lotNo){
   }
   h += activity.map(a=>
     '<div class="act-row">'+
-      '<span class="act-when">'+fmtWhen(a.when)+'</span>'+
+      '<span class="act-when">'+fmtWhen(a.when)+
+        (a.manual_date?(' <span class="muted" title="Actual work date entered by the master">(manual: '+fmtDate(a.manual_date)+')</span>'):'')+'</span>'+
       '<span class="act-pill act-stage">'+esc(ACT_STAGE_LABEL[a.stage]||a.stage)+'</span>'+
       '<span class="act-pill act-k-'+esc(a.kind)+'">'+esc(a.label)+'</span>'+
       '<span class="act-meta">'+

--- a/views/stitchingEvents.ejs
+++ b/views/stitchingEvents.ejs
@@ -1738,6 +1738,7 @@ function buildTakeCard() {
       </div>
       ${hasRewash ? '<div class="sx-form-row"><input type="text" data-input="rewash-reason" placeholder="Reason for rewash (e.g. still wet, improper wash)" /></div>' : ''}
       <div class="sx-form-row"><input type="text" data-input="reject-reason" placeholder="Reason for reject (e.g. fabric defect)" /></div>
+      <div class="sx-form-row"><label style="display:flex;align-items:center;gap:.5rem;width:100%;">Actual date (optional)<input type="date" data-input="take-date" max="${istToday()}" title="Actual date the work happened — leave blank for today" style="flex:1;" /></label></div>
       <div class="sx-form-row"><input type="text" data-input="take-remark" placeholder="Add remarks (optional)" /></div>
       <button class="sx-action-cta" data-action="take-confirm">
         Take ${fmt(totalAvailable)} pieces
@@ -1794,7 +1795,7 @@ function buildTakeCard() {
   card.querySelector('[data-action="take-confirm"]').addEventListener('click', () => {
     // Route based on current state: pure all-take → fast path; any exception → submit splits.
     if (cardHasException(card)) doTakeFromForm(card);
-    else                        doTakeAll();
+    else                        doTakeAll(card);
   });
 
   recalcTakeTotal(card);
@@ -1878,7 +1879,15 @@ function recalcTakeTotal(card) {
   }
 }
 
-async function doTakeAll() {
+// IST calendar day for the date-picker max (no future manual dates; server re-validates).
+function istToday() { return new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' }); }
+function cardManualDate(card, key) {
+  if (!card) return null;
+  const i = card.querySelector('[data-input="' + key + '"]');
+  return (i && i.value) ? i.value : null;
+}
+
+async function doTakeAll(card) {
   const upstream = currentState.upstream_sizes;
   const sizes = upstream
     .filter(s => (s.available || 0) > 0)
@@ -1886,7 +1895,7 @@ async function doTakeAll() {
   if (!sizes.length) return;
   const total = sizes.reduce((a, s) => a + s.pieces, 0);
   if (!confirm('Take ' + fmt(total) + ' pieces of ' + (currentLot.lot_no || '').toUpperCase() + ' into ' + STAGE_LABEL.toLowerCase() + '?')) return;
-  await doTakeRequest({ sizes, rejected_sizes: [], rewash_sizes: [] });
+  await doTakeRequest({ sizes, rejected_sizes: [], rewash_sizes: [], manual_date: cardManualDate(card, 'take-date') });
 }
 
 async function doTakeFromForm(card) {
@@ -1921,6 +1930,7 @@ async function doTakeFromForm(card) {
   if (!confirm(msg + ' for ' + (currentLot.lot_no || '').toUpperCase() + '?')) return;
   await doTakeRequest({
     sizes, rejected_sizes, rewash_sizes,
+    manual_date: cardManualDate(card, 'take-date'),
     remark: remark.trim() || null,
     reject_reason: reject_reason.trim() || null,
     rewash_reason: rewash_reason.trim() || null,
@@ -1958,6 +1968,7 @@ function buildDoneCard(approve) {
         <span class="gl">Grand Total</span>
         <span class="gv is-done-gv">Done <strong data-display="done-total">0</strong> pcs<span class="gx" data-x="reject" style="display:none;"> · <strong data-display="reject-total">0</strong> reject</span></span>
       </div>
+      <div class="sx-form-row"><label style="display:flex;align-items:center;gap:.5rem;width:100%;">Actual date (optional)<input type="date" data-input="done-date" max="${istToday()}" title="Actual date the work happened — leave blank for today" style="flex:1;" /></label></div>
       <div class="sx-form-row"><input type="text" data-input="done-remark" placeholder="Completion note (optional)" /></div>
       <button class="sx-action-cta" data-action="done-confirm">
         Mark ${fmt(approve.inline)} pieces done
@@ -2003,7 +2014,7 @@ function buildDoneCard(approve) {
   card.querySelector('[data-action="done-confirm"]').addEventListener('click', () => {
     // Reduced any size or added any reject → submit the form; otherwise fast all-done path.
     if (doneCardDirty(card)) doMarkDoneFromForm(card, approve);
-    else doMarkDoneAll(approve);
+    else doMarkDoneAll(approve, card);
   });
 
   recalcDoneTotals(card, approve);
@@ -2073,11 +2084,11 @@ function recalcDoneTotals(card, approve) {
     : ('Mark ' + fmt(done) + ' pieces done');
 }
 
-async function doMarkDoneAll(approve) {
+async function doMarkDoneAll(approve, card) {
   const completed = Object.entries(approve.remaining_sizes).map(([size_label, pieces]) => ({ size_label, pieces }));
   const total = completed.reduce((a, s) => a + s.pieces, 0);
   if (!confirm('Mark ' + fmt(total) + ' pieces of ' + (currentLot.lot_no || '').toUpperCase() + ' as done?')) return;
-  await doMarkDoneRequest(approve.event_id, completed, [], null, null);
+  await doMarkDoneRequest(approve.event_id, completed, [], null, null, cardManualDate(card, 'done-date'));
 }
 
 async function doMarkDoneFromForm(card, approve) {
@@ -2103,14 +2114,14 @@ async function doMarkDoneFromForm(card, approve) {
 
   const remark = card.querySelector('[data-input="done-remark"]').value.trim() || null;
   const reason = card.querySelector('[data-input="reject-reason"]').value.trim() || null;
-  await doMarkDoneRequest(approve.event_id, cs, rs, remark, reason);
+  await doMarkDoneRequest(approve.event_id, cs, rs, remark, reason, cardManualDate(card, 'done-date'));
 }
 
-async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason) {
+async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason, manual_date) {
   try {
     await api('POST', BASE + '/event/complete', {
       parent_event_id: parentId, completed_sizes, rejected_sizes,
-      complete_remark, reject_reason,
+      complete_remark, reject_reason, manual_date,
     });
     toast('Saved ✓', 'success');
     await refreshState();

--- a/views/washingEvents.ejs
+++ b/views/washingEvents.ejs
@@ -1729,6 +1729,7 @@ function buildTakeCard() {
       </div>
       ${hasRewash ? '<div class="sx-form-row"><input type="text" data-input="rewash-reason" placeholder="Reason for rewash (e.g. still wet, improper wash)" /></div>' : ''}
       <div class="sx-form-row"><input type="text" data-input="reject-reason" placeholder="Reason for reject (e.g. fabric defect)" /></div>
+      <div class="sx-form-row"><label style="display:flex;align-items:center;gap:.5rem;width:100%;">Actual date (optional)<input type="date" data-input="take-date" max="${istToday()}" title="Actual date the work happened — leave blank for today" style="flex:1;" /></label></div>
       <div class="sx-form-row"><input type="text" data-input="take-remark" placeholder="Add remarks (optional)" /></div>
       <button class="sx-action-cta" data-action="take-confirm">
         Take ${fmt(totalAvailable)} pieces
@@ -1785,7 +1786,7 @@ function buildTakeCard() {
   card.querySelector('[data-action="take-confirm"]').addEventListener('click', () => {
     // Route based on current state: pure all-take → fast path; any exception → submit splits.
     if (cardHasException(card)) doTakeFromForm(card);
-    else                        doTakeAll();
+    else                        doTakeAll(card);
   });
 
   recalcTakeTotal(card);
@@ -1869,7 +1870,15 @@ function recalcTakeTotal(card) {
   }
 }
 
-async function doTakeAll() {
+// IST calendar day for the date-picker max (no future manual dates; server re-validates).
+function istToday() { return new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' }); }
+function cardManualDate(card, key) {
+  if (!card) return null;
+  const i = card.querySelector('[data-input="' + key + '"]');
+  return (i && i.value) ? i.value : null;
+}
+
+async function doTakeAll(card) {
   const upstream = currentState.upstream_sizes;
   const sizes = upstream
     .filter(s => (s.available || 0) > 0)
@@ -1877,7 +1886,7 @@ async function doTakeAll() {
   if (!sizes.length) return;
   const total = sizes.reduce((a, s) => a + s.pieces, 0);
   if (!confirm('Take ' + fmt(total) + ' pieces of ' + (currentLot.lot_no || '').toUpperCase() + ' into ' + STAGE_LABEL.toLowerCase() + '?')) return;
-  await doTakeRequest({ sizes, rejected_sizes: [], rewash_sizes: [] });
+  await doTakeRequest({ sizes, rejected_sizes: [], rewash_sizes: [], manual_date: cardManualDate(card, 'take-date') });
 }
 
 async function doTakeFromForm(card) {
@@ -1912,6 +1921,7 @@ async function doTakeFromForm(card) {
   if (!confirm(msg + ' for ' + (currentLot.lot_no || '').toUpperCase() + '?')) return;
   await doTakeRequest({
     sizes, rejected_sizes, rewash_sizes,
+    manual_date: cardManualDate(card, 'take-date'),
     remark: remark.trim() || null,
     reject_reason: reject_reason.trim() || null,
     rewash_reason: rewash_reason.trim() || null,
@@ -1949,6 +1959,7 @@ function buildDoneCard(approve) {
         <span class="gl">Grand Total</span>
         <span class="gv is-done-gv">Done <strong data-display="done-total">0</strong> pcs<span class="gx" data-x="reject" style="display:none;"> · <strong data-display="reject-total">0</strong> reject</span></span>
       </div>
+      <div class="sx-form-row"><label style="display:flex;align-items:center;gap:.5rem;width:100%;">Actual date (optional)<input type="date" data-input="done-date" max="${istToday()}" title="Actual date the work happened — leave blank for today" style="flex:1;" /></label></div>
       <div class="sx-form-row"><input type="text" data-input="done-remark" placeholder="Completion note (optional)" /></div>
       <button class="sx-action-cta" data-action="done-confirm">
         Mark ${fmt(approve.inline)} pieces done
@@ -1994,7 +2005,7 @@ function buildDoneCard(approve) {
   card.querySelector('[data-action="done-confirm"]').addEventListener('click', () => {
     // Reduced any size or added any reject → submit the form; otherwise fast all-done path.
     if (doneCardDirty(card)) doMarkDoneFromForm(card, approve);
-    else doMarkDoneAll(approve);
+    else doMarkDoneAll(approve, card);
   });
 
   recalcDoneTotals(card, approve);
@@ -2064,11 +2075,11 @@ function recalcDoneTotals(card, approve) {
     : ('Mark ' + fmt(done) + ' pieces done');
 }
 
-async function doMarkDoneAll(approve) {
+async function doMarkDoneAll(approve, card) {
   const completed = Object.entries(approve.remaining_sizes).map(([size_label, pieces]) => ({ size_label, pieces }));
   const total = completed.reduce((a, s) => a + s.pieces, 0);
   if (!confirm('Mark ' + fmt(total) + ' pieces of ' + (currentLot.lot_no || '').toUpperCase() + ' as done?')) return;
-  await doMarkDoneRequest(approve.event_id, completed, [], null, null);
+  await doMarkDoneRequest(approve.event_id, completed, [], null, null, cardManualDate(card, 'done-date'));
 }
 
 async function doMarkDoneFromForm(card, approve) {
@@ -2094,14 +2105,14 @@ async function doMarkDoneFromForm(card, approve) {
 
   const remark = card.querySelector('[data-input="done-remark"]').value.trim() || null;
   const reason = card.querySelector('[data-input="reject-reason"]').value.trim() || null;
-  await doMarkDoneRequest(approve.event_id, cs, rs, remark, reason);
+  await doMarkDoneRequest(approve.event_id, cs, rs, remark, reason, cardManualDate(card, 'done-date'));
 }
 
-async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason) {
+async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason, manual_date) {
   try {
     await api('POST', BASE + '/event/complete', {
       parent_event_id: parentId, completed_sizes, rejected_sizes,
-      complete_remark, reject_reason,
+      complete_remark, reject_reason, manual_date,
     });
     toast('Saved ✓', 'success');
     await refreshState();

--- a/views/washingInEvents.ejs
+++ b/views/washingInEvents.ejs
@@ -1729,6 +1729,7 @@ function buildTakeCard() {
       </div>
       ${hasRewash ? '<div class="sx-form-row"><input type="text" data-input="rewash-reason" placeholder="Reason for rewash (e.g. still wet, improper wash)" /></div>' : ''}
       <div class="sx-form-row"><input type="text" data-input="reject-reason" placeholder="Reason for reject (e.g. fabric defect)" /></div>
+      <div class="sx-form-row"><label style="display:flex;align-items:center;gap:.5rem;width:100%;">Actual date (optional)<input type="date" data-input="take-date" max="${istToday()}" title="Actual date the work happened — leave blank for today" style="flex:1;" /></label></div>
       <div class="sx-form-row"><input type="text" data-input="take-remark" placeholder="Add remarks (optional)" /></div>
       <button class="sx-action-cta" data-action="take-confirm">
         Take ${fmt(totalAvailable)} pieces
@@ -1785,7 +1786,7 @@ function buildTakeCard() {
   card.querySelector('[data-action="take-confirm"]').addEventListener('click', () => {
     // Route based on current state: pure all-take → fast path; any exception → submit splits.
     if (cardHasException(card)) doTakeFromForm(card);
-    else                        doTakeAll();
+    else                        doTakeAll(card);
   });
 
   recalcTakeTotal(card);
@@ -1869,7 +1870,15 @@ function recalcTakeTotal(card) {
   }
 }
 
-async function doTakeAll() {
+// IST calendar day for the date-picker max (no future manual dates; server re-validates).
+function istToday() { return new Date().toLocaleDateString('en-CA', { timeZone: 'Asia/Kolkata' }); }
+function cardManualDate(card, key) {
+  if (!card) return null;
+  const i = card.querySelector('[data-input="' + key + '"]');
+  return (i && i.value) ? i.value : null;
+}
+
+async function doTakeAll(card) {
   const upstream = currentState.upstream_sizes;
   const sizes = upstream
     .filter(s => (s.available || 0) > 0)
@@ -1877,7 +1886,7 @@ async function doTakeAll() {
   if (!sizes.length) return;
   const total = sizes.reduce((a, s) => a + s.pieces, 0);
   if (!confirm('Take ' + fmt(total) + ' pieces of ' + (currentLot.lot_no || '').toUpperCase() + ' into ' + STAGE_LABEL.toLowerCase() + '?')) return;
-  await doTakeRequest({ sizes, rejected_sizes: [], rewash_sizes: [] });
+  await doTakeRequest({ sizes, rejected_sizes: [], rewash_sizes: [], manual_date: cardManualDate(card, 'take-date') });
 }
 
 async function doTakeFromForm(card) {
@@ -1912,6 +1921,7 @@ async function doTakeFromForm(card) {
   if (!confirm(msg + ' for ' + (currentLot.lot_no || '').toUpperCase() + '?')) return;
   await doTakeRequest({
     sizes, rejected_sizes, rewash_sizes,
+    manual_date: cardManualDate(card, 'take-date'),
     remark: remark.trim() || null,
     reject_reason: reject_reason.trim() || null,
     rewash_reason: rewash_reason.trim() || null,
@@ -1949,6 +1959,7 @@ function buildDoneCard(approve) {
         <span class="gl">Grand Total</span>
         <span class="gv is-done-gv">Done <strong data-display="done-total">0</strong> pcs<span class="gx" data-x="reject" style="display:none;"> · <strong data-display="reject-total">0</strong> reject</span></span>
       </div>
+      <div class="sx-form-row"><label style="display:flex;align-items:center;gap:.5rem;width:100%;">Actual date (optional)<input type="date" data-input="done-date" max="${istToday()}" title="Actual date the work happened — leave blank for today" style="flex:1;" /></label></div>
       <div class="sx-form-row"><input type="text" data-input="done-remark" placeholder="Completion note (optional)" /></div>
       <button class="sx-action-cta" data-action="done-confirm">
         Mark ${fmt(approve.inline)} pieces done
@@ -1994,7 +2005,7 @@ function buildDoneCard(approve) {
   card.querySelector('[data-action="done-confirm"]').addEventListener('click', () => {
     // Reduced any size or added any reject → submit the form; otherwise fast all-done path.
     if (doneCardDirty(card)) doMarkDoneFromForm(card, approve);
-    else doMarkDoneAll(approve);
+    else doMarkDoneAll(approve, card);
   });
 
   recalcDoneTotals(card, approve);
@@ -2064,11 +2075,11 @@ function recalcDoneTotals(card, approve) {
     : ('Mark ' + fmt(done) + ' pieces done');
 }
 
-async function doMarkDoneAll(approve) {
+async function doMarkDoneAll(approve, card) {
   const completed = Object.entries(approve.remaining_sizes).map(([size_label, pieces]) => ({ size_label, pieces }));
   const total = completed.reduce((a, s) => a + s.pieces, 0);
   if (!confirm('Mark ' + fmt(total) + ' pieces of ' + (currentLot.lot_no || '').toUpperCase() + ' as done?')) return;
-  await doMarkDoneRequest(approve.event_id, completed, [], null, null);
+  await doMarkDoneRequest(approve.event_id, completed, [], null, null, cardManualDate(card, 'done-date'));
 }
 
 async function doMarkDoneFromForm(card, approve) {
@@ -2094,14 +2105,14 @@ async function doMarkDoneFromForm(card, approve) {
 
   const remark = card.querySelector('[data-input="done-remark"]').value.trim() || null;
   const reason = card.querySelector('[data-input="reject-reason"]').value.trim() || null;
-  await doMarkDoneRequest(approve.event_id, cs, rs, remark, reason);
+  await doMarkDoneRequest(approve.event_id, cs, rs, remark, reason, cardManualDate(card, 'done-date'));
 }
 
-async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason) {
+async function doMarkDoneRequest(parentId, completed_sizes, rejected_sizes, complete_remark, reject_reason, manual_date) {
   try {
     await api('POST', BASE + '/event/complete', {
       parent_event_id: parentId, completed_sizes, rejected_sizes,
-      complete_remark, reject_reason,
+      complete_remark, reject_reason, manual_date,
     });
     toast('Saved ✓', 'success');
     await refreshState();


### PR DESCRIPTION
## What

Extends the cutting-only "manual date" (the actual day work happened on the floor, vs the day it was typed in) to **all five production stages** — stitching, jeans assembly, washing, washing-in, finishing — on both the **Take (approve)** and **Mark done (complete)** forms.

## Design: shadow column, never an override

Stage event timestamps silently drive money and inventory math, so the manual date is a separate nullable `manual_date DATE` beside `created_at`:

- **Payments stay safe** — the payable-lots query (`stagePaymentRoutes`) keeps ordering by real `created_at`; a backdated completion can't fall off the payable list.
- **Cut recommendations stay safe** — the 120-day in-flight window (`utils/onOrder`) keeps using `created_at`; backdating can't inflate suggested cut quantities.
- **Audit stays truthful** — the lot-journey feed still sorts by real entry time; the manual date is displayed alongside (`(manual: …)` suffix + Excel column), so a complete can never appear to precede its own approve.

Display/bucketing consumers prefer the effective date via `COALESCE(manual_date, created_at)`: **lot TAT**, **lot journey**, **day activity**, **PIC + size reports** (assignedOn filter + five new "Manual Date" Excel columns), **stitching TAT**.

## Validation (server-side, single choke point)

New `resolveManualDate()` in `utils/stageEvents.js`, called once per request:
- format + **no future dates** (IST via the DB session clock)
- **complete** ≥ its parent approve's effective date
- **approve** ≥ the nearest upstream stage's earliest effective date (hosiery lots fall through the empty denim tables; terminates at the cutting lot's effective date, so legacy lots are never blocked)

Every manual date is recorded in `pm_lot_audit_log` (`action: 'manual_date'`, with pieces + event ids + who).

## Cutting gap fixes (same PR)

The original cutting feature had zero validation and no audit — both added now. Also fixed: the edit-lot UPDATE was scoped by `lotId` alone, letting any operator hit any lot id; it now requires `AND user_id = ?` (matching the GET's scoping).

## Deploy order

⚠️ **Run `sql/2026_08_stage_events_manual_date.sql` on prod BEFORE merging** — the code names `manual_date` in INSERT/SELECTs and errors on an unmigrated DB. The reverse is safe (old code ignores the nullable column). 5 nullable ADD COLUMNs, INSTANT on MySQL 8.

## Tests

220 passing (`npm test`): new `test/manualDate.test.js` (validation walk incl. hosiery fall-through, cutting fallback, same-day Date-serialization regression), recordEvent binding, mergeActivity ordering-stability, PIC column coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)